### PR TITLE
fix: improve color contrast for accessibility on dark theme

### DIFF
--- a/cli/src/tui/theme.rs
+++ b/cli/src/tui/theme.rs
@@ -5,11 +5,16 @@ use ratatui::widgets::BorderType;
 pub const BG: Color = Color::Rgb(30, 30, 46);
 // Surface: slightly lighter for panels
 pub const SURFACE: Color = Color::Rgb(36, 36, 54);
-// Text
-#[allow(dead_code)]
+// Text: primary readable text
 pub const TEXT: Color = Color::Rgb(205, 214, 244);
-// Dimmed text
-pub const TEXT_DIM: Color = Color::Rgb(108, 112, 134);
+// Dimmed text: secondary info (counts, dates, badges, hints)
+pub const TEXT_DIM: Color = Color::Rgb(148, 155, 180);
+// Subtle: borders, separators when inactive
+pub const SUBTLE: Color = Color::Rgb(88, 91, 112);
+// Subgroup labels (yellow family, accessible on dark bg)
+pub const SUBGROUP: Color = Color::Rgb(249, 226, 145);
+// User dir labels (magenta/lavender family)
+pub const USER_DIR: Color = Color::Rgb(203, 166, 247);
 
 // Border type: rounded corners
 pub const BORDER_TYPE: BorderType = BorderType::Rounded;

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -22,7 +22,7 @@ impl<'a> DocViewer<'a> {
         let border_style = if is_active {
             Style::default().fg(Color::Cyan)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme::SUBTLE)
         };
 
         let title = match &self.app.current_doc {
@@ -101,7 +101,7 @@ fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<
     let title = Style::default()
         .fg(Color::Cyan)
         .add_modifier(Modifier::BOLD);
-    let dim = Style::default().fg(Color::DarkGray);
+    let dim = Style::default().fg(theme::SUBTLE);
     let key = Style::default()
         .fg(Color::Yellow)
         .add_modifier(Modifier::BOLD);

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -24,7 +24,7 @@ impl Widget for MetadataPanel<'_> {
         let border_style = if is_active {
             Style::default().fg(Color::Cyan)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme::SUBTLE)
         };
 
         let block = Block::default()
@@ -47,7 +47,7 @@ impl Widget for MetadataPanel<'_> {
             None => {
                 let line = Line::from(Span::styled(
                     " No document selected",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::TEXT_DIM),
                 ));
                 Paragraph::new(vec![line]).render(inner, buf);
                 return;
@@ -59,12 +59,12 @@ impl Widget for MetadataPanel<'_> {
             None => {
                 let lines = vec![
                     Line::from(vec![
-                        Span::styled(" File:  ", Style::default().fg(Color::DarkGray)),
+                        Span::styled(" File:  ", Style::default().fg(theme::TEXT_DIM)),
                         Span::styled(doc.filename.clone(), Style::default().fg(Color::White)),
                     ]),
                     Line::from(Span::styled(
                         " No frontmatter",
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme::TEXT_DIM),
                     )),
                 ];
                 Paragraph::new(lines)
@@ -74,7 +74,7 @@ impl Widget for MetadataPanel<'_> {
             }
         };
 
-        let l = Style::default().fg(Color::DarkGray);
+        let l = Style::default().fg(theme::TEXT_DIM);
         let v = Style::default().fg(Color::White);
         let mut lines: Vec<Line<'static>> = Vec::new();
 
@@ -166,7 +166,7 @@ impl Widget for MetadataPanel<'_> {
         if !fm.related.is_empty() {
             lines.push(Line::from(Span::styled(
                 " ─────────────────────────────",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::TEXT_DIM),
             )));
 
             let hint = if self.app.selected_related.is_some() {
@@ -176,7 +176,7 @@ impl Widget for MetadataPanel<'_> {
             };
             lines.push(Line::from(vec![
                 Span::styled(" Related      ", l),
-                Span::styled(hint, Style::default().fg(Color::DarkGray)),
+                Span::styled(hint, Style::default().fg(theme::TEXT_DIM)),
             ]));
 
             let max_link_width = inner.width.saturating_sub(4) as usize; // 3 marker + 1 padding
@@ -228,8 +228,8 @@ fn status_style(status: &DocStatus) -> (&'static str, Color) {
         DocStatus::Draft => ("○", Color::Yellow),
         DocStatus::Accepted => ("■", Color::Green),
         DocStatus::Deprecated => ("✗", Color::Red),
-        DocStatus::Superseded => ("◌", Color::DarkGray),
-        DocStatus::Unknown => ("?", Color::DarkGray),
+        DocStatus::Superseded => ("◌", theme::TEXT_DIM),
+        DocStatus::Unknown => ("?", theme::TEXT_DIM),
     }
 }
 
@@ -238,7 +238,7 @@ fn confidence_bar(level: &ConfidenceLevel) -> (usize, usize, Color, &'static str
         ConfidenceLevel::High => (8, 10, Color::Green, "high"),
         ConfidenceLevel::Medium => (5, 10, Color::Yellow, "medium"),
         ConfidenceLevel::Low => (2, 10, Color::Red, "low"),
-        ConfidenceLevel::Unknown => (0, 10, Color::DarkGray, "unknown"),
+        ConfidenceLevel::Unknown => (0, 10, theme::TEXT_DIM, "unknown"),
     }
 }
 
@@ -248,7 +248,7 @@ fn risk_bar(level: &RiskLevel) -> (usize, usize, Color, &'static str) {
         RiskLevel::Medium => (5, 10, Color::Yellow, "medium"),
         RiskLevel::High => (7, 10, Color::Red, "high"),
         RiskLevel::Critical => (10, 10, Color::Red, "critical"),
-        RiskLevel::Unknown => (0, 10, Color::DarkGray, "unknown"),
+        RiskLevel::Unknown => (0, 10, theme::TEXT_DIM, "unknown"),
     }
 }
 

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -24,7 +24,7 @@ impl Widget for NavTree<'_> {
         let border_style = if is_active {
             Style::default().fg(Color::Cyan)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme::SUBTLE)
         };
 
         let block = Block::default()
@@ -71,7 +71,7 @@ impl Widget for NavTree<'_> {
 
             let style = if is_selected {
                 Style::default()
-                    .bg(Color::DarkGray)
+                    .bg(theme::SUBTLE)
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD)
             } else {
@@ -84,7 +84,7 @@ impl Widget for NavTree<'_> {
             lines.push(Line::from(vec![
                 Span::styled(format!(" {arrow} "), Style::default().fg(Color::Cyan)),
                 Span::styled(group.label.clone(), style),
-                Span::styled(count_str, Style::default().fg(Color::DarkGray)),
+                Span::styled(count_str, Style::default().fg(theme::TEXT_DIM)),
             ]));
 
             if show_children {
@@ -112,11 +112,11 @@ impl Widget for NavTree<'_> {
                     let sg_arrow = if sg_expanded { "▾" } else { "▸" };
                     let sg_style = if is_sel {
                         Style::default()
-                            .bg(Color::DarkGray)
-                            .fg(Color::Yellow)
+                            .bg(theme::SUBTLE)
+                            .fg(theme::SUBGROUP)
                             .add_modifier(Modifier::BOLD)
                     } else {
-                        Style::default().fg(Color::Yellow)
+                        Style::default().fg(theme::SUBGROUP)
                     };
 
                     if is_sel {
@@ -124,11 +124,11 @@ impl Widget for NavTree<'_> {
                     }
                     lines.push(Line::from(vec![
                         Span::raw("   "),
-                        Span::styled(format!("{sg_arrow} "), Style::default().fg(Color::Yellow)),
+                        Span::styled(format!("{sg_arrow} "), Style::default().fg(theme::SUBGROUP)),
                         Span::styled(format!("{}/", sg.label), sg_style),
                         Span::styled(
                             format!(" ({sg_count})"),
-                            Style::default().fg(Color::DarkGray),
+                            Style::default().fg(theme::TEXT_DIM),
                         ),
                     ]));
 
@@ -162,11 +162,11 @@ impl Widget for NavTree<'_> {
                             let ud_arrow = if ud_expanded { "▾" } else { "▸" };
                             let ud_style = if is_sel {
                                 Style::default()
-                                    .bg(Color::DarkGray)
-                                    .fg(Color::Magenta)
+                                    .bg(theme::SUBTLE)
+                                    .fg(theme::USER_DIR)
                                     .add_modifier(Modifier::BOLD)
                             } else {
-                                Style::default().fg(Color::Magenta)
+                                Style::default().fg(theme::USER_DIR)
                             };
 
                             if is_sel {
@@ -176,12 +176,12 @@ impl Widget for NavTree<'_> {
                                 Span::raw("     "),
                                 Span::styled(
                                     format!("{ud_arrow} "),
-                                    Style::default().fg(Color::Magenta),
+                                    Style::default().fg(theme::USER_DIR),
                                 ),
                                 Span::styled(format!("{}/", ud.name), ud_style),
                                 Span::styled(
                                     format!(" ({ud_count})"),
-                                    Style::default().fg(Color::DarkGray),
+                                    Style::default().fg(theme::TEXT_DIM),
                                 ),
                             ]));
 
@@ -225,8 +225,8 @@ impl Widget for NavTree<'_> {
 
 fn file_entry_line(entry: &DocEntry, indent: &str, max_width: usize, selected: bool) -> Line<'static> {
     let style = file_style(selected);
-    let badge_style = Style::default().fg(Color::DarkGray);
-    let date_style = Style::default().fg(Color::DarkGray);
+    let badge_style = Style::default().fg(theme::TEXT_DIM);
+    let date_style = Style::default().fg(theme::TEXT_DIM);
 
     let badge = if entry.doc_type.is_empty() {
         String::from("   ")
@@ -266,7 +266,7 @@ fn file_style(selected: bool) -> Style {
             .fg(Color::White)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::Gray)
+        Style::default().fg(theme::TEXT)
     }
 }
 


### PR DESCRIPTION
## Summary

Fix low-contrast text on the dark theme that made counts, badges, dates, subgroup labels, and inactive borders hard to read.

- `TEXT_DIM`: raised from `(108,112,134)` to `(148,155,180)` — counts, badges, dates, hints
- `SUBTLE`: new at `(88,91,112)` — inactive borders, selection highlight bg
- `SUBGROUP`: warm yellow `(249,226,145)` — replaces basic Yellow
- `USER_DIR`: lavender `(203,166,247)` — replaces basic Magenta
- `TEXT`: `(205,214,244)` for unselected file titles (was Gray)
- All `Color::DarkGray` replaced with appropriate themed constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)