### PR TITLE
docs: add explore and repair commands to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Check installed versions with `devtrail status` or `devtrail about`.
 | `devtrail update-cli` | Update the CLI binary |
 | `devtrail remove [--full]` | Remove DevTrail from project |
 | `devtrail status [path]` | Show installation health and doc stats |
+| `devtrail repair [path]` | Restore missing directories and framework files |
+| `devtrail explore [path]` | Browse documentation interactively in a TUI |
 | `devtrail about` | Show version and license info |
 
 See [CLI Reference](docs/adopters/CLI-REFERENCE.md) for detailed usage.

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -12,7 +12,7 @@
 
 1. [Installation](#installation)
 2. [Versioning](#versioning)
-3. [Commands](#commands)
+3. [Commands](#commands) — init, update, remove, status, repair, explore, about
 4. [Environment Variables](#environment-variables)
 5. [Exit Codes](#exit-codes)
 
@@ -191,27 +191,121 @@ Show installation health and documentation statistics.
 
 **Example:**
 
-```bash
-$ devtrail status
-DevTrail Status
-───────────────
-Path:              /home/user/my-project
-Framework version: fw-2.1.0
-CLI version:       cli-1.0.0
-Language:          en
-Structure:         ✔ Complete
-
-Documents:
-  AILOG:  12
-  AIDEC:   4
-  ADR:     7
-  REQ:     3
-  TES:     2
-  TDE:     1
-  INC:     0
-  ETH:     1
-  Total:  30
 ```
+$ devtrail status
+
+  ╔════════════════════════════════════════════════╗
+  ║ DevTrail Status                                ║
+  ╚════════════════════════════════════════════════╝
+
+  Project
+  ┌───────────┬──────────────────────────┐
+  │ Path      │ /home/user/my-project    │
+  │ Framework │ fw-2.1.0                 │
+  │ CLI       │ cli-1.0.4                │
+  │ Language  │ en                       │
+  └───────────┴──────────────────────────┘
+
+  Structure
+  ✓ All 15 items present
+  ┌──────────────────────────────┬────────┐
+  │ Directory / File             │ Status │
+  ├──────────────────────────────┼────────┤
+  │ 00-governance/               │ ✓ OK   │
+  │ ...                          │ ...    │
+  └──────────────────────────────┴────────┘
+
+  Documentation
+  ┌──────────────────────────────┬───────┐
+  │ Type                         │ Count │
+  ├──────────────────────────────┼───────┤
+  │ AILOG AI Action Logs         │    12 │
+  │ ADR   Architecture Decisions │     7 │
+  │ ...                          │   ... │
+  ├──────────────────────────────┼───────┤
+  │ Total                        │    30 │
+  └──────────────────────────────┴───────┘
+
+  → Run devtrail explore to browse documentation interactively
+```
+
+---
+
+### `devtrail repair [path]`
+
+Repair a broken DevTrail installation by restoring missing directories and framework files.
+
+**Arguments:**
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `path` | `.` (current directory) | Target project directory |
+
+**What it does:**
+
+1. Checks for missing directories and restores them with `.gitkeep`
+2. Downloads the framework release **once** if files need restoration (templates, governance docs, config)
+3. Re-injects directives if `DEVTRAIL.md` is missing
+4. Recalculates checksums after repair
+5. Never modifies or deletes user-generated documents
+
+**Example:**
+
+```bash
+$ devtrail repair
+Repairing DevTrail in /home/user/my-project
+  → Found 1 issue(s) to repair
+→ Restoring 1 missing directory...
+✓ Restored .devtrail/templates/
+→ Downloading framework to restore missing files...
+  Using version: fw-2.1.0
+✓ Restored 16 file(s) from framework
+→ Updating checksums...
+
+✓ DevTrail repaired successfully!
+```
+
+---
+
+### `devtrail explore [path]`
+
+Browse and read DevTrail documentation interactively in a terminal UI.
+
+**Arguments:**
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `path` | `.` (current directory) | Target project directory |
+
+**Features:**
+
+- Two-panel layout: navigation tree + document viewer
+- Metadata panel showing status, confidence, risk, tags, and related links
+- Markdown rendering with colors, tables, code blocks, and heading indentation
+- Navigate between related documents via hyperlinks
+- Search by filename, title, tags, or date
+- Fullscreen document mode, vim-style keybindings
+
+**Key bindings:**
+
+| Key | Action |
+|-----|--------|
+| `↑↓` / `j/k` | Navigate / Scroll |
+| `Enter` | Expand group / Open document |
+| `Tab` | Cycle panels: Navigation → Metadata → Document |
+| `f` | Toggle fullscreen document |
+| `/` | Search |
+| `Esc` | Back / Collapse / Clear search |
+| `?` | Help popup with all shortcuts |
+| `q` | Quit |
+
+**Example:**
+
+```bash
+$ devtrail explore
+```
+
+> **Note:** The `explore` command requires the `tui` feature (enabled by default). To compile without it: `cargo build --no-default-features`.
 
 ---
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -144,6 +144,8 @@ Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 | `devtrail update-cli` | Actualizar el binario del CLI |
 | `devtrail remove [--full]` | Eliminar DevTrail del proyecto |
 | `devtrail status [path]` | Mostrar estado de la instalación y estadísticas |
+| `devtrail repair [path]` | Restaurar directorios y archivos del framework faltantes |
+| `devtrail explore [path]` | Explorar documentación interactivamente en terminal (TUI) |
 | `devtrail about` | Mostrar información de versión y licencia |
 
 Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -12,7 +12,7 @@
 
 1. [Instalación](#instalación)
 2. [Versionado](#versionado)
-3. [Comandos](#comandos)
+3. [Comandos](#comandos) — init, update, remove, status, repair, explore, about
 4. [Variables de Entorno](#variables-de-entorno)
 5. [Códigos de Salida](#códigos-de-salida)
 
@@ -212,6 +212,82 @@ Documents:
   ETH:     1
   Total:  30
 ```
+
+---
+
+### `devtrail repair [path]`
+
+Repara una instalación de DevTrail rota restaurando directorios y archivos del framework faltantes.
+
+**Argumentos:**
+
+| Argumento | Default | Descripción |
+|-----------|---------|-------------|
+| `path` | `.` (directorio actual) | Directorio del proyecto |
+
+**Qué hace:**
+
+1. Verifica directorios faltantes y los restaura con `.gitkeep`
+2. Descarga el release del framework **una sola vez** si se necesitan archivos (templates, governance, config)
+3. Re-inyecta directivas si falta `DEVTRAIL.md`
+4. Recalcula checksums después de la reparación
+5. Nunca modifica ni elimina documentos generados por el usuario
+
+**Ejemplo:**
+
+```bash
+$ devtrail repair
+Repairing DevTrail in /home/user/mi-proyecto
+  → Found 1 issue(s) to repair
+→ Restoring 1 missing directory...
+✓ Restored .devtrail/templates/
+→ Downloading framework to restore missing files...
+✓ Restored 16 file(s) from framework
+
+✓ DevTrail repaired successfully!
+```
+
+---
+
+### `devtrail explore [path]`
+
+Explora y lee la documentación de DevTrail interactivamente en una interfaz de terminal (TUI).
+
+**Argumentos:**
+
+| Argumento | Default | Descripción |
+|-----------|---------|-------------|
+| `path` | `.` (directorio actual) | Directorio del proyecto |
+
+**Características:**
+
+- Layout de dos paneles: árbol de navegación + visor de documentos
+- Panel de metadatos con estado, confianza, riesgo, tags y enlaces relacionados
+- Renderizado de Markdown con colores, tablas, bloques de código e indentación por niveles
+- Navegación entre documentos relacionados mediante hipervínculos
+- Búsqueda por nombre de archivo, título, tags o fecha
+- Modo pantalla completa, atajos estilo vim
+
+**Atajos de teclado:**
+
+| Tecla | Acción |
+|-------|--------|
+| `↑↓` / `j/k` | Navegar / Scroll |
+| `Enter` | Expandir grupo / Abrir documento |
+| `Tab` | Ciclar paneles: Navegación → Metadatos → Documento |
+| `f` | Pantalla completa del documento |
+| `/` | Buscar |
+| `Esc` | Volver / Colapsar / Limpiar búsqueda |
+| `?` | Popup de ayuda con todos los atajos |
+| `q` | Salir |
+
+**Ejemplo:**
+
+```bash
+$ devtrail explore
+```
+
+> **Nota:** El comando `explore` requiere la feature `tui` (habilitada por defecto). Para compilar sin ella: `cargo build --no-default-features`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `devtrail explore` and `devtrail repair` to README command table (EN + ES)
- Add full documentation for both commands in CLI Reference (EN + ES)
- Update `devtrail status` example output with new table format
- Update Table of Contents in CLI Reference

## Files updated

- `README.md` — command table
- `docs/adopters/CLI-REFERENCE.md` — full command docs + updated status example
- `docs/i18n/es/adopters/CLI-REFERENCE.md` — Spanish translation
- `docs/i18n/es/README.md` — Spanish command table

🤖 Generated with [Claude Code](https://claude.com/claude-code)