### PR TITLE
fix: skip framework download when already at latest version

### DIFF
--- a/cli/src/commands/update_framework.rs
+++ b/cli/src/commands/update_framework.rs
@@ -42,6 +42,24 @@ pub fn run() -> Result<()> {
         display_version.green()
     );
 
+    // Compare versions — skip if already up to date
+    let current_ver_str = download::strip_tag_prefix(&current_checksums.version);
+    if !current_ver_str.is_empty() {
+        if let (Ok(current), Ok(latest)) = (
+            semver::Version::parse(current_ver_str),
+            semver::Version::parse(display_version),
+        ) {
+            if latest <= current {
+                println!();
+                utils::success(&format!(
+                    "Framework is already at the latest version ({})",
+                    current_checksums.version
+                ));
+                return Ok(());
+            }
+        }
+    }
+
     // Download ZIP
     let temp_dir = tempfile::tempdir().context("Failed to create temp directory")?;
     let zip_path = temp_dir.path().join("devtrail.zip");


### PR DESCRIPTION
## Summary
- Add semver version comparison in `update-framework` before downloading, matching the pattern already used by `update-cli` in `self_update.rs`
- Without this fix, every `devtrail update` re-downloads and overwrites all 65 framework files even when the installed version matches the latest release

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — 25 tests passing
- [x] Verified version comparison chain: `checksums.version` ("fw-2.1.0") → `strip_tag_prefix` ("2.1.0") → semver parse → correct comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)