### PR TITLE
feat: show fallback path indicators in explore TUI

### DIFF
--- a/cli/src/commands/explore.rs
+++ b/cli/src/commands/explore.rs
@@ -12,12 +12,5 @@ pub fn run(path: &str) -> Result<()> {
         }
     };
 
-    if resolved.is_fallback {
-        utils::info(&format!(
-            "Using DevTrail installation at repo root: {}",
-            resolved.path.display()
-        ));
-    }
-
-    crate::tui::run(&resolved.path)
+    crate::tui::run(&resolved.path, resolved.is_fallback)
 }

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -87,10 +87,12 @@ pub struct App {
     pub should_quit: bool,
     /// Project root path
     pub project_root: PathBuf,
+    /// Whether we're using a fallback path (repo root instead of cwd)
+    pub is_fallback: bool,
 }
 
 impl App {
-    pub fn new(project_root: &Path) -> Self {
+    pub fn new(project_root: &Path, is_fallback: bool) -> Self {
         let devtrail_dir = project_root.join(".devtrail");
         let index = DocIndex::build(&devtrail_dir);
         let num_groups = index.groups.len();
@@ -115,6 +117,7 @@ impl App {
             notification: None,
             should_quit: false,
             project_root: project_root.to_path_buf(),
+            is_fallback,
         }
     }
 

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -128,7 +128,8 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         // Refresh
         KeyCode::Char('r') => {
             let root = app.project_root.clone();
-            *app = App::new(&root);
+            let fallback = app.is_fallback;
+            *app = App::new(&root, fallback);
         }
 
         _ => {}

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -20,7 +20,7 @@ use ratatui::Terminal;
 use app::App;
 
 /// Run the TUI explorer
-pub fn run(project_root: &Path) -> anyhow::Result<()> {
+pub fn run(project_root: &Path, is_fallback: bool) -> anyhow::Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -29,7 +29,7 @@ pub fn run(project_root: &Path) -> anyhow::Result<()> {
     let mut terminal = Terminal::new(backend)?;
 
     // Create app state
-    let mut app = App::new(project_root);
+    let mut app = App::new(project_root, is_fallback);
 
     // Main loop
     let result = run_loop(&mut terminal, &mut app);

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -44,7 +44,12 @@ impl<'a> DocViewer<'a> {
         block.render(area, buf);
 
         if self.app.current_doc.is_none() {
-            let welcome = render_welcome(self.app.index.total_docs);
+            let fallback_info = if self.app.is_fallback {
+                Some(self.app.project_root.display().to_string())
+            } else {
+                None
+            };
+            let welcome = render_welcome(self.app.index.total_docs, fallback_info);
             let paragraph = Paragraph::new(welcome);
             paragraph.render(inner, buf);
             return;
@@ -89,7 +94,7 @@ impl<'a> DocViewer<'a> {
     }
 }
 
-fn render_welcome(total_docs: usize) -> Vec<Line<'static>> {
+fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<'static>> {
     let title = Style::default()
         .fg(Color::Cyan)
         .add_modifier(Modifier::BOLD);
@@ -99,7 +104,7 @@ fn render_welcome(total_docs: usize) -> Vec<Line<'static>> {
         .add_modifier(Modifier::BOLD);
     let text = Style::default().fg(Color::White);
 
-    vec![
+    let mut lines = vec![
         Line::from(""),
         Line::from(""),
         Line::from(Span::styled("  DevTrail Explorer", title)),
@@ -107,62 +112,73 @@ fn render_welcome(total_docs: usize) -> Vec<Line<'static>> {
             "  Documentation Governance for AI-Assisted Development",
             dim,
         )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("  Total documents: ", dim),
-            Span::styled(
-                total_docs.to_string(),
-                text.add_modifier(Modifier::BOLD),
-            ),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled("  Quick start", title)),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("    ↑↓ ", key),
-            Span::styled("Navigate groups in the left panel", text),
-        ]),
-        Line::from(vec![
-            Span::styled("  Enter ", key),
-            Span::styled("Expand a group and open a document", text),
-        ]),
-        Line::from(vec![
-            Span::styled("   Tab  ", key),
-            Span::styled("Cycle panels: Navigation → Metadata → Document", text),
-        ]),
-        Line::from(vec![
-            Span::styled("     /  ", key),
-            Span::styled("Search by filename, title, tags, or date", text),
-        ]),
-        Line::from(vec![
-            Span::styled("     f  ", key),
-            Span::styled("Toggle document fullscreen", text),
-        ]),
-        Line::from(vec![
-            Span::styled("     ?  ", key),
-            Span::styled("Show all keyboard shortcuts", text),
-        ]),
-        Line::from(vec![
-            Span::styled("     q  ", key),
-            Span::styled("Quit", text),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "  ─────────────────────────────────────────────",
-            dim,
-        )),
-        Line::from(vec![
-            Span::styled("  Developed by ", dim),
-            Span::styled("Strange Days Tech, S.A.S.", text),
-        ]),
-        Line::from(vec![
-            Span::raw("  "),
-            Span::styled(
-                "https://strangedays.tech",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::UNDERLINED),
-            ),
-        ]),
-    ]
+    ];
+
+    if let Some(ref path) = fallback_path {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("  → Using repo root: ", Style::default().fg(Color::Yellow)),
+            Span::styled(path.clone(), text),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("  Total documents: ", dim),
+        Span::styled(
+            total_docs.to_string(),
+            text.add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled("  Quick start", title)));
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("    ↑↓ ", key),
+        Span::styled("Navigate groups in the left panel", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("  Enter ", key),
+        Span::styled("Expand a group and open a document", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("   Tab  ", key),
+        Span::styled("Cycle panels: Navigation → Metadata → Document", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("     /  ", key),
+        Span::styled("Search by filename, title, tags, or date", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("     f  ", key),
+        Span::styled("Toggle document fullscreen", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("     ?  ", key),
+        Span::styled("Show all keyboard shortcuts", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("     q  ", key),
+        Span::styled("Quit", text),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  ─────────────────────────────────────────────",
+        dim,
+    )));
+    lines.push(Line::from(vec![
+        Span::styled("  Developed by ", dim),
+        Span::styled("Strange Days Tech, S.A.S.", text),
+    ]));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "https://strangedays.tech",
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::UNDERLINED),
+        ),
+    ]));
+
+    lines
 }

--- a/cli/src/tui/widgets/status_bar.rs
+++ b/cli/src/tui/widgets/status_bar.rs
@@ -82,17 +82,26 @@ impl Widget for StatusBar<'_> {
             Span::styled("help ", desc_style),
         ];
 
-        // Right-aligned doc count
-        let count_str = format!(" {} docs ", self.app.index.total_docs);
+        // Right-aligned: path + doc count
+        let path_display = self.app.project_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?");
+        let right_str = format!(" {}  │  {} docs ", path_display, self.app.index.total_docs);
         let used_width: usize = spans.iter().map(|s| s.content.len()).sum();
         let remaining = area.width as usize - used_width.min(area.width as usize);
-        if remaining > count_str.len() {
-            let padding = remaining - count_str.len();
+        if remaining > right_str.len() {
+            let padding = remaining - right_str.len();
+            spans.push(Span::styled(" ".repeat(padding), Style::default()));
             spans.push(Span::styled(
-                " ".repeat(padding),
-                Style::default(),
+                format!(" {} ", path_display),
+                desc_style,
             ));
-            spans.push(Span::styled(count_str, info_style));
+            spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled(
+                format!("{} docs ", self.app.index.total_docs),
+                info_style,
+            ));
         }
 
         let line = Line::from(spans);


### PR DESCRIPTION
## Summary

- Welcome screen shows fallback notice when using repo root instead of cwd
- Status bar shows project folder name + doc count with │ separator
- Passes `is_fallback` through tui::run → App for consistent state

🤖 Generated with [Claude Code](https://claude.com/claude-code)