### PR TITLE
fix: align framework update output with CLI update format

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/cli/src/commands/update_framework.rs
+++ b/cli/src/commands/update_framework.rs
@@ -25,11 +25,7 @@ pub fn run() -> Result<()> {
     // Load current checksums
     let current_checksums = Checksums::load(&target)?;
     if !current_checksums.version.is_empty() {
-        println!(
-            "  {} {}",
-            "Current version:".dimmed(),
-            current_checksums.version
-        );
+        utils::info(&format!("Current version: {}", current_checksums.version));
     }
 
     // Fetch latest release
@@ -50,7 +46,6 @@ pub fn run() -> Result<()> {
             semver::Version::parse(display_version),
         ) {
             if latest <= current {
-                println!();
                 utils::success(&format!(
                     "Framework is already at the latest version ({})",
                     current_checksums.version


### PR DESCRIPTION
## Summary
- Remove extra blank line before framework success message
- Use `utils::info` for current version so it shows `→` prefix like CLI does
- Bump CLI to 1.0.3

## Test plan
- [x] `cargo test` — 25 tests passing
- [x] Both `update-framework` and `update-cli` now follow identical output pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)