### PR TITLE
feat: add devtrail explore interactive TUI documentation viewer

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +196,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +301,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +323,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -364,6 +399,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +431,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -401,16 +495,19 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "1.0.0"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
  "colored",
+ "crossterm",
  "dialoguer",
  "flate2",
  "indicatif",
  "predicates",
+ "pulldown-cmark",
+ "ratatui",
  "reqwest",
  "semver",
  "serde",
@@ -462,6 +559,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -632,6 +735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +808,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -927,6 +1041,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,8 +1088,17 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -979,6 +1108,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1002,6 +1144,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1056,8 +1207,14 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1072,10 +1229,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1133,6 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1236,6 +1412,35 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -1357,6 +1562,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1677,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1561,6 +1815,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1568,7 +1835,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1627,6 +1894,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1760,6 +2033,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,10 +2098,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1877,7 +2209,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2095,16 +2427,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2323,6 +2684,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2625,7 +3008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,6 +31,13 @@ anyhow = "1"
 semver = "1"
 flate2 = "1"
 tar = "0.4"
+ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.28", optional = true }
+pulldown-cmark = { version = "0.12", optional = true }
+
+[features]
+default = ["tui"]
+tui = ["ratatui", "crossterm", "pulldown-cmark"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/cli/src/commands/explore.rs
+++ b/cli/src/commands/explore.rs
@@ -1,0 +1,23 @@
+use anyhow::{bail, Result};
+use std::path::PathBuf;
+
+use crate::utils;
+
+pub fn run(path: &str) -> Result<()> {
+    let target = PathBuf::from(path)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(path));
+
+    let devtrail_dir = target.join(".devtrail");
+
+    if !devtrail_dir.exists() {
+        utils::warn(&format!(
+            "DevTrail is not initialized in {}",
+            target.display()
+        ));
+        utils::info("Run 'devtrail init' to initialize DevTrail in this directory.");
+        bail!("No DevTrail installation found");
+    }
+
+    crate::tui::run(&target)
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod about;
+#[cfg(feature = "tui")]
+pub mod explore;
 pub mod init;
 pub mod remove;
 pub mod status;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,8 @@ mod inject;
 mod manifest;
 mod platform;
 mod self_update;
+#[cfg(feature = "tui")]
+mod tui;
 mod utils;
 
 /// DevTrail CLI - Documentation Governance for AI-Assisted Development
@@ -47,6 +49,13 @@ enum Commands {
     },
     /// Show version, author, and license information
     About,
+    /// Explore DevTrail documentation interactively
+    #[cfg(feature = "tui")]
+    Explore {
+        /// Target directory (default: current directory)
+        #[arg(default_value = ".")]
+        path: String,
+    },
 }
 
 fn main() {
@@ -63,6 +72,8 @@ fn main() {
         Commands::Remove { full } => commands::remove::run(full),
         Commands::Status { path } => commands::status::run(&path),
         Commands::About => commands::about::run(),
+        #[cfg(feature = "tui")]
+        Commands::Explore { path } => commands::explore::run(&path),
     };
 
     if let Err(e) = result {

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -1,0 +1,557 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::document::Document;
+use super::index::DocIndex;
+
+/// Which panel is currently active
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivePanel {
+    Navigation,
+    Metadata,
+    Document,
+}
+
+/// Current view mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    /// Two-panel layout (≥100 cols) or single-panel nav (<100 cols)
+    Normal,
+    /// Document takes full screen
+    Fullscreen,
+    /// Help popup is shown
+    Help,
+}
+
+/// What is selected in the navigation tree
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NavSelection {
+    /// A top-level group is selected
+    Group(usize),
+    /// A subgroup within a group is selected
+    Subgroup(usize, usize),
+    /// A file in a group's direct files
+    GroupFile(usize, usize),
+    /// A file within a subgroup
+    SubgroupFile(usize, usize, usize),
+}
+
+/// Sort order for file listings
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortOrder {
+    Name,
+    Date,
+}
+
+/// Navigation history entry for hyperlinked navigation
+#[derive(Debug, Clone)]
+struct HistoryEntry {
+    selection: NavSelection,
+    scroll_offset: u16,
+}
+
+pub struct App {
+    pub index: DocIndex,
+    pub active_panel: ActivePanel,
+    pub view_mode: ViewMode,
+    pub selection: NavSelection,
+    /// Which groups are expanded in the tree
+    pub expanded_groups: Vec<bool>,
+    /// Scroll offset for the document viewer
+    pub doc_scroll: u16,
+    /// Total lines in current document (for scroll bounds)
+    pub doc_total_lines: usize,
+    /// Currently loaded document
+    pub current_doc: Option<Document>,
+    /// Document cache: path -> Document
+    doc_cache: HashMap<PathBuf, Document>,
+    /// Navigation history stack for hyperlinked navigation
+    nav_history: Vec<HistoryEntry>,
+    /// Sort order
+    pub sort_order: SortOrder,
+    /// Search/filter query
+    pub search_query: Option<String>,
+    pub search_input: String,
+    pub is_searching: bool,
+    /// Currently selected related link index (for Tab cycling in document panel)
+    pub selected_related: Option<usize>,
+    /// Temporary notification message shown in the status bar
+    pub notification: Option<String>,
+    /// Should the app quit
+    pub should_quit: bool,
+    /// Project root path
+    pub project_root: PathBuf,
+}
+
+impl App {
+    pub fn new(project_root: &Path) -> Self {
+        let devtrail_dir = project_root.join(".devtrail");
+        let index = DocIndex::build(&devtrail_dir);
+        let num_groups = index.groups.len();
+
+        Self {
+            index,
+            active_panel: ActivePanel::Navigation,
+            view_mode: ViewMode::Normal,
+            selection: NavSelection::Group(0),
+            expanded_groups: vec![false; num_groups],
+            doc_scroll: 0,
+            doc_total_lines: 0,
+            current_doc: None,
+            doc_cache: HashMap::new(),
+            nav_history: Vec::new(),
+            sort_order: SortOrder::Name,
+            search_query: None,
+            search_input: String::new(),
+            is_searching: false,
+            selected_related: None,
+            notification: None,
+            should_quit: false,
+            project_root: project_root.to_path_buf(),
+        }
+    }
+
+    /// Move selection up in the navigation tree
+    pub fn nav_up(&mut self) {
+        let items = self.build_nav_items();
+        if items.is_empty() {
+            return;
+        }
+        let current = items.iter().position(|s| *s == self.selection);
+        match current {
+            Some(0) | None => self.selection = items.last().unwrap().clone(),
+            Some(i) => self.selection = items[i - 1].clone(),
+        }
+    }
+
+    /// Move selection down in the navigation tree
+    pub fn nav_down(&mut self) {
+        let items = self.build_nav_items();
+        if items.is_empty() {
+            return;
+        }
+        let current = items.iter().position(|s| *s == self.selection);
+        match current {
+            Some(i) if i + 1 < items.len() => self.selection = items[i + 1].clone(),
+            _ => self.selection = items[0].clone(),
+        }
+    }
+
+    /// Enter/expand: toggle group expansion or open a file
+    pub fn nav_enter(&mut self) {
+        match &self.selection {
+            NavSelection::Group(gi) => {
+                let gi = *gi;
+                self.expanded_groups[gi] = !self.expanded_groups[gi];
+            }
+            NavSelection::Subgroup(gi, _si) => {
+                // Subgroups are always expanded when visible, so treat as entering
+                let gi = *gi;
+                self.expanded_groups[gi] = true;
+            }
+            NavSelection::GroupFile(gi, fi) => {
+                let gi = *gi;
+                let fi = *fi;
+                if let Some(entry) = self.index.groups.get(gi).and_then(|g| g.files.get(fi)) {
+                    self.load_document(&entry.path.clone());
+                }
+            }
+            NavSelection::SubgroupFile(gi, si, fi) => {
+                let gi = *gi;
+                let si = *si;
+                let fi = *fi;
+                if let Some(entry) = self
+                    .index
+                    .groups
+                    .get(gi)
+                    .and_then(|g| g.subgroups.get(si))
+                    .and_then(|sg| sg.files.get(fi))
+                {
+                    self.load_document(&entry.path.clone());
+                }
+            }
+        }
+    }
+
+    /// Go back: collapse group or go to parent
+    pub fn nav_back(&mut self) {
+        if self.view_mode == ViewMode::Fullscreen {
+            self.view_mode = ViewMode::Normal;
+            return;
+        }
+
+        // Try navigation history first
+        if let Some(entry) = self.nav_history.pop() {
+            self.selection = entry.selection;
+            self.doc_scroll = entry.scroll_offset;
+            // Reload the document at that selection if it was a file
+            match &self.selection {
+                NavSelection::GroupFile(gi, fi) => {
+                    if let Some(e) = self.index.groups.get(*gi).and_then(|g| g.files.get(*fi)) {
+                        self.load_document(&e.path.clone());
+                    }
+                }
+                NavSelection::SubgroupFile(gi, si, fi) => {
+                    if let Some(e) = self
+                        .index
+                        .groups
+                        .get(*gi)
+                        .and_then(|g| g.subgroups.get(*si))
+                        .and_then(|sg| sg.files.get(*fi))
+                    {
+                        self.load_document(&e.path.clone());
+                    }
+                }
+                _ => {
+                    self.current_doc = None;
+                }
+            }
+            return;
+        }
+
+        match &self.selection {
+            NavSelection::GroupFile(gi, _) | NavSelection::Subgroup(gi, _) => {
+                let gi = *gi;
+                self.selection = NavSelection::Group(gi);
+            }
+            NavSelection::SubgroupFile(gi, si, _) => {
+                let gi = *gi;
+                let si = *si;
+                self.selection = NavSelection::Subgroup(gi, si);
+            }
+            NavSelection::Group(gi) => {
+                let gi = *gi;
+                self.expanded_groups[gi] = false;
+            }
+        }
+    }
+
+    /// Toggle between panels, or cycle related links when in document panel
+    pub fn toggle_panel(&mut self) {
+        if self.current_doc.is_some() {
+            match self.active_panel {
+                ActivePanel::Navigation => {
+                    // Nav → Metadata (if doc has frontmatter)
+                    self.selected_related = None;
+                    self.active_panel = ActivePanel::Metadata;
+                }
+                ActivePanel::Metadata => {
+                    // In Metadata panel, Tab cycles related links
+                    let related_count = self.related_count();
+                    if related_count > 0 {
+                        match self.selected_related {
+                            None => {
+                                self.selected_related = Some(0);
+                            }
+                            Some(idx) => {
+                                let next = idx + 1;
+                                if next >= related_count {
+                                    // Past last related → move to Document
+                                    self.selected_related = None;
+                                    self.active_panel = ActivePanel::Document;
+                                } else {
+                                    self.selected_related = Some(next);
+                                }
+                            }
+                        }
+                    } else {
+                        // No related links → move to Document
+                        self.active_panel = ActivePanel::Document;
+                    }
+                }
+                ActivePanel::Document => {
+                    // Doc → back to Navigation
+                    self.selected_related = None;
+                    self.active_panel = ActivePanel::Navigation;
+                }
+            }
+        }
+    }
+
+    /// Follow the currently selected related link
+    pub fn follow_selected_related(&mut self) {
+        if let Some(idx) = self.selected_related {
+            if let Some(ref doc) = self.current_doc {
+                if let Some(ref fm) = doc.frontmatter {
+                    if let Some(related_id) = fm.related.get(idx) {
+                        let id = related_id.clone();
+                        self.selected_related = None;
+                        self.navigate_to_id(&id);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get the number of related links in the current document
+    fn related_count(&self) -> usize {
+        self.current_doc
+            .as_ref()
+            .and_then(|doc| doc.frontmatter.as_ref())
+            .map(|fm| fm.related.len())
+            .unwrap_or(0)
+    }
+
+    /// Toggle fullscreen mode for document
+    pub fn toggle_fullscreen(&mut self) {
+        if self.current_doc.is_some() {
+            self.view_mode = match self.view_mode {
+                ViewMode::Fullscreen => ViewMode::Normal,
+                _ => ViewMode::Fullscreen,
+            };
+        }
+    }
+
+    /// Toggle help popup
+    pub fn toggle_help(&mut self) {
+        self.view_mode = match self.view_mode {
+            ViewMode::Help => ViewMode::Normal,
+            _ => ViewMode::Help,
+        };
+    }
+
+    /// Scroll document down
+    pub fn scroll_down(&mut self, amount: u16) {
+        if self.doc_total_lines > 0 {
+            let max = self.doc_total_lines.saturating_sub(5) as u16;
+            self.doc_scroll = (self.doc_scroll + amount).min(max);
+        }
+    }
+
+    /// Scroll document up
+    pub fn scroll_up(&mut self, amount: u16) {
+        self.doc_scroll = self.doc_scroll.saturating_sub(amount);
+    }
+
+    /// Scroll to top
+    pub fn scroll_to_top(&mut self) {
+        self.doc_scroll = 0;
+    }
+
+    /// Scroll to bottom
+    pub fn scroll_to_bottom(&mut self) {
+        if self.doc_total_lines > 5 {
+            self.doc_scroll = (self.doc_total_lines - 5) as u16;
+        }
+    }
+
+    /// Jump to a specific group by number (1-8)
+    pub fn jump_to_group(&mut self, num: usize) {
+        let idx = num.saturating_sub(1);
+        if idx < self.index.groups.len() {
+            self.selection = NavSelection::Group(idx);
+            self.expanded_groups[idx] = true;
+        }
+    }
+
+    /// Cycle sort order
+    pub fn cycle_sort(&mut self) {
+        self.sort_order = match self.sort_order {
+            SortOrder::Name => SortOrder::Date,
+            SortOrder::Date => SortOrder::Name,
+        };
+    }
+
+    /// Navigate to a document by its ID (hyperlinked navigation)
+    pub fn navigate_to_id(&mut self, id: &str) {
+        let path = match self.index.find_by_ref(id) {
+            Some(p) => p,
+            None => {
+                self.notification = Some(format!("Document not found: {id}"));
+                return;
+            }
+        };
+
+        // Save current position to history
+        self.nav_history.push(HistoryEntry {
+            selection: self.selection.clone(),
+            scroll_offset: self.doc_scroll,
+        });
+
+        // Find the selection that corresponds to this path
+        if let Some(sel) = self.find_selection_for_path(&path) {
+            self.selection = sel;
+            // Ensure parent group is expanded
+            match &self.selection {
+                NavSelection::GroupFile(gi, _)
+                | NavSelection::Subgroup(gi, _)
+                | NavSelection::SubgroupFile(gi, _, _) => {
+                    self.expanded_groups[*gi] = true;
+                }
+                _ => {}
+            }
+        }
+
+        self.load_document(&path);
+    }
+
+    /// Navigate to next document in the current group/subgroup
+    pub fn next_document(&mut self) {
+        self.navigate_sibling(1);
+    }
+
+    /// Navigate to previous document in the current group/subgroup
+    pub fn prev_document(&mut self) {
+        self.navigate_sibling(-1);
+    }
+
+    /// Start search mode
+    pub fn start_search(&mut self) {
+        self.is_searching = true;
+        self.search_input.clear();
+    }
+
+    /// Cancel search
+    pub fn cancel_search(&mut self) {
+        self.is_searching = false;
+        self.search_input.clear();
+        self.search_query = None;
+    }
+
+    /// Apply search filter
+    pub fn apply_search(&mut self) {
+        if self.search_input.is_empty() {
+            self.search_query = None;
+        } else {
+            self.search_query = Some(self.search_input.clone());
+        }
+        self.is_searching = false;
+    }
+
+    // ── Private helpers ──
+
+    fn load_document(&mut self, path: &Path) {
+        if let Some(cached) = self.doc_cache.get(path) {
+            self.current_doc = Some(cached.clone());
+        } else if let Some(doc) = Document::load(path) {
+            self.doc_cache.insert(path.to_path_buf(), doc.clone());
+            self.current_doc = Some(doc);
+        }
+        self.doc_scroll = 0;
+        self.selected_related = None;
+        self.active_panel = ActivePanel::Document;
+    }
+
+    fn navigate_sibling(&mut self, direction: i32) {
+        match &self.selection {
+            NavSelection::GroupFile(gi, fi) => {
+                let gi = *gi;
+                let fi = *fi;
+                let len = self.index.groups[gi].files.len();
+                if len == 0 {
+                    return;
+                }
+                let new_fi = (fi as i32 + direction).rem_euclid(len as i32) as usize;
+                self.selection = NavSelection::GroupFile(gi, new_fi);
+                let path = self.index.groups[gi].files[new_fi].path.clone();
+                self.load_document(&path);
+            }
+            NavSelection::SubgroupFile(gi, si, fi) => {
+                let gi = *gi;
+                let si = *si;
+                let fi = *fi;
+                let len = self.index.groups[gi].subgroups[si].files.len();
+                if len == 0 {
+                    return;
+                }
+                let new_fi = (fi as i32 + direction).rem_euclid(len as i32) as usize;
+                self.selection = NavSelection::SubgroupFile(gi, si, new_fi);
+                let path = self.index.groups[gi].subgroups[si].files[new_fi].path.clone();
+                self.load_document(&path);
+            }
+            _ => {}
+        }
+    }
+
+    fn find_selection_for_path(&self, target: &Path) -> Option<NavSelection> {
+        for (gi, group) in self.index.groups.iter().enumerate() {
+            for (fi, entry) in group.files.iter().enumerate() {
+                if entry.path == target {
+                    return Some(NavSelection::GroupFile(gi, fi));
+                }
+            }
+            for (si, sg) in group.subgroups.iter().enumerate() {
+                for (fi, entry) in sg.files.iter().enumerate() {
+                    if entry.path == target {
+                        return Some(NavSelection::SubgroupFile(gi, si, fi));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Build a flat list of all visible navigation items in order
+    fn build_nav_items(&self) -> Vec<NavSelection> {
+        let mut items = Vec::new();
+        let search = self.search_query.as_deref();
+        let has_search = search.is_some();
+
+        for (gi, group) in self.index.groups.iter().enumerate() {
+            let show_children = if has_search {
+                group_has_matches(group, search)
+            } else {
+                self.expanded_groups[gi]
+            };
+
+            // When searching, skip groups with no matches
+            if has_search && !show_children {
+                continue;
+            }
+
+            items.push(NavSelection::Group(gi));
+
+            if show_children {
+                // Direct files
+                for (fi, entry) in group.files.iter().enumerate() {
+                    if !entry_matches_search(entry, search) {
+                        continue;
+                    }
+                    items.push(NavSelection::GroupFile(gi, fi));
+                }
+                // Subgroups and their files
+                for (si, sg) in group.subgroups.iter().enumerate() {
+                    let sg_has_matches =
+                        sg.files.iter().any(|e| entry_matches_search(e, search));
+                    if has_search && !sg_has_matches {
+                        continue;
+                    }
+                    items.push(NavSelection::Subgroup(gi, si));
+                    for (fi, entry) in sg.files.iter().enumerate() {
+                        if !entry_matches_search(entry, search) {
+                            continue;
+                        }
+                        items.push(NavSelection::SubgroupFile(gi, si, fi));
+                    }
+                }
+            }
+        }
+        items
+    }
+}
+
+fn group_has_matches(
+    group: &crate::tui::index::DocGroup,
+    search: Option<&str>,
+) -> bool {
+    group.files.iter().any(|e| entry_matches_search(e, search))
+        || group
+            .subgroups
+            .iter()
+            .any(|sg| sg.files.iter().any(|e| entry_matches_search(e, search)))
+}
+
+fn entry_matches_search(
+    entry: &crate::tui::index::DocEntry,
+    search: Option<&str>,
+) -> bool {
+    let Some(q) = search else {
+        return true;
+    };
+    let query = q.to_lowercase();
+    entry.filename.to_lowercase().contains(&query)
+        || entry.title.to_lowercase().contains(&query)
+        || entry.tags.iter().any(|t| t.to_lowercase().contains(&query))
+        || (!entry.created.is_empty() && entry.created.contains(&query))
+        || entry.id.to_lowercase().contains(&query)
+}

--- a/cli/src/tui/document.rs
+++ b/cli/src/tui/document.rs
@@ -1,0 +1,150 @@
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DocStatus {
+    Draft,
+    Accepted,
+    Deprecated,
+    Superseded,
+    #[serde(other)]
+    Unknown,
+}
+
+impl std::fmt::Display for DocStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Draft => write!(f, "DRAFT"),
+            Self::Accepted => write!(f, "ACCEPTED"),
+            Self::Deprecated => write!(f, "DEPRECATED"),
+            Self::Superseded => write!(f, "SUPERSEDED"),
+            Self::Unknown => write!(f, "UNKNOWN"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfidenceLevel {
+    High,
+    Medium,
+    Low,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+    Critical,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct DocFrontMatter {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub status: Option<DocStatus>,
+    #[serde(default)]
+    pub created: Option<String>,
+    #[serde(default)]
+    pub updated: Option<String>,
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub confidence: Option<ConfidenceLevel>,
+    #[serde(default)]
+    pub review_required: Option<bool>,
+    #[serde(default)]
+    pub risk_level: Option<RiskLevel>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub related: Vec<String>,
+    #[serde(default)]
+    pub supersedes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub frontmatter: Option<DocFrontMatter>,
+    pub body: String,
+    pub filename: String,
+}
+
+impl Document {
+    pub fn load(path: &Path) -> Option<Self> {
+        let content = std::fs::read_to_string(path).ok()?;
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let (frontmatter, body) = parse_frontmatter(&content);
+
+        Some(Self {
+            frontmatter,
+            body,
+            filename,
+        })
+    }
+}
+
+fn parse_frontmatter(content: &str) -> (Option<DocFrontMatter>, String) {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, content.to_string());
+    }
+
+    // Find the closing ---
+    let after_first = &trimmed[3..];
+    let closing = after_first.find("\n---");
+    match closing {
+        Some(pos) => {
+            let yaml_str = &after_first[..pos];
+            let body_start = pos + 4; // skip \n---
+            let body = after_first[body_start..].trim_start_matches('\n').to_string();
+            let fm: Option<DocFrontMatter> = serde_yaml::from_str(yaml_str).ok();
+            (fm, body)
+        }
+        None => (None, content.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_frontmatter() {
+        let content = r#"---
+id: ADR-2025-06-15-001
+title: Test Document
+status: accepted
+created: 2025-06-15
+risk_level: low
+tags: [rust, tui]
+related: [REQ-2025-06-10-003]
+---
+
+# Test Document
+
+Some content here.
+"#;
+        let (fm, body) = parse_frontmatter(content);
+        let fm = fm.unwrap();
+        assert_eq!(fm.id, "ADR-2025-06-15-001");
+        assert_eq!(fm.status, Some(DocStatus::Accepted));
+        assert!(body.starts_with("# Test Document"));
+    }
+}

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -1,0 +1,150 @@
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use std::time::Duration;
+
+use super::app::{ActivePanel, App, ViewMode};
+
+/// Process events and update app state. Returns true if a redraw is needed.
+pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
+    if !event::poll(Duration::from_millis(50))? {
+        return Ok(false);
+    }
+
+    let event = event::read()?;
+
+    match event {
+        Event::Key(key) if key.kind == KeyEventKind::Press => {
+            handle_key(app, key);
+            Ok(true)
+        }
+        Event::Resize(_, _) => Ok(true),
+        _ => Ok(false),
+    }
+}
+
+fn handle_key(app: &mut App, key: KeyEvent) {
+    // Search mode: capture typed characters
+    if app.is_searching {
+        handle_search_key(app, key);
+        return;
+    }
+
+    // Notification: any key dismisses it
+    if app.notification.is_some() {
+        app.notification = None;
+        return;
+    }
+
+    // Help mode: any key closes it
+    if app.view_mode == ViewMode::Help {
+        app.view_mode = ViewMode::Normal;
+        return;
+    }
+
+    // Ctrl+C / Ctrl+Q: always quit regardless of mode
+    if key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('q'))
+    {
+        app.should_quit = true;
+        return;
+    }
+
+    match key.code {
+        KeyCode::Char('q') => app.should_quit = true,
+        KeyCode::Char('?') => app.toggle_help(),
+        KeyCode::Tab => app.toggle_panel(),
+        KeyCode::Char('f') => app.toggle_fullscreen(),
+        KeyCode::Char('/') => app.start_search(),
+        KeyCode::Char('s') => app.cycle_sort(),
+
+        // Group jumping with number keys
+        KeyCode::Char(c @ '1'..='8') => {
+            app.jump_to_group(c.to_digit(10).unwrap() as usize);
+        }
+
+        // Navigation or document scrolling depending on active panel
+        KeyCode::Char('j') | KeyCode::Down => match app.active_panel {
+            ActivePanel::Document => app.scroll_down(1),
+            ActivePanel::Navigation => app.nav_down(),
+            ActivePanel::Metadata => {}
+        },
+        KeyCode::Char('k') | KeyCode::Up => match app.active_panel {
+            ActivePanel::Document => app.scroll_up(1),
+            ActivePanel::Navigation => app.nav_up(),
+            ActivePanel::Metadata => {}
+        },
+
+        // Enter: open/expand or follow selected related link
+        KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => {
+            if app.active_panel == ActivePanel::Navigation {
+                app.nav_enter();
+            } else if app.active_panel == ActivePanel::Metadata
+                && app.selected_related.is_some()
+            {
+                app.follow_selected_related();
+            }
+        }
+
+        // Back: collapse/go back / clear search
+        KeyCode::Esc | KeyCode::Char('h') | KeyCode::Left => {
+            match app.active_panel {
+                ActivePanel::Document if key.code == KeyCode::Esc => {
+                    if app.view_mode == ViewMode::Fullscreen {
+                        app.view_mode = ViewMode::Normal;
+                    } else {
+                        app.active_panel = ActivePanel::Navigation;
+                    }
+                }
+                ActivePanel::Metadata if key.code == KeyCode::Esc => {
+                    app.selected_related = None;
+                    app.active_panel = ActivePanel::Navigation;
+                }
+                ActivePanel::Navigation => {
+                    if key.code == KeyCode::Esc && app.search_query.is_some() {
+                        app.cancel_search();
+                    } else {
+                        app.nav_back();
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Document scroll shortcuts
+        KeyCode::Char('g') => app.scroll_to_top(),
+        KeyCode::Char('G') => app.scroll_to_bottom(),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.scroll_down(15);
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.scroll_up(15);
+        }
+        KeyCode::PageDown => app.scroll_down(20),
+        KeyCode::PageUp => app.scroll_up(20),
+
+        // Next/Previous document
+        KeyCode::Char('n') => app.next_document(),
+        KeyCode::Char('N') => app.prev_document(),
+
+        // Refresh
+        KeyCode::Char('r') => {
+            let root = app.project_root.clone();
+            *app = App::new(&root);
+        }
+
+        _ => {}
+    }
+}
+
+fn handle_search_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc => app.cancel_search(),
+        KeyCode::Enter => app.apply_search(),
+        KeyCode::Backspace => {
+            app.search_input.pop();
+        }
+        KeyCode::Char(c) => {
+            app.search_input.push(c);
+        }
+        _ => {}
+    }
+}

--- a/cli/src/tui/index.rs
+++ b/cli/src/tui/index.rs
@@ -1,0 +1,361 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::document::DocFrontMatter;
+
+/// A group in the documentation hierarchy (e.g., "02-design")
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DocGroup {
+    /// Directory name (e.g., "02-design")
+    pub name: String,
+    /// Display label (e.g., "Design")
+    pub label: String,
+    pub path: PathBuf,
+    pub subgroups: Vec<DocSubgroup>,
+    /// Files directly in this group (not in a subgroup)
+    pub files: Vec<DocEntry>,
+}
+
+/// A subgroup within a group (e.g., "decisions" under "02-design")
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DocSubgroup {
+    /// Directory name (e.g., "technical-debt")
+    pub name: String,
+    /// Display label (e.g., "Technical debt")
+    pub label: String,
+    pub path: PathBuf,
+    pub files: Vec<DocEntry>,
+}
+
+/// A documentation file entry
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DocEntry {
+    pub filename: String,
+    pub path: PathBuf,
+    pub title: String,
+    pub id: String,
+    pub tags: Vec<String>,
+    pub created: String,
+    pub has_frontmatter: bool,
+}
+
+/// Bidirectional relationship index
+#[derive(Debug, Default)]
+pub struct RelationIndex {
+    /// doc_id -> list of doc_ids it references
+    pub references: HashMap<String, Vec<String>>,
+    /// doc_id -> list of doc_ids that reference it
+    pub referenced_by: HashMap<String, Vec<String>>,
+    /// doc_id -> file path
+    pub id_to_path: HashMap<String, PathBuf>,
+}
+
+/// The full documentation index
+pub struct DocIndex {
+    pub groups: Vec<DocGroup>,
+    pub relations: RelationIndex,
+    pub total_docs: usize,
+}
+
+/// Subgroup definition: (dir_name, display_label)
+type SubgroupDef = (&'static str, &'static str);
+
+/// Known documentation group definitions: (dir_name, display_label, subgroups)
+const GROUP_DEFS: &[(&str, &str, &[SubgroupDef])] = &[
+    ("00-governance", "Governance", &[("exceptions", "Exceptions")]),
+    ("01-requirements", "Requirements", &[]),
+    ("02-design", "Design", &[("decisions", "Decisions")]),
+    ("03-implementation", "Implementation", &[]),
+    ("04-testing", "Testing", &[]),
+    (
+        "05-operations",
+        "Operations",
+        &[("incidents", "Incidents"), ("runbooks", "Runbooks")],
+    ),
+    (
+        "06-evolution",
+        "Evolution",
+        &[("technical-debt", "Technical debt")],
+    ),
+    (
+        "07-ai-audit",
+        "AI Audit",
+        &[
+            ("agent-logs", "Agent logs"),
+            ("decisions", "Decisions"),
+            ("ethical-reviews", "Ethical reviews"),
+        ],
+    ),
+];
+
+impl DocIndex {
+    /// Build the index by scanning the .devtrail directory
+    pub fn build(devtrail_dir: &Path) -> Self {
+        let mut groups = Vec::new();
+        let mut relations = RelationIndex::default();
+        let mut total_docs = 0;
+
+        for &(group_name, group_label, subgroup_defs) in GROUP_DEFS {
+            let group_path = devtrail_dir.join(group_name);
+            if !group_path.exists() {
+                groups.push(DocGroup {
+                    name: group_name.to_string(),
+                    label: group_label.to_string(),
+                    path: group_path,
+                    subgroups: Vec::new(),
+                    files: Vec::new(),
+                });
+                continue;
+            }
+
+            // Scan files directly in the group dir
+            let files = scan_md_files(&group_path, &mut relations);
+            total_docs += files.len();
+
+            // Scan subgroups
+            let mut subgroups = Vec::new();
+            for &(sg_name, sg_label) in subgroup_defs {
+                let sg_path = group_path.join(sg_name);
+                if sg_path.exists() {
+                    let sg_files = scan_md_files(&sg_path, &mut relations);
+                    total_docs += sg_files.len();
+                    subgroups.push(DocSubgroup {
+                        name: sg_name.to_string(),
+                        label: sg_label.to_string(),
+                        path: sg_path,
+                        files: sg_files,
+                    });
+                } else {
+                    subgroups.push(DocSubgroup {
+                        name: sg_name.to_string(),
+                        label: sg_label.to_string(),
+                        path: sg_path,
+                        files: Vec::new(),
+                    });
+                }
+            }
+
+            groups.push(DocGroup {
+                name: group_name.to_string(),
+                label: group_label.to_string(),
+                path: group_path,
+                subgroups,
+                files,
+            });
+        }
+
+        Self {
+            groups,
+            relations,
+            total_docs,
+        }
+    }
+
+    /// Find the file path for a related link.
+    /// Tries multiple resolution strategies:
+    /// 1. Exact document ID match (e.g., "ADR-2025-06-15-001")
+    /// 2. Filename match (e.g., "AGENT-RULES.md")
+    /// 3. Path suffix match (e.g., "00-governance/AGENT-RULES.md")
+    pub fn find_by_ref(&self, reference: &str) -> Option<PathBuf> {
+        // 1. Try as document ID
+        if let Some(path) = self.relations.id_to_path.get(reference) {
+            return Some(path.clone());
+        }
+
+        // Normalize: strip leading ./ or ../ segments for matching
+        let clean_ref = reference
+            .trim_start_matches("../")
+            .trim_start_matches("./");
+
+        // Extract just the filename part
+        let ref_filename = std::path::Path::new(clean_ref)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(clean_ref);
+
+        // Search all entries across all groups
+        let mut candidates: Vec<&PathBuf> = Vec::new();
+
+        for group in &self.groups {
+            for entry in &group.files {
+                if entry_matches(&entry.filename, &entry.path, ref_filename, clean_ref) {
+                    candidates.push(&entry.path);
+                }
+            }
+            for sg in &group.subgroups {
+                for entry in &sg.files {
+                    if entry_matches(&entry.filename, &entry.path, ref_filename, clean_ref) {
+                        candidates.push(&entry.path);
+                    }
+                }
+            }
+        }
+
+        // If exactly one match, return it. If multiple, prefer the one
+        // whose path ends with the clean reference.
+        match candidates.len() {
+            0 => None,
+            1 => Some(candidates[0].clone()),
+            _ => {
+                // Prefer path suffix match
+                let suffix_match = candidates.iter().find(|p| {
+                    p.to_str()
+                        .map(|s| s.ends_with(clean_ref))
+                        .unwrap_or(false)
+                });
+                Some(suffix_match.unwrap_or(&candidates[0]).to_path_buf())
+            }
+        }
+    }
+}
+
+fn entry_matches(filename: &str, path: &Path, ref_filename: &str, clean_ref: &str) -> bool {
+    // Exact filename match
+    if filename == ref_filename {
+        return true;
+    }
+    // Path suffix match (e.g., "00-governance/AGENT-RULES.md")
+    if let Some(path_str) = path.to_str() {
+        if path_str.ends_with(clean_ref) {
+            return true;
+        }
+    }
+    false
+}
+
+fn scan_md_files(dir: &Path, relations: &mut RelationIndex) -> Vec<DocEntry> {
+    let mut entries = Vec::new();
+
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return entries;
+    };
+
+    let mut paths: Vec<PathBuf> = read_dir
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.extension().and_then(|e| e.to_str()) == Some("md")
+                && !p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with("TEMPLATE-") || n.starts_with('.'))
+                    .unwrap_or(true)
+        })
+        .collect();
+
+    paths.sort();
+
+    for path in paths {
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Quick frontmatter scan (just read enough to get id/title/tags/created/related)
+        let meta = quick_scan_frontmatter(&path, relations);
+
+        entries.push(DocEntry {
+            filename,
+            path,
+            title: meta.title,
+            id: meta.id,
+            tags: meta.tags,
+            created: meta.created,
+            has_frontmatter: meta.has_frontmatter,
+        });
+    }
+
+    entries
+}
+
+struct ScannedMeta {
+    title: String,
+    id: String,
+    tags: Vec<String>,
+    created: String,
+    has_frontmatter: bool,
+}
+
+fn fallback_meta(path: &Path) -> ScannedMeta {
+    ScannedMeta {
+        title: path
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Unknown")
+            .to_string(),
+        id: String::new(),
+        tags: Vec::new(),
+        created: String::new(),
+        has_frontmatter: false,
+    }
+}
+
+fn quick_scan_frontmatter(path: &Path, relations: &mut RelationIndex) -> ScannedMeta {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return fallback_meta(path),
+    };
+
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return fallback_meta(path);
+    }
+
+    let after = &trimmed[3..];
+    let Some(end) = after.find("\n---") else {
+        return fallback_meta(path);
+    };
+
+    let yaml_str = &after[..end];
+    let fm: Option<DocFrontMatter> = serde_yaml::from_str(yaml_str).ok();
+
+    match fm {
+        Some(fm) => {
+            let id = fm.id.clone();
+            let title = if fm.title.is_empty() {
+                path.file_stem()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("Unknown")
+                    .to_string()
+            } else {
+                fm.title.clone()
+            };
+            let tags = fm.tags.clone();
+            let created = fm.created.clone().unwrap_or_default();
+
+            // Index relationships
+            if !id.is_empty() {
+                relations.id_to_path.insert(id.clone(), path.to_path_buf());
+
+                if !fm.related.is_empty() {
+                    for related_id in &fm.related {
+                        relations
+                            .referenced_by
+                            .entry(related_id.clone())
+                            .or_default()
+                            .push(id.clone());
+                    }
+                    relations
+                        .references
+                        .entry(id.clone())
+                        .or_default()
+                        .extend(fm.related.iter().cloned());
+                }
+            }
+
+            ScannedMeta {
+                title,
+                id,
+                tags,
+                created,
+                has_frontmatter: true,
+            }
+        }
+        None => fallback_meta(path),
+    }
+}

--- a/cli/src/tui/markdown.rs
+++ b/cli/src/tui/markdown.rs
@@ -1,0 +1,402 @@
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// Convert markdown text to styled ratatui Lines
+pub fn markdown_to_lines(markdown: &str) -> Vec<Line<'static>> {
+    let options = Options::ENABLE_TABLES
+        | Options::ENABLE_STRIKETHROUGH
+        | Options::ENABLE_TASKLISTS;
+    let parser = Parser::new_ext(markdown, options);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut current_spans: Vec<Span<'static>> = Vec::new();
+    let mut style_stack: Vec<Style> = vec![Style::default()];
+    let mut in_code_block = false;
+    let mut list_depth: usize = 0;
+    let mut ordered_index: Option<u64> = None;
+    let mut in_heading = false;
+    let mut heading_level = HeadingLevel::H1;
+    let mut table_row: Vec<String> = Vec::new();
+    let mut table_alignments: Vec<pulldown_cmark::Alignment> = Vec::new();
+    let mut table_header_done = false;
+    let mut in_table_cell = false;
+    let mut cell_text = String::new();
+    let mut table_header_row: Vec<String> = Vec::new();
+    let mut table_body_rows: Vec<Vec<String>> = Vec::new();
+    // Current indent level based on last heading seen (2 spaces per level, max 3)
+    let mut content_indent: usize = 0;
+
+    for event in parser {
+        match event {
+            Event::Start(tag) => match tag {
+                Tag::Heading { level, .. } => {
+                    in_heading = true;
+                    heading_level = level;
+                }
+                Tag::Paragraph => {}
+                Tag::Emphasis => {
+                    let current = current_style(&style_stack);
+                    style_stack.push(current.add_modifier(Modifier::ITALIC));
+                }
+                Tag::Strong => {
+                    let current = current_style(&style_stack);
+                    style_stack.push(current.add_modifier(Modifier::BOLD));
+                }
+                Tag::Strikethrough => {
+                    let current = current_style(&style_stack);
+                    style_stack.push(current.add_modifier(Modifier::CROSSED_OUT));
+                }
+                Tag::CodeBlock(_) => {
+                    in_code_block = true;
+                    flush_spans(&mut current_spans, &mut lines, content_indent);
+                    push_indented(&mut lines, content_indent, Span::styled(
+                        "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄",
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+                Tag::List(start) => {
+                    list_depth += 1;
+                    ordered_index = start;
+                }
+                Tag::Item => {
+                    flush_spans(&mut current_spans, &mut lines, content_indent);
+                    let list_indent = "  ".repeat(list_depth.saturating_sub(1));
+                    let bullet = if let Some(ref mut idx) = ordered_index {
+                        let s = format!("{list_indent}{idx}. ");
+                        *idx += 1;
+                        s
+                    } else {
+                        format!("{list_indent}• ")
+                    };
+                    // Prepend content indent + bullet
+                    if content_indent > 0 {
+                        current_spans.push(Span::raw(" ".repeat(content_indent)));
+                    }
+                    current_spans.push(Span::styled(
+                        bullet,
+                        Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD),
+                    ));
+                }
+                Tag::Link { dest_url, .. } => {
+                    let current = current_style(&style_stack);
+                    style_stack.push(
+                        current
+                            .fg(Color::Blue)
+                            .add_modifier(Modifier::UNDERLINED),
+                    );
+                    let _ = dest_url;
+                }
+                Tag::Table(alignments) => {
+                    table_alignments = alignments;
+                    table_header_done = false;
+                    flush_spans(&mut current_spans, &mut lines, content_indent);
+                }
+                Tag::TableHead => {
+                    table_row.clear();
+                }
+                Tag::TableRow => {
+                    table_row.clear();
+                }
+                Tag::TableCell => {
+                    in_table_cell = true;
+                    cell_text.clear();
+                }
+                Tag::BlockQuote(_) => {
+                    let current = current_style(&style_stack);
+                    style_stack.push(current.fg(Color::DarkGray).add_modifier(Modifier::ITALIC));
+                }
+                _ => {}
+            },
+            Event::End(tag_end) => match tag_end {
+                TagEnd::Heading(_) => {
+                    in_heading = false;
+                    let style = heading_style(heading_level);
+                    let text: String = current_spans
+                        .drain(..)
+                        .map(|s| s.content.to_string())
+                        .collect();
+
+                    // Heading indent: H1=0, H2=2, H3+=4 (capped)
+                    let heading_indent = heading_indent_level(heading_level);
+                    // Update content indent for subsequent content
+                    content_indent = heading_indent + 2;
+                    // Cap content indent at 6
+                    if content_indent > 6 {
+                        content_indent = 6;
+                    }
+
+                    if heading_indent > 0 {
+                        let spans = vec![
+                            Span::raw(" ".repeat(heading_indent)),
+                            Span::styled(text, style),
+                        ];
+                        lines.push(Line::from(spans));
+                    } else {
+                        lines.push(Line::from(Span::styled(text, style)));
+                    }
+
+                    if heading_level == HeadingLevel::H1 {
+                        lines.push(Line::from(Span::styled(
+                            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+                            style.remove_modifier(Modifier::BOLD),
+                        )));
+                    }
+                    lines.push(Line::from(""));
+                }
+                TagEnd::Paragraph => {
+                    flush_spans(&mut current_spans, &mut lines, content_indent);
+                    lines.push(Line::from(""));
+                }
+                TagEnd::Emphasis | TagEnd::Strong | TagEnd::Strikethrough => {
+                    if style_stack.len() > 1 {
+                        style_stack.pop();
+                    }
+                }
+                TagEnd::CodeBlock => {
+                    in_code_block = false;
+                    push_indented(&mut lines, content_indent, Span::styled(
+                        "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄",
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                    lines.push(Line::from(""));
+                }
+                TagEnd::List(_) => {
+                    list_depth = list_depth.saturating_sub(1);
+                    if list_depth == 0 {
+                        ordered_index = None;
+                        lines.push(Line::from(""));
+                    }
+                }
+                TagEnd::Item => {
+                    flush_spans(&mut current_spans, &mut lines, content_indent);
+                }
+                TagEnd::Link => {
+                    if style_stack.len() > 1 {
+                        style_stack.pop();
+                    }
+                }
+                TagEnd::TableCell => {
+                    in_table_cell = false;
+                    table_row.push(cell_text.clone());
+                    cell_text.clear();
+                }
+                TagEnd::TableHead => {
+                    table_header_row = table_row.clone();
+                    table_header_done = true;
+                    table_row.clear();
+                }
+                TagEnd::TableRow => {
+                    if table_header_done {
+                        table_body_rows.push(table_row.clone());
+                    }
+                    table_row.clear();
+                }
+                TagEnd::Table => {
+                    // Calculate column widths from all rows
+                    let col_widths = compute_column_widths(&table_header_row, &table_body_rows);
+                    // Render header
+                    render_table_row(&table_header_row, &col_widths, true, &mut lines, content_indent);
+                    render_table_separator(&col_widths, &mut lines, content_indent);
+                    // Render body rows
+                    for row in &table_body_rows {
+                        render_table_row(row, &col_widths, false, &mut lines, content_indent);
+                    }
+                    table_alignments.clear();
+                    table_header_row.clear();
+                    table_body_rows.clear();
+                    table_header_done = false;
+                    lines.push(Line::from(""));
+                }
+                TagEnd::BlockQuote(_) => {
+                    if style_stack.len() > 1 {
+                        style_stack.pop();
+                    }
+                }
+                _ => {}
+            },
+            Event::Text(text) => {
+                if in_table_cell {
+                    cell_text.push_str(&text);
+                } else if in_code_block {
+                    for code_line in text.lines() {
+                        let mut spans: Vec<Span<'static>> = Vec::new();
+                        if content_indent > 0 {
+                            spans.push(Span::raw(" ".repeat(content_indent)));
+                        }
+                        spans.push(Span::styled(
+                            format!("  {code_line}  "),
+                            Style::default().fg(Color::White).bg(Color::DarkGray),
+                        ));
+                        lines.push(Line::from(spans));
+                    }
+                } else if in_heading {
+                    current_spans.push(Span::raw(text.to_string()));
+                } else {
+                    let style = current_style(&style_stack);
+                    current_spans.push(Span::styled(text.to_string(), style));
+                }
+            }
+            Event::Code(code) => {
+                if in_table_cell {
+                    cell_text.push_str(&format!("`{code}`"));
+                } else {
+                    current_spans.push(Span::styled(
+                        format!(" {code} "),
+                        Style::default().fg(Color::White).bg(Color::Rgb(60, 60, 60)),
+                    ));
+                }
+            }
+            Event::SoftBreak => {
+                if in_table_cell {
+                    cell_text.push(' ');
+                } else {
+                    current_spans.push(Span::raw(" "));
+                }
+            }
+            Event::HardBreak => {
+                flush_spans(&mut current_spans, &mut lines, content_indent);
+            }
+            Event::Rule => {
+                flush_spans(&mut current_spans, &mut lines, content_indent);
+                push_indented(&mut lines, content_indent, Span::styled(
+                    "────────────────────────────────────────────────────",
+                    Style::default().fg(Color::DarkGray),
+                ));
+                lines.push(Line::from(""));
+            }
+            Event::TaskListMarker(checked) => {
+                let marker = if checked {
+                    Span::styled(" ✓ ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))
+                } else {
+                    Span::styled(" □ ", Style::default().fg(Color::DarkGray))
+                };
+                current_spans.push(marker);
+            }
+            _ => {}
+        }
+    }
+
+    flush_spans(&mut current_spans, &mut lines, content_indent);
+    lines
+}
+
+fn current_style(stack: &[Style]) -> Style {
+    stack.last().copied().unwrap_or_default()
+}
+
+fn flush_spans(spans: &mut Vec<Span<'static>>, lines: &mut Vec<Line<'static>>, indent: usize) {
+    if !spans.is_empty() {
+        if indent > 0 {
+            spans.insert(0, Span::raw(" ".repeat(indent)));
+        }
+        lines.push(Line::from(spans.drain(..).collect::<Vec<_>>()));
+    }
+}
+
+fn push_indented(lines: &mut Vec<Line<'static>>, indent: usize, span: Span<'static>) {
+    if indent > 0 {
+        lines.push(Line::from(vec![Span::raw(" ".repeat(indent)), span]));
+    } else {
+        lines.push(Line::from(span));
+    }
+}
+
+/// Indent for heading itself: H1=0, H2=2, H3+=4
+fn heading_indent_level(level: HeadingLevel) -> usize {
+    match level {
+        HeadingLevel::H1 => 0,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 4,
+        _ => 4,
+    }
+}
+
+fn heading_style(level: HeadingLevel) -> Style {
+    let color = match level {
+        HeadingLevel::H1 => Color::Cyan,
+        HeadingLevel::H2 => Color::Yellow,
+        HeadingLevel::H3 => Color::Green,
+        HeadingLevel::H4 => Color::Magenta,
+        _ => Color::White,
+    };
+    Style::default().fg(color).add_modifier(Modifier::BOLD)
+}
+
+fn compute_column_widths(header: &[String], body: &[Vec<String>]) -> Vec<usize> {
+    let num_cols = header.len().max(
+        body.iter().map(|r| r.len()).max().unwrap_or(0),
+    );
+    let mut widths = vec![0usize; num_cols];
+
+    for (i, cell) in header.iter().enumerate() {
+        widths[i] = widths[i].max(cell.len());
+    }
+    for row in body {
+        for (i, cell) in row.iter().enumerate() {
+            if i < num_cols {
+                widths[i] = widths[i].max(cell.len());
+            }
+        }
+    }
+
+    // Minimum width of 3 per column
+    for w in &mut widths {
+        *w = (*w).max(3);
+    }
+
+    widths
+}
+
+fn render_table_row(
+    cells: &[String],
+    col_widths: &[usize],
+    is_header: bool,
+    lines: &mut Vec<Line<'static>>,
+    indent: usize,
+) {
+    let style = if is_header {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let border = Style::default().fg(Color::DarkGray);
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    if indent > 0 {
+        spans.push(Span::raw(" ".repeat(indent)));
+    }
+    spans.push(Span::styled("│ ", border));
+    for (i, width) in col_widths.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" │ ", border));
+        }
+        let text = cells.get(i).map(|s| s.as_str()).unwrap_or("");
+        spans.push(Span::styled(format!("{:<width$}", text, width = width), style));
+    }
+    spans.push(Span::styled(" │", border));
+    lines.push(Line::from(spans));
+}
+
+fn render_table_separator(
+    col_widths: &[usize],
+    lines: &mut Vec<Line<'static>>,
+    indent: usize,
+) {
+    let sep_style = Style::default().fg(Color::DarkGray);
+    let mut s = String::new();
+    if indent > 0 {
+        s.push_str(&" ".repeat(indent));
+    }
+    s.push_str("├─");
+    for (i, width) in col_widths.iter().enumerate() {
+        if i > 0 {
+            s.push_str("─┼─");
+        }
+        s.push_str(&"─".repeat(*width));
+    }
+    s.push_str("─┤");
+    lines.push(Line::from(Span::styled(s, sep_style)));
+}

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -1,0 +1,64 @@
+pub mod app;
+pub mod document;
+pub mod event;
+pub mod index;
+pub mod markdown;
+pub mod ui;
+pub mod widgets;
+
+use std::io;
+use std::path::Path;
+
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+
+use app::App;
+
+/// Run the TUI explorer
+pub fn run(project_root: &Path) -> anyhow::Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Create app state
+    let mut app = App::new(project_root);
+
+    // Main loop
+    let result = run_loop(&mut terminal, &mut app);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> anyhow::Result<()> {
+    loop {
+        terminal.draw(|frame| ui::render(frame, app))?;
+
+        if event::handle_events(app)? && app.should_quit {
+            return Ok(());
+        }
+
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -1,0 +1,115 @@
+use ratatui::layout::{Constraint, Layout};
+use ratatui::Frame;
+
+use super::app::{App, ViewMode};
+use super::widgets::doc_viewer::DocViewer;
+use super::widgets::help_popup::HelpPopup;
+use super::widgets::metadata_panel::MetadataPanel;
+use super::widgets::nav_tree::NavTree;
+use super::widgets::status_bar::StatusBar;
+
+pub fn render(frame: &mut Frame, app: &mut App) {
+    let area = frame.area();
+    let terminal_width = area.width;
+
+    // Split: main area + status bar at bottom
+    let vertical = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);
+
+    let main_area = vertical[0];
+    let status_area = vertical[1];
+
+    // Render status bar
+    frame.render_widget(StatusBar::new(app), status_area);
+
+    match app.view_mode {
+        ViewMode::Fullscreen => {
+            DocViewer::new(app).render(main_area, frame.buffer_mut());
+        }
+        ViewMode::Help => {
+            render_main_layout(frame, app, main_area, terminal_width);
+            frame.render_widget(HelpPopup, main_area);
+        }
+        ViewMode::Normal => {
+            render_main_layout(frame, app, main_area, terminal_width);
+        }
+    }
+}
+
+fn render_main_layout(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect, width: u16) {
+    if width >= 100 {
+        // Two-column layout: left (nav + metadata) | right (document)
+        let horizontal =
+            Layout::horizontal([Constraint::Percentage(30), Constraint::Percentage(70)])
+                .split(area);
+
+        // Left column: navigation on top, metadata on bottom
+        // Give metadata a fair share: at least 40% of left column, but not more than needed
+        let available = horizontal[0].height;
+        let ideal_metadata = metadata_panel_height(app);
+        // Ensure metadata gets at least 40% but cap at its ideal height
+        let min_metadata = (available * 40 / 100).max(8);
+        let metadata_h = ideal_metadata.max(min_metadata).min(available.saturating_sub(6));
+        let left_split = Layout::vertical([
+            Constraint::Min(6),
+            Constraint::Length(metadata_h),
+        ])
+        .split(horizontal[0]);
+
+        frame.render_widget(NavTree::new(app), left_split[0]);
+        frame.render_widget(MetadataPanel::new(app), left_split[1]);
+        DocViewer::new(app).render(horizontal[1], frame.buffer_mut());
+    } else {
+        // Single-panel mode
+        if app.current_doc.is_some() {
+            DocViewer::new(app).render(area, frame.buffer_mut());
+        } else {
+            frame.render_widget(NavTree::new(app), area);
+        }
+    }
+}
+
+/// Calculate how tall the metadata panel should be based on content
+fn metadata_panel_height(app: &App) -> u16 {
+    let base = 2; // borders
+
+    let doc = match &app.current_doc {
+        Some(d) => d,
+        None => return base + 1,
+    };
+
+    let fm = match &doc.frontmatter {
+        Some(fm) => fm,
+        None => return base + 2,
+    };
+
+    let mut lines: u16 = 0;
+
+    // Each field on its own line
+    if fm.status.is_some() {
+        lines += 1;
+    }
+    if fm.created.is_some() {
+        lines += 1;
+    }
+    if fm.agent.is_some() {
+        lines += 1;
+    }
+    if fm.confidence.is_some() {
+        lines += 1;
+    }
+    if fm.risk_level.is_some() {
+        lines += 1;
+    }
+    if fm.review_required == Some(true) {
+        lines += 1;
+    }
+    if !fm.tags.is_empty() {
+        lines += 1;
+    }
+    // Related: separator + header + one per link
+    if !fm.related.is_empty() {
+        lines += 2 + fm.related.len() as u16;
+    }
+
+    (base + lines).max(base + 1)
+}

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -1,0 +1,167 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget, Wrap};
+
+use crate::tui::app::{ActivePanel, App};
+use crate::tui::markdown::markdown_to_lines;
+
+pub struct DocViewer<'a> {
+    app: &'a mut App,
+}
+
+impl<'a> DocViewer<'a> {
+    pub fn new(app: &'a mut App) -> Self {
+        Self { app }
+    }
+
+    pub fn render(self, area: Rect, buf: &mut Buffer) {
+        let is_active = self.app.active_panel == ActivePanel::Document;
+        let border_style = if is_active {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let title = match &self.app.current_doc {
+            Some(doc) => format!(" {} ", doc.filename),
+            None => " Document ".to_string(),
+        };
+
+        let block = Block::default()
+            .title(title)
+            .title_style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .borders(Borders::ALL)
+            .border_style(border_style);
+
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        if self.app.current_doc.is_none() {
+            let welcome = render_welcome(self.app.index.total_docs);
+            let paragraph = Paragraph::new(welcome);
+            paragraph.render(inner, buf);
+            return;
+        }
+
+        let doc = self.app.current_doc.as_ref().unwrap();
+
+        // Render markdown body only (metadata is in separate panel)
+        let mut all_lines = vec![Line::from(""); 1];
+        all_lines.extend(markdown_to_lines(&doc.body));
+
+        // Estimate total lines accounting for wrapping
+        let width = inner.width.max(1) as usize;
+        let wrapped_count: usize = all_lines
+            .iter()
+            .map(|line| {
+                let line_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
+                if line_width == 0 {
+                    1
+                } else {
+                    (line_width + width - 1) / width
+                }
+            })
+            .sum();
+        self.app.doc_total_lines = wrapped_count;
+
+        let text = Text::from(all_lines);
+        let paragraph = Paragraph::new(text)
+            .wrap(Wrap { trim: false })
+            .scroll((self.app.doc_scroll, 0));
+        paragraph.render(inner, buf);
+
+        // Render scrollbar
+        if self.app.doc_total_lines > inner.height as usize {
+            let mut scrollbar_state = ScrollbarState::new(self.app.doc_total_lines)
+                .position(self.app.doc_scroll as usize);
+            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓"));
+            scrollbar.render(inner, buf, &mut scrollbar_state);
+        }
+    }
+}
+
+fn render_welcome(total_docs: usize) -> Vec<Line<'static>> {
+    let title = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(Color::DarkGray);
+    let key = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let text = Style::default().fg(Color::White);
+
+    vec![
+        Line::from(""),
+        Line::from(""),
+        Line::from(Span::styled("  DevTrail Explorer", title)),
+        Line::from(Span::styled(
+            "  Documentation Governance for AI-Assisted Development",
+            dim,
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Total documents: ", dim),
+            Span::styled(
+                total_docs.to_string(),
+                text.add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled("  Quick start", title)),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("    ↑↓ ", key),
+            Span::styled("Navigate groups in the left panel", text),
+        ]),
+        Line::from(vec![
+            Span::styled("  Enter ", key),
+            Span::styled("Expand a group and open a document", text),
+        ]),
+        Line::from(vec![
+            Span::styled("   Tab  ", key),
+            Span::styled("Cycle panels: Navigation → Metadata → Document", text),
+        ]),
+        Line::from(vec![
+            Span::styled("     /  ", key),
+            Span::styled("Search by filename, title, tags, or date", text),
+        ]),
+        Line::from(vec![
+            Span::styled("     f  ", key),
+            Span::styled("Toggle document fullscreen", text),
+        ]),
+        Line::from(vec![
+            Span::styled("     ?  ", key),
+            Span::styled("Show all keyboard shortcuts", text),
+        ]),
+        Line::from(vec![
+            Span::styled("     q  ", key),
+            Span::styled("Quit", text),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ─────────────────────────────────────────────",
+            dim,
+        )),
+        Line::from(vec![
+            Span::styled("  Developed by ", dim),
+            Span::styled("Strange Days Tech, S.A.S.", text),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                "https://strangedays.tech",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+        ]),
+    ]
+}

--- a/cli/src/tui/widgets/help_popup.rs
+++ b/cli/src/tui/widgets/help_popup.rs
@@ -1,0 +1,98 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
+
+pub struct HelpPopup;
+
+impl Widget for HelpPopup {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let popup = centered_rect(65, 80, area);
+
+        Clear.render(popup, buf);
+
+        let block = Block::default()
+            .title(" Keyboard Shortcuts ")
+            .title_style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+
+        let key_style = Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD);
+        let desc_style = Style::default().fg(Color::White);
+        let section_style = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD);
+        let dim = Style::default().fg(Color::DarkGray);
+
+        let lines = vec![
+            Line::from(""),
+            Line::from(Span::styled("  Navigation panel", section_style)),
+            help_line("  j / ↓       ", "Move selection down", key_style, desc_style),
+            help_line("  k / ↑       ", "Move selection up", key_style, desc_style),
+            help_line("  Enter       ", "Expand group / Open document", key_style, desc_style),
+            help_line("  Esc         ", "Collapse group / Clear search", key_style, desc_style),
+            help_line("  1-8         ", "Jump to group by number", key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled("  Metadata panel", section_style)),
+            help_line("  Tab         ", "Cycle through related links", key_style, desc_style),
+            help_line("  Enter       ", "Follow selected related link", key_style, desc_style),
+            help_line("  Esc         ", "Back to Navigation", key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled("  Document panel", section_style)),
+            help_line("  j / ↓       ", "Scroll down", key_style, desc_style),
+            help_line("  k / ↑       ", "Scroll up", key_style, desc_style),
+            help_line("  g / G       ", "Top / Bottom of document", key_style, desc_style),
+            help_line("  Ctrl+d / u  ", "Half page down / up", key_style, desc_style),
+            help_line("  PgDn / PgUp ", "Page down / up", key_style, desc_style),
+            help_line("  n / N       ", "Next / Previous document", key_style, desc_style),
+            help_line("  f           ", "Toggle fullscreen", key_style, desc_style),
+            help_line("  Esc         ", "Exit fullscreen / Back to Nav", key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled("  General", section_style)),
+            help_line("  Tab         ", "Cycle: Nav → Metadata → Doc", key_style, desc_style),
+            help_line("  /           ", "Search by name, title, tags, date", key_style, desc_style),
+            help_line("  s           ", "Cycle sort order", key_style, desc_style),
+            help_line("  r           ", "Refresh document index", key_style, desc_style),
+            help_line("  q           ", "Quit", key_style, desc_style),
+            help_line("  Ctrl+C      ", "Force quit", key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Press any key to close",
+                dim,
+            )),
+        ];
+
+        let paragraph = Paragraph::new(lines).block(block);
+        paragraph.render(popup, buf);
+    }
+}
+
+fn help_line<'a>(key: &'a str, desc: &'a str, key_style: Style, desc_style: Style) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(key, key_style),
+        Span::styled(desc, desc_style),
+    ])
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let vertical = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(r);
+
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(vertical[1])[1]
+}

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -1,0 +1,260 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+
+use crate::tui::app::{ActivePanel, App};
+use crate::tui::document::{ConfidenceLevel, DocStatus, RiskLevel};
+
+pub struct MetadataPanel<'a> {
+    app: &'a App,
+}
+
+impl<'a> MetadataPanel<'a> {
+    pub fn new(app: &'a App) -> Self {
+        Self { app }
+    }
+}
+
+impl Widget for MetadataPanel<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let is_active = self.app.active_panel == ActivePanel::Metadata;
+        let border_style = if is_active {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let block = Block::default()
+            .title(" Metadata ")
+            .title_style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .borders(Borders::ALL)
+            .border_style(border_style);
+
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        let doc = match &self.app.current_doc {
+            Some(d) => d,
+            None => {
+                let line = Line::from(Span::styled(
+                    " No document selected",
+                    Style::default().fg(Color::DarkGray),
+                ));
+                Paragraph::new(vec![line]).render(inner, buf);
+                return;
+            }
+        };
+
+        let fm = match &doc.frontmatter {
+            Some(fm) => fm,
+            None => {
+                let lines = vec![
+                    Line::from(vec![
+                        Span::styled(" File:  ", Style::default().fg(Color::DarkGray)),
+                        Span::styled(doc.filename.clone(), Style::default().fg(Color::White)),
+                    ]),
+                    Line::from(Span::styled(
+                        " No frontmatter",
+                        Style::default().fg(Color::DarkGray),
+                    )),
+                ];
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: false })
+                    .render(inner, buf);
+                return;
+            }
+        };
+
+        let l = Style::default().fg(Color::DarkGray);
+        let v = Style::default().fg(Color::White);
+        let mut lines: Vec<Line<'static>> = Vec::new();
+
+        // Status
+        if let Some(ref status) = fm.status {
+            let (indicator, color) = status_style(status);
+            lines.push(Line::from(vec![
+                Span::styled(" Status:      ", l),
+                Span::styled(
+                    format!("{indicator} {status}"),
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                ),
+            ]));
+        }
+
+        // Created
+        if let Some(ref created) = fm.created {
+            lines.push(Line::from(vec![
+                Span::styled(" Created:     ", l),
+                Span::styled(created.clone(), v),
+            ]));
+        }
+
+        // Agent
+        if let Some(ref agent) = fm.agent {
+            lines.push(Line::from(vec![
+                Span::styled(" Agent:       ", l),
+                Span::styled(agent.clone(), v),
+            ]));
+        }
+
+        // Confidence
+        if let Some(ref confidence) = fm.confidence {
+            let (filled, total, color, label) = confidence_bar(confidence);
+            lines.push(Line::from(vec![
+                Span::styled(" Confidence:  ", l),
+                Span::styled(
+                    format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
+                    Style::default().fg(color),
+                ),
+                Span::styled(format!("  {label}"), Style::default().fg(color)),
+            ]));
+        }
+
+        // Risk
+        if let Some(ref risk) = fm.risk_level {
+            let (filled, total, color, label) = risk_bar(risk);
+            lines.push(Line::from(vec![
+                Span::styled(" Risk:        ", l),
+                Span::styled(
+                    format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
+                    Style::default().fg(color),
+                ),
+                Span::styled(format!("  {label}"), Style::default().fg(color)),
+            ]));
+        }
+
+        // Review required
+        if let Some(true) = fm.review_required {
+            lines.push(Line::from(vec![
+                Span::styled(" Review:      ", l),
+                Span::styled(
+                    "⚠ REQUIRED",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]));
+        }
+
+        // Tags
+        if !fm.tags.is_empty() {
+            let mut spans: Vec<Span<'static>> = vec![Span::styled(" Tags:        ", l)];
+            let colors = [
+                Color::Cyan,
+                Color::Magenta,
+                Color::Green,
+                Color::Yellow,
+                Color::Blue,
+            ];
+            for (i, tag) in fm.tags.iter().enumerate() {
+                let color = colors[i % colors.len()];
+                spans.push(Span::styled(format!("[{tag}]"), Style::default().fg(color)));
+            }
+            lines.push(Line::from(spans));
+        }
+
+        // Separator before related
+        if !fm.related.is_empty() {
+            lines.push(Line::from(Span::styled(
+                " ─────────────────────────────",
+                Style::default().fg(Color::DarkGray),
+            )));
+
+            let hint = if self.app.selected_related.is_some() {
+                "Enter: follow  Tab: next"
+            } else {
+                "Tab: select"
+            };
+            lines.push(Line::from(vec![
+                Span::styled(" Related      ", l),
+                Span::styled(hint, Style::default().fg(Color::DarkGray)),
+            ]));
+
+            let max_link_width = inner.width.saturating_sub(4) as usize; // 3 marker + 1 padding
+            for (i, rel) in fm.related.iter().enumerate() {
+                let is_selected = self.app.selected_related == Some(i);
+                let marker = if is_selected { " ▸ " } else { "   " };
+                let style = if is_selected {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::UNDERLINED)
+                };
+                let display = truncate_str(rel, max_link_width);
+                lines.push(Line::from(vec![
+                    Span::styled(marker, l),
+                    Span::styled(display, style),
+                ]));
+            }
+        }
+
+        // Calculate scroll to ensure selected related is visible
+        let total_lines = lines.len() as u16;
+        let scroll = if total_lines > inner.height {
+            if let Some(sel_idx) = self.app.selected_related {
+                // The selected related link's line position in the list
+                let related_start = total_lines.saturating_sub(fm.related.len() as u16);
+                let selected_line = related_start + sel_idx as u16;
+                // Scroll so the selected line is visible
+                selected_line.saturating_sub(inner.height.saturating_sub(1))
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+
+        Paragraph::new(lines)
+            .scroll((scroll, 0))
+            .render(inner, buf);
+    }
+}
+
+fn status_style(status: &DocStatus) -> (&'static str, Color) {
+    match status {
+        DocStatus::Draft => ("○", Color::Yellow),
+        DocStatus::Accepted => ("■", Color::Green),
+        DocStatus::Deprecated => ("✗", Color::Red),
+        DocStatus::Superseded => ("◌", Color::DarkGray),
+        DocStatus::Unknown => ("?", Color::DarkGray),
+    }
+}
+
+fn confidence_bar(level: &ConfidenceLevel) -> (usize, usize, Color, &'static str) {
+    match level {
+        ConfidenceLevel::High => (8, 10, Color::Green, "high"),
+        ConfidenceLevel::Medium => (5, 10, Color::Yellow, "medium"),
+        ConfidenceLevel::Low => (2, 10, Color::Red, "low"),
+        ConfidenceLevel::Unknown => (0, 10, Color::DarkGray, "unknown"),
+    }
+}
+
+fn risk_bar(level: &RiskLevel) -> (usize, usize, Color, &'static str) {
+    match level {
+        RiskLevel::Low => (2, 10, Color::Green, "low"),
+        RiskLevel::Medium => (5, 10, Color::Yellow, "medium"),
+        RiskLevel::High => (7, 10, Color::Red, "high"),
+        RiskLevel::Critical => (10, 10, Color::Red, "critical"),
+        RiskLevel::Unknown => (0, 10, Color::DarkGray, "unknown"),
+    }
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else if max > 3 {
+        format!("{}...", &s[..max - 3])
+    } else {
+        s[..max].to_string()
+    }
+}

--- a/cli/src/tui/widgets/mod.rs
+++ b/cli/src/tui/widgets/mod.rs
@@ -1,0 +1,5 @@
+pub mod doc_viewer;
+pub mod help_popup;
+pub mod metadata_panel;
+pub mod nav_tree;
+pub mod status_bar;

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -1,0 +1,216 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Widget};
+
+use crate::tui::app::{ActivePanel, App, NavSelection};
+use crate::tui::index::DocEntry;
+
+pub struct NavTree<'a> {
+    app: &'a App,
+}
+
+impl<'a> NavTree<'a> {
+    pub fn new(app: &'a App) -> Self {
+        Self { app }
+    }
+}
+
+impl Widget for NavTree<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let is_active = self.app.active_panel == ActivePanel::Navigation;
+        let border_style = if is_active {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let block = Block::default()
+            .title(" Navigation ")
+            .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+            .borders(Borders::ALL)
+            .border_style(border_style);
+
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        let search = self.app.search_query.as_deref();
+
+        let has_search = search.is_some();
+
+        for (gi, group) in self.app.index.groups.iter().enumerate() {
+            let is_expanded = self.app.expanded_groups[gi];
+            let is_selected = self.app.selection == NavSelection::Group(gi);
+
+            // When searching, auto-expand groups that have matches
+            let show_children = if has_search {
+                group_has_matches(group, search)
+            } else {
+                is_expanded
+            };
+
+            // When searching, skip groups with no matches
+            if has_search && !show_children {
+                continue;
+            }
+
+            let arrow = if show_children { "▾" } else { "▸" };
+            let doc_count = count_group_docs(group);
+
+            let count_str = if doc_count > 0 {
+                format!(" ({doc_count})")
+            } else {
+                String::new()
+            };
+
+            let style = if is_selected {
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(format!(" {arrow} "), Style::default().fg(Color::Cyan)),
+                Span::styled(group.label.clone(), style),
+                Span::styled(count_str, Style::default().fg(Color::DarkGray)),
+            ]));
+
+            if show_children {
+                // Direct files in group
+                for (fi, entry) in group.files.iter().enumerate() {
+                    if !matches_search(entry, search) {
+                        continue;
+                    }
+                    let is_sel = self.app.selection == NavSelection::GroupFile(gi, fi);
+                    let style = file_style(is_sel);
+                    lines.push(Line::from(vec![
+                        Span::raw("     "),
+                        Span::styled(truncate_filename(&entry.filename, inner.width as usize - 6), style),
+                    ]));
+                }
+
+                // Subgroups
+                for (si, sg) in group.subgroups.iter().enumerate() {
+                    // When searching, skip subgroups with no matches
+                    let sg_has_matches = sg.files.iter().any(|e| matches_search(e, search));
+                    if has_search && !sg_has_matches {
+                        continue;
+                    }
+
+                    let is_sel = self.app.selection == NavSelection::Subgroup(gi, si);
+                    let sg_count = sg.files.len();
+                    let sg_style = if is_sel {
+                        Style::default()
+                            .bg(Color::DarkGray)
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::Yellow)
+                    };
+
+                    lines.push(Line::from(vec![
+                        Span::raw("   "),
+                        Span::styled("▸ ", Style::default().fg(Color::Yellow)),
+                        Span::styled(format!("{}/", sg.label), sg_style),
+                        Span::styled(
+                            format!(" ({sg_count})"),
+                            Style::default().fg(Color::DarkGray),
+                        ),
+                    ]));
+
+                    // Files in subgroup
+                    for (fi, entry) in sg.files.iter().enumerate() {
+                        if !matches_search(entry, search) {
+                            continue;
+                        }
+                        let is_sel =
+                            self.app.selection == NavSelection::SubgroupFile(gi, si, fi);
+                        let style = file_style(is_sel);
+                        lines.push(Line::from(vec![
+                            Span::raw("       "),
+                            Span::styled(
+                                truncate_filename(&entry.filename, inner.width as usize - 8),
+                                style,
+                            ),
+                        ]));
+                    }
+                }
+            }
+        }
+
+        let paragraph = Paragraph::new(lines);
+        paragraph.render(inner, buf);
+    }
+}
+
+fn file_style(selected: bool) -> Style {
+    if selected {
+        Style::default()
+            .bg(Color::Blue)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Gray)
+    }
+}
+
+fn count_group_docs(group: &crate::tui::index::DocGroup) -> usize {
+    let direct = group.files.len();
+    let sub: usize = group.subgroups.iter().map(|sg| sg.files.len()).sum();
+    direct + sub
+}
+
+fn truncate_filename(name: &str, max_width: usize) -> String {
+    if name.len() <= max_width {
+        name.to_string()
+    } else if max_width > 3 {
+        format!("{}...", &name[..max_width - 3])
+    } else {
+        name[..max_width].to_string()
+    }
+}
+
+fn group_has_matches(group: &crate::tui::index::DocGroup, search: Option<&str>) -> bool {
+    if group.files.iter().any(|e| matches_search(e, search)) {
+        return true;
+    }
+    group
+        .subgroups
+        .iter()
+        .any(|sg| sg.files.iter().any(|e| matches_search(e, search)))
+}
+
+fn matches_search(entry: &DocEntry, search: Option<&str>) -> bool {
+    let Some(q) = search else {
+        return true;
+    };
+    let query = q.to_lowercase();
+
+    // Search in filename
+    if entry.filename.to_lowercase().contains(&query) {
+        return true;
+    }
+    // Search in title
+    if entry.title.to_lowercase().contains(&query) {
+        return true;
+    }
+    // Search in tags
+    if entry.tags.iter().any(|t| t.to_lowercase().contains(&query)) {
+        return true;
+    }
+    // Search in created date
+    if !entry.created.is_empty() && entry.created.contains(&query) {
+        return true;
+    }
+    // Search in id
+    if entry.id.to_lowercase().contains(&query) {
+        return true;
+    }
+
+    false
+}

--- a/cli/src/tui/widgets/status_bar.rs
+++ b/cli/src/tui/widgets/status_bar.rs
@@ -1,0 +1,101 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Widget;
+
+use crate::tui::app::App;
+
+pub struct StatusBar<'a> {
+    app: &'a App,
+}
+
+impl<'a> StatusBar<'a> {
+    pub fn new(app: &'a App) -> Self {
+        Self { app }
+    }
+}
+
+impl Widget for StatusBar<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let key_style = Style::default()
+            .fg(Color::Black)
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD);
+        let desc_style = Style::default().fg(Color::DarkGray);
+        let info_style = Style::default().fg(Color::Cyan);
+
+        // Show notification if present
+        if let Some(ref msg) = self.app.notification {
+            let line = Line::from(vec![
+                Span::styled(
+                    " ⚠ ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!(" {msg} "),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    "  (press any key to dismiss)",
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+            buf.set_line(area.x, area.y, &line, area.width);
+            return;
+        }
+
+        if self.app.is_searching {
+            let line = Line::from(vec![
+                Span::styled(" / ", key_style),
+                Span::styled(
+                    format!(" {} ", self.app.search_input),
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled("█", Style::default().fg(Color::White)),
+                Span::styled("  Enter", key_style),
+                Span::styled(" apply  ", desc_style),
+                Span::styled("Esc", key_style),
+                Span::styled(" cancel", desc_style),
+            ]);
+            buf.set_line(area.x, area.y, &line, area.width);
+            return;
+        }
+
+        let mut spans: Vec<Span> = vec![
+            Span::styled(" q ", key_style),
+            Span::styled("quit ", desc_style),
+            Span::styled(" / ", key_style),
+            Span::styled("search ", desc_style),
+            Span::styled(" Tab ", key_style),
+            Span::styled("panel ", desc_style),
+            Span::styled(" Enter ", key_style),
+            Span::styled("open ", desc_style),
+            Span::styled(" f ", key_style),
+            Span::styled("fullscreen ", desc_style),
+            Span::styled(" Esc ", key_style),
+            Span::styled("back ", desc_style),
+            Span::styled(" ? ", key_style),
+            Span::styled("help ", desc_style),
+        ];
+
+        // Right-aligned doc count
+        let count_str = format!(" {} docs ", self.app.index.total_docs);
+        let used_width: usize = spans.iter().map(|s| s.content.len()).sum();
+        let remaining = area.width as usize - used_width.min(area.width as usize);
+        if remaining > count_str.len() {
+            let padding = remaining - count_str.len();
+            spans.push(Span::styled(
+                " ".repeat(padding),
+                Style::default(),
+            ));
+            spans.push(Span::styled(count_str, info_style));
+        }
+
+        let line = Line::from(spans);
+        buf.set_line(area.x, area.y, &line, area.width);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `devtrail explore` command: a full terminal UI for browsing and reading DevTrail documentation interactively
- Two-panel layout (Navigation + Document) with a Metadata panel showing status badges, confidence/risk bars, tags, and navigable related links
- Markdown rendering with heading indentation, dynamic-width tables, styled code blocks, lists, and checkboxes
- Hyperlinked navigation between related documents with history stack (Tab to select, Enter to follow, Esc to go back)
- Search/filter across filename, title, tags, date, and document ID with auto-expanding results
- Fullscreen document mode, vim-style keybindings, adaptive layout for narrow terminals, and help popup
- Feature-flagged under `tui` (enabled by default), adds ~600KB to binary via ratatui + crossterm + pulldown-cmark

## Test plan

- [ ] `cargo build --release` compiles without warnings
- [ ] `cargo build --no-default-features` compiles without TUI
- [ ] `cargo test` passes all 26 tests
- [ ] `devtrail explore` in a DevTrail project opens the TUI
- [ ] `devtrail explore /tmp` shows friendly error
- [ ] Navigate groups with arrows, expand with Enter, open documents
- [ ] Tab cycles Navigation → Metadata → Document panels
- [ ] Search with `/` filters by tags, title, date
- [ ] Related links navigable with Tab + Enter in Metadata panel
- [ ] `f` toggles fullscreen, `?` shows help, `q` / `Ctrl+C` quits

🤖 Generated with [Claude Code](https://claude.com/claude-code)