### PR TITLE
fix: show devtrail repair hint in status when items are missing

### DIFF
--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -214,13 +214,22 @@ pub fn run(path: &str) -> Result<()> {
     print_border("  └", type_w, "┴", count_w, "┘");
     println!();
 
-    // ── Hint ──
+    // ── Hints ──
+    if total_missing > 0 {
+        println!(
+            "  {} Run {} to restore missing directories and files",
+            "→".blue().bold(),
+            "devtrail repair".cyan().bold()
+        );
+    }
     if total > 0 {
         println!(
             "  {} Run {} to browse documentation interactively",
             "→".blue().bold(),
             "devtrail explore".cyan().bold()
         );
+    }
+    if total_missing > 0 || total > 0 {
         println!();
     }
 


### PR DESCRIPTION
## Summary

- Show `→ Run devtrail repair` hint in status output when structure has missing items
- Hint only appears when there are actual issues to fix
- `devtrail explore` hint still shown when documents exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)