### PR TITLE
feat(cli): translate TUI shell strings (i18n labels)

### DIFF
--- a/cli/src/tui/i18n_strings.rs
+++ b/cli/src/tui/i18n_strings.rs
@@ -1,0 +1,210 @@
+//! Translation table for static UI strings rendered by the TUI shell:
+//! navigation tree group labels, status-bar key hints, help-popup sections
+//! and action descriptions.
+//!
+//! The single entry point is [`t`]: callers pass the canonical English
+//! literal, and the function returns either a translation for `lang` or
+//! the English original (silent fallback) when no entry matches. This
+//! mirrors the file-level fallback behavior in `utils::resolve_localized_path`.
+//!
+//! Translated document content (governance docs, templates, adopter
+//! markdown) is *not* handled here — those go through the file-resolution
+//! path in `utils.rs` and `tui::index`.
+
+/// Translate a canonical English UI string. Returns the original `en`
+/// when `lang == "en"`, when the language is unknown, or when the
+/// specific string has not been translated. Callers MUST pass the exact
+/// English literal that appears as a key in the match arms below.
+pub fn t<'a>(en: &'a str, lang: &str) -> &'a str {
+    if lang == "en" {
+        return en;
+    }
+    match (en, lang) {
+        // ── Navigation tree group labels ──────────────────────────────
+        ("Governance", "es") => "Gobernanza",
+        ("Governance", "zh-CN") => "治理",
+        ("Requirements", "es") => "Requisitos",
+        ("Requirements", "zh-CN") => "需求",
+        ("Design", "es") => "Diseño",
+        ("Design", "zh-CN") => "设计",
+        ("Implementation", "es") => "Implementación",
+        ("Implementation", "zh-CN") => "实施",
+        ("Testing", "es") => "Pruebas",
+        ("Testing", "zh-CN") => "测试",
+        ("Operations", "es") => "Operaciones",
+        ("Operations", "zh-CN") => "运营",
+        ("Evolution", "es") => "Evolución",
+        ("Evolution", "zh-CN") => "演进",
+        ("AI Audit", "es") => "Auditoría IA",
+        ("AI Audit", "zh-CN") => "AI 审计",
+        ("Security", "es") => "Seguridad",
+        ("Security", "zh-CN") => "安全",
+        ("AI Models", "es") => "Modelos IA",
+        ("AI Models", "zh-CN") => "AI 模型",
+
+        // ── Subgroup labels ───────────────────────────────────────────
+        ("Exceptions", "es") => "Excepciones",
+        ("Exceptions", "zh-CN") => "例外",
+        ("Decisions", "es") => "Decisiones",
+        ("Decisions", "zh-CN") => "决策",
+        ("Incidents", "es") => "Incidentes",
+        ("Incidents", "zh-CN") => "事件",
+        ("Runbooks", "es") => "Runbooks",
+        ("Runbooks", "zh-CN") => "操作手册",
+        ("Technical debt", "es") => "Deuda técnica",
+        ("Technical debt", "zh-CN") => "技术债务",
+        ("Agent logs", "es") => "Bitácoras de agentes",
+        ("Agent logs", "zh-CN") => "代理日志",
+        ("Ethical reviews", "es") => "Revisiones éticas",
+        ("Ethical reviews", "zh-CN") => "伦理审查",
+
+        // ── Nav tree title and sort hints ─────────────────────────────
+        ("Navigation", "es") => "Navegación",
+        ("Navigation", "zh-CN") => "导航",
+        ("[s:sort ↓name]", "es") => "[s:orden ↓nombre]",
+        ("[s:sort ↓name]", "zh-CN") => "[s:排序 ↓名称]",
+        ("[s:sort ↓date]", "es") => "[s:orden ↓fecha]",
+        ("[s:sort ↓date]", "zh-CN") => "[s:排序 ↓日期]",
+
+        // ── Status bar key hints ──────────────────────────────────────
+        ("quit", "es") => "salir",
+        ("quit", "zh-CN") => "退出",
+        ("search", "es") => "buscar",
+        ("search", "zh-CN") => "搜索",
+        ("panel", "es") => "panel",
+        ("panel", "zh-CN") => "面板",
+        ("open", "es") => "abrir",
+        ("open", "zh-CN") => "打开",
+        ("fullscreen", "es") => "pantalla completa",
+        ("fullscreen", "zh-CN") => "全屏",
+        ("back", "es") => "volver",
+        ("back", "zh-CN") => "返回",
+        ("help", "es") => "ayuda",
+        ("help", "zh-CN") => "帮助",
+        ("apply", "es") => "aplicar",
+        ("apply", "zh-CN") => "应用",
+        ("cancel", "es") => "cancelar",
+        ("cancel", "zh-CN") => "取消",
+        ("(press any key to dismiss)", "es") => "(presiona una tecla para descartar)",
+        ("(press any key to dismiss)", "zh-CN") => "（按任意键关闭）",
+        ("docs", "es") => "docs",
+        ("docs", "zh-CN") => "文档",
+
+        // ── Help popup: title, section headers, footer ────────────────
+        ("Keyboard Shortcuts", "es") => "Atajos de teclado",
+        ("Keyboard Shortcuts", "zh-CN") => "键盘快捷键",
+        ("Navigation panel", "es") => "Panel de navegación",
+        ("Navigation panel", "zh-CN") => "导航面板",
+        ("Metadata panel", "es") => "Panel de metadatos",
+        ("Metadata panel", "zh-CN") => "元数据面板",
+        ("Document panel", "es") => "Panel del documento",
+        ("Document panel", "zh-CN") => "文档面板",
+        ("General", "es") => "General",
+        ("General", "zh-CN") => "通用",
+        ("Press any key to close", "es") => "Presiona cualquier tecla para cerrar",
+        ("Press any key to close", "zh-CN") => "按任意键关闭",
+
+        // ── Help popup: action descriptions ───────────────────────────
+        ("Move selection down", "es") => "Mover selección hacia abajo",
+        ("Move selection down", "zh-CN") => "向下移动选择",
+        ("Move selection up", "es") => "Mover selección hacia arriba",
+        ("Move selection up", "zh-CN") => "向上移动选择",
+        ("Expand group / Open document", "es") => "Expandir grupo / Abrir documento",
+        ("Expand group / Open document", "zh-CN") => "展开分组 / 打开文档",
+        ("Collapse group / Clear search", "es") => "Colapsar grupo / Limpiar búsqueda",
+        ("Collapse group / Clear search", "zh-CN") => "折叠分组 / 清除搜索",
+        ("Jump to group by number", "es") => "Saltar al grupo por número",
+        ("Jump to group by number", "zh-CN") => "按编号跳到分组",
+        ("Move between related links", "es") => "Mover entre enlaces relacionados",
+        ("Move between related links", "zh-CN") => "在关联链接间移动",
+        ("Follow selected related link", "es") => "Seguir enlace relacionado seleccionado",
+        ("Follow selected related link", "zh-CN") => "跳转到选中的关联链接",
+        ("Back to Navigation", "es") => "Volver a navegación",
+        ("Back to Navigation", "zh-CN") => "返回导航",
+        ("Scroll down", "es") => "Desplazarse hacia abajo",
+        ("Scroll down", "zh-CN") => "向下滚动",
+        ("Scroll up", "es") => "Desplazarse hacia arriba",
+        ("Scroll up", "zh-CN") => "向上滚动",
+        ("Top / Bottom of document", "es") => "Inicio / Fin del documento",
+        ("Top / Bottom of document", "zh-CN") => "文档开头 / 末尾",
+        ("Half page down / up", "es") => "Media página abajo / arriba",
+        ("Half page down / up", "zh-CN") => "向下 / 向上半页",
+        ("Page down / up", "es") => "Página abajo / arriba",
+        ("Page down / up", "zh-CN") => "向下 / 向上一页",
+        ("Next / Previous document", "es") => "Documento siguiente / anterior",
+        ("Next / Previous document", "zh-CN") => "下一个 / 上一个文档",
+        ("Toggle fullscreen", "es") => "Alternar pantalla completa",
+        ("Toggle fullscreen", "zh-CN") => "切换全屏",
+        ("Exit fullscreen / Back to Nav", "es") => "Salir de pantalla completa / Volver",
+        ("Exit fullscreen / Back to Nav", "zh-CN") => "退出全屏 / 返回导航",
+        ("Next panel: Nav → Meta → Doc", "es") => "Panel siguiente: Nav → Meta → Doc",
+        ("Next panel: Nav → Meta → Doc", "zh-CN") => "下一面板：导航 → 元数据 → 文档",
+        ("Prev panel: Doc → Meta → Nav", "es") => "Panel anterior: Doc → Meta → Nav",
+        ("Prev panel: Doc → Meta → Nav", "zh-CN") => "上一面板：文档 → 元数据 → 导航",
+        ("Search by name, title, tags, date", "es") => {
+            "Buscar por nombre, título, etiquetas, fecha"
+        }
+        ("Search by name, title, tags, date", "zh-CN") => "按名称、标题、标签、日期搜索",
+        ("Cycle sort order", "es") => "Cambiar orden de clasificación",
+        ("Cycle sort order", "zh-CN") => "切换排序方式",
+        ("Refresh document index", "es") => "Refrescar índice de documentos",
+        ("Refresh document index", "zh-CN") => "刷新文档索引",
+        ("Quit", "es") => "Salir",
+        ("Quit", "zh-CN") => "退出",
+        ("Force quit", "es") => "Forzar salida",
+        ("Force quit", "zh-CN") => "强制退出",
+
+        _ => en,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn english_passes_through() {
+        assert_eq!(t("Governance", "en"), "Governance");
+        assert_eq!(t("anything not in the table", "en"), "anything not in the table");
+    }
+
+    #[test]
+    fn unknown_lang_falls_back_to_english() {
+        assert_eq!(t("Governance", "fr"), "Governance");
+        assert_eq!(t("Governance", ""), "Governance");
+    }
+
+    #[test]
+    fn missing_translation_falls_back_silently() {
+        // A string the table has never heard of must not panic.
+        assert_eq!(t("Some unknown label", "zh-CN"), "Some unknown label");
+    }
+
+    #[test]
+    fn group_labels_translate() {
+        assert_eq!(t("Governance", "es"), "Gobernanza");
+        assert_eq!(t("Governance", "zh-CN"), "治理");
+        assert_eq!(t("AI Audit", "es"), "Auditoría IA");
+        assert_eq!(t("AI Audit", "zh-CN"), "AI 审计");
+    }
+
+    #[test]
+    fn subgroup_labels_translate() {
+        assert_eq!(t("Technical debt", "es"), "Deuda técnica");
+        assert_eq!(t("Technical debt", "zh-CN"), "技术债务");
+    }
+
+    #[test]
+    fn status_bar_keys_translate() {
+        assert_eq!(t("quit", "es"), "salir");
+        assert_eq!(t("quit", "zh-CN"), "退出");
+        assert_eq!(t("search", "zh-CN"), "搜索");
+    }
+
+    #[test]
+    fn help_popup_strings_translate() {
+        assert_eq!(t("Keyboard Shortcuts", "es"), "Atajos de teclado");
+        assert_eq!(t("Keyboard Shortcuts", "zh-CN"), "键盘快捷键");
+        assert_eq!(t("Force quit", "zh-CN"), "强制退出");
+    }
+}

--- a/cli/src/tui/index.rs
+++ b/cli/src/tui/index.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::document::DocFrontMatter;
+use super::i18n_strings::t;
 use crate::utils;
 
 /// A group in the documentation hierarchy (e.g., "02-design")
@@ -125,10 +126,11 @@ impl DocIndex {
 
         for &(group_name, group_label, subgroup_defs) in GROUP_DEFS {
             let group_path = devtrail_dir.join(group_name);
+            let localized_group_label = t(group_label, language).to_string();
             if !group_path.exists() {
                 groups.push(DocGroup {
                     name: group_name.to_string(),
-                    label: group_label.to_string(),
+                    label: localized_group_label,
                     path: group_path,
                     subgroups: Vec::new(),
                     files: Vec::new(),
@@ -179,7 +181,7 @@ impl DocIndex {
 
                     subgroups.push(DocSubgroup {
                         name: sg_name.to_string(),
-                        label: sg_label.to_string(),
+                        label: t(sg_label, language).to_string(),
                         path: sg_path,
                         files: sg_files,
                         user_dirs,
@@ -187,7 +189,7 @@ impl DocIndex {
                 } else {
                     subgroups.push(DocSubgroup {
                         name: sg_name.to_string(),
-                        label: sg_label.to_string(),
+                        label: t(sg_label, language).to_string(),
                         path: sg_path,
                         files: Vec::new(),
                         user_dirs: Vec::new(),
@@ -197,7 +199,7 @@ impl DocIndex {
 
             groups.push(DocGroup {
                 name: group_name.to_string(),
-                label: group_label.to_string(),
+                label: localized_group_label,
                 path: group_path,
                 subgroups,
                 files,

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod document;
 pub mod event;
+pub mod i18n_strings;
 pub mod index;
 pub mod markdown;
 pub mod theme;

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -34,7 +34,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         }
         ViewMode::Help => {
             render_main_layout(frame, app, main_area, terminal_width);
-            frame.render_widget(HelpPopup, main_area);
+            frame.render_widget(HelpPopup::new(&app.language), main_area);
         }
         ViewMode::Normal => {
             render_main_layout(frame, app, main_area, terminal_width);

--- a/cli/src/tui/widgets/help_popup.rs
+++ b/cli/src/tui/widgets/help_popup.rs
@@ -4,18 +4,29 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 
+use crate::tui::i18n_strings::t;
 use crate::tui::theme;
 
-pub struct HelpPopup;
+pub struct HelpPopup<'a> {
+    language: &'a str,
+}
 
-impl Widget for HelpPopup {
+impl<'a> HelpPopup<'a> {
+    pub fn new(language: &'a str) -> Self {
+        Self { language }
+    }
+}
+
+impl Widget for HelpPopup<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let popup = centered_rect(65, 80, area);
+        let lang = self.language;
 
         Clear.render(popup, buf);
 
+        let title = format!(" {} ", t("Keyboard Shortcuts", lang));
         let block = Block::default()
-            .title(" Keyboard Shortcuts ")
+            .title(title)
             .title_style(
                 Style::default()
                     .fg(theme::ACCENT)
@@ -37,40 +48,52 @@ impl Widget for HelpPopup {
 
         let lines = vec![
             Line::from(""),
-            Line::from(Span::styled("  Navigation panel", section_style)),
-            help_line("  j / ↓       ", "Move selection down", key_style, desc_style),
-            help_line("  k / ↑       ", "Move selection up", key_style, desc_style),
-            help_line("  Enter       ", "Expand group / Open document", key_style, desc_style),
-            help_line("  Esc         ", "Collapse group / Clear search", key_style, desc_style),
-            help_line("  1-8         ", "Jump to group by number", key_style, desc_style),
-            Line::from(""),
-            Line::from(Span::styled("  Metadata panel", section_style)),
-            help_line("  j / ↓       ", "Move between related links", key_style, desc_style),
-            help_line("  k / ↑       ", "Move between related links", key_style, desc_style),
-            help_line("  Enter       ", "Follow selected related link", key_style, desc_style),
-            help_line("  Esc         ", "Back to Navigation", key_style, desc_style),
-            Line::from(""),
-            Line::from(Span::styled("  Document panel", section_style)),
-            help_line("  j / ↓       ", "Scroll down", key_style, desc_style),
-            help_line("  k / ↑       ", "Scroll up", key_style, desc_style),
-            help_line("  g / G       ", "Top / Bottom of document", key_style, desc_style),
-            help_line("  Ctrl+d / u  ", "Half page down / up", key_style, desc_style),
-            help_line("  PgDn / PgUp ", "Page down / up", key_style, desc_style),
-            help_line("  n / N       ", "Next / Previous document", key_style, desc_style),
-            help_line("  f           ", "Toggle fullscreen", key_style, desc_style),
-            help_line("  Esc         ", "Exit fullscreen / Back to Nav", key_style, desc_style),
-            Line::from(""),
-            Line::from(Span::styled("  General", section_style)),
-            help_line("  Tab         ", "Next panel: Nav → Meta → Doc", key_style, desc_style),
-            help_line("  Shift+Tab   ", "Prev panel: Doc → Meta → Nav", key_style, desc_style),
-            help_line("  /           ", "Search by name, title, tags, date", key_style, desc_style),
-            help_line("  s           ", "Cycle sort order", key_style, desc_style),
-            help_line("  r           ", "Refresh document index", key_style, desc_style),
-            help_line("  q           ", "Quit", key_style, desc_style),
-            help_line("  Ctrl+C      ", "Force quit", key_style, desc_style),
+            Line::from(Span::styled(
+                format!("  {}", t("Navigation panel", lang)),
+                section_style,
+            )),
+            help_line("  j / ↓       ", t("Move selection down", lang), key_style, desc_style),
+            help_line("  k / ↑       ", t("Move selection up", lang), key_style, desc_style),
+            help_line("  Enter       ", t("Expand group / Open document", lang), key_style, desc_style),
+            help_line("  Esc         ", t("Collapse group / Clear search", lang), key_style, desc_style),
+            help_line("  1-8         ", t("Jump to group by number", lang), key_style, desc_style),
             Line::from(""),
             Line::from(Span::styled(
-                "  Press any key to close",
+                format!("  {}", t("Metadata panel", lang)),
+                section_style,
+            )),
+            help_line("  j / ↓       ", t("Move between related links", lang), key_style, desc_style),
+            help_line("  k / ↑       ", t("Move between related links", lang), key_style, desc_style),
+            help_line("  Enter       ", t("Follow selected related link", lang), key_style, desc_style),
+            help_line("  Esc         ", t("Back to Navigation", lang), key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  {}", t("Document panel", lang)),
+                section_style,
+            )),
+            help_line("  j / ↓       ", t("Scroll down", lang), key_style, desc_style),
+            help_line("  k / ↑       ", t("Scroll up", lang), key_style, desc_style),
+            help_line("  g / G       ", t("Top / Bottom of document", lang), key_style, desc_style),
+            help_line("  Ctrl+d / u  ", t("Half page down / up", lang), key_style, desc_style),
+            help_line("  PgDn / PgUp ", t("Page down / up", lang), key_style, desc_style),
+            help_line("  n / N       ", t("Next / Previous document", lang), key_style, desc_style),
+            help_line("  f           ", t("Toggle fullscreen", lang), key_style, desc_style),
+            help_line("  Esc         ", t("Exit fullscreen / Back to Nav", lang), key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  {}", t("General", lang)),
+                section_style,
+            )),
+            help_line("  Tab         ", t("Next panel: Nav → Meta → Doc", lang), key_style, desc_style),
+            help_line("  Shift+Tab   ", t("Prev panel: Doc → Meta → Nav", lang), key_style, desc_style),
+            help_line("  /           ", t("Search by name, title, tags, date", lang), key_style, desc_style),
+            help_line("  s           ", t("Cycle sort order", lang), key_style, desc_style),
+            help_line("  r           ", t("Refresh document index", lang), key_style, desc_style),
+            help_line("  q           ", t("Quit", lang), key_style, desc_style),
+            help_line("  Ctrl+C      ", t("Force quit", lang), key_style, desc_style),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  {}", t("Press any key to close", lang)),
                 dim,
             )),
         ];

--- a/cli/src/tui/widgets/nav_tree.rs
+++ b/cli/src/tui/widgets/nav_tree.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget};
 
 use crate::tui::app::{ActivePanel, App, NavSelection, SortOrder};
+use crate::tui::i18n_strings::t;
 use crate::tui::index::DocEntry;
 use crate::tui::theme;
 use crate::utils::{truncate_visual, visual_width};
@@ -28,11 +29,16 @@ impl Widget for NavTree<'_> {
             Style::default().fg(theme::SUBTLE)
         };
 
+        let lang = self.app.language.as_str();
         let block = Block::default()
-            .title(format!(" Navigation {} ", match self.app.sort_order {
-                SortOrder::Name => "[s:sort ↓name]",
-                SortOrder::Date => "[s:sort ↓date]",
-            }))
+            .title(format!(
+                " {} {} ",
+                t("Navigation", lang),
+                match self.app.sort_order {
+                    SortOrder::Name => t("[s:sort ↓name]", lang),
+                    SortOrder::Date => t("[s:sort ↓date]", lang),
+                }
+            ))
             .title_style(if is_active {
                 Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)
             } else {

--- a/cli/src/tui/widgets/status_bar.rs
+++ b/cli/src/tui/widgets/status_bar.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Widget;
 
 use crate::tui::app::App;
+use crate::tui::i18n_strings::t;
 use crate::tui::theme;
 use crate::utils::visual_width;
 
@@ -31,6 +32,8 @@ impl Widget for StatusBar<'_> {
         let desc_style = Style::default().fg(theme::TEXT_DIM);
         let info_style = Style::default().fg(theme::ACCENT);
 
+        let lang = self.app.language.as_str();
+
         // Show notification if present
         if let Some(ref msg) = self.app.notification {
             let line = Line::from(vec![
@@ -46,7 +49,7 @@ impl Widget for StatusBar<'_> {
                     Style::default().fg(Color::Yellow),
                 ),
                 Span::styled(
-                    "  (press any key to dismiss)",
+                    format!("  {}", t("(press any key to dismiss)", lang)),
                     Style::default().fg(Color::DarkGray),
                 ),
             ]);
@@ -63,9 +66,9 @@ impl Widget for StatusBar<'_> {
                 ),
                 Span::styled("█", Style::default().fg(theme::TEXT)),
                 Span::styled("  Enter", key_style),
-                Span::styled(" apply  ", desc_style),
+                Span::styled(format!(" {}  ", t("apply", lang)), desc_style),
                 Span::styled("Esc", key_style),
-                Span::styled(" cancel", desc_style),
+                Span::styled(format!(" {}", t("cancel", lang)), desc_style),
             ]);
             buf.set_line(area.x, area.y, &line, area.width);
             return;
@@ -73,19 +76,19 @@ impl Widget for StatusBar<'_> {
 
         let mut spans: Vec<Span> = vec![
             Span::styled(" q ", key_style),
-            Span::styled("quit ", desc_style),
+            Span::styled(format!("{} ", t("quit", lang)), desc_style),
             Span::styled(" / ", key_style),
-            Span::styled("search ", desc_style),
+            Span::styled(format!("{} ", t("search", lang)), desc_style),
             Span::styled(" Tab ", key_style),
-            Span::styled("panel ", desc_style),
+            Span::styled(format!("{} ", t("panel", lang)), desc_style),
             Span::styled(" Enter ", key_style),
-            Span::styled("open ", desc_style),
+            Span::styled(format!("{} ", t("open", lang)), desc_style),
             Span::styled(" f ", key_style),
-            Span::styled("fullscreen ", desc_style),
+            Span::styled(format!("{} ", t("fullscreen", lang)), desc_style),
             Span::styled(" Esc ", key_style),
-            Span::styled("back ", desc_style),
+            Span::styled(format!("{} ", t("back", lang)), desc_style),
             Span::styled(" ? ", key_style),
-            Span::styled("help ", desc_style),
+            Span::styled(format!("{} ", t("help", lang)), desc_style),
         ];
 
         // Right-aligned: path + doc count
@@ -93,7 +96,12 @@ impl Widget for StatusBar<'_> {
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("?");
-        let right_str = format!(" {}  │  {} docs ", path_display, self.app.index.total_docs);
+        let right_str = format!(
+            " {}  │  {} {} ",
+            path_display,
+            self.app.index.total_docs,
+            t("docs", lang)
+        );
         let used_width: usize = spans.iter().map(|s| visual_width(s.content.as_ref())).sum();
         let remaining = (area.width as usize).saturating_sub(used_width);
         let right_cols = visual_width(&right_str);
@@ -106,7 +114,7 @@ impl Widget for StatusBar<'_> {
             ));
             spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
             spans.push(Span::styled(
-                format!("{} docs ", self.app.index.total_docs),
+                format!("{} {} ", self.app.index.total_docs, t("docs", lang)),
                 info_style,
             ));
         }


### PR DESCRIPTION
## Summary
- Pendiente (1) of 3 from the optional follow-ups planned in cli-3.4.0. **No version bump in this PR** — bump and tag will happen at the end of the series, bundling all three.
- Translate the TUI chrome that stayed in English after `--lang` was added: navigation tree group/subgroup labels (`Governance` → `治理` / `Gobernanza`, etc.), nav tree title and sort hints, status bar action keys and notifications, and every label in the help popup (`?`).
- New `cli/src/tui/i18n_strings.rs` with a single `t(en, lang)` lookup. ~70 strings covered for `es` and `zh-CN`. Unknown languages or untranslated entries fall back to the English original silently — same contract as `utils::resolve_localized_path` for files.
- Wired into `DocIndex::build` (labels), `NavTree`, `StatusBar`, `HelpPopup` (now takes `&language`).

## Test plan
- [x] `cargo test` — 130 unit tests + 86 integration tests pass; 7 new tests for `i18n_strings::t` (passthrough, unknown-lang fallback, samples per call site).
- [x] `cargo check --all-targets` — clean.
- [ ] Manual TUI: `devtrail explore --lang zh-CN` should show 治理, 需求, 设计, etc. as group headers, and the help popup (`?`) should appear in Chinese.
- [ ] `--lang es` should show Gobernanza, Requisitos, etc.; default `--lang en` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)