### PR TITLE
chore: bump CLI to 3.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ DevTrail uses **independent versions** for framework and CLI:
 | Component | Tag format | Current | Example |
 |-----------|-----------|---------|---------|
 | Framework | `fw-X.Y.Z` | fw-4.1.0 | `fw-4.1.0` |
-| CLI | `cli-X.Y.Z` | cli-3.0.0 | `cli-3.0.0` |
+| CLI | `cli-X.Y.Z` | cli-3.0.1 | `cli-3.0.1` |
 
 Follow [semver](https://semver.org/):
 - **Major**: breaking changes

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.1.0` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.0.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.0.1` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.1.0` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.0.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.0.1` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.1.0
 Updating CLI...
-✔ CLI updated to cli-3.0.0
+✔ CLI updated to cli-3.0.1
 ```
 
 ---
@@ -138,7 +138,7 @@ Auto-update the `devtrail` binary itself. Looks for the latest `cli-*` release o
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.0.0
+✔ CLI updated to cli-3.0.1
 ```
 
 ---
@@ -201,7 +201,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.1.0                 │
-  │ CLI       │ cli-3.0.0                │
+  │ CLI       │ cli-3.0.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -625,7 +625,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.0.0
+  CLI version:       cli-3.0.1
   Framework version: fw-4.1.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -147,7 +147,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.1.0` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.0.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.0.1` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.1.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.0.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.0.1` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.1.0
 Updating CLI...
-✔ CLI updated to cli-3.0.0
+✔ CLI updated to cli-3.0.1
 ```
 
 ---
@@ -137,7 +137,7 @@ Auto-actualiza el binario `devtrail`. Busca el último release `cli-*` en GitHub
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.0.0
+✔ CLI updated to cli-3.0.1
 ```
 
 ---
@@ -195,7 +195,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.1.0
-CLI version:       cli-3.0.0
+CLI version:       cli-3.0.1
 Language:          en
 Structure:         ✔ Complete
 
@@ -504,7 +504,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.0.0
+  CLI version:       cli-3.0.1
   Framework version: fw-4.1.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary
- Bump CLI 3.0.0 → 3.0.1 for reduced false positives in validate (REF-001 + SEC-001)
- Updated version references in 7 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)