### PR TITLE
fix: use #B3BEFE for active panel borders

### DIFF
--- a/cli/src/tui/theme.rs
+++ b/cli/src/tui/theme.rs
@@ -16,5 +16,8 @@ pub const SUBGROUP: Color = Color::Rgb(249, 226, 145);
 // User dir labels (magenta/lavender family)
 pub const USER_DIR: Color = Color::Rgb(203, 166, 247);
 
+// Active panel border
+pub const BORDER_ACTIVE: Color = Color::Rgb(179, 190, 254);
+
 // Border type: rounded corners
 pub const BORDER_TYPE: BorderType = BorderType::Rounded;

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -20,7 +20,7 @@ impl<'a> DocViewer<'a> {
     pub fn render(self, area: Rect, buf: &mut Buffer) {
         let is_active = self.app.active_panel == ActivePanel::Document;
         let border_style = if is_active {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme::BORDER_ACTIVE)
         } else {
             Style::default().fg(theme::SUBTLE)
         };

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -22,7 +22,7 @@ impl Widget for MetadataPanel<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let is_active = self.app.active_panel == ActivePanel::Metadata;
         let border_style = if is_active {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme::BORDER_ACTIVE)
         } else {
             Style::default().fg(theme::SUBTLE)
         };

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -22,7 +22,7 @@ impl Widget for NavTree<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let is_active = self.app.active_panel == ActivePanel::Navigation;
         let border_style = if is_active {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme::BORDER_ACTIVE)
         } else {
             Style::default().fg(theme::SUBTLE)
         };


### PR DESCRIPTION
## Summary

- New `BORDER_ACTIVE` constant: `#B3BEFE` (Rgb 179,190,254)
- Applied to Navigation, Document, and Metadata panel borders when active
- Softer lavender tone replaces Cyan for better theme cohesion
- Inactive borders unchanged (theme::SUBTLE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)