### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -67,7 +67,7 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-version.outputs.tag }}
 
@@ -113,7 +113,7 @@ jobs:
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cli-${{ matrix.target }}
           path: ${{ env.ARCHIVE }}
@@ -123,10 +123,10 @@ jobs:
     needs: [resolve-version, build-cli]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: release-artifacts
 

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -18,7 +18,7 @@ jobs:
     name: Package Framework
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v5 → v6
- `actions/upload-artifact` v5 → v7
- `actions/download-artifact` v5 → v8

Resolves Node.js 20 deprecation warnings. Node.js 20 becomes mandatory June 2nd 2026, removed September 16th 2026.

## Test plan
- [ ] Next release build should show no Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)