### PR TITLE
chore: bump CLI to 1.2.0 and Framework to 2.2.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "2.1.0"
+version: "2.2.0"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -202,7 +202,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-2.1.0                 │
-  │ CLI       │ cli-1.1.0                │
+  │ CLI       │ cli-1.2.0                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 


### PR DESCRIPTION
## Summary

Version bump for both components after significant changes.

### CLI 1.2.0
- Dark theme (Catppuccin-inspired), rounded borders, muted semantic colors
- Navigable tags in Metadata (Enter → search)
- Tab/Shift+Tab panel cycling, arrows within panels
- Code blocks with uniform background, UTF-8 safe truncation
- Improved accessibility contrast

### Framework 2.2.0
- Formalized tags and related conventions in governance docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)