### PR TITLE
fix: consistent fw-/cli- version display across all commands

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/cli/src/commands/about.rs
+++ b/cli/src/commands/about.rs
@@ -15,7 +15,7 @@ pub fn run() -> Result<()> {
     println!(
         "  {} {}",
         "DevTrail CLI".bold(),
-        format!("v{version}").dimmed()
+        format!("cli-{version}").dimmed()
     );
 
     // Show framework version if installed
@@ -25,7 +25,7 @@ pub fn run() -> Result<()> {
             println!(
                 "  {} {}",
                 "Framework:".dimmed(),
-                format!("v{}", manifest.version).dimmed()
+                format!("fw-{}", manifest.version).dimmed()
             );
         }
     }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -58,8 +58,8 @@ pub fn run(path: &str) -> Result<()> {
     println!();
     println!("{}", "DevTrail Status".bold());
     println!("  {}      {}", "Path:".dimmed(), target.display());
-    println!("  {} {}", "Framework:".dimmed(), version);
-    println!("  {}       {}", "CLI:".dimmed(), cli_version);
+    println!("  {} fw-{}", "Framework:".dimmed(), version);
+    println!("  {}       cli-{}", "CLI:".dimmed(), cli_version);
     println!("  {}  {}", "Language:".dimmed(), language);
 
     // Phase 2: Structure check

--- a/cli/src/commands/update_framework.rs
+++ b/cli/src/commands/update_framework.rs
@@ -39,7 +39,7 @@ pub fn run() -> Result<()> {
     println!(
         "  {} {}",
         "Latest version:".dimmed(),
-        display_version.green()
+        release.tag_name.green()
     );
 
     // Compare versions — skip if already up to date

--- a/cli/src/self_update.rs
+++ b/cli/src/self_update.rs
@@ -9,7 +9,7 @@ use crate::utils;
 /// Perform the CLI self-update
 pub fn perform_update() -> Result<()> {
     let current_version = env!("CARGO_PKG_VERSION");
-    utils::info(&format!("Current CLI version: v{}", current_version));
+    utils::info(&format!("Current version: cli-{}", current_version));
 
     // Fetch latest release
     utils::info("Checking for updates...");
@@ -17,9 +17,9 @@ pub fn perform_update() -> Result<()> {
     let tag_version = download::strip_tag_prefix(&release.tag_name);
 
     println!(
-        "  {} v{}",
-        "Latest release:".dimmed(),
-        tag_version.green()
+        "  {} {}",
+        "Latest version:".dimmed(),
+        release.tag_name.green()
     );
 
     // Compare versions
@@ -30,7 +30,7 @@ pub fn perform_update() -> Result<()> {
 
     if latest <= current {
         utils::success(&format!(
-            "CLI is already at the latest version (v{})",
+            "CLI is already at the latest version (cli-{})",
             current_version
         ));
         return Ok(());
@@ -48,7 +48,7 @@ pub fn perform_update() -> Result<()> {
         .find(|a| a.name == expected_name)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "No CLI binary found for {} in release v{}",
+                "No CLI binary found for {} in release cli-{}",
                 target,
                 tag_version
             )
@@ -82,7 +82,7 @@ pub fn perform_update() -> Result<()> {
 
     replace_binary(&extracted_binary, &current_exe)?;
 
-    utils::success(&format!("CLI updated to v{}!", tag_version));
+    utils::success(&format!("CLI updated to cli-{}!", tag_version));
 
     #[cfg(windows)]
     println!(


### PR DESCRIPTION
## Summary
- Standardize version display to always use `fw-X.Y.Z` and `cli-X.Y.Z` format
- Affects `update`, `update-framework`, `update-cli`, `about`, and `status` commands
- Removes mixed `v`-prefix formatting that was inconsistent with the split versioning scheme
- Bumps CLI version to 1.0.2

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — 25 tests passing
- [x] No remaining `"v{` display patterns in CLI source (only in `strip_tag_prefix` for legacy compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)