### PR TITLE
fix: soften primary text color to #A4ABC7 for cohesive theme

### DIFF
--- a/cli/src/tui/markdown.rs
+++ b/cli/src/tui/markdown.rs
@@ -2,6 +2,8 @@ use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::tui::theme;
+
 /// Convert markdown text to styled ratatui Lines
 pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'static>> {
     let options = Options::ENABLE_TABLES
@@ -52,7 +54,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                     flush_spans(&mut current_spans, &mut lines, content_indent);
                     push_indented(&mut lines, content_indent, Span::styled(
                         "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄",
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme::SUBTLE),
                     ));
                 }
                 Tag::List(start) => {
@@ -104,7 +106,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 }
                 Tag::BlockQuote(_) => {
                     let current = current_style(&style_stack);
-                    style_stack.push(current.fg(Color::DarkGray).add_modifier(Modifier::ITALIC));
+                    style_stack.push(current.fg(theme::SUBTLE).add_modifier(Modifier::ITALIC));
                 }
                 _ => {}
             },
@@ -157,7 +159,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                     in_code_block = false;
                     push_indented(&mut lines, content_indent, Span::styled(
                         "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄",
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme::SUBTLE),
                     ));
                     lines.push(Line::from(""));
                 }
@@ -230,7 +232,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                         }
                         spans.push(Span::styled(
                             format!("  {code_line}  "),
-                            Style::default().fg(Color::White).bg(Color::DarkGray),
+                            Style::default().fg(theme::TEXT).bg(theme::SUBTLE),
                         ));
                         lines.push(Line::from(spans));
                     }
@@ -247,7 +249,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 } else {
                     current_spans.push(Span::styled(
                         format!(" {code} "),
-                        Style::default().fg(Color::White).bg(Color::Rgb(60, 60, 60)),
+                        Style::default().fg(theme::TEXT).bg(Color::Rgb(60, 60, 60)),
                     ));
                 }
             }
@@ -265,7 +267,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 flush_spans(&mut current_spans, &mut lines, content_indent);
                 push_indented(&mut lines, content_indent, Span::styled(
                     "────────────────────────────────────────────────────",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::SUBTLE),
                 ));
                 lines.push(Line::from(""));
             }
@@ -273,7 +275,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 let marker = if checked {
                     Span::styled(" ✓ ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))
                 } else {
-                    Span::styled(" □ ", Style::default().fg(Color::DarkGray))
+                    Span::styled(" □ ", Style::default().fg(theme::SUBTLE))
                 };
                 current_spans.push(marker);
             }
@@ -322,7 +324,7 @@ fn heading_style(level: HeadingLevel) -> Style {
         HeadingLevel::H2 => Color::Yellow,
         HeadingLevel::H3 => Color::Green,
         HeadingLevel::H4 => Color::Magenta,
-        _ => Color::White,
+        _ => theme::TEXT,
     };
     Style::default().fg(color).add_modifier(Modifier::BOLD)
 }
@@ -441,7 +443,7 @@ fn render_table_row(
     } else {
         Style::default()
     };
-    let border = Style::default().fg(Color::DarkGray);
+    let border = Style::default().fg(theme::SUBTLE);
 
     // Wrap each cell's content and determine how many visual lines this row needs
     let wrapped: Vec<Vec<String>> = col_widths
@@ -486,7 +488,7 @@ fn render_table_separator(
     lines: &mut Vec<Line<'static>>,
     indent: usize,
 ) {
-    let sep_style = Style::default().fg(Color::DarkGray);
+    let sep_style = Style::default().fg(theme::SUBTLE);
     let mut s = String::new();
     if indent > 0 {
         s.push_str(&" ".repeat(indent));

--- a/cli/src/tui/theme.rs
+++ b/cli/src/tui/theme.rs
@@ -6,7 +6,7 @@ pub const BG: Color = Color::Rgb(30, 30, 46);
 // Surface: slightly lighter for panels
 pub const SURFACE: Color = Color::Rgb(36, 36, 54);
 // Text: primary readable text
-pub const TEXT: Color = Color::Rgb(205, 214, 244);
+pub const TEXT: Color = Color::Rgb(164, 171, 199);
 // Dimmed text: secondary info (counts, dates, badges, hints)
 pub const TEXT_DIM: Color = Color::Rgb(148, 155, 180);
 // Subtle: borders, separators when inactive

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -105,7 +105,7 @@ fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<
     let key = Style::default()
         .fg(Color::Yellow)
         .add_modifier(Modifier::BOLD);
-    let text = Style::default().fg(Color::White);
+    let text = Style::default().fg(theme::TEXT);
 
     let mut lines = vec![
         Line::from(""),

--- a/cli/src/tui/widgets/help_popup.rs
+++ b/cli/src/tui/widgets/help_popup.rs
@@ -29,7 +29,7 @@ impl Widget for HelpPopup {
         let key_style = Style::default()
             .fg(Color::Yellow)
             .add_modifier(Modifier::BOLD);
-        let desc_style = Style::default().fg(Color::White);
+        let desc_style = Style::default().fg(theme::TEXT);
         let section_style = Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD);

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -60,7 +60,7 @@ impl Widget for MetadataPanel<'_> {
                 let lines = vec![
                     Line::from(vec![
                         Span::styled(" File:  ", Style::default().fg(theme::TEXT_DIM)),
-                        Span::styled(doc.filename.clone(), Style::default().fg(Color::White)),
+                        Span::styled(doc.filename.clone(), Style::default().fg(theme::TEXT)),
                     ]),
                     Line::from(Span::styled(
                         " No frontmatter",
@@ -75,7 +75,7 @@ impl Widget for MetadataPanel<'_> {
         };
 
         let l = Style::default().fg(theme::TEXT_DIM);
-        let v = Style::default().fg(Color::White);
+        let v = Style::default().fg(theme::TEXT);
         let mut lines: Vec<Line<'static>> = Vec::new();
 
         // Status

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -72,10 +72,10 @@ impl Widget for NavTree<'_> {
             let style = if is_selected {
                 Style::default()
                     .bg(theme::SUBTLE)
-                    .fg(Color::White)
+                    .fg(theme::TEXT)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(Color::White)
+                Style::default().fg(theme::TEXT)
             };
 
             if is_selected {
@@ -263,7 +263,7 @@ fn file_style(selected: bool) -> Style {
     if selected {
         Style::default()
             .bg(Color::Blue)
-            .fg(Color::White)
+            .fg(theme::TEXT)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::TEXT)

--- a/cli/src/tui/widgets/status_bar.rs
+++ b/cli/src/tui/widgets/status_bar.rs
@@ -59,9 +59,9 @@ impl Widget for StatusBar<'_> {
                 Span::styled(" / ", key_style),
                 Span::styled(
                     format!(" {} ", self.app.search_input),
-                    Style::default().fg(Color::White),
+                    Style::default().fg(theme::TEXT),
                 ),
-                Span::styled("█", Style::default().fg(Color::White)),
+                Span::styled("█", Style::default().fg(theme::TEXT)),
                 Span::styled("  Enter", key_style),
                 Span::styled(" apply  ", desc_style),
                 Span::styled("Esc", key_style),


### PR DESCRIPTION
## Summary

Replace all `Color::White` with `theme::TEXT` (`#A4ABC7` / `Rgb(164,171,199)`) for a softer, more cohesive look across the entire TUI. Also replaces remaining `Color::DarkGray` in markdown renderer with `theme::SUBTLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)