### PR TITLE
ci: auto-delete previous releases on new version

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -155,3 +155,16 @@ jobs:
               --latest \
               release/*
           fi
+
+      - name: Delete previous CLI releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          CURRENT_TAG="${{ needs.resolve-version.outputs.tag }}"
+          gh release list --json tagName --jq '.[].tagName' | while read -r tag; do
+            if [[ "$tag" == cli-* && "$tag" != "$CURRENT_TAG" ]]; then
+              echo "Deleting old release $tag..."
+              gh release delete "$tag" --yes --cleanup-tag
+            fi
+          done

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -66,3 +66,15 @@ jobs:
               --generate-notes \
               "$ASSET"
           fi
+
+      - name: Delete previous framework releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_TAG="${{ steps.version.outputs.tag }}"
+          gh release list --json tagName --jq '.[].tagName' | while read -r tag; do
+            if [[ "$tag" == fw-* && "$tag" != "$CURRENT_TAG" ]]; then
+              echo "Deleting old release $tag..."
+              gh release delete "$tag" --yes --cleanup-tag
+            fi
+          done


### PR DESCRIPTION
## Summary
- Both workflows now auto-delete older releases of the same component after creating the new one
- Uses `gh release delete --cleanup-tag` to also remove stale tags
- Only deletes releases matching the same prefix (`fw-*` or `cli-*`), never cross-component

## Test plan
- [ ] Next release should show "Deleting old release..." in CI logs
- [ ] Only latest release per component should remain on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)