### PR TITLE
feat: enable all 12 arborist-metrics languages

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -116,11 +116,17 @@ checksum = "e47936cdcd6e58f4c016b50f0250225cfa95c89a099d3a4516dca8ac327ed87d"
 dependencies = [
  "serde",
  "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
+ "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-swift",
  "tree-sitter-typescript",
 ]
 
@@ -2498,6 +2504,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,10 +2564,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"
@@ -2548,6 +2604,16 @@ name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,7 @@ tar = "0.4"
 ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.28", optional = true }
 pulldown-cmark = { version = "0.12", optional = true }
-arborist-metrics = { version = "0.1", optional = true }
+arborist-metrics = { version = "0.1", optional = true, features = ["all"] }
 
 [features]
 default = ["tui", "analyze"]

--- a/cli/src/analysis_engine.rs
+++ b/cli/src/analysis_engine.rs
@@ -16,9 +16,10 @@ const EXCLUDED_DIRS: &[&str] = &[
     "__pycache__",
 ];
 
-/// File extensions recognized for analysis (matches arborist default features)
+/// File extensions recognized for analysis (matches arborist "all" features)
 const SOURCE_EXTENSIONS: &[&str] = &[
     "rs", "py", "js", "ts", "jsx", "tsx", "java", "go",
+    "cs", "cpp", "cc", "cxx", "c", "h", "php", "kt", "swift",
 ];
 
 /// Full analysis report

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -468,7 +468,7 @@ Analyze code complexity using cognitive and cyclomatic metrics powered by [arbor
 | `--output` | `text` | Output format: `text`, `json`, or `markdown` |
 | `--top` | — | Show only top N most complex functions |
 
-**Supported languages:** Rust, Python, JavaScript, TypeScript, Java, Go
+**Supported languages:** Rust, Python, JavaScript, TypeScript, Java, Go, C, C++, C#, PHP, Kotlin, Swift
 
 **Threshold resolution:** CLI flag → `.devtrail/config.yml` → default (8)
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -366,7 +366,7 @@ Analiza la complejidad del código fuente usando métricas cognitivas y ciclomá
 | `--output` | `text` | Formato de salida: `text`, `json` o `markdown` |
 | `--top` | — | Mostrar solo las N funciones más complejas |
 
-**Lenguajes soportados:** Rust, Python, JavaScript, TypeScript, Java, Go
+**Lenguajes soportados:** Rust, Python, JavaScript, TypeScript, Java, Go, C, C++, C#, PHP, Kotlin, Swift
 
 **Resolución de umbral:** flag CLI → `.devtrail/config.yml` → predeterminado (8)
 


### PR DESCRIPTION
## Summary
- Enable `features = ["all"]` for arborist-metrics, adding C, C++, C#, PHP, Kotlin, and Swift
- Update `SOURCE_EXTENSIONS` to include `.cs`, `.cpp`, `.cc`, `.cxx`, `.c`, `.h`, `.php`, `.kt`, `.swift`
- Update CLI-REFERENCE docs (EN+ES) with full 12-language list

## Test plan
- [x] `cargo test --all-targets` — 121 tests passing
- [x] `cargo check` — compiles with all 12 tree-sitter grammars

🤖 Generated with [Claude Code](https://claude.com/claude-code)