### PR TITLE
feat: add dark theme with rounded borders to explore TUI

### DIFF
--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -3,6 +3,7 @@ pub mod document;
 pub mod event;
 pub mod index;
 pub mod markdown;
+pub mod theme;
 pub mod ui;
 pub mod widgets;
 

--- a/cli/src/tui/theme.rs
+++ b/cli/src/tui/theme.rs
@@ -1,0 +1,15 @@
+use ratatui::style::Color;
+use ratatui::widgets::BorderType;
+
+// Background: dark blue-gray (Catppuccin Mocha inspired)
+pub const BG: Color = Color::Rgb(30, 30, 46);
+// Surface: slightly lighter for panels
+pub const SURFACE: Color = Color::Rgb(36, 36, 54);
+// Text
+#[allow(dead_code)]
+pub const TEXT: Color = Color::Rgb(205, 214, 244);
+// Dimmed text
+pub const TEXT_DIM: Color = Color::Rgb(108, 112, 134);
+
+// Border type: rounded corners
+pub const BORDER_TYPE: BorderType = BorderType::Rounded;

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -1,7 +1,10 @@
 use ratatui::layout::{Constraint, Layout};
+use ratatui::style::Style;
+use ratatui::widgets::{Block, Widget};
 use ratatui::Frame;
 
 use super::app::{App, ViewMode};
+use super::theme;
 use super::widgets::doc_viewer::DocViewer;
 use super::widgets::help_popup::HelpPopup;
 use super::widgets::metadata_panel::MetadataPanel;
@@ -11,6 +14,10 @@ use super::widgets::status_bar::StatusBar;
 pub fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
     let terminal_width = area.width;
+
+    // Fill entire background
+    let bg = Block::default().style(Style::default().bg(theme::BG));
+    bg.render(area, frame.buffer_mut());
 
     // Split: main area + status bar at bottom
     let vertical = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientatio
 
 use crate::tui::app::{ActivePanel, App};
 use crate::tui::markdown::markdown_to_lines;
+use crate::tui::theme;
 
 pub struct DocViewer<'a> {
     app: &'a mut App,
@@ -38,7 +39,9 @@ impl<'a> DocViewer<'a> {
                     .add_modifier(Modifier::BOLD),
             )
             .borders(Borders::ALL)
-            .border_style(border_style);
+            .border_type(theme::BORDER_TYPE)
+            .border_style(border_style)
+            .style(Style::default().bg(theme::SURFACE));
 
         let inner = block.inner(area);
         block.render(area, buf);

--- a/cli/src/tui/widgets/help_popup.rs
+++ b/cli/src/tui/widgets/help_popup.rs
@@ -4,6 +4,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 
+use crate::tui::theme;
+
 pub struct HelpPopup;
 
 impl Widget for HelpPopup {
@@ -20,7 +22,9 @@ impl Widget for HelpPopup {
                     .add_modifier(Modifier::BOLD),
             )
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan));
+            .border_type(theme::BORDER_TYPE)
+            .border_style(Style::default().fg(Color::Cyan))
+            .style(Style::default().bg(theme::SURFACE));
 
         let key_style = Style::default()
             .fg(Color::Yellow)

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 
 use crate::tui::app::{ActivePanel, App};
 use crate::tui::document::{ConfidenceLevel, DocStatus, RiskLevel};
+use crate::tui::theme;
 
 pub struct MetadataPanel<'a> {
     app: &'a App,
@@ -34,7 +35,9 @@ impl Widget for MetadataPanel<'_> {
                     .add_modifier(Modifier::BOLD),
             )
             .borders(Borders::ALL)
-            .border_style(border_style);
+            .border_type(theme::BORDER_TYPE)
+            .border_style(border_style)
+            .style(Style::default().bg(theme::SURFACE));
 
         let inner = block.inner(area);
         block.render(area, buf);

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Widget};
 
 use crate::tui::app::{ActivePanel, App, NavSelection, SortOrder};
 use crate::tui::index::DocEntry;
+use crate::tui::theme;
 
 pub struct NavTree<'a> {
     app: &'a App,
@@ -33,7 +34,9 @@ impl Widget for NavTree<'_> {
             }))
             .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
             .borders(Borders::ALL)
-            .border_style(border_style);
+            .border_type(theme::BORDER_TYPE)
+            .border_style(border_style)
+            .style(Style::default().bg(theme::SURFACE));
 
         let inner = block.inner(area);
         block.render(area, buf);

--- a/cli/src/tui/widgets/status_bar.rs
+++ b/cli/src/tui/widgets/status_bar.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Widget;
 
 use crate::tui::app::App;
+use crate::tui::theme;
 
 pub struct StatusBar<'a> {
     app: &'a App,
@@ -18,11 +19,16 @@ impl<'a> StatusBar<'a> {
 
 impl Widget for StatusBar<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
+        // Fill status bar background
+        for x in area.x..area.x + area.width {
+            buf[(x, area.y)].set_bg(theme::SURFACE);
+        }
+
         let key_style = Style::default()
             .fg(Color::Black)
             .bg(Color::DarkGray)
             .add_modifier(Modifier::BOLD);
-        let desc_style = Style::default().fg(Color::DarkGray);
+        let desc_style = Style::default().fg(theme::TEXT_DIM);
         let info_style = Style::default().fg(Color::Cyan);
 
         // Show notification if present


### PR DESCRIPTION
## Summary

- New `theme.rs` module with centralized color constants (Catppuccin Mocha-inspired)
- Dark blue-gray background fills entire terminal area
- Panels use slightly lighter surface color
- Rounded border corners (╭╮╰╯) on all panels including help popup
- Status bar uses themed text colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)