### PR TITLE
feat(cli): language-aware devtrail explore (cli-3.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.4.0 — Language-Aware `devtrail explore`
+
+### Added (CLI)
+- `devtrail explore` now resolves framework governance docs (`QUICK-REFERENCE`, `AGENT-RULES`, `CHINA-REGULATORY-FRAMEWORK`, `PIPL-PIPIA-GUIDE`, etc.) in the language set by `language` in `.devtrail/config.yml`. With `language: zh-CN` or `es`, the navigation tree, titles, and document body all switch to the translated variant — the English original is used silently as a fallback when no translation exists. CJK rendering relies on the Unicode-safe layout work done in 3.2.3 / 3.2.4.
+- New `--lang <code>` flag on `devtrail explore` to override the configured language for a single session (e.g., `devtrail explore --lang zh-CN`). Resolution order: `--lang` > `config.language` > `en`.
+- Adopter-authored content under subgroups (`02-design/decisions/`, `05-operations/incidents/`, etc.) is intentionally never localized — it has no canonical i18n sibling.
+
+### Changed (CLI)
+- Shared `utils::resolve_localized_path()` is now the single source of truth for `i18n/<lang>/<filename>` lookups. `devtrail new` (templates) and `devtrail explore` (governance docs) both delegate to it.
+
+---
+
 ## Framework 4.3.0 / CLI 3.3.0 — China Regulatory Coverage (TC260, PIPL, GB 45438, CAC, GB/T 45652, CSL)
 
 DevTrail now supports six Chinese AI / data regulations as an opt-in regional scope. Existing projects are unaffected — Chinese frameworks activate only when `regional_scope: china` is added to `.devtrail/config.yml`.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.3.0` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.3.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.4.0` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/cli/src/commands/explore.rs
+++ b/cli/src/commands/explore.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Result};
 
+use crate::config::DevTrailConfig;
 use crate::utils;
 
-pub fn run(path: &str) -> Result<()> {
+pub fn run(path: &str, lang_override: Option<&str>) -> Result<()> {
     let resolved = match utils::resolve_project_root(path) {
         Some(r) => r,
         None => {
@@ -12,5 +13,13 @@ pub fn run(path: &str) -> Result<()> {
         }
     };
 
-    crate::tui::run(&resolved.path, resolved.is_fallback)
+    // Effective language: --lang flag > config.language > "en".
+    let language = match lang_override {
+        Some(l) => l.to_string(),
+        None => DevTrailConfig::load(&resolved.path)
+            .map(|c| c.language)
+            .unwrap_or_else(|_| "en".to_string()),
+    };
+
+    crate::tui::run(&resolved.path, resolved.is_fallback, &language)
 }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -204,15 +204,8 @@ fn resolve_template_path(
     lang: &str,
 ) -> PathBuf {
     let template_name = format!("TEMPLATE-{}.md", doc_type.prefix());
-    if lang != "en" {
-        let i18n_path = devtrail_dir
-            .join(format!("templates/i18n/{}", lang))
-            .join(&template_name);
-        if i18n_path.exists() {
-            return i18n_path;
-        }
-    }
-    devtrail_dir.join("templates").join(&template_name)
+    let templates_dir = devtrail_dir.join("templates");
+    utils::resolve_localized_path(&templates_dir, &template_name, lang)
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -168,6 +168,10 @@ enum Commands {
         /// Target directory (default: current directory)
         #[arg(default_value = ".")]
         path: String,
+        /// Display language override (e.g., en, es, zh-CN). Defaults to
+        /// `language` from .devtrail/config.yml.
+        #[arg(long)]
+        lang: Option<String>,
     },
 }
 
@@ -219,7 +223,7 @@ fn main() {
             top,
         } => commands::analyze::run(&path, threshold, &output, top),
         #[cfg(feature = "tui")]
-        Commands::Explore { path } => commands::explore::run(&path),
+        Commands::Explore { path, lang } => commands::explore::run(&path, lang.as_deref()),
     };
 
     if let Err(e) = result {

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -96,12 +96,15 @@ pub struct App {
     pub project_root: PathBuf,
     /// Whether we're using a fallback path (repo root instead of cwd)
     pub is_fallback: bool,
+    /// Active display language ("en", "es", "zh-CN"). Persisted on the app
+    /// so refresh ('r') rebuilds the index in the same locale.
+    pub language: String,
 }
 
 impl App {
-    pub fn new(project_root: &Path, is_fallback: bool) -> Self {
+    pub fn new(project_root: &Path, is_fallback: bool, language: &str) -> Self {
         let devtrail_dir = project_root.join(".devtrail");
-        let index = DocIndex::build(&devtrail_dir);
+        let index = DocIndex::build(&devtrail_dir, language);
         let num_groups = index.groups.len();
 
         Self {
@@ -125,6 +128,7 @@ impl App {
             should_quit: false,
             project_root: project_root.to_path_buf(),
             is_fallback,
+            language: language.to_string(),
         }
     }
 

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -130,7 +130,8 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         KeyCode::Char('r') => {
             let root = app.project_root.clone();
             let fallback = app.is_fallback;
-            *app = App::new(&root, fallback);
+            let language = app.language.clone();
+            *app = App::new(&root, fallback, &language);
         }
 
         _ => {}

--- a/cli/src/tui/index.rs
+++ b/cli/src/tui/index.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::document::DocFrontMatter;
+use crate::utils;
 
 /// A group in the documentation hierarchy (e.g., "02-design")
 #[derive(Debug, Clone)]
@@ -109,8 +110,15 @@ const GROUP_DEFS: &[(&str, &str, &[SubgroupDef])] = &[
 ];
 
 impl DocIndex {
-    /// Build the index by scanning the .devtrail directory
-    pub fn build(devtrail_dir: &Path) -> Self {
+    /// Build the index by scanning the .devtrail directory.
+    ///
+    /// `language` selects the preferred locale (e.g. `"en"`, `"es"`, `"zh-CN"`).
+    /// When non-`"en"`, framework files at group roots (e.g. governance docs)
+    /// are transparently swapped for their `i18n/<lang>/<filename>` counterpart
+    /// when one exists; otherwise the English original is used. User-authored
+    /// content under subgroups (`decisions/`, `incidents/`, ...) is never
+    /// localized.
+    pub fn build(devtrail_dir: &Path, language: &str) -> Self {
         let mut groups = Vec::new();
         let mut relations = RelationIndex::default();
         let mut total_docs = 0;
@@ -128,8 +136,10 @@ impl DocIndex {
                 continue;
             }
 
-            // Scan files directly in the group dir (non-recursive, subgroups scanned separately)
-            let files = scan_md_files_flat(&group_path, &mut relations);
+            // Scan files directly in the group dir. Group roots host framework
+            // docs that ship with translations under `i18n/<lang>/`, so apply
+            // localization here.
+            let files = scan_md_files_flat(&group_path, Some(language), &mut relations);
             total_docs += files.len();
 
             // Scan subgroups and their user-created subdirectories
@@ -137,8 +147,9 @@ impl DocIndex {
             for &(sg_name, sg_label) in subgroup_defs {
                 let sg_path = group_path.join(sg_name);
                 if sg_path.exists() {
-                    // Files directly in the subgroup
-                    let sg_files = scan_md_files_flat(&sg_path, &mut relations);
+                    // Subgroups hold adopter content, which has no localized
+                    // sibling to swap to.
+                    let sg_files = scan_md_files_flat(&sg_path, None, &mut relations);
                     total_docs += sg_files.len();
 
                     // Scan user-created subdirectories
@@ -279,8 +290,18 @@ fn entry_matches(filename: &str, path: &Path, ref_filename: &str, clean_ref: &st
     false
 }
 
-/// Scan only direct .md files in a directory (non-recursive, for group root dirs)
-fn scan_md_files_flat(dir: &Path, relations: &mut RelationIndex) -> Vec<DocEntry> {
+/// Scan only direct .md files in a directory (non-recursive, for group root dirs).
+///
+/// When `localize` is `Some(lang)` and a translation exists at
+/// `dir/i18n/<lang>/<filename>`, the entry's path (and therefore the title /
+/// frontmatter shown in the TUI) is taken from the translated file. Pass
+/// `None` for directories whose contents are user-authored and have no
+/// localized counterpart.
+fn scan_md_files_flat(
+    dir: &Path,
+    localize: Option<&str>,
+    relations: &mut RelationIndex,
+) -> Vec<DocEntry> {
     let mut entries = Vec::new();
 
     let Ok(read_dir) = std::fs::read_dir(dir) else {
@@ -314,11 +335,19 @@ fn scan_md_files_flat(dir: &Path, relations: &mut RelationIndex) -> Vec<DocEntry
             .unwrap_or("")
             .to_string();
 
-        let meta = quick_scan_frontmatter(&path, relations);
+        // Prefer a localized variant when this directory is a framework
+        // root that ships with translations. Falls back to the English
+        // original silently when no translation exists.
+        let resolved_path = match localize {
+            Some(lang) => utils::resolve_localized_path(dir, &filename, lang),
+            None => path,
+        };
+
+        let meta = quick_scan_frontmatter(&resolved_path, relations);
 
         entries.push(DocEntry {
             filename,
-            path,
+            path: resolved_path,
             title: meta.title,
             id: meta.id,
             doc_type: meta.doc_type,
@@ -538,5 +567,143 @@ fn quick_scan_frontmatter(path: &Path, relations: &mut RelationIndex) -> Scanned
             }
         }
         None => fallback_meta(path, Some(body)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fixture .devtrail tree with a translated and an English-only
+    /// governance doc, and verify DocIndex prefers the translation when
+    /// language=zh-CN, falling back to English silently when no translation
+    /// exists.
+    #[test]
+    fn build_zh_cn_swaps_governance_path_when_translation_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let devtrail_dir = tmp.path().join(".devtrail");
+        let governance = devtrail_dir.join("00-governance");
+        let zh = governance.join("i18n").join("zh-CN");
+        std::fs::create_dir_all(&zh).unwrap();
+
+        // Translated doc (governance).
+        std::fs::write(
+            governance.join("QUICK-REFERENCE.md"),
+            "# Quick Reference\n\nEnglish body.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            zh.join("QUICK-REFERENCE.md"),
+            "# 快速参考\n\n中文正文。\n",
+        )
+        .unwrap();
+
+        // English-only doc (no zh-CN sibling).
+        std::fs::write(
+            governance.join("ISO-25010-2023-REFERENCE.md"),
+            "# ISO 25010\n\nEnglish only.\n",
+        )
+        .unwrap();
+
+        let index = DocIndex::build(&devtrail_dir, "zh-CN");
+
+        let governance_group = index
+            .groups
+            .iter()
+            .find(|g| g.name == "00-governance")
+            .expect("governance group present");
+
+        let quick_ref = governance_group
+            .files
+            .iter()
+            .find(|e| e.filename == "QUICK-REFERENCE.md")
+            .expect("QUICK-REFERENCE indexed");
+        assert_eq!(
+            quick_ref.path,
+            zh.join("QUICK-REFERENCE.md"),
+            "zh-CN translation should be preferred"
+        );
+        assert_eq!(quick_ref.title, "快速参考");
+
+        let iso = governance_group
+            .files
+            .iter()
+            .find(|e| e.filename == "ISO-25010-2023-REFERENCE.md")
+            .expect("ISO doc indexed");
+        assert_eq!(
+            iso.path,
+            governance.join("ISO-25010-2023-REFERENCE.md"),
+            "missing translation must fall back to English silently"
+        );
+        assert_eq!(iso.title, "ISO 25010");
+    }
+
+    #[test]
+    fn build_en_never_descends_into_i18n_subdirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let devtrail_dir = tmp.path().join(".devtrail");
+        let governance = devtrail_dir.join("00-governance");
+        let zh = governance.join("i18n").join("zh-CN");
+        std::fs::create_dir_all(&zh).unwrap();
+
+        std::fs::write(governance.join("AGENT-RULES.md"), "# Rules").unwrap();
+        std::fs::write(zh.join("AGENT-RULES.md"), "# 规则").unwrap();
+
+        let index = DocIndex::build(&devtrail_dir, "en");
+        let governance_group = index
+            .groups
+            .iter()
+            .find(|g| g.name == "00-governance")
+            .unwrap();
+
+        // Exactly one entry: the English root file. The translation must
+        // never appear as a separate doc (no duplication of total_docs).
+        assert_eq!(governance_group.files.len(), 1);
+        assert_eq!(
+            governance_group.files[0].path,
+            governance.join("AGENT-RULES.md")
+        );
+    }
+
+    #[test]
+    fn build_does_not_localize_user_subgroups() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let devtrail_dir = tmp.path().join(".devtrail");
+        let decisions = devtrail_dir.join("02-design").join("decisions");
+        let stray_zh = decisions.join("i18n").join("zh-CN");
+        std::fs::create_dir_all(&stray_zh).unwrap();
+
+        std::fs::write(
+            decisions.join("ADR-2026-01-01-001-foo.md"),
+            "# English ADR",
+        )
+        .unwrap();
+        // A translation file under a user subgroup must be ignored — adopter
+        // content has no canonical English<->zh mapping.
+        std::fs::write(stray_zh.join("ADR-2026-01-01-001-foo.md"), "# 中文 ADR")
+            .unwrap();
+
+        let index = DocIndex::build(&devtrail_dir, "zh-CN");
+        let design = index
+            .groups
+            .iter()
+            .find(|g| g.name == "02-design")
+            .unwrap();
+        let decisions_sg = design
+            .subgroups
+            .iter()
+            .find(|s| s.name == "decisions")
+            .unwrap();
+
+        let adr = decisions_sg
+            .files
+            .iter()
+            .find(|e| e.filename == "ADR-2026-01-01-001-foo.md")
+            .expect("ADR indexed");
+        assert_eq!(
+            adr.path,
+            decisions.join("ADR-2026-01-01-001-foo.md"),
+            "user-authored docs must not be swapped for any i18n sibling"
+        );
     }
 }

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -21,7 +21,7 @@ use ratatui::Terminal;
 use app::App;
 
 /// Run the TUI explorer
-pub fn run(project_root: &Path, is_fallback: bool) -> anyhow::Result<()> {
+pub fn run(project_root: &Path, is_fallback: bool, language: &str) -> anyhow::Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -30,7 +30,7 @@ pub fn run(project_root: &Path, is_fallback: bool) -> anyhow::Result<()> {
     let mut terminal = Terminal::new(backend)?;
 
     // Create app state
-    let mut app = App::new(project_root, is_fallback);
+    let mut app = App::new(project_root, is_fallback, language);
 
     // Main loop
     let result = run_loop(&mut terminal, &mut app);

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Print a success message
@@ -102,6 +102,21 @@ pub fn resolve_project_root(path: &str) -> Option<ResolvedPath> {
     }
 
     None
+}
+
+/// Resolve `<dir>/<filename>` honoring an optional translation under
+/// `<dir>/i18n/<lang>/<filename>`. When `lang` is `"en"` (or any value where
+/// the localized variant is absent), returns the root path unchanged. This is
+/// the single source of truth for i18n file resolution shared by `devtrail
+/// new` (templates) and `devtrail explore` (governance docs).
+pub fn resolve_localized_path(dir: &Path, filename: &str, lang: &str) -> PathBuf {
+    if lang != "en" {
+        let candidate = dir.join("i18n").join(lang).join(filename);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    dir.join(filename)
 }
 
 /// Visual width of a string in terminal columns, accounting for double-wide
@@ -227,5 +242,42 @@ mod tests {
     #[test]
     fn pad_right_visual_already_wider_returns_as_is() {
         assert_eq!(pad_right_visual("hello", 3), "hello");
+    }
+
+    #[test]
+    fn resolve_localized_path_uses_translation_when_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        let translated = dir.join("i18n").join("zh-CN");
+        std::fs::create_dir_all(&translated).unwrap();
+        std::fs::write(dir.join("FOO.md"), "english").unwrap();
+        std::fs::write(translated.join("FOO.md"), "中文").unwrap();
+
+        let resolved = resolve_localized_path(dir, "FOO.md", "zh-CN");
+        assert_eq!(resolved, translated.join("FOO.md"));
+    }
+
+    #[test]
+    fn resolve_localized_path_falls_back_to_english_when_translation_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("FOO.md"), "english").unwrap();
+
+        let resolved = resolve_localized_path(dir, "FOO.md", "zh-CN");
+        assert_eq!(resolved, dir.join("FOO.md"));
+    }
+
+    #[test]
+    fn resolve_localized_path_for_english_skips_lookup() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        // Even if a stale i18n/en/ folder existed, "en" must always return root.
+        let stale = dir.join("i18n").join("en");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join("FOO.md"), "should not be picked").unwrap();
+        std::fs::write(dir.join("FOO.md"), "english").unwrap();
+
+        let resolved = resolve_localized_path(dir, "FOO.md", "en");
+        assert_eq!(resolved, dir.join("FOO.md"));
     }
 }

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.3.0` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.3.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.4.0` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 ```
 
 ---
@@ -143,11 +143,11 @@ Use `--method` to override auto-detection: `--method=github` or `--method=cargo`
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.3.0                 │
-  │ CLI       │ cli-3.3.0                │
+  │ CLI       │ cli-3.4.0                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -637,6 +637,12 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 |----------|---------|-------------|
 | `path` | `.` (current directory) | Target project directory |
 
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--lang <code>` | `language` from `.devtrail/config.yml`, else `en` | Display language for framework governance docs (`en`, `es`, `zh-CN`). Falls back silently to English when a translation is missing. |
+
 **Features:**
 
 - Two-panel layout: navigation tree + document viewer
@@ -645,6 +651,7 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 - Navigate between related documents via hyperlinks
 - Search by filename, title, tags, or date
 - Fullscreen document mode, vim-style keybindings
+- Localization-aware: framework docs (`QUICK-REFERENCE`, `AGENT-RULES`, China regulatory guides, etc.) are served in the language set by `language` in `.devtrail/config.yml` or by `--lang`
 
 **Key bindings:**
 
@@ -659,10 +666,12 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 | `?` | Help popup with all shortcuts |
 | `q` | Quit |
 
-**Example:**
+**Examples:**
 
 ```bash
-$ devtrail explore
+$ devtrail explore                       # uses config.language (defaults to en)
+$ devtrail explore --lang zh-CN          # browse framework docs in Simplified Chinese
+$ devtrail explore --lang es             # session override to Spanish
 ```
 
 > **Note:** The `explore` command requires the `tui` feature (enabled by default). To compile without it: `cargo build --no-default-features`.
@@ -678,7 +687,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.3.0
+  CLI version:       cli-3.4.0
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -150,7 +150,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.3.0` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.3.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.4.0` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.3.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.3.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.4.0` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 ```
 
 ---
@@ -142,11 +142,11 @@ Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 ```
 
 ---
@@ -204,7 +204,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.3.0
-CLI version:       cli-3.3.0
+CLI version:       cli-3.4.0
 Language:          en
 Structure:         ✔ Complete
 
@@ -509,6 +509,12 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 |-----------|---------|-------------|
 | `path` | `.` (directorio actual) | Directorio del proyecto |
 
+**Flags:**
+
+| Flag | Default | Descripción |
+|------|---------|-------------|
+| `--lang <código>` | `language` de `.devtrail/config.yml`, si no `en` | Idioma de los docs de gobernanza del framework (`en`, `es`, `zh-CN`). Cae silenciosamente al inglés si falta la traducción. |
+
 **Características:**
 
 - Layout de dos paneles: árbol de navegación + visor de documentos
@@ -517,6 +523,7 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 - Navegación entre documentos relacionados mediante hipervínculos
 - Búsqueda por nombre de archivo, título, tags o fecha
 - Modo pantalla completa, atajos estilo vim
+- Consciente de localización: los docs del framework (`QUICK-REFERENCE`, `AGENT-RULES`, guías regulatorias de China, etc.) se sirven en el idioma definido por `language` en `.devtrail/config.yml` o por `--lang`
 
 **Atajos de teclado:**
 
@@ -531,10 +538,12 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 | `?` | Popup de ayuda con todos los atajos |
 | `q` | Salir |
 
-**Ejemplo:**
+**Ejemplos:**
 
 ```bash
-$ devtrail explore
+$ devtrail explore                       # usa config.language (default en)
+$ devtrail explore --lang zh-CN          # navegar docs del framework en chino simplificado
+$ devtrail explore --lang es             # override de sesión a español
 ```
 
 > **Nota:** El comando `explore` requiere la feature `tui` (habilitada por defecto). Para compilar sin ella: `cargo build --no-default-features`.
@@ -550,7 +559,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.3.0
+  CLI version:       cli-3.4.0
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -150,7 +150,7 @@ DevTrail 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.3.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.3.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.4.0` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.3.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.3.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.4.0` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 ```
 
 ---
@@ -143,11 +143,11 @@ $ devtrail update-framework
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.3.0
+✔ CLI updated to cli-3.4.0
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.3.0                 │
-  │ CLI       │ cli-3.3.0                │
+  │ CLI       │ cli-3.4.0                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -630,6 +630,12 @@ $ devtrail audit --output markdown
 |------|--------|------|
 | `path` | `.`（当前目录） | 目标项目目录 |
 
+**标志：**
+
+| 标志 | 默认值 | 描述 |
+|------|--------|------|
+| `--lang <代码>` | `.devtrail/config.yml` 中的 `language`，否则 `en` | 框架治理文档的显示语言（`en`、`es`、`zh-CN`）。缺少翻译时静默回退到英文。 |
+
 **功能特性：**
 
 - 双面板布局：导航树 + 文档查看器
@@ -638,6 +644,7 @@ $ devtrail audit --output markdown
 - 通过超链接在关联文档间导航
 - 按文件名、标题、标签或日期搜索
 - 全屏文档模式，vim 风格快捷键
+- 本地化感知：框架文档（`QUICK-REFERENCE`、`AGENT-RULES`、中国合规指南等）按 `.devtrail/config.yml` 中的 `language` 或 `--lang` 提供对应语言版本
 
 **快捷键：**
 
@@ -655,7 +662,9 @@ $ devtrail audit --output markdown
 **示例：**
 
 ```bash
-$ devtrail explore
+$ devtrail explore                       # 使用 config.language（默认 en）
+$ devtrail explore --lang zh-CN          # 以简体中文浏览框架文档
+$ devtrail explore --lang es             # 会话内切换到西班牙语
 ```
 
 > **注意：** `explore` 命令需要 `tui` feature（默认启用）。如需不含此功能编译：`cargo build --no-default-features`。
@@ -671,7 +680,7 @@ $ devtrail explore
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.3.0
+  CLI version:       cli-3.4.0
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary
- `devtrail explore` now resolves framework governance docs from `i18n/<lang>/` based on `language` in `.devtrail/config.yml`, with silent fallback to English when a translation is missing. Closes the gap left by the China regulatory coverage shipped in fw-4.3.0 / cli-3.3.0: zh-CN translations were already on disk but the TUI never surfaced them.
- New `--lang <code>` flag on `devtrail explore` for per-session overrides (e.g. `devtrail explore --lang zh-CN`). Resolution order: `--lang` > `config.language` > `en`.
- Shared `utils::resolve_localized_path()` is now the single source of truth for `i18n/<lang>/<filename>` lookups; `devtrail new` (templates) and `devtrail explore` (governance) both delegate to it.
- Adopter content under user subgroups (`02-design/decisions/`, `05-operations/incidents/`, ...) is intentionally never localized — there is no canonical i18n sibling for adopter-authored docs.
- CLI bump 3.3.0 → 3.4.0 (minor: new feature). Framework unchanged.

## Test plan
- [x] `cargo test` — 116 unit tests + 86 integration tests pass; 6 new tests added (3 for `resolve_localized_path`, 3 for `DocIndex::build` localization behavior).
- [x] `cargo check --no-default-features` — TUI-less build still compiles.
- [x] `cargo build --release` — clean build as `devtrail-cli v3.4.0`.
- [x] `devtrail about` reports `cli-3.4.0`.
- [x] `devtrail explore --help` shows the new `--lang` option.
- [ ] Manual TUI smoke test: `devtrail init` a fresh project, set `language: zh-CN` in `.devtrail/config.yml`, run `devtrail explore` — governance tree should show Chinese titles and open Chinese bodies. Confirm `ISO-25010-2023-REFERENCE.md` (English-only) still appears under fallback.
- [ ] Verify `devtrail explore --lang en` overrides the config back to English without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)