### PR TITLE
fix: use absolute URLs for language links in crates.io README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [Documentation](#documentation) •
 [Contributing](#contributing)
 
-**Languages**: English | [Español](docs/i18n/es/README.md) | [简体中文](docs/i18n/zh-CN/README.md)
+**Languages**: English | [Español](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/i18n/es/README.md) | [简体中文](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/i18n/zh-CN/README.md)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Fix broken Español and 简体中文 language links on crates.io
- Convert relative paths to absolute GitHub URLs so they resolve correctly on both GitHub and crates.io

## Root cause

crates.io cannot resolve repo-relative paths like `docs/i18n/es/README.md`. Absolute URLs work everywhere.

## Test plan

- [x] Links verified on GitHub: both point to existing files on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)