### PR TITLE
docs(adopters): document China regulatory coverage

### DIFF
--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -145,6 +145,19 @@ DevTrail aligns with and supports compliance for:
 | **ISO/IEC 23894:2023** | AI risk management aligned with ETH and AI-RISK-CATALOG (Fase 3) |
 | **GDPR** | ETH documents with GDPR Legal Basis section, DPIA for privacy impact assessments |
 
+### China Regulatory Coverage *(opt-in via `regional_scope: china`)*
+
+| Standard | How DevTrail Helps |
+|----------|-------------------|
+| **TC260 AI Safety Governance Framework v2.0** | Five-level risk grading (TC260RA), `tc260_*` fields on ETH/MCARD/AILOG/SEC |
+| **PIPL — Personal Information Protection Law** | PIPIA template with PIPL Art. 55-56 sections, `pipl_*` fields, retention ≥ 3 years (`TYPE-003`) |
+| **GB 45438-2025** *(mandatory)* | AILABEL template covering explicit + implicit labeling for generative content |
+| **CAC Algorithm Filing** | CACFILE template with single + dual filing tracking; cross-checks from MCARD via `cac_filing_required` |
+| **GB/T 45652-2025** | Training-data security section in SBOM and MCARD; `gb45652_training_data_compliance` field |
+| **CSL 2026** | INC extension with `csl_severity_level`, deadline-coherence rules (1h / 4h+72h+30d windows) |
+
+> Activate by adding `china` to `regional_scope` in `.devtrail/config.yml`. See the *Configuration* section below and the installed `CHINA-REGULATORY-FRAMEWORK.md` guide for details.
+
 ### Architecture Documentation
 
 | Standard | How DevTrail Helps |
@@ -353,6 +366,28 @@ The CLI automatically:
 ---
 
 ## Configuration
+
+### Regional Regulatory Scope
+
+`.devtrail/config.yml` controls which compliance frameworks are evaluated by `devtrail compliance` and which document types are exposed by `devtrail new`:
+
+```yaml
+regional_scope:
+  - global   # NIST AI RMF + ISO/IEC 42001 (always recommended)
+  - eu       # EU AI Act + GDPR
+  - china    # TC260 v2.0, PIPL/PIPIA, GB 45438, CAC, GB/T 45652, CSL 2026
+```
+
+**Default if omitted**: `[global, eu]` — preserves the behavior of every DevTrail version prior to `fw-4.3.0`.
+
+When you add `china` to the list:
+
+- Four China-specific document types become available via `devtrail new`: `PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`.
+- Six new compliance checkers run with `devtrail compliance` (or via `--region china` / `--standard china-*`).
+- Twelve scope-aware validation rules activate (`CROSS-004` to `CROSS-011`, `TYPE-003` to `TYPE-006`).
+- Five new governance guides are referenced from `.devtrail/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, plus per-framework guides for TC260, PIPL/PIPIA, CAC filing, and GB 45438 labeling) — all available in EN, ES, and zh-CN.
+
+A project without `china` in `regional_scope` is unaffected: no new files, no new prompts, no new rules. Adding `china` later is fully reversible.
 
 ### Customizing Agent Identifiers
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -296,6 +296,8 @@ Validate DevTrail documents for compliance and correctness.
 - Sensitive information detection (API keys, passwords)
 - Related document existence
 
+When `regional_scope` includes `china`, twelve additional rules activate (`CROSS-004` to `CROSS-011`, `TYPE-003` to `TYPE-006`) covering TC260 review escalation, PIPIA linkage from sensitive-data documents, CACFILE / AILABEL cross-references, CSL severity-to-deadline coherence, and PIPIA 3-year retention. Without `china` in scope, these rules are skipped — no false positives.
+
 **Example:**
 
 ```bash
@@ -321,10 +323,10 @@ Create a new DevTrail document from a template.
 | Argument/Flag | Default | Description |
 |---------------|---------|-------------|
 | `path` | `.` (current directory) | Target project directory |
-| `--doc-type`, `-t` | — | Document type: `ailog`, `aidec`, `adr`, `eth`, `req`, `tes`, `inc`, `tde`, `sec`, `mcard`, `sbom`, `dpia` |
+| `--doc-type`, `-t` | — | Document type. Core (12): `ailog`, `aidec`, `adr`, `eth`, `req`, `tes`, `inc`, `tde`, `sec`, `mcard`, `sbom`, `dpia`. China (4, opt-in): `pipia`, `cacfile`, `tc260ra`, `ailabel`. |
 | `--title` | — | Title for the new document |
 
-If `--doc-type` or `--title` are omitted, the command prompts interactively.
+If `--doc-type` or `--title` are omitted, the command prompts interactively. China-only types are filtered out of the prompt (and rejected from `-t`) when `regional_scope` does not include `china`.
 
 **Examples:**
 
@@ -353,31 +355,44 @@ $ devtrail new -t ailog --title "Implement JWT authentication"
 
 ---
 
-### `devtrail compliance [path] [--standard <name>] [--all] [--output <format>]`
+### `devtrail compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
 
-Check regulatory compliance against EU AI Act, ISO/IEC 42001, and NIST AI RMF.
+Check regulatory compliance. By default, evaluates the standards whose region is in `regional_scope` from `.devtrail/config.yml` (default `[global, eu]`). Six Chinese frameworks are available opt-in when `china` is added to `regional_scope`.
 
 **Arguments and flags:**
 
 | Argument/Flag | Default | Description |
 |---------------|---------|-------------|
 | `path` | `.` (current directory) | Target project directory |
-| `--standard` | — | Check a specific standard: `eu-ai-act`, `iso-42001`, or `nist-ai-rmf` |
-| `--all` | — | Check all three standards |
+| `--standard` | — | Check a specific standard: `eu-ai-act`, `iso-42001`, `nist-ai-rmf`, `china-tc260`, `china-pipl`, `china-gb45438`, `china-cac`, `china-gb45652`, `china-csl` |
+| `--region` | — | Run all standards in a region: `global`, `eu`, `china`, or `all` |
+| `--all` | — | Check every standard, regardless of `regional_scope` |
 | `--output` | `text` | Output format: `text`, `markdown`, or `json` |
 
-If neither `--standard` nor `--all` is specified, defaults to `--all`.
+Precedence: `--standard` > `--all` > `--region` > the project's `regional_scope`.
 
 **What it checks:**
+
+Global / EU (always available):
 
 - **EU AI Act**: Risk classification, ethical review linkage, DPIA existence, incident reporting
 - **ISO/IEC 42001**: Governance policy, risk planning (ETH), operations documentation (AILOG/AIDEC), Annex A coverage
 - **NIST AI RMF**: MAP (AILOG), MEASURE (TES), MANAGE (ETH/INC), GOVERN (policy + ADR), GenAI risk coverage (12 NIST 600-1 categories)
 
-**Example:**
+China (opt-in via `regional_scope: china`):
+
+- **TC260 v2.0**: TC260RA exists; high/very-high/extremely-severe levels require review; the three grading criteria (scenario × intelligence × scale) are populated
+- **PIPL**: PIPIA exists when `pipl_applicable`; cross-border transfer documented; retention ≥ 3 years per Art. 56
+- **GB 45438**: AILABEL exists for generative content; both explicit and implicit labeling tracks declared; mandatory metadata fields populated
+- **CAC Algorithm Filing**: CACFILE exists when required; explicit `cac_filing_status`; `cac_filing_number` populated when status is `*_approved`
+- **GB/T 45652**: SBOM and MCARD declare training-data security compliance
+- **CSL 2026**: Every INC has `csl_severity_level`; deadline hours coherent with severity (1h ↔ particularly_serious, 4h ↔ relatively_major); 30-day post-mortem documented for major+ incidents
+
+**Examples:**
 
 ```bash
-$ devtrail compliance --all
+# Default: runs only standards whose region is in regional_scope
+$ devtrail compliance
   DevTrail Compliance
   /home/user/my-project
   12 document(s) analyzed
@@ -395,17 +410,46 @@ $ devtrail compliance --all
     ✓ [ISO-004] Annex A control coverage (6/6 groups)
 
   ■ NIST AI RMF 60%
-    ✓ [NIST-MAP-001] MAP function — AI actions documented (AILOG)
-    ✓ [NIST-MEASURE-001] MEASURE function — Test plans exist (TES)
-    ✓ [NIST-MANAGE-001] MANAGE function — Risk management documented (ETH + INC)
-    ✓ [NIST-GOVERN-001] GOVERN function — Governance policy and decisions documented
     ~ [NIST-GENAI-001] GenAI risk coverage — NIST AI 600-1 (4/12 categories)
 
   Overall compliance: 78%
 
-$ devtrail compliance --standard eu-ai-act --output json
-[{"standard":"EuAiAct","checks":[...],"score":75.0}]
+# Run only the six Chinese frameworks (requires regional_scope: china)
+$ devtrail compliance --region china
+  ■ China TC260 v2.0 67%
+    ✓ [TC260-001] At least one TC260 Risk Assessment (TC260RA) is present
+    ~ [TC260-002] High / very-high / extremely-severe TC260 levels mandate review
+    ✗ [TC260-003] TC260RA documents specify scenario × intelligence × scale
+
+  ■ China PIPL 100%
+    ✓ [PIPL-001] PIPIA exists when pipl_applicable is true
+    ✓ [PIPL-002] Documents handling sensitive personal info link to a PIPIA
+    ✓ [PIPL-003] Cross-border personal info transfer is documented in a PIPIA
+    ✓ [PIPL-004] PIPIA retention is ≥ 3 years per PIPL Art. 56
+
+  ■ China GB 45438 ...
+  ■ China CAC Algorithm Filing ...
+  ■ China GB/T 45652 ...
+  ■ China CSL 2026 ...
+
+# A single Chinese framework
+$ devtrail compliance --standard china-pipl --output json
+[{"standard":"ChinaPipl","standard_label":"China PIPL","checks":[...],"score":100.0}]
+
+# Force every standard, ignoring regional_scope
+$ devtrail compliance --all
 ```
+
+> **Activation note**: Chinese frameworks evaluate only when you opt in. Add to `.devtrail/config.yml`:
+>
+> ```yaml
+> regional_scope:
+>   - global
+>   - eu
+>   - china
+> ```
+>
+> Use `--standard china-*` or `--region china` to run them ad-hoc even when not in scope. See the `CHINA-REGULATORY-FRAMEWORK.md` guide installed under `.devtrail/00-governance/`.
 
 ---
 

--- a/docs/adopters/WORKFLOWS.md
+++ b/docs/adopters/WORKFLOWS.md
@@ -157,6 +157,67 @@ When multiple team members use AI assistants on the same project:
 
 ---
 
+## China Regulatory Workflow *(opt-in)*
+
+If your project operates in mainland China or processes personal information of mainland China users, enable the China scope and follow this workflow.
+
+### One-time Setup
+
+1. Edit `.devtrail/config.yml` and add `china` to `regional_scope`:
+   ```yaml
+   regional_scope:
+     - global
+     - eu      # if also EU-subject
+     - china
+   ```
+2. Run `devtrail compliance --region china` to see the baseline (all checks will fail until you create the supporting documents).
+3. Read the guides installed under `.devtrail/00-governance/`:
+   - `CHINA-REGULATORY-FRAMEWORK.md` — overview and coverage matrix
+   - `TC260-IMPLEMENTATION-GUIDE.md` — five-level risk grading
+   - `PIPL-PIPIA-GUIDE.md` — when a PIPIA is required and what it must contain
+   - `CAC-FILING-GUIDE.md` — single vs dual filing, status lifecycle
+   - `GB-45438-LABELING-GUIDE.md` — explicit + implicit labeling design
+
+### When You Add a Generative AI Model
+
+Bundle of documents to create together (cross-linked via `related:`):
+
+| Document | Purpose | Required when |
+|----------|---------|---------------|
+| `MCARD` | Model card with `cac_filing_required`, `gb45438_applicable`, `tc260_risk_level` | Always for in-scope models |
+| `TC260RA` | Risk grading (scenario × intelligence × scale → 5 levels) | Always |
+| `AILABEL` | Explicit + implicit labeling per GB 45438 | When the model generates content |
+| `CACFILE` | Algorithm filing record | When `cac_filing_required: true` |
+| `PIPIA` | Personal-info impact assessment (Art. 55-56) | When personal info is processed |
+| `SBOM` | Training-data inventory + GB/T 45652 compliance | Always |
+
+`devtrail compliance --region china` confirms the bundle is complete.
+
+### When an Incident Occurs
+
+The `INC` template includes a *CSL 2026 Incident Reporting* section. Set:
+
+```yaml
+csl_severity_level: relatively_major   # or particularly_serious | major | general
+csl_report_deadline_hours: 4           # 1 for particularly_serious, 4 for relatively_major
+```
+
+`devtrail validate` enforces severity-to-deadline coherence (`CROSS-008`, `CROSS-009`). Major+ incidents must be closed (status `accepted`) within 30 days for the `CSL-003` check to pass.
+
+### Cross-Border Data Transfer
+
+When a process involves transferring personal information out of mainland China, set `pipl_cross_border_transfer: true` on the PIPIA and document the chosen mechanism (CAC security assessment / certification / standard contract) in the *Cross-Border Transfer Analysis* section. `CROSS-011` will warn if none is documented.
+
+### Daily Compliance Check
+
+```bash
+# Before merging a feature branch that touches AI services
+devtrail validate                    # cross-rules including CROSS-004..011
+devtrail compliance --region china   # per-framework score
+```
+
+---
+
 ## Understanding Versions
 
 DevTrail uses **independent versioning** for its two components:

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -159,6 +159,19 @@ DevTrail se alinea con y soporta cumplimiento para:
 | **NIST AI RMF** | Documentación de riesgos en registros de decisión |
 | **IEEE 7000** | Consideraciones éticas en documentos ETH |
 
+### Cobertura Regulatoria China *(opt-in vía `regional_scope: china`)*
+
+| Estándar | Cómo Ayuda DevTrail |
+|----------|---------------------|
+| **TC260 AI Safety Governance Framework v2.0** | Clasificación de riesgo en 5 niveles (TC260RA), campos `tc260_*` en ETH/MCARD/AILOG/SEC |
+| **PIPL — Personal Information Protection Law** | Plantilla PIPIA con secciones del Art. 55-56, campos `pipl_*`, retención ≥ 3 años (`TYPE-003`) |
+| **GB 45438-2025** *(obligatorio)* | Plantilla AILABEL cubriendo etiquetado explícito + implícito para contenido generativo |
+| **CAC Algorithm Filing** | Plantilla CACFILE con seguimiento de registro simple + dual; cross-checks desde MCARD vía `cac_filing_required` |
+| **GB/T 45652-2025** | Sección de seguridad de datos de entrenamiento en SBOM y MCARD; campo `gb45652_training_data_compliance` |
+| **CSL 2026** | Extensión de INC con `csl_severity_level`, reglas de coherencia de plazos (ventanas 1h / 4h+72h+30d) |
+
+> Activar añadiendo `china` a `regional_scope` en `.devtrail/config.yml`. Ver la sección *Configuración* abajo y la guía instalada `CHINA-REGULATORY-FRAMEWORK.md` para detalles.
+
 ---
 
 ## Ruta de Adopción A: Proyectos Nuevos
@@ -345,6 +358,28 @@ El CLI automáticamente:
 ---
 
 ## Configuración
+
+### Alcance Regulatorio Regional
+
+`.devtrail/config.yml` controla qué frameworks de cumplimiento evalúa `devtrail compliance` y qué tipos de documento expone `devtrail new`:
+
+```yaml
+regional_scope:
+  - global   # NIST AI RMF + ISO/IEC 42001 (siempre recomendado)
+  - eu       # EU AI Act + GDPR
+  - china    # TC260 v2.0, PIPL/PIPIA, GB 45438, CAC, GB/T 45652, CSL 2026
+```
+
+**Default si se omite**: `[global, eu]` — preserva el comportamiento de toda versión de DevTrail anterior a `fw-4.3.0`.
+
+Cuando añades `china` a la lista:
+
+- Cuatro tipos de documento específicos de China están disponibles vía `devtrail new`: `PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`.
+- Seis nuevos checkers de cumplimiento se ejecutan con `devtrail compliance` (o vía `--region china` / `--standard china-*`).
+- Doce reglas de validación scope-aware se activan (`CROSS-004` a `CROSS-011`, `TYPE-003` a `TYPE-006`).
+- Cinco nuevas guías de gobernanza referenciadas desde `.devtrail/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, más guías por framework para TC260, PIPL/PIPIA, registro CAC, y etiquetado GB 45438) — todas disponibles en EN, ES y zh-CN.
+
+Un proyecto sin `china` en `regional_scope` no se ve afectado: ningún archivo nuevo, ningún prompt nuevo, ninguna regla nueva. Añadir `china` después es totalmente reversible.
 
 ### Personalizar Identificadores de Agente
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -278,6 +278,8 @@ Valida documentos DevTrail verificando cumplimiento y corrección.
 - `SEC-001`: No contiene información sensible
 - `OBS-001`: Tag observabilidad requiere sección de alcance
 
+Cuando `regional_scope` incluye `china`, se activan doce reglas adicionales (`CROSS-004` a `CROSS-011`, `TYPE-003` a `TYPE-006`) que cubren escalado de revisión TC260, vínculo PIPIA desde documentos con datos sensibles, cross-references de CACFILE / AILABEL, coherencia severidad-deadline CSL, y retención de 3 años de PIPIA. Sin `china` en scope, estas reglas se omiten — sin falsos positivos.
+
 **Código de salida:** 0 si no hay errores (warnings OK), 1 si hay errores.
 
 ---
@@ -291,10 +293,10 @@ Crea un nuevo documento DevTrail a partir de una plantilla.
 | Argumento/Flag | Default | Descripción |
 |----------------|---------|-------------|
 | `path` | `.` (directorio actual) | Directorio del proyecto |
-| `--doc-type`, `-t` | — | Tipo de documento: `ailog`, `aidec`, `adr`, `eth`, `req`, `tes`, `inc`, `tde`, `sec`, `mcard`, `sbom`, `dpia` |
+| `--doc-type`, `-t` | — | Tipo de documento. Core (12): `ailog`, `aidec`, `adr`, `eth`, `req`, `tes`, `inc`, `tde`, `sec`, `mcard`, `sbom`, `dpia`. China (4, opt-in): `pipia`, `cacfile`, `tc260ra`, `ailabel`. |
 | `--title` | — | Título del documento |
 
-Si no se especifica `--doc-type` o `--title`, se solicitan de forma interactiva.
+Si no se especifica `--doc-type` o `--title`, se solicitan de forma interactiva. Los tipos chinos se filtran del prompt (y se rechazan en `-t`) cuando `regional_scope` no incluye `china`.
 
 **Ejemplos:**
 
@@ -323,20 +325,55 @@ $ devtrail new -t ailog --title "Refactorizar módulo de pagos"
 
 ---
 
-### `devtrail compliance [path] [--standard <nombre>] [--all] [--output <formato>]`
+### `devtrail compliance [path] [--standard <nombre>] [--region <nombre>] [--all] [--output <formato>]`
 
-Verifica cumplimiento regulatorio contra EU AI Act, ISO/IEC 42001 y NIST AI RMF.
+Verifica cumplimiento regulatorio. Por defecto evalúa los estándares cuya región esté incluida en `regional_scope` de `.devtrail/config.yml` (default `[global, eu]`). Seis frameworks chinos disponibles opt-in cuando `china` se añade a `regional_scope`.
 
 **Argumentos y flags:**
 
 | Argumento/Flag | Default | Descripción |
 |----------------|---------|-------------|
 | `path` | `.` (directorio actual) | Directorio del proyecto |
-| `--standard` | — | Verificar estándar específico: `eu-ai-act`, `iso-42001`, o `nist-ai-rmf` |
-| `--all` | — | Verificar los tres estándares |
+| `--standard` | — | Verificar estándar específico: `eu-ai-act`, `iso-42001`, `nist-ai-rmf`, `china-tc260`, `china-pipl`, `china-gb45438`, `china-cac`, `china-gb45652`, `china-csl` |
+| `--region` | — | Ejecutar todos los estándares de una región: `global`, `eu`, `china`, o `all` |
+| `--all` | — | Verificar todos los estándares (ignora `regional_scope`) |
 | `--output` | `text` | Formato de salida: `text`, `markdown`, o `json` |
 
-Si no se especifica `--standard` ni `--all`, por defecto ejecuta `--all`.
+Precedencia: `--standard` > `--all` > `--region` > el `regional_scope` del proyecto.
+
+**Estándares chinos (opt-in vía `regional_scope: china`):**
+
+- **TC260 v2.0**: existe TC260RA; niveles altos requieren review; los tres criterios (escenario × inteligencia × escala) están completos
+- **PIPL**: PIPIA cuando `pipl_applicable: true`; transferencia transfronteriza documentada; retención ≥ 3 años (Art. 56)
+- **GB 45438**: AILABEL para contenido generativo; estrategia explícita + implícita declaradas; campos de metadata mandatorios
+- **CAC**: CACFILE cuando es requerido; `cac_filing_status` explícito; `cac_filing_number` cuando el estado es `*_approved`
+- **GB/T 45652**: SBOM y MCARD declaran cumplimiento de seguridad de datos de entrenamiento
+- **CSL 2026**: cada INC con `csl_severity_level`; horas coherentes con severidad (1h ↔ particularly_serious, 4h ↔ relatively_major); post-mortem 30 días para incidentes major+
+
+**Ejemplos:**
+
+```bash
+# Default: solo estándares cuya región esté en regional_scope
+$ devtrail compliance
+
+# Los seis frameworks chinos (requiere regional_scope: china)
+$ devtrail compliance --region china
+
+# Un solo framework chino
+$ devtrail compliance --standard china-pipl --output json
+
+# Todos los estándares ignorando regional_scope
+$ devtrail compliance --all
+```
+
+> **Activación**: para evaluar los frameworks chinos automáticamente, añadir a `.devtrail/config.yml`:
+>
+> ```yaml
+> regional_scope:
+>   - global
+>   - eu
+>   - china
+> ```
 
 ---
 

--- a/docs/i18n/es/adopters/WORKFLOWS.md
+++ b/docs/i18n/es/adopters/WORKFLOWS.md
@@ -157,6 +157,67 @@ Cuando múltiples miembros del equipo usan asistentes IA en el mismo proyecto:
 
 ---
 
+## Flujo de Cumplimiento China *(opt-in)*
+
+Si tu proyecto opera en China continental o procesa información personal de usuarios de China continental, habilita el alcance china y sigue este flujo.
+
+### Configuración Inicial
+
+1. Edita `.devtrail/config.yml` y añade `china` a `regional_scope`:
+   ```yaml
+   regional_scope:
+     - global
+     - eu      # si también está sujeto a EU
+     - china
+   ```
+2. Ejecuta `devtrail compliance --region china` para ver el baseline (todos los checks fallarán hasta crear los documentos correspondientes).
+3. Lee las guías instaladas en `.devtrail/00-governance/`:
+   - `CHINA-REGULATORY-FRAMEWORK.md` — visión general y matriz de cobertura
+   - `TC260-IMPLEMENTATION-GUIDE.md` — clasificación de riesgo en 5 niveles
+   - `PIPL-PIPIA-GUIDE.md` — cuándo se requiere PIPIA y qué debe contener
+   - `CAC-FILING-GUIDE.md` — registro simple vs dual, ciclo de vida de estado
+   - `GB-45438-LABELING-GUIDE.md` — diseño de etiquetado explícito + implícito
+
+### Cuando Añades un Modelo de IA Generativa
+
+Conjunto de documentos a crear juntos (cross-linked vía `related:`):
+
+| Documento | Propósito | Requerido cuando |
+|-----------|-----------|------------------|
+| `MCARD` | Model card con `cac_filing_required`, `gb45438_applicable`, `tc260_risk_level` | Siempre para modelos en alcance |
+| `TC260RA` | Clasificación de riesgo (escenario × inteligencia × escala → 5 niveles) | Siempre |
+| `AILABEL` | Etiquetado explícito + implícito per GB 45438 | Cuando el modelo genera contenido |
+| `CACFILE` | Registro de algoritmo CAC | Cuando `cac_filing_required: true` |
+| `PIPIA` | Evaluación de impacto de info personal (Art. 55-56) | Cuando se procesa info personal |
+| `SBOM` | Inventario de datos de entrenamiento + cumplimiento GB/T 45652 | Siempre |
+
+`devtrail compliance --region china` confirma que el conjunto está completo.
+
+### Cuando Ocurre un Incidente
+
+La plantilla `INC` incluye una sección *CSL 2026 Incident Reporting*. Setea:
+
+```yaml
+csl_severity_level: relatively_major   # o particularly_serious | major | general
+csl_report_deadline_hours: 4           # 1 para particularly_serious, 4 para relatively_major
+```
+
+`devtrail validate` aplica la coherencia severidad-deadline (`CROSS-008`, `CROSS-009`). Los incidentes major+ deben cerrarse (status `accepted`) en 30 días para que el check `CSL-003` apruebe.
+
+### Transferencia Transfronteriza de Datos
+
+Cuando un proceso involucra transferencia de información personal fuera de China continental, setea `pipl_cross_border_transfer: true` en el PIPIA y documenta el mecanismo elegido (evaluación de seguridad CAC / certificación / contrato estándar) en la sección *Cross-Border Transfer Analysis*. `CROSS-011` advertirá si no hay ninguno documentado.
+
+### Verificación Diaria de Cumplimiento
+
+```bash
+# Antes de mergear una rama de feature que toca servicios IA
+devtrail validate                    # cross-rules incluyendo CROSS-004..011
+devtrail compliance --region china   # score por framework
+```
+
+---
+
 ## Entender las Versiones
 
 DevTrail usa **versionado independiente** para sus dos componentes:

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -145,6 +145,19 @@ DevTrail 对齐并支持以下标准的合规：
 | **ISO/IEC 23894:2023** | AI 风险管理与 ETH 和 AI-RISK-CATALOG 对齐 |
 | **GDPR** | ETH 文档含 GDPR 法律依据部分，DPIA 用于隐私影响评估 |
 
+### 中国法规覆盖 *(通过 `regional_scope: china` opt-in)*
+
+| 标准 | DevTrail 如何帮助 |
+|------|-------------------|
+| **TC260 人工智能安全治理框架 v2.0** | 五级风险分级(TC260RA),ETH/MCARD/AILOG/SEC 上的 `tc260_*` 字段 |
+| **PIPL — 个人信息保护法** | PIPIA 模板含第55-56条节,`pipl_*` 字段,留存 ≥ 3 年(`TYPE-003`) |
+| **GB 45438-2025** *(强制)* | AILABEL 模板覆盖生成式内容的显式 + 隐式标识 |
+| **CAC 算法备案** | CACFILE 模板跟踪单一/双重备案;通过 `cac_filing_required` 从 MCARD 交叉检查 |
+| **GB/T 45652-2025** | SBOM 与 MCARD 的训练数据安全部分;`gb45652_training_data_compliance` 字段 |
+| **CSL 2026** | INC 扩展含 `csl_severity_level`、时限一致性规则(1h / 4h+72h+30d 窗口) |
+
+> 在 `.devtrail/config.yml` 的 `regional_scope` 中加入 `china` 即可启用。详见下方 *配置* 章节及安装在 `.devtrail/00-governance/` 下的 `CHINA-REGULATORY-FRAMEWORK.md` 指南。
+
 ### 架构文档
 
 | 标准 | DevTrail 如何帮助 |
@@ -353,6 +366,28 @@ CLI 自动完成：
 ---
 
 ## 配置
+
+### 区域法规范围(Regional Regulatory Scope)
+
+`.devtrail/config.yml` 控制 `devtrail compliance` 评估哪些合规框架,以及 `devtrail new` 暴露哪些文档类型:
+
+```yaml
+regional_scope:
+  - global   # NIST AI RMF + ISO/IEC 42001(始终建议)
+  - eu       # EU AI Act + GDPR
+  - china    # TC260 v2.0、PIPL/PIPIA、GB 45438、CAC、GB/T 45652、CSL 2026
+```
+
+**省略时的默认值**:`[global, eu]` — 保持 `fw-4.3.0` 之前所有 DevTrail 版本的行为。
+
+将 `china` 加入列表时:
+
+- 通过 `devtrail new` 可使用 4 种中国专属文档类型:`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`。
+- `devtrail compliance` 运行 6 个新的合规检查器(也可通过 `--region china` / `--standard china-*`)。
+- 启用 12 条范围感知的验证规则(`CROSS-004` 至 `CROSS-011`、`TYPE-003` 至 `TYPE-006`)。
+- 在 `.devtrail/00-governance/` 下提供 5 份新的治理指南(`CHINA-REGULATORY-FRAMEWORK.md`,以及 TC260、PIPL/PIPIA、CAC 备案、GB 45438 标识的逐项指南)— 全部提供 EN、ES、zh-CN 三种语言。
+
+`regional_scope` 中不含 `china` 的项目不受任何影响:无新增文件、无新提示、无新规则。后续添加 `china` 完全可逆。
 
 ### 自定义 Agent 标识符
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -296,6 +296,8 @@ Repairing DevTrail in /home/user/my-project
 - 敏感信息检测（API 密钥、密码）
 - 关联文档存在性
 
+当 `regional_scope` 包含 `china` 时,启用十二条额外规则(`CROSS-004` 至 `CROSS-011`、`TYPE-003` 至 `TYPE-006`),涵盖 TC260 审核升级、敏感数据文档的 PIPIA 关联、CACFILE / AILABEL 交叉引用、CSL 严重程度-时限一致性、PIPIA 三年留存。未启用 `china` 时,这些规则被跳过 — 不会产生误报。
+
 **示例：**
 
 ```bash
@@ -321,10 +323,10 @@ $ devtrail validate --fix
 | 参数/标志 | 默认值 | 描述 |
 |-----------|--------|------|
 | `path` | `.`（当前目录） | 目标项目目录 |
-| `--doc-type`, `-t` | — | 文档类型：`ailog`、`aidec`、`adr`、`eth`、`req`、`tes`、`inc`、`tde`、`sec`、`mcard`、`sbom`、`dpia` |
+| `--doc-type`, `-t` | — | 文档类型。核心(12 种):`ailog`、`aidec`、`adr`、`eth`、`req`、`tes`、`inc`、`tde`、`sec`、`mcard`、`sbom`、`dpia`。中国(4 种,opt-in):`pipia`、`cacfile`、`tc260ra`、`ailabel`。 |
 | `--title` | — | 新文档的标题 |
 
-如果未指定 `--doc-type` 或 `--title`，将以交互方式提示。
+如果未指定 `--doc-type` 或 `--title`,将以交互方式提示。当 `regional_scope` 不包含 `china` 时,中国专属类型从提示中过滤(`-t` 也会拒绝)。
 
 **示例：**
 
@@ -353,20 +355,55 @@ $ devtrail new -t ailog --title "Implement JWT authentication"
 
 ---
 
-### `devtrail compliance [path] [--standard <name>] [--all] [--output <format>]`
+### `devtrail compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
 
-检查 EU AI Act、ISO/IEC 42001 和 NIST AI RMF 的法规合规状态。
+检查法规合规状态。默认评估 `.devtrail/config.yml` 中 `regional_scope` 所列区域的标准(默认 `[global, eu]`)。在 `regional_scope` 中加入 `china` 后,六个中国法规框架可用。
 
 **参数和标志：**
 
 | 参数/标志 | 默认值 | 描述 |
 |-----------|--------|------|
-| `path` | `.`（当前目录） | 目标项目目录 |
-| `--standard` | — | 检查特定标准：`eu-ai-act`、`iso-42001` 或 `nist-ai-rmf` |
-| `--all` | — | 检查全部三个标准 |
-| `--output` | `text` | 输出格式：`text`、`markdown` 或 `json` |
+| `path` | `.`(当前目录) | 目标项目目录 |
+| `--standard` | — | 检查特定标准:`eu-ai-act`、`iso-42001`、`nist-ai-rmf`、`china-tc260`、`china-pipl`、`china-gb45438`、`china-cac`、`china-gb45652`、`china-csl` |
+| `--region` | — | 运行某区域的全部标准:`global`、`eu`、`china` 或 `all` |
+| `--all` | — | 运行全部标准(忽略 `regional_scope`) |
+| `--output` | `text` | 输出格式:`text`、`markdown` 或 `json` |
 
-如果未指定 `--standard` 或 `--all`，默认执行 `--all`。
+优先级:`--standard` > `--all` > `--region` > 项目的 `regional_scope`。
+
+**中国标准(通过 `regional_scope: china` 启用):**
+
+- **TC260 v2.0**:存在 TC260RA;高/很高/极重等级要求人工审核;三项分级标准(场景 × 智能 × 规模)已填充
+- **PIPL**:`pipl_applicable: true` 时存在 PIPIA;跨境传输已记录;留存 ≥ 3 年(第56条)
+- **GB 45438**:生成式内容存在 AILABEL;声明显式 + 隐式标识策略;必填元数据字段已填充
+- **CAC**:必要时存在 CACFILE;`cac_filing_status` 已显式设置;状态为 `*_approved` 时填写 `cac_filing_number`
+- **GB/T 45652**:SBOM 与 MCARD 声明训练数据安全合规
+- **CSL 2026**:每个 INC 有 `csl_severity_level`;时限与严重程度一致(1h ↔ particularly_serious、4h ↔ relatively_major);major+ 事件 30 天内提交事后审查
+
+**示例:**
+
+```bash
+# 默认:仅运行 regional_scope 中包含的区域的标准
+$ devtrail compliance
+
+# 六个中国框架(需要 regional_scope: china)
+$ devtrail compliance --region china
+
+# 单一中国框架
+$ devtrail compliance --standard china-pipl --output json
+
+# 强制运行全部标准,忽略 regional_scope
+$ devtrail compliance --all
+```
+
+> **启用方式**:在 `.devtrail/config.yml` 中添加:
+>
+> ```yaml
+> regional_scope:
+>   - global
+>   - eu
+>   - china
+> ```
 
 **检查内容：**
 

--- a/docs/i18n/zh-CN/adopters/WORKFLOWS.md
+++ b/docs/i18n/zh-CN/adopters/WORKFLOWS.md
@@ -157,6 +157,67 @@ DevTrail 有两个文档系统：
 
 ---
 
+## 中国合规工作流 *(opt-in)*
+
+如果项目在中国大陆运营或处理中国大陆用户的个人信息,启用 china 范围并按以下流程操作。
+
+### 一次性设置
+
+1. 编辑 `.devtrail/config.yml` 并将 `china` 加入 `regional_scope`:
+   ```yaml
+   regional_scope:
+     - global
+     - eu      # 如同时受 EU 约束
+     - china
+   ```
+2. 运行 `devtrail compliance --region china` 查看基线(在创建相应文档前所有检查都会失败)。
+3. 阅读 `.devtrail/00-governance/` 下安装的指南:
+   - `CHINA-REGULATORY-FRAMEWORK.md` — 概览与覆盖矩阵
+   - `TC260-IMPLEMENTATION-GUIDE.md` — 五级风险分级
+   - `PIPL-PIPIA-GUIDE.md` — 何时需要 PIPIA 及其内容
+   - `CAC-FILING-GUIDE.md` — 单一 vs 双重备案、状态生命周期
+   - `GB-45438-LABELING-GUIDE.md` — 显式 + 隐式标识设计
+
+### 添加生成式 AI 模型时
+
+需一并创建并通过 `related:` 互相关联的文档集:
+
+| 文档 | 用途 | 何时必需 |
+|------|------|--------|
+| `MCARD` | 含 `cac_filing_required`、`gb45438_applicable`、`tc260_risk_level` 的模型卡 | 范围内模型始终需要 |
+| `TC260RA` | 风险分级(场景 × 智能 × 规模 → 5 级) | 始终 |
+| `AILABEL` | 依据 GB 45438 的显式 + 隐式标识 | 模型生成内容时 |
+| `CACFILE` | 算法备案记录 | `cac_filing_required: true` 时 |
+| `PIPIA` | 个人信息影响评估(第55-56条) | 处理个人信息时 |
+| `SBOM` | 训练数据清单 + GB/T 45652 合规 | 始终 |
+
+`devtrail compliance --region china` 确认套件完整。
+
+### 发生事件时
+
+`INC` 模板包含 *CSL 2026 Incident Reporting* 部分。设置:
+
+```yaml
+csl_severity_level: relatively_major   # 或 particularly_serious | major | general
+csl_report_deadline_hours: 4           # particularly_serious 为 1,relatively_major 为 4
+```
+
+`devtrail validate` 强制严重程度-时限一致性(`CROSS-008`、`CROSS-009`)。major+ 事件须在 30 天内关闭(状态 `accepted`)以使 `CSL-003` 检查通过。
+
+### 跨境数据传输
+
+当过程涉及将个人信息传输至中国大陆境外时,在 PIPIA 上设置 `pipl_cross_border_transfer: true`,并在 *Cross-Border Transfer Analysis* 部分记录所选机制(CAC 安全评估 / 认证 / 标准合同)。`CROSS-011` 在未记录任何机制时发出警告。
+
+### 日常合规检查
+
+```bash
+# 在合并涉及 AI 服务的功能分支之前
+devtrail validate                    # 跨规则,包括 CROSS-004..011
+devtrail compliance --region china   # 各框架得分
+```
+
+---
+
 ## 理解版本
 
 DevTrail 为两个组件使用**独立版本管理**：


### PR DESCRIPTION
## Summary

Updates the three adopter-facing docs (CLI-REFERENCE, ADOPTION-GUIDE, WORKFLOWS) in **EN, ES, and zh-CN** to reflect the China regulatory support shipped in `fw-4.3.0` / `cli-3.3.0` (PR #55). Pure documentation — no code changes, no version bump.

## What's documented

### CLI-REFERENCE
- New `--region <global|eu|china|all>` flag on `devtrail compliance`
- Six new `--standard` values: `china-tc260`, `china-pipl`, `china-gb45438`, `china-cac`, `china-gb45652`, `china-csl`
- Four new China DocTypes on `devtrail new` (`pipia`, `cacfile`, `tc260ra`, `ailabel`) — opt-in
- Note about twelve scope-aware validation rules (`CROSS-004..011`, `TYPE-003..006`)

### ADOPTION-GUIDE
- New **"China Regulatory Coverage"** subsection in *Standards Compliance* with per-framework table
- New **"Regional Regulatory Scope"** subsection in *Configuration*

### WORKFLOWS
- New **"China Regulatory Workflow"** section covering one-time setup, document bundle for new generative AI models, CSL incident reporting, cross-border data transfer, and daily compliance checks

## Test plan

- [x] All three EN docs updated and proofread
- [x] ES translations follow the existing style and tone
- [x] zh-CN translations use established terminology (与 fw-4.3.0 安装的中文治理指南一致)
- [x] Cross-references to installed governance guides (`CHINA-REGULATORY-FRAMEWORK.md`, etc.) are correct
- [x] No version bump required (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)