### PR TITLE
fix: remove redundant header from framework update output

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/cli/src/commands/update_framework.rs
+++ b/cli/src/commands/update_framework.rs
@@ -20,8 +20,6 @@ pub fn run() -> Result<()> {
         );
     }
 
-    println!("{} DevTrail framework...", "Updating".cyan().bold());
-
     // Load current checksums
     let current_checksums = Checksums::load(&target)?;
     if !current_checksums.version.is_empty() {


### PR DESCRIPTION
## Summary
- Remove "Updating DevTrail framework..." line so `update-framework` and `update-cli` produce identical output structure
- Bump CLI to 1.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)