### PR TITLE
feat: auto-detect DevTrail installation from git repo root

### DIFF
--- a/cli/src/commands/explore.rs
+++ b/cli/src/commands/explore.rs
@@ -1,23 +1,23 @@
 use anyhow::{bail, Result};
-use std::path::PathBuf;
 
 use crate::utils;
 
 pub fn run(path: &str) -> Result<()> {
-    let target = PathBuf::from(path)
-        .canonicalize()
-        .unwrap_or_else(|_| PathBuf::from(path));
+    let resolved = match utils::resolve_project_root(path) {
+        Some(r) => r,
+        None => {
+            utils::warn("DevTrail is not initialized in this directory or repo root.");
+            utils::info("Run 'devtrail init' to initialize DevTrail.");
+            bail!("No DevTrail installation found");
+        }
+    };
 
-    let devtrail_dir = target.join(".devtrail");
-
-    if !devtrail_dir.exists() {
-        utils::warn(&format!(
-            "DevTrail is not initialized in {}",
-            target.display()
+    if resolved.is_fallback {
+        utils::info(&format!(
+            "Using DevTrail installation at repo root: {}",
+            resolved.path.display()
         ));
-        utils::info("Run 'devtrail init' to initialize DevTrail in this directory.");
-        bail!("No DevTrail installation found");
     }
 
-    crate::tui::run(&target)
+    crate::tui::run(&resolved.path)
 }

--- a/cli/src/commands/repair.rs
+++ b/cli/src/commands/repair.rs
@@ -25,20 +25,23 @@ const EXPECTED_DIRS: &[&str] = &[
 ];
 
 pub fn run(path: &str) -> Result<()> {
-    let target = PathBuf::from(path)
-        .canonicalize()
-        .unwrap_or_else(|_| PathBuf::from(path));
+    let resolved = match utils::resolve_project_root(path) {
+        Some(r) => r,
+        None => {
+            utils::warn("DevTrail is not installed in this directory or repo root.");
+            utils::info("Run 'devtrail init' to initialize DevTrail.");
+            bail!("No DevTrail installation found");
+        }
+    };
 
-    let devtrail_dir = target.join(".devtrail");
-
-    if !devtrail_dir.exists() {
-        utils::warn(&format!(
-            "DevTrail is not installed in {}",
-            target.display()
+    if resolved.is_fallback {
+        utils::info(&format!(
+            "Using DevTrail installation at repo root: {}",
+            resolved.path.display()
         ));
-        utils::info("Run 'devtrail init' to initialize DevTrail in this directory.");
-        bail!("No DevTrail installation found");
     }
+
+    let target = resolved.path;
 
     println!(
         "{} DevTrail in {}",

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -42,20 +42,30 @@ const DOC_TYPES: &[(&str, &str)] = &[
 ];
 
 pub fn run(path: &str) -> Result<()> {
-    let target = PathBuf::from(path)
-        .canonicalize()
-        .unwrap_or_else(|_| PathBuf::from(path));
+    let resolved = match utils::resolve_project_root(path) {
+        Some(r) => r,
+        None => {
+            let target = PathBuf::from(path)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(path));
+            utils::info(&format!(
+                "DevTrail is not installed in {}",
+                target.display()
+            ));
+            utils::info("Run 'devtrail init' to initialize DevTrail in this directory.");
+            return Ok(());
+        }
+    };
 
-    let devtrail_dir = target.join(".devtrail");
-
-    if !devtrail_dir.exists() {
+    if resolved.is_fallback {
         utils::info(&format!(
-            "DevTrail is not installed in {}",
-            target.display()
+            "Using DevTrail installation at repo root: {}",
+            resolved.path.display()
         ));
-        utils::info("Run 'devtrail init' to initialize DevTrail in this directory.");
-        return Ok(());
     }
+
+    let target = resolved.path;
+    let devtrail_dir = target.join(".devtrail");
 
     let version = load_version(&target);
     let language = load_language(&target);

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -47,3 +47,57 @@ pub fn ensure_dir(path: &Path) -> std::io::Result<()> {
     }
     Ok(())
 }
+
+/// Result of resolving the DevTrail project root
+pub struct ResolvedPath {
+    /// The resolved project root where .devtrail/ exists
+    pub path: std::path::PathBuf,
+    /// Whether we fell back to the git repo root (not the original path)
+    pub is_fallback: bool,
+}
+
+/// Resolve the DevTrail project root from a given path.
+///
+/// 1. If `path` has `.devtrail/`, use it directly
+/// 2. If not, try the git repo root
+/// 3. If neither has `.devtrail/`, return None
+pub fn resolve_project_root(path: &str) -> Option<ResolvedPath> {
+    let target = std::path::PathBuf::from(path)
+        .canonicalize()
+        .unwrap_or_else(|_| std::path::PathBuf::from(path));
+
+    // Check the given path first
+    if target.join(".devtrail").exists() {
+        return Some(ResolvedPath {
+            path: target,
+            is_fallback: false,
+        });
+    }
+
+    // Try git repo root
+    let git_root = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&target)
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                Some(std::path::PathBuf::from(root))
+            } else {
+                None
+            }
+        });
+
+    if let Some(root) = git_root {
+        // Don't fallback to the same path we already checked
+        if root != target && root.join(".devtrail").exists() {
+            return Some(ResolvedPath {
+                path: root,
+                is_fallback: true,
+            });
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
## Summary

When running `devtrail status`, `explore`, or `repair` from a subdirectory of a project, DevTrail now automatically detects the installation at the git repository root.

- New `resolve_project_root()` function in utils.rs
- Checks given path first, then falls back to `git rev-parse --show-toplevel`
- Informs user: `→ Using DevTrail installation at repo root: /path/to/repo`
- Clear error if not found in either location

## Test plan

- [ ] `devtrail status` from repo root → works as before
- [ ] `devtrail status` from a subdirectory → finds and uses repo root
- [ ] `devtrail status` from a non-git directory without DevTrail → shows "not installed"
- [ ] Same behavior for `explore` and `repair`
- [ ] All 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)