### PR TITLE
chore: bump CLI version to 3.1.1

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -181,7 +181,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Copy README into crate directory
+        run: cp README.md cli/README.md
+
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish --manifest-path cli/Cargo.toml
+        run: cargo publish --manifest-path cli/Cargo.toml --allow-dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.1.1 — crates.io README Fix
+
+### Fixed (CLI)
+- Include project README in crates.io package (copy from repo root during CI publish)
+- Restore `readme` field in `Cargo.toml` pointing to local copy
+
+---
+
 ## CLI 3.1.0 — crates.io Distribution & Smart Self-Update
 
 ### Added (CLI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ DevTrail uses **independent versions** for framework and CLI:
 | Component | Tag format | Current | Example |
 |-----------|-----------|---------|---------|
 | Framework | `fw-X.Y.Z` | fw-4.1.1 | `fw-4.1.1` |
-| CLI | `cli-X.Y.Z` | cli-3.1.0 | `cli-3.1.0` |
+| CLI | `cli-X.Y.Z` | cli-3.1.1 | `cli-3.1.1` |
 
 Follow [semver](https://semver.org/):
 - **Major**: breaking changes

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.1.1` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.1.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.1.1` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "devtrail-cli"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"
 repository = "https://github.com/StrangeDaysTech/devtrail"
 homepage = "https://strangedays.tech"
+readme = "README.md"
 keywords = ["devtrail", "documentation", "governance", "ai", "cli"]
 categories = ["command-line-utilities", "development-tools"]
 authors = ["Strange Days Tech, S.A.S."]
-include = ["src/**/*", "Cargo.toml", "Cargo.lock"]
+include = ["src/**/*", "Cargo.toml", "Cargo.lock", "README.md"]
 
 [[bin]]
 name = "devtrail"

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.1.1` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.1.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.1.1` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.1.1
 Updating CLI...
-✔ CLI updated to cli-3.1.0
+✔ CLI updated to cli-3.1.1
 ```
 
 ---
@@ -143,11 +143,11 @@ Use `--method` to override auto-detection: `--method=github` or `--method=cargo`
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.1.0
+✔ CLI updated to cli-3.1.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.1.0
+✔ CLI updated to cli-3.1.1
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.1.1                 │
-  │ CLI       │ cli-3.1.0                │
+  │ CLI       │ cli-3.1.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -634,7 +634,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.1.0
+  CLI version:       cli-3.1.1
   Framework version: fw-4.1.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -150,7 +150,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.1.1` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.1.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.1.1` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.1.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.1.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.1.1` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.1.1
 Updating CLI...
-✔ CLI updated to cli-3.1.0
+✔ CLI updated to cli-3.1.1
 ```
 
 ---
@@ -142,11 +142,11 @@ Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.1.0
+✔ CLI updated to cli-3.1.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.1.0
+✔ CLI updated to cli-3.1.1
 ```
 
 ---
@@ -204,7 +204,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.1.1
-CLI version:       cli-3.1.0
+CLI version:       cli-3.1.1
 Language:          en
 Structure:         ✔ Complete
 
@@ -513,7 +513,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.1.0
+  CLI version:       cli-3.1.1
   Framework version: fw-4.1.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary
- Fix missing README on crates.io: copy repo README into `cli/` during CI publish
- Restore `readme = "README.md"` in Cargo.toml, add to `include` list
- Add `--allow-dirty` to `cargo publish` (needed since README is copied at build time)

## Test plan
- [ ] After merge + tag: verify README appears on https://crates.io/crates/devtrail-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)