### PR TITLE
chore: bump Framework version to 4.1.1

### DIFF
--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g., fw-4.1.0)'
+        description: 'Release tag (e.g., fw-4.1.1)'
         required: true
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.1.1 — Status Skill Complexity Fix
+
+### Fixed (Framework)
+- **devtrail-status skill**: Replace outdated ">10 lines of changes" heuristic with `devtrail analyze --output json` (cognitive complexity, threshold 8) as the primary method for AILOG triggers, with >20 lines fallback when CLI is unavailable
+- Updated across all 3 platform variants: Claude Code, Gemini, and generic agent workflow
+
+---
+
 ## CLI 3.0.1 — Validate False Positive Fix
 
 ### Fixed (CLI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ DevTrail uses **independent versions** for framework and CLI:
 
 | Component | Tag format | Current | Example |
 |-----------|-----------|---------|---------|
-| Framework | `fw-X.Y.Z` | fw-4.1.0 | `fw-4.1.0` |
+| Framework | `fw-X.Y.Z` | fw-4.1.1 | `fw-4.1.1` |
 | CLI | `cli-X.Y.Z` | cli-3.0.1 | `cli-3.0.1` |
 
 Follow [semver](https://semver.org/):

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ DevTrail uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.1.0` | Templates (12 types), governance, directives |
+| Framework | `fw-` | `fw-4.1.1` | Templates (12 types), governance, directives |
 | CLI | `cli-` | `cli-3.0.1` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
@@ -177,7 +177,7 @@ See [CLI Reference](docs/adopters/CLI-REFERENCE.md) for detailed usage.
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/devtrail/releases
-# and download the latest fw-* release (e.g., fw-4.1.0)
+# and download the latest fw-* release (e.g., fw-4.1.1)
 
 # Extract and copy to your project
 unzip devtrail-fw-*.zip -d your-project/

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -268,4 +268,4 @@ When a change modifies API endpoints:
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
@@ -247,4 +247,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -270,4 +270,4 @@ Cuando un cambio modifica endpoints de API:
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -249,4 +249,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*DevTrail v4.1.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/QUICK-REFERENCE.md
+++ b/dist/.devtrail/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.1.0 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.1.1 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.1.0"
+version: "4.1.1"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -213,7 +213,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.1.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.1.1`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ DevTrail uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.1.0` | Templates (12 types), governance docs, directives |
+| Framework | `fw-` | `fw-4.1.1` | Templates (12 types), governance docs, directives |
 | CLI | `cli-` | `cli-3.0.1` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -86,7 +86,7 @@ Initialize DevTrail in a project directory.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.1.0
+✔ Downloaded DevTrail fw-4.1.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +108,7 @@ If `.devtrail/` does not exist in the current directory, the framework update is
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.1.0
+✔ Framework updated to fw-4.1.1
 Updating CLI...
 ✔ CLI updated to cli-3.0.1
 ```
@@ -125,7 +125,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.1.0
+✔ Framework updated to fw-4.1.1
 ```
 
 ---
@@ -200,7 +200,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.1.0                 │
+  │ Framework │ fw-4.1.1                 │
   │ CLI       │ cli-3.0.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -257,7 +257,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.1.0
+  Using version: fw-4.1.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -626,7 +626,7 @@ Show version, authorship, and license information.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.0.1
-  Framework version: fw-4.1.0
+  Framework version: fw-4.1.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -146,7 +146,7 @@ DevTrail usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.1.0` | Plantillas (12 tipos), gobernanza, directivas |
+| Framework | `fw-` | `fw-4.1.1` | Plantillas (12 tipos), gobernanza, directivas |
 | CLI | `cli-` | `cli-3.0.1` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
@@ -177,7 +177,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/devtrail/releases
-# y descarga el último release fw-* (ej. fw-4.1.0)
+# y descarga el último release fw-* (ej. fw-4.1.1)
 
 # Extraer y copiar a tu proyecto
 unzip devtrail-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -204,7 +204,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.1.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.1.1`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.1.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.1.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.0.1` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -86,7 +86,7 @@ Inicializa DevTrail en un directorio de proyecto.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.1.0
+✔ Downloaded DevTrail fw-4.1.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -107,7 +107,7 @@ Si `.devtrail/` no existe en el directorio actual, la actualización del framewo
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.1.0
+✔ Framework updated to fw-4.1.1
 Updating CLI...
 ✔ CLI updated to cli-3.0.1
 ```
@@ -124,7 +124,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.1.0
+✔ Framework updated to fw-4.1.1
 ```
 
 ---
@@ -194,7 +194,7 @@ $ devtrail status
 DevTrail Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.1.0
+Framework version: fw-4.1.1
 CLI version:       cli-3.0.1
 Language:          en
 Structure:         ✔ Complete
@@ -505,7 +505,7 @@ Muestra información de versión, autoría y licencia.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.0.1
-  Framework version: fw-4.1.0
+  Framework version: fw-4.1.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail


### PR DESCRIPTION
## Summary

- Bump Framework version from 4.1.0 to 4.1.1 across 19 files (manifest, docs EN+ES, governance footers, workflow)
- Add CHANGELOG entry: "Framework 4.1.1 — Status Skill Complexity Fix"
- Follows merge of #42 which fixed the devtrail-status skill to use `devtrail analyze` instead of the outdated line-count heuristic

## Test plan

- [ ] Verify `dist/dist-manifest.yml` shows `version: "4.1.1"`
- [ ] Verify no remaining references to `4.1.0` outside of CHANGELOG.md historical entries
- [ ] After merge: tag `fw-4.1.1` and push to trigger `release-framework.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)