### PR TITLE
chore: bump CLI version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.1.0 — crates.io Distribution & Smart Self-Update
+
+### Added (CLI)
+- **crates.io distribution**: `cargo install devtrail-cli` now available as an installation method
+- **Install method detection**: `devtrail update-cli` auto-detects whether the CLI was installed via cargo or prebuilt binary and uses the appropriate update mechanism
+- **`--method` flag**: Override auto-detection on `update-cli` and `update` commands (`auto`, `github`, `cargo`)
+- **`devtrail about`**: Now displays the detected installation method
+- **CI**: `release-cli.yml` workflow publishes to crates.io after GitHub Release upload
+
+### Changed (CLI)
+- `Cargo.toml`: Added `include` field for crate packaging, removed `readme` path (outside crate boundary)
+
+---
+
 ## Framework 4.1.1 — Status Skill Complexity Fix
 
 ### Fixed (Framework)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ DevTrail uses **independent versions** for framework and CLI:
 | Component | Tag format | Current | Example |
 |-----------|-----------|---------|---------|
 | Framework | `fw-X.Y.Z` | fw-4.1.1 | `fw-4.1.1` |
-| CLI | `cli-X.Y.Z` | cli-3.0.1 | `cli-3.0.1` |
+| CLI | `cli-X.Y.Z` | cli-3.1.0 | `cli-3.1.0` |
 
 Follow [semver](https://semver.org/):
 - **Major**: breaking changes

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.1.1` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.0.1` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.1.0` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.1.1` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.0.1` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.1.0` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.1.1
 Updating CLI...
-✔ CLI updated to cli-3.0.1
+✔ CLI updated to cli-3.1.0
 ```
 
 ---
@@ -132,13 +132,22 @@ $ devtrail update-framework
 
 ### `devtrail update-cli`
 
-Auto-update the `devtrail` binary itself. Looks for the latest `cli-*` release on GitHub and replaces the current binary.
+Auto-update the `devtrail` binary itself. Automatically detects the installation method and uses the appropriate update mechanism:
+
+- **Prebuilt binary** (installed via `install.sh` / `install.ps1`): Downloads the latest binary from GitHub Releases
+- **Cargo** (installed via `cargo install`): Runs `cargo install --force devtrail-cli`
+
+Use `--method` to override auto-detection: `--method=github` or `--method=cargo`.
 
 **Example:**
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.0.1
+✔ CLI updated to cli-3.1.0
+
+$ devtrail update-cli --method=cargo
+Compiling from source, this may take a few minutes...
+✔ CLI updated to cli-3.1.0
 ```
 
 ---
@@ -201,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.1.1                 │
-  │ CLI       │ cli-3.0.1                │
+  │ CLI       │ cli-3.1.0                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -625,7 +634,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.0.1
+  CLI version:       cli-3.1.0
   Framework version: fw-4.1.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -150,7 +150,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.1.1` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.0.1` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.1.0` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.1.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.0.1` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.1.0` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.1.1
 Updating CLI...
-✔ CLI updated to cli-3.0.1
+✔ CLI updated to cli-3.1.0
 ```
 
 ---
@@ -131,13 +131,22 @@ $ devtrail update-framework
 
 ### `devtrail update-cli`
 
-Auto-actualiza el binario `devtrail`. Busca el último release `cli-*` en GitHub y reemplaza el binario actual.
+Auto-actualiza el binario `devtrail`. Detecta automáticamente el método de instalación y usa el mecanismo de actualización apropiado:
+
+- **Binario precompilado** (instalado via `install.sh` / `install.ps1`): Descarga el último binario de GitHub Releases
+- **Cargo** (instalado via `cargo install`): Ejecuta `cargo install --force devtrail-cli`
+
+Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 **Ejemplo:**
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.0.1
+✔ CLI updated to cli-3.1.0
+
+$ devtrail update-cli --method=cargo
+Compiling from source, this may take a few minutes...
+✔ CLI updated to cli-3.1.0
 ```
 
 ---
@@ -195,7 +204,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.1.1
-CLI version:       cli-3.0.1
+CLI version:       cli-3.1.0
 Language:          en
 Structure:         ✔ Complete
 
@@ -504,7 +513,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.0.1
+  CLI version:       cli-3.1.0
   Framework version: fw-4.1.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary
- Bump CLI version from 3.0.1 to 3.1.0
- Update version references across all docs (EN + ES)
- Add CHANGELOG entry for CLI 3.1.0 (crates.io distribution, smart self-update, `--method` flag)
- Update `update-cli` documentation to reflect new install method detection and `--method` flag

## Test plan
- [x] `cargo check` passes with new version
- [ ] After merge: create `cli-3.1.0` tag to trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)