### PR TITLE
chore: bump CLI version to 1.1.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "1.0.4"
+version = "1.1.0"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -202,7 +202,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-2.1.0                 │
-  │ CLI       │ cli-1.0.4                │
+  │ CLI       │ cli-1.1.0                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 


### PR DESCRIPTION
## Summary

Bump CLI version from 1.0.4 to 1.1.0 (minor version bump for new features).

### New in 1.1.0
- `devtrail explore` — interactive TUI documentation browser (ratatui + crossterm)
- `devtrail repair` — restore missing directories and framework files
- Redesigned `devtrail status` with aligned ASCII tables and colors
- Multiple explorer improvements: collapsible tree, search, hyperlinked navigation, metadata panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)