### PR TITLE
chore: bump CLI version to 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.2.1 — crates.io README Language Links Fix
+
+### Fixed (CLI)
+- Use absolute GitHub URLs for Español and 简体中文 language links in README so they resolve correctly on crates.io
+
+---
+
 ## Framework 4.2.0 / CLI 3.2.0 — Simplified Chinese (zh-CN) Localization
 
 ### Added (Framework)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ DevTrail uses **independent versions** for framework and CLI:
 | Component | Tag format | Current | Example |
 |-----------|-----------|---------|---------|
 | Framework | `fw-X.Y.Z` | fw-4.2.0 | `fw-4.2.0` |
-| CLI | `cli-X.Y.Z` | cli-3.2.0 | `cli-3.2.0` |
+| CLI | `cli-X.Y.Z` | cli-3.2.1 | `cli-3.2.1` |
 
 Follow [semver](https://semver.org/):
 - **Major**: breaking changes

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.2.0` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.2.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.2.1` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.2.0` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.2.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.2.1` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.2.0
 Updating CLI...
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 ```
 
 ---
@@ -143,11 +143,11 @@ Use `--method` to override auto-detection: `--method=github` or `--method=cargo`
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.2.0                 │
-  │ CLI       │ cli-3.2.0                │
+  │ CLI       │ cli-3.2.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -634,7 +634,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.2.0
+  CLI version:       cli-3.2.1
   Framework version: fw-4.2.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -150,7 +150,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.2.0` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.2.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.2.1` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.2.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.2.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.2.1` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.2.0
 Updating CLI...
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 ```
 
 ---
@@ -142,11 +142,11 @@ Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 ```
 
 ---
@@ -204,7 +204,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.2.0
-CLI version:       cli-3.2.0
+CLI version:       cli-3.2.1
 Language:          en
 Structure:         ✔ Complete
 
@@ -513,7 +513,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.2.0
+  CLI version:       cli-3.2.1
   Framework version: fw-4.2.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -150,7 +150,7 @@ DevTrail 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.2.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.2.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.2.1` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.2.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.2.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.2.1` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.2.0
 Updating CLI...
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 ```
 
 ---
@@ -143,11 +143,11 @@ $ devtrail update-framework
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.2.0
+✔ CLI updated to cli-3.2.1
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.2.0                 │
-  │ CLI       │ cli-3.2.0                │
+  │ CLI       │ cli-3.2.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -634,7 +634,7 @@ $ devtrail explore
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.2.0
+  CLI version:       cli-3.2.1
   Framework version: fw-4.2.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary

- Patch release to republish crate with fixed language links in README
- CLI 3.2.0 was published with relative paths that break on crates.io
- PR #49 fixed the README, this bump triggers a new crates.io publish

## Test plan

- [x] `cargo check` passes
- [x] Language URLs are now absolute GitHub links

🤖 Generated with [Claude Code](https://claude.com/claude-code)