### PR TITLE
docs: promote arborist-metrics in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Built-in CLI tools for governance:
 - **`devtrail validate`** — 13 validation rules for document correctness
 - **`devtrail compliance`** — Regulatory compliance scoring (EU AI Act, ISO 42001, NIST AI RMF)
 - **`devtrail metrics`** — Governance KPIs, review rates, risk distribution, trends
-- **`devtrail analyze`** — Code complexity analysis (cognitive + cyclomatic) via arborist-metrics
+- **`devtrail analyze`** — Code complexity analysis (cognitive + cyclomatic) powered by [arborist-metrics](https://github.com/StrangeDaysTech/arborist), our open-source Rust library for multi-language code metrics
 - **`devtrail audit`** — Audit trail reports with timeline, traceability maps, and HTML export
 - **Pre-commit hooks** + **GitHub Actions** for CI/CD validation
 
@@ -487,7 +487,14 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 <div align="center">
 
-**[Strange Days Tech](https://strangedays.tech)** builds tools for responsible AI-assisted software development. DevTrail is one of our open-source projects.
+**[Strange Days Tech](https://strangedays.tech)** builds tools for responsible AI-assisted software development.
+
+Our open-source ecosystem:
+
+| Project | Description |
+|---------|-------------|
+| **[DevTrail](https://github.com/StrangeDaysTech/devtrail)** | AI governance platform for responsible software development |
+| **[arborist-metrics](https://github.com/StrangeDaysTech/arborist)** | Multi-language code complexity analysis library for Rust — [crates.io](https://crates.io/crates/arborist-metrics) |
 
 [Website](https://strangedays.tech) • [GitHub](https://github.com/StrangeDaysTech)
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -103,7 +103,7 @@ Herramientas CLI integradas para gobernanza:
 - **`devtrail validate`** — 13 reglas de validación para corrección documental
 - **`devtrail compliance`** — Puntuación de cumplimiento regulatorio (EU AI Act, ISO 42001, NIST AI RMF)
 - **`devtrail metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
-- **`devtrail analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) via arborist-metrics
+- **`devtrail analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) impulsado por [arborist-metrics](https://github.com/StrangeDaysTech/arborist), nuestra librería open-source en Rust para métricas de código multi-lenguaje
 - **`devtrail audit`** — Reportes de auditoría con línea temporal, mapas de trazabilidad y exportación HTML
 - **Hooks pre-commit** + **GitHub Actions** para validación CI/CD
 
@@ -497,7 +497,14 @@ Este proyecto está licenciado bajo la Licencia MIT - ver el archivo [LICENSE](.
 
 <div align="center">
 
-**[Strange Days Tech](https://strangedays.tech)** construye herramientas para desarrollo de software responsable asistido por IA. DevTrail es uno de nuestros proyectos de código abierto.
+**[Strange Days Tech](https://strangedays.tech)** construye herramientas para desarrollo de software responsable asistido por IA.
+
+Nuestro ecosistema open-source:
+
+| Proyecto | Descripción |
+|----------|-------------|
+| **[DevTrail](https://github.com/StrangeDaysTech/devtrail)** | Plataforma de gobernanza de IA para desarrollo de software responsable |
+| **[arborist-metrics](https://github.com/StrangeDaysTech/arborist)** | Librería de análisis de complejidad de código multi-lenguaje para Rust — [crates.io](https://crates.io/crates/arborist-metrics) |
 
 [Sitio Web](https://strangedays.tech) • [GitHub](https://github.com/StrangeDaysTech)
 


### PR DESCRIPTION
## Summary
- Expand `devtrail analyze` description in Features section to link to arborist-metrics GitHub repo and describe it as our open-source Rust library for multi-language code metrics
- Add "Open Source Ecosystem" table in the About section showcasing both DevTrail and arborist-metrics with links to GitHub and crates.io
- Both EN and ES READMEs updated

## Test plan
- [ ] Verify links render correctly on GitHub (arborist repo, crates.io)
- [ ] Verify table renders correctly in About section

🤖 Generated with [Claude Code](https://claude.com/claude-code)