### PR TITLE
feat: theme overhaul, navigation redesign, and navigable tags

### DIFF
--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -40,6 +40,13 @@ pub enum NavSelection {
     UserDirFile(usize, usize, usize, usize),
 }
 
+/// What is selected within the Metadata panel
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetaSelection {
+    Tag(usize),
+    Related(usize),
+}
+
 /// Sort order for file listings
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortOrder {
@@ -79,8 +86,8 @@ pub struct App {
     pub search_query: Option<String>,
     pub search_input: String,
     pub is_searching: bool,
-    /// Currently selected related link index (for Tab cycling in document panel)
-    pub selected_related: Option<usize>,
+    /// Current selection within the Metadata panel
+    pub meta_selection: Option<MetaSelection>,
     /// Temporary notification message shown in the status bar
     pub notification: Option<String>,
     /// Should the app quit
@@ -113,7 +120,7 @@ impl App {
             search_query: None,
             search_input: String::new(),
             is_searching: false,
-            selected_related: None,
+            meta_selection: None,
             notification: None,
             should_quit: false,
             project_root: project_root.to_path_buf(),
@@ -270,60 +277,141 @@ impl App {
     }
 
     /// Toggle between panels, or cycle related links when in document panel
+    /// Cycle panels forward: Navigation → Metadata → Document → Navigation
     pub fn toggle_panel(&mut self) {
         if self.current_doc.is_some() {
             match self.active_panel {
                 ActivePanel::Navigation => {
-                    // Nav → Metadata (if doc has frontmatter)
-                    self.selected_related = None;
                     self.active_panel = ActivePanel::Metadata;
+                    self.enter_metadata();
                 }
                 ActivePanel::Metadata => {
-                    // In Metadata panel, Tab cycles related links
-                    let related_count = self.related_count();
-                    if related_count > 0 {
-                        match self.selected_related {
-                            None => {
-                                self.selected_related = Some(0);
-                            }
-                            Some(idx) => {
-                                let next = idx + 1;
-                                if next >= related_count {
-                                    // Past last related → move to Document
-                                    self.selected_related = None;
-                                    self.active_panel = ActivePanel::Document;
-                                } else {
-                                    self.selected_related = Some(next);
-                                }
-                            }
-                        }
-                    } else {
-                        // No related links → move to Document
-                        self.active_panel = ActivePanel::Document;
-                    }
+                    self.meta_selection = None;
+                    self.active_panel = ActivePanel::Document;
                 }
                 ActivePanel::Document => {
-                    // Doc → back to Navigation
-                    self.selected_related = None;
                     self.active_panel = ActivePanel::Navigation;
                 }
             }
         }
     }
 
-    /// Follow the currently selected related link
-    pub fn follow_selected_related(&mut self) {
-        if let Some(idx) = self.selected_related {
-            if let Some(ref doc) = self.current_doc {
-                if let Some(ref fm) = doc.frontmatter {
-                    if let Some(related_id) = fm.related.get(idx) {
-                        let id = related_id.clone();
-                        self.selected_related = None;
-                        self.navigate_to_id(&id);
-                    }
+    /// Cycle panels reverse: Navigation → Document → Metadata → Navigation
+    pub fn toggle_panel_reverse(&mut self) {
+        if self.current_doc.is_some() {
+            match self.active_panel {
+                ActivePanel::Document => {
+                    self.active_panel = ActivePanel::Metadata;
+                    self.enter_metadata();
+                }
+                ActivePanel::Metadata => {
+                    self.meta_selection = None;
+                    self.active_panel = ActivePanel::Navigation;
+                }
+                ActivePanel::Navigation => {
+                    self.active_panel = ActivePanel::Document;
                 }
             }
         }
+    }
+
+    /// When entering Metadata panel, preselect first navigable item
+    fn enter_metadata(&mut self) {
+        let tags = self.tag_count();
+        let related = self.related_count();
+        if tags > 0 {
+            self.meta_selection = Some(MetaSelection::Tag(0));
+        } else if related > 0 {
+            self.meta_selection = Some(MetaSelection::Related(0));
+        } else {
+            self.meta_selection = None;
+        }
+    }
+
+    /// Move selection down in metadata (tags then related)
+    pub fn metadata_down(&mut self) {
+        let tags = self.tag_count();
+        let related = self.related_count();
+        match self.meta_selection {
+            None => {
+                if tags > 0 {
+                    self.meta_selection = Some(MetaSelection::Tag(0));
+                } else if related > 0 {
+                    self.meta_selection = Some(MetaSelection::Related(0));
+                }
+            }
+            Some(MetaSelection::Tag(idx)) => {
+                if idx + 1 < tags {
+                    self.meta_selection = Some(MetaSelection::Tag(idx + 1));
+                } else if related > 0 {
+                    self.meta_selection = Some(MetaSelection::Related(0));
+                }
+            }
+            Some(MetaSelection::Related(idx)) => {
+                if idx + 1 < related {
+                    self.meta_selection = Some(MetaSelection::Related(idx + 1));
+                }
+            }
+        }
+    }
+
+    /// Move selection up in metadata (related then tags)
+    pub fn metadata_up(&mut self) {
+        let tags = self.tag_count();
+        match self.meta_selection {
+            None => {}
+            Some(MetaSelection::Tag(0)) => {}
+            Some(MetaSelection::Tag(idx)) => {
+                self.meta_selection = Some(MetaSelection::Tag(idx - 1));
+            }
+            Some(MetaSelection::Related(0)) => {
+                if tags > 0 {
+                    self.meta_selection = Some(MetaSelection::Tag(tags - 1));
+                }
+            }
+            Some(MetaSelection::Related(idx)) => {
+                self.meta_selection = Some(MetaSelection::Related(idx - 1));
+            }
+        }
+    }
+
+    /// Execute action on the selected metadata item
+    pub fn metadata_enter(&mut self) {
+        match self.meta_selection {
+            Some(MetaSelection::Tag(idx)) => {
+                // Search by this tag
+                if let Some(ref doc) = self.current_doc {
+                    if let Some(ref fm) = doc.frontmatter {
+                        if let Some(tag) = fm.tags.get(idx) {
+                            self.search_query = Some(tag.clone());
+                            self.meta_selection = None;
+                            self.active_panel = ActivePanel::Navigation;
+                        }
+                    }
+                }
+            }
+            Some(MetaSelection::Related(idx)) => {
+                if let Some(ref doc) = self.current_doc {
+                    if let Some(ref fm) = doc.frontmatter {
+                        if let Some(related_id) = fm.related.get(idx) {
+                            let id = related_id.clone();
+                            self.meta_selection = None;
+                            self.navigate_to_id(&id);
+                        }
+                    }
+                }
+            }
+            None => {}
+        }
+    }
+
+    /// Get the number of tags in the current document
+    fn tag_count(&self) -> usize {
+        self.current_doc
+            .as_ref()
+            .and_then(|doc| doc.frontmatter.as_ref())
+            .map(|fm| fm.tags.len())
+            .unwrap_or(0)
     }
 
     /// Get the number of related links in the current document
@@ -495,7 +583,7 @@ impl App {
             self.current_doc = Some(doc);
         }
         self.doc_scroll = 0;
-        self.selected_related = None;
+        self.meta_selection = None;
         self.active_panel = ActivePanel::Document;
     }
 

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -51,6 +51,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Char('q') => app.should_quit = true,
         KeyCode::Char('?') => app.toggle_help(),
+        KeyCode::BackTab => app.toggle_panel_reverse(),
         KeyCode::Tab => app.toggle_panel(),
         KeyCode::Char('f') => app.toggle_fullscreen(),
         KeyCode::Char('/') => app.start_search(),
@@ -61,16 +62,16 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.jump_to_group(c.to_digit(10).unwrap() as usize);
         }
 
-        // Navigation or document scrolling depending on active panel
+        // Navigation, metadata, or document scrolling depending on active panel
         KeyCode::Char('j') | KeyCode::Down => match app.active_panel {
             ActivePanel::Document => app.scroll_down(1),
             ActivePanel::Navigation => app.nav_down(),
-            ActivePanel::Metadata => {}
+            ActivePanel::Metadata => app.metadata_down(),
         },
         KeyCode::Char('k') | KeyCode::Up => match app.active_panel {
             ActivePanel::Document => app.scroll_up(1),
             ActivePanel::Navigation => app.nav_up(),
-            ActivePanel::Metadata => {}
+            ActivePanel::Metadata => app.metadata_up(),
         },
 
         // Enter: open/expand or follow selected related link
@@ -78,9 +79,9 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             if app.active_panel == ActivePanel::Navigation {
                 app.nav_enter();
             } else if app.active_panel == ActivePanel::Metadata
-                && app.selected_related.is_some()
+                && app.meta_selection.is_some()
             {
-                app.follow_selected_related();
+                app.metadata_enter();
             }
         }
 
@@ -95,7 +96,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
                     }
                 }
                 ActivePanel::Metadata if key.code == KeyCode::Esc => {
-                    app.selected_related = None;
+                    app.meta_selection = None;
                     app.active_panel = ActivePanel::Navigation;
                 }
                 ActivePanel::Navigation => {

--- a/cli/src/tui/markdown.rs
+++ b/cli/src/tui/markdown.rs
@@ -26,6 +26,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
     let mut cell_text = String::new();
     let mut table_header_row: Vec<String> = Vec::new();
     let mut table_body_rows: Vec<Vec<String>> = Vec::new();
+    let mut code_block_lines: Vec<String> = Vec::new();
     // Current indent level based on last heading seen (2 spaces per level, max 3)
     let mut content_indent: usize = 0;
 
@@ -51,11 +52,8 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 }
                 Tag::CodeBlock(_) => {
                     in_code_block = true;
+                    code_block_lines.clear();
                     flush_spans(&mut current_spans, &mut lines, content_indent);
-                    push_indented(&mut lines, content_indent, Span::styled(
-                        "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄",
-                        Style::default().fg(theme::SUBTLE),
-                    ));
                 }
                 Tag::List(start) => {
                     list_depth += 1;
@@ -77,7 +75,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                     }
                     current_spans.push(Span::styled(
                         bullet,
-                        Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD),
+                        Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
                     ));
                 }
                 Tag::Link { dest_url, .. } => {
@@ -106,7 +104,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 }
                 Tag::BlockQuote(_) => {
                     let current = current_style(&style_stack);
-                    style_stack.push(current.fg(theme::SUBTLE).add_modifier(Modifier::ITALIC));
+                    style_stack.push(current.fg(theme::TEXT_DIM).add_modifier(Modifier::ITALIC));
                 }
                 _ => {}
             },
@@ -128,21 +126,18 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                         content_indent = 6;
                     }
 
-                    if heading_indent > 0 {
-                        let spans = vec![
+                    if heading_level == HeadingLevel::H1 {
+                        lines.push(
+                            Line::from(Span::styled(text, style))
+                                .alignment(ratatui::layout::Alignment::Center),
+                        );
+                    } else if heading_indent > 0 {
+                        lines.push(Line::from(vec![
                             Span::raw(" ".repeat(heading_indent)),
                             Span::styled(text, style),
-                        ];
-                        lines.push(Line::from(spans));
+                        ]));
                     } else {
                         lines.push(Line::from(Span::styled(text, style)));
-                    }
-
-                    if heading_level == HeadingLevel::H1 {
-                        lines.push(Line::from(Span::styled(
-                            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-                            style.remove_modifier(Modifier::BOLD),
-                        )));
                     }
                     lines.push(Line::from(""));
                 }
@@ -157,10 +152,26 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                 }
                 TagEnd::CodeBlock => {
                     in_code_block = false;
-                    push_indented(&mut lines, content_indent, Span::styled(
-                        "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄",
-                        Style::default().fg(theme::SUBTLE),
-                    ));
+                    // Calculate uniform width: max line length + padding
+                    let max_len = code_block_lines
+                        .iter()
+                        .map(|l| l.len())
+                        .max()
+                        .unwrap_or(0);
+                    let code_bg = Style::default()
+                        .fg(Color::Rgb(210, 215, 235))
+                        .bg(Color::Rgb(45, 45, 60));
+
+                    for code_line in &code_block_lines {
+                        let padded = format!("  {:<width$}  ", code_line, width = max_len);
+                        let mut spans: Vec<Span<'static>> = Vec::new();
+                        if content_indent > 0 {
+                            spans.push(Span::raw(" ".repeat(content_indent)));
+                        }
+                        spans.push(Span::styled(padded, code_bg));
+                        lines.push(Line::from(spans));
+                    }
+                    code_block_lines.clear();
                     lines.push(Line::from(""));
                 }
                 TagEnd::List(_) => {
@@ -226,15 +237,7 @@ pub fn markdown_to_lines(markdown: &str, available_width: usize) -> Vec<Line<'st
                     cell_text.push_str(&text);
                 } else if in_code_block {
                     for code_line in text.lines() {
-                        let mut spans: Vec<Span<'static>> = Vec::new();
-                        if content_indent > 0 {
-                            spans.push(Span::raw(" ".repeat(content_indent)));
-                        }
-                        spans.push(Span::styled(
-                            format!("  {code_line}  "),
-                            Style::default().fg(theme::TEXT).bg(theme::SUBTLE),
-                        ));
-                        lines.push(Line::from(spans));
+                        code_block_lines.push(code_line.to_string());
                     }
                 } else if in_heading {
                     current_spans.push(Span::raw(text.to_string()));
@@ -318,15 +321,10 @@ fn heading_indent_level(level: HeadingLevel) -> usize {
     }
 }
 
-fn heading_style(level: HeadingLevel) -> Style {
-    let color = match level {
-        HeadingLevel::H1 => Color::Cyan,
-        HeadingLevel::H2 => Color::Yellow,
-        HeadingLevel::H3 => Color::Green,
-        HeadingLevel::H4 => Color::Magenta,
-        _ => theme::TEXT,
-    };
-    Style::default().fg(color).add_modifier(Modifier::BOLD)
+fn heading_style(_level: HeadingLevel) -> Style {
+    Style::default()
+        .fg(Color::Rgb(250, 179, 135))
+        .add_modifier(Modifier::BOLD)
 }
 
 fn compute_column_widths(
@@ -438,7 +436,7 @@ fn render_table_row(
 ) {
     let style = if is_header {
         Style::default()
-            .fg(Color::Cyan)
+            .fg(theme::ACCENT)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default()

--- a/cli/src/tui/theme.rs
+++ b/cli/src/tui/theme.rs
@@ -16,8 +16,15 @@ pub const SUBGROUP: Color = Color::Rgb(249, 226, 145);
 // User dir labels (magenta/lavender family)
 pub const USER_DIR: Color = Color::Rgb(203, 166, 247);
 
+// Accent: panel titles, expand/collapse icons, shortcut keys
+pub const ACCENT: Color = Color::Rgb(116, 199, 236);
 // Active panel border
 pub const BORDER_ACTIVE: Color = Color::Rgb(179, 190, 254);
+
+// Semantic colors (muted variants)
+pub const GREEN: Color = Color::Rgb(166, 218, 149);
+pub const YELLOW: Color = Color::Rgb(229, 200, 144);
+pub const RED: Color = Color::Rgb(237, 135, 150);
 
 // Border type: rounded corners
 pub const BORDER_TYPE: BorderType = BorderType::Rounded;

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -111,7 +111,7 @@ fn metadata_panel_height(app: &App) -> u16 {
         lines += 1;
     }
     if !fm.tags.is_empty() {
-        lines += 1;
+        lines += 1 + fm.tags.len() as u16; // header + one per tag
     }
     // Related: separator + header + one per link
     if !fm.related.is_empty() {

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -33,11 +33,11 @@ impl<'a> DocViewer<'a> {
         let block = Block::default()
             .title(title)
             .title_alignment(ratatui::layout::Alignment::Center)
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
+            .title_style(if is_active {
+                Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::SUBTLE)
+            })
             .borders(Borders::ALL)
             .border_type(theme::BORDER_TYPE)
             .border_style(border_style)
@@ -61,7 +61,7 @@ impl<'a> DocViewer<'a> {
         let doc = self.app.current_doc.as_ref().unwrap();
 
         // Render markdown body only (metadata is in separate panel)
-        let mut all_lines = vec![Line::from(""); 1];
+        let mut all_lines = vec![Line::from(""); 2];
         all_lines.extend(markdown_to_lines(&doc.body, inner.width as usize));
 
         // Estimate total lines accounting for wrapping
@@ -99,7 +99,7 @@ impl<'a> DocViewer<'a> {
 
 fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<'static>> {
     let title = Style::default()
-        .fg(Color::Cyan)
+        .fg(theme::ACCENT)
         .add_modifier(Modifier::BOLD);
     let dim = Style::default().fg(theme::SUBTLE);
     let key = Style::default()
@@ -146,7 +146,9 @@ fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<
     ]));
     lines.push(Line::from(vec![
         Span::styled("   Tab  ", key),
-        Span::styled("Cycle panels: Navigation → Metadata → Document", text),
+        Span::styled("Next panel / ", text),
+        Span::styled("Shift+Tab  ", key),
+        Span::styled("Previous panel", text),
     ]));
     lines.push(Line::from(vec![
         Span::styled("     /  ", key),

--- a/cli/src/tui/widgets/help_popup.rs
+++ b/cli/src/tui/widgets/help_popup.rs
@@ -18,22 +18,22 @@ impl Widget for HelpPopup {
             .title(" Keyboard Shortcuts ")
             .title_style(
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             )
             .borders(Borders::ALL)
             .border_type(theme::BORDER_TYPE)
-            .border_style(Style::default().fg(Color::Cyan))
+            .border_style(Style::default().fg(theme::ACCENT))
             .style(Style::default().bg(theme::SURFACE));
 
         let key_style = Style::default()
-            .fg(Color::Yellow)
+            .fg(theme::ACCENT)
             .add_modifier(Modifier::BOLD);
         let desc_style = Style::default().fg(theme::TEXT);
         let section_style = Style::default()
-            .fg(Color::Cyan)
+            .fg(Color::Rgb(250, 179, 135))
             .add_modifier(Modifier::BOLD);
-        let dim = Style::default().fg(Color::DarkGray);
+        let dim = Style::default().fg(theme::TEXT_DIM);
 
         let lines = vec![
             Line::from(""),
@@ -45,7 +45,8 @@ impl Widget for HelpPopup {
             help_line("  1-8         ", "Jump to group by number", key_style, desc_style),
             Line::from(""),
             Line::from(Span::styled("  Metadata panel", section_style)),
-            help_line("  Tab         ", "Cycle through related links", key_style, desc_style),
+            help_line("  j / ↓       ", "Move between related links", key_style, desc_style),
+            help_line("  k / ↑       ", "Move between related links", key_style, desc_style),
             help_line("  Enter       ", "Follow selected related link", key_style, desc_style),
             help_line("  Esc         ", "Back to Navigation", key_style, desc_style),
             Line::from(""),
@@ -60,7 +61,8 @@ impl Widget for HelpPopup {
             help_line("  Esc         ", "Exit fullscreen / Back to Nav", key_style, desc_style),
             Line::from(""),
             Line::from(Span::styled("  General", section_style)),
-            help_line("  Tab         ", "Cycle: Nav → Metadata → Doc", key_style, desc_style),
+            help_line("  Tab         ", "Next panel: Nav → Meta → Doc", key_style, desc_style),
+            help_line("  Shift+Tab   ", "Prev panel: Doc → Meta → Nav", key_style, desc_style),
             help_line("  /           ", "Search by name, title, tags, date", key_style, desc_style),
             help_line("  s           ", "Cycle sort order", key_style, desc_style),
             help_line("  r           ", "Refresh document index", key_style, desc_style),

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 
-use crate::tui::app::{ActivePanel, App};
+use crate::tui::app::{ActivePanel, App, MetaSelection};
 use crate::tui::document::{ConfidenceLevel, DocStatus, RiskLevel};
 use crate::tui::theme;
 
@@ -29,11 +29,11 @@ impl Widget for MetadataPanel<'_> {
 
         let block = Block::default()
             .title(" Metadata ")
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
+            .title_style(if is_active {
+                Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::SUBTLE)
+            })
             .borders(Borders::ALL)
             .border_type(theme::BORDER_TYPE)
             .border_style(border_style)
@@ -76,7 +76,7 @@ impl Widget for MetadataPanel<'_> {
 
         let l = Style::default().fg(theme::TEXT_DIM);
         let v = Style::default().fg(theme::TEXT);
-        let mut lines: Vec<Line<'static>> = Vec::new();
+        let mut lines: Vec<Line<'static>> = vec![Line::from("")];
 
         // Status
         if let Some(ref status) = fm.status {
@@ -139,7 +139,7 @@ impl Widget for MetadataPanel<'_> {
                 Span::styled(
                     "⚠ REQUIRED",
                     Style::default()
-                        .fg(Color::Yellow)
+                        .fg(theme::YELLOW)
                         .add_modifier(Modifier::BOLD),
                 ),
             ]));
@@ -147,50 +147,61 @@ impl Widget for MetadataPanel<'_> {
 
         // Tags
         if !fm.tags.is_empty() {
-            let mut spans: Vec<Span<'static>> = vec![Span::styled(" Tags:        ", l)];
-            let colors = [
-                Color::Cyan,
-                Color::Magenta,
-                Color::Green,
-                Color::Yellow,
-                Color::Blue,
-            ];
+            let tag_hint = match self.app.meta_selection {
+                Some(MetaSelection::Tag(_)) => " (Enter: search)",
+                _ => "",
+            };
+            lines.push(Line::from(vec![
+                Span::styled(" Tags:", l),
+                Span::styled(tag_hint, Style::default().fg(theme::TEXT_DIM)),
+            ]));
+            let tag_style = Style::default()
+                .fg(theme::TEXT_DIM)
+                .bg(Color::Rgb(45, 45, 60));
+            let tag_selected_style = Style::default()
+                .fg(Color::Rgb(220, 224, 242))
+                .bg(Color::Rgb(45, 50, 80))
+                .add_modifier(Modifier::BOLD);
             for (i, tag) in fm.tags.iter().enumerate() {
-                let color = colors[i % colors.len()];
-                spans.push(Span::styled(format!("[{tag}]"), Style::default().fg(color)));
+                let is_sel = self.app.meta_selection == Some(MetaSelection::Tag(i));
+                let marker = if is_sel { " ▸ " } else { "   " };
+                let st = if is_sel { tag_selected_style } else { tag_style };
+                lines.push(Line::from(vec![
+                    Span::styled(marker, l),
+                    Span::styled(format!(" {tag} "), st),
+                ]));
             }
-            lines.push(Line::from(spans));
         }
 
         // Separator before related
         if !fm.related.is_empty() {
+            let sep_width = inner.width.saturating_sub(2) as usize;
             lines.push(Line::from(Span::styled(
-                " ─────────────────────────────",
-                Style::default().fg(theme::TEXT_DIM),
+                format!(" {}", "─".repeat(sep_width)),
+                Style::default().fg(theme::SUBTLE),
             )));
 
-            let hint = if self.app.selected_related.is_some() {
-                "Enter: follow  Tab: next"
-            } else {
-                "Tab: select"
+            let hint = match self.app.meta_selection {
+                Some(MetaSelection::Related(_)) => " (Enter: follow)",
+                _ => "",
             };
             lines.push(Line::from(vec![
-                Span::styled(" Related      ", l),
+                Span::styled(" Related:", l),
                 Span::styled(hint, Style::default().fg(theme::TEXT_DIM)),
             ]));
 
-            let max_link_width = inner.width.saturating_sub(4) as usize; // 3 marker + 1 padding
+            let max_link_width = inner.width.saturating_sub(4) as usize;
             for (i, rel) in fm.related.iter().enumerate() {
-                let is_selected = self.app.selected_related == Some(i);
+                let is_selected = self.app.meta_selection == Some(MetaSelection::Related(i));
                 let marker = if is_selected { " ▸ " } else { "   " };
                 let style = if is_selected {
                     Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::Rgb(220, 224, 242))
+                        .bg(Color::Rgb(45, 50, 80))
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
                 } else {
                     Style::default()
-                        .fg(Color::Blue)
+                        .fg(theme::TEXT)
                         .add_modifier(Modifier::UNDERLINED)
                 };
                 let display = truncate_str(rel, max_link_width);
@@ -201,15 +212,22 @@ impl Widget for MetadataPanel<'_> {
             }
         }
 
-        // Calculate scroll to ensure selected related is visible
+        // Calculate scroll: find the line with ▸ marker to keep it visible
         let total_lines = lines.len() as u16;
         let scroll = if total_lines > inner.height {
-            if let Some(sel_idx) = self.app.selected_related {
-                // The selected related link's line position in the list
-                let related_start = total_lines.saturating_sub(fm.related.len() as u16);
-                let selected_line = related_start + sel_idx as u16;
-                // Scroll so the selected line is visible
-                selected_line.saturating_sub(inner.height.saturating_sub(1))
+            if let Some(selected_pos) = lines.iter().position(|line| {
+                line.spans
+                    .first()
+                    .map(|s| s.content.contains('▸'))
+                    .unwrap_or(false)
+            }) {
+                let sel = selected_pos as u16;
+                if sel >= inner.height {
+                    sel.saturating_sub(inner.height.saturating_sub(3))
+                        .min(total_lines.saturating_sub(inner.height))
+                } else {
+                    0
+                }
             } else {
                 0
             }
@@ -225,9 +243,9 @@ impl Widget for MetadataPanel<'_> {
 
 fn status_style(status: &DocStatus) -> (&'static str, Color) {
     match status {
-        DocStatus::Draft => ("○", Color::Yellow),
-        DocStatus::Accepted => ("■", Color::Green),
-        DocStatus::Deprecated => ("✗", Color::Red),
+        DocStatus::Draft => ("○", theme::YELLOW),
+        DocStatus::Accepted => ("■", theme::GREEN),
+        DocStatus::Deprecated => ("✗", theme::RED),
         DocStatus::Superseded => ("◌", theme::TEXT_DIM),
         DocStatus::Unknown => ("?", theme::TEXT_DIM),
     }
@@ -235,29 +253,31 @@ fn status_style(status: &DocStatus) -> (&'static str, Color) {
 
 fn confidence_bar(level: &ConfidenceLevel) -> (usize, usize, Color, &'static str) {
     match level {
-        ConfidenceLevel::High => (8, 10, Color::Green, "high"),
-        ConfidenceLevel::Medium => (5, 10, Color::Yellow, "medium"),
-        ConfidenceLevel::Low => (2, 10, Color::Red, "low"),
+        ConfidenceLevel::High => (8, 10, theme::GREEN, "high"),
+        ConfidenceLevel::Medium => (5, 10, theme::YELLOW, "medium"),
+        ConfidenceLevel::Low => (2, 10, theme::RED, "low"),
         ConfidenceLevel::Unknown => (0, 10, theme::TEXT_DIM, "unknown"),
     }
 }
 
 fn risk_bar(level: &RiskLevel) -> (usize, usize, Color, &'static str) {
     match level {
-        RiskLevel::Low => (2, 10, Color::Green, "low"),
-        RiskLevel::Medium => (5, 10, Color::Yellow, "medium"),
-        RiskLevel::High => (7, 10, Color::Red, "high"),
-        RiskLevel::Critical => (10, 10, Color::Red, "critical"),
+        RiskLevel::Low => (2, 10, theme::GREEN, "low"),
+        RiskLevel::Medium => (5, 10, theme::YELLOW, "medium"),
+        RiskLevel::High => (7, 10, theme::RED, "high"),
+        RiskLevel::Critical => (10, 10, theme::RED, "critical"),
         RiskLevel::Unknown => (0, 10, theme::TEXT_DIM, "unknown"),
     }
 }
 
 fn truncate_str(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    let char_count: usize = s.chars().count();
+    if char_count <= max {
         s.to_string()
     } else if max > 3 {
-        format!("{}...", &s[..max - 3])
+        let truncated: String = s.chars().take(max - 3).collect();
+        format!("{truncated}...")
     } else {
-        s[..max].to_string()
+        s.chars().take(max).collect()
     }
 }

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -32,7 +32,11 @@ impl Widget for NavTree<'_> {
                 SortOrder::Name => "[s:sort ↓name]",
                 SortOrder::Date => "[s:sort ↓date]",
             }))
-            .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+            .title_style(if is_active {
+                Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::SUBTLE)
+            })
             .borders(Borders::ALL)
             .border_type(theme::BORDER_TYPE)
             .border_style(border_style)
@@ -41,7 +45,7 @@ impl Widget for NavTree<'_> {
         let inner = block.inner(area);
         block.render(area, buf);
 
-        let mut lines: Vec<Line<'static>> = Vec::new();
+        let mut lines: Vec<Line<'static>> = vec![Line::from("")];
         let mut selected_line: Option<usize> = None;
         let search = self.app.search_query.as_deref();
         let has_search = search.is_some();
@@ -82,7 +86,7 @@ impl Widget for NavTree<'_> {
                 selected_line = Some(lines.len());
             }
             lines.push(Line::from(vec![
-                Span::styled(format!(" {arrow} "), Style::default().fg(Color::Cyan)),
+                Span::styled(format!(" {arrow} "), Style::default().fg(theme::ACCENT)),
                 Span::styled(group.label.clone(), style),
                 Span::styled(count_str, Style::default().fg(theme::TEXT_DIM)),
             ]));
@@ -96,7 +100,7 @@ impl Widget for NavTree<'_> {
                     if is_sel {
                         selected_line = Some(lines.len());
                     }
-                    lines.push(file_entry_line(entry, "     ", inner.width as usize, is_sel));
+                    lines.push(file_entry_line(entry, "   ", inner.width as usize, is_sel));
                 }
 
                 for (si, sg) in group.subgroups.iter().enumerate() {
@@ -143,7 +147,7 @@ impl Widget for NavTree<'_> {
                             if is_sel {
                                 selected_line = Some(lines.len());
                             }
-                            lines.push(file_entry_line(entry, "       ", inner.width as usize, is_sel));
+                            lines.push(file_entry_line(entry, "     ", inner.width as usize, is_sel));
                         }
 
                         // User-created subdirectories
@@ -196,7 +200,7 @@ impl Widget for NavTree<'_> {
                                     if is_sel {
                                         selected_line = Some(lines.len());
                                     }
-                                    lines.push(file_entry_line(entry, "         ", inner.width as usize, is_sel));
+                                    lines.push(file_entry_line(entry, "       ", inner.width as usize, is_sel));
                                 }
                             }
                         }
@@ -225,15 +229,13 @@ impl Widget for NavTree<'_> {
 
 fn file_entry_line(entry: &DocEntry, indent: &str, max_width: usize, selected: bool) -> Line<'static> {
     let style = file_style(selected);
-    let badge_style = Style::default().fg(theme::TEXT_DIM);
+    let badge_style = Style::default()
+        .fg(theme::TEXT_DIM)
+        .bg(Color::Rgb(45, 45, 60));
     let date_style = Style::default().fg(theme::TEXT_DIM);
 
-    let badge = if entry.doc_type.is_empty() {
-        String::from("   ")
-    } else {
-        format!("{} ", entry.doc_type)
-    };
-    let badge_len = badge.len();
+    let has_badge = !entry.doc_type.is_empty();
+    let badge_len = if has_badge { entry.doc_type.len() + 1 } else { 0 }; // badge + space
 
     // Compact date: show MM-DD from YYYY-MM-DD
     let date = if entry.created.len() >= 10 {
@@ -251,19 +253,21 @@ fn file_entry_line(entry: &DocEntry, indent: &str, max_width: usize, selected: b
 
     let title = truncate_str(&entry.title, title_budget);
 
-    Line::from(vec![
-        Span::raw(indent.to_string()),
-        Span::styled(badge, badge_style),
-        Span::styled(title, style),
-        Span::styled(date, date_style),
-    ])
+    let mut spans = vec![Span::raw(indent.to_string())];
+    if has_badge {
+        spans.push(Span::styled(entry.doc_type.clone(), badge_style));
+        spans.push(Span::raw(" "));
+    }
+    spans.push(Span::styled(title, style));
+    spans.push(Span::styled(date, date_style));
+    Line::from(spans)
 }
 
 fn file_style(selected: bool) -> Style {
     if selected {
         Style::default()
-            .bg(Color::Blue)
-            .fg(theme::TEXT)
+            .bg(Color::Rgb(45, 50, 80))
+            .fg(Color::Rgb(220, 224, 242))
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::TEXT)
@@ -284,12 +288,14 @@ fn count_group_docs(group: &crate::tui::index::DocGroup) -> usize {
 }
 
 fn truncate_str(name: &str, max_width: usize) -> String {
-    if name.len() <= max_width {
+    let char_count: usize = name.chars().count();
+    if char_count <= max_width {
         name.to_string()
     } else if max_width > 3 {
-        format!("{}...", &name[..max_width - 3])
+        let truncated: String = name.chars().take(max_width - 3).collect();
+        format!("{truncated}...")
     } else {
-        name[..max_width].to_string()
+        name.chars().take(max_width).collect()
     }
 }
 

--- a/cli/src/tui/widgets/status_bar.rs
+++ b/cli/src/tui/widgets/status_bar.rs
@@ -25,11 +25,10 @@ impl Widget for StatusBar<'_> {
         }
 
         let key_style = Style::default()
-            .fg(Color::Black)
-            .bg(Color::DarkGray)
+            .fg(theme::ACCENT)
             .add_modifier(Modifier::BOLD);
         let desc_style = Style::default().fg(theme::TEXT_DIM);
-        let info_style = Style::default().fg(Color::Cyan);
+        let info_style = Style::default().fg(theme::ACCENT);
 
         // Show notification if present
         if let Some(ref msg) = self.app.notification {


### PR DESCRIPTION
## Summary

Major visual and interaction update to the explore TUI.

### Theme
- Accent color `#74C7EC` for titles, arrows, keys, table headers
- Heading color `#FAB387` for all markdown levels (indentation differentiates)
- Muted semantic colors in metadata (green/yellow/red)
- Active borders `#B3BEFE`, softer text `#A4ABC7`
- Code blocks with uniform-width background, blockquotes with better contrast
- UTF-8 safe truncation (fixes panic on terminal resize with multibyte chars)

### Navigation
- `Tab`/`Shift+Tab` cycles panels only
- `↑↓`/`j/k` navigates within the focused panel
- Metadata panel: unified navigation through tags + related links
- `Enter` on tag triggers search, `Enter` on related follows link
- Scroll follows selection in metadata

### Visual
- H1 centered, top padding in all panels, inactive titles dimmed
- Corrected indent hierarchy, badges with subtle background
- Updated help popup and welcome screen

## Test plan
- [ ] Tab/Shift+Tab cycles panels correctly
- [ ] Navigate tags with arrows in Metadata, Enter searches
- [ ] Navigate related with arrows, Enter follows link
- [ ] Resize terminal without crash
- [ ] All 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)