### PR TITLE
fix(cli): translate metadata panel and welcome screen (cli-3.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.5.1 — Metadata Panel and Welcome Screen i18n Coverage
+
+### Fixed (CLI)
+- The Metadata panel (title `Metadata`, the empty-state `No document selected`, and field labels `Status:`, `Created:`, `Agent:`, `Confidence:`, `Risk:`, `Review:`, `Tags:`, `Related:`, plus the `(Enter: search)` / `(Enter: follow)` hints and `⚠ REQUIRED`) now switches with the active language. Field labels are padded to a consistent visual width so values stay aligned across `en` / `es` / `zh-CN`.
+- The Document panel title and welcome screen (`DevTrail Explorer` brand line aside) now translate: `Documentation Governance for AI-Assisted Development`, `Total documents:`, `Quick start`, the keyboard-shortcut descriptions, `Developed by`, and the repo-root fallback notice. Brand and company names stay in their canonical form on purpose.
+- Frontmatter values themselves (status, tags, related IDs, dates) are still read verbatim from each document — they're authored content, not UI strings.
+
+---
+
 ## CLI 3.5.0 — TUI i18n Polish: Translated Shell, Live Switcher, Locale Auto-Detect
 
 Three changes that complete the language-aware `devtrail explore` work started in 3.4.0. Together they make the TUI feel native to non-English users instead of just "translated docs inside an English shell."

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.3.0` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.5.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.5.1` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/cli/src/tui/i18n_strings.rs
+++ b/cli/src/tui/i18n_strings.rs
@@ -153,6 +153,80 @@ pub fn t<'a>(en: &'a str, lang: &str) -> &'a str {
         ("Cycle display language", "zh-CN") => "切换显示语言",
         ("Language", "es") => "Idioma",
         ("Language", "zh-CN") => "语言",
+
+        // ── Metadata panel ────────────────────────────────────────────
+        ("Metadata", "es") => "Metadatos",
+        ("Metadata", "zh-CN") => "元数据",
+        ("No document selected", "es") => "Sin documento seleccionado",
+        ("No document selected", "zh-CN") => "未选择文档",
+        ("File:", "es") => "Archivo:",
+        ("File:", "zh-CN") => "文件:",
+        ("No frontmatter", "es") => "Sin frontmatter",
+        ("No frontmatter", "zh-CN") => "无 frontmatter",
+        ("Status:", "es") => "Estado:",
+        ("Status:", "zh-CN") => "状态:",
+        ("Created:", "es") => "Creado:",
+        ("Created:", "zh-CN") => "创建:",
+        ("Agent:", "es") => "Agente:",
+        ("Agent:", "zh-CN") => "代理:",
+        ("Confidence:", "es") => "Confianza:",
+        ("Confidence:", "zh-CN") => "可信度:",
+        ("Risk:", "es") => "Riesgo:",
+        ("Risk:", "zh-CN") => "风险:",
+        ("Review:", "es") => "Revisión:",
+        ("Review:", "zh-CN") => "审查:",
+        ("⚠ REQUIRED", "es") => "⚠ REQUERIDA",
+        ("⚠ REQUIRED", "zh-CN") => "⚠ 需要",
+        ("Tags:", "es") => "Etiquetas:",
+        ("Tags:", "zh-CN") => "标签:",
+        ("Related:", "es") => "Relacionados:",
+        ("Related:", "zh-CN") => "关联:",
+        (" (Enter: search)", "es") => " (Enter: buscar)",
+        (" (Enter: search)", "zh-CN") => "（Enter: 搜索）",
+        (" (Enter: follow)", "es") => " (Enter: seguir)",
+        (" (Enter: follow)", "zh-CN") => "（Enter: 跳转）",
+
+        // ── Document panel ────────────────────────────────────────────
+        ("Document", "es") => "Documento",
+        ("Document", "zh-CN") => "文档",
+
+        // ── Welcome screen (empty doc state) ──────────────────────────
+        ("Documentation Governance for AI-Assisted Development", "es") => {
+            "Gobernanza de documentación para desarrollo asistido por IA"
+        }
+        ("Documentation Governance for AI-Assisted Development", "zh-CN") => {
+            "AI 辅助开发的文档治理"
+        }
+        ("Using repo root: ", "es") => "Usando raíz del repo: ",
+        ("Using repo root: ", "zh-CN") => "使用仓库根目录：",
+        ("Total documents: ", "es") => "Total de documentos: ",
+        ("Total documents: ", "zh-CN") => "文档总数：",
+        ("Quick start", "es") => "Inicio rápido",
+        ("Quick start", "zh-CN") => "快速开始",
+        ("Navigate groups in the left panel", "es") => {
+            "Navega grupos en el panel izquierdo"
+        }
+        ("Navigate groups in the left panel", "zh-CN") => "在左侧面板中导航分组",
+        ("Expand a group and open a document", "es") => {
+            "Expande un grupo y abre un documento"
+        }
+        ("Expand a group and open a document", "zh-CN") => "展开分组并打开文档",
+        ("Next panel / ", "es") => "Panel siguiente / ",
+        ("Next panel / ", "zh-CN") => "下一面板 / ",
+        ("Previous panel", "es") => "Panel anterior",
+        ("Previous panel", "zh-CN") => "上一面板",
+        ("Search by filename, title, tags, or date", "es") => {
+            "Buscar por archivo, título, etiquetas o fecha"
+        }
+        ("Search by filename, title, tags, or date", "zh-CN") => {
+            "按文件名、标题、标签或日期搜索"
+        }
+        ("Toggle document fullscreen", "es") => "Alternar pantalla completa",
+        ("Toggle document fullscreen", "zh-CN") => "切换文档全屏",
+        ("Show all keyboard shortcuts", "es") => "Mostrar todos los atajos",
+        ("Show all keyboard shortcuts", "zh-CN") => "显示所有快捷键",
+        ("Developed by ", "es") => "Desarrollado por ",
+        ("Developed by ", "zh-CN") => "由 ",
         ("Quit", "es") => "Salir",
         ("Quit", "zh-CN") => "退出",
         ("Force quit", "es") => "Forzar salida",

--- a/cli/src/tui/widgets/doc_viewer.rs
+++ b/cli/src/tui/widgets/doc_viewer.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientatio
 use unicode_width::UnicodeWidthStr;
 
 use crate::tui::app::{ActivePanel, App};
+use crate::tui::i18n_strings::t;
 use crate::tui::markdown::markdown_to_lines;
 use crate::tui::theme;
 
@@ -26,9 +27,10 @@ impl<'a> DocViewer<'a> {
             Style::default().fg(theme::SUBTLE)
         };
 
+        let lang = self.app.language.as_str();
         let title = match &self.app.current_doc {
             Some(doc) => format!(" {} ", doc.filename),
-            None => " Document ".to_string(),
+            None => format!(" {} ", t("Document", lang)),
         };
 
         let block = Block::default()
@@ -53,7 +55,7 @@ impl<'a> DocViewer<'a> {
             } else {
                 None
             };
-            let welcome = render_welcome(self.app.index.total_docs, fallback_info);
+            let welcome = render_welcome(self.app.index.total_docs, fallback_info, lang);
             let paragraph = Paragraph::new(welcome);
             paragraph.render(inner, buf);
             return;
@@ -129,7 +131,11 @@ impl<'a> DocViewer<'a> {
     }
 }
 
-fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<'static>> {
+fn render_welcome(
+    total_docs: usize,
+    fallback_path: Option<String>,
+    lang: &str,
+) -> Vec<Line<'static>> {
     let title = Style::default()
         .fg(theme::ACCENT)
         .add_modifier(Modifier::BOLD);
@@ -142,9 +148,13 @@ fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<
     let mut lines = vec![
         Line::from(""),
         Line::from(""),
+        // Brand name stays English in every locale.
         Line::from(Span::styled("  DevTrail Explorer", title)),
         Line::from(Span::styled(
-            "  Documentation Governance for AI-Assisted Development",
+            format!(
+                "  {}",
+                t("Documentation Governance for AI-Assisted Development", lang)
+            ),
             dim,
         )),
     ];
@@ -152,51 +162,63 @@ fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<
     if let Some(ref path) = fallback_path {
         lines.push(Line::from(""));
         lines.push(Line::from(vec![
-            Span::styled("  → Using repo root: ", Style::default().fg(Color::Yellow)),
+            Span::styled(
+                format!("  → {}", t("Using repo root: ", lang)),
+                Style::default().fg(Color::Yellow),
+            ),
             Span::styled(path.clone(), text),
         ]));
     }
 
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
-        Span::styled("  Total documents: ", dim),
+        Span::styled(format!("  {}", t("Total documents: ", lang)), dim),
         Span::styled(
             total_docs.to_string(),
             text.add_modifier(Modifier::BOLD),
         ),
     ]));
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled("  Quick start", title)));
+    lines.push(Line::from(Span::styled(
+        format!("  {}", t("Quick start", lang)),
+        title,
+    )));
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("    ↑↓ ", key),
-        Span::styled("Navigate groups in the left panel", text),
+        Span::styled(t("Navigate groups in the left panel", lang).to_string(), text),
     ]));
     lines.push(Line::from(vec![
         Span::styled("  Enter ", key),
-        Span::styled("Expand a group and open a document", text),
+        Span::styled(
+            t("Expand a group and open a document", lang).to_string(),
+            text,
+        ),
     ]));
     lines.push(Line::from(vec![
         Span::styled("   Tab  ", key),
-        Span::styled("Next panel / ", text),
+        Span::styled(t("Next panel / ", lang).to_string(), text),
         Span::styled("Shift+Tab  ", key),
-        Span::styled("Previous panel", text),
+        Span::styled(t("Previous panel", lang).to_string(), text),
     ]));
     lines.push(Line::from(vec![
         Span::styled("     /  ", key),
-        Span::styled("Search by filename, title, tags, or date", text),
+        Span::styled(
+            t("Search by filename, title, tags, or date", lang).to_string(),
+            text,
+        ),
     ]));
     lines.push(Line::from(vec![
         Span::styled("     f  ", key),
-        Span::styled("Toggle document fullscreen", text),
+        Span::styled(t("Toggle document fullscreen", lang).to_string(), text),
     ]));
     lines.push(Line::from(vec![
         Span::styled("     ?  ", key),
-        Span::styled("Show all keyboard shortcuts", text),
+        Span::styled(t("Show all keyboard shortcuts", lang).to_string(), text),
     ]));
     lines.push(Line::from(vec![
         Span::styled("     q  ", key),
-        Span::styled("Quit", text),
+        Span::styled(t("Quit", lang).to_string(), text),
     ]));
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
@@ -204,7 +226,8 @@ fn render_welcome(total_docs: usize, fallback_path: Option<String>) -> Vec<Line<
         dim,
     )));
     lines.push(Line::from(vec![
-        Span::styled("  Developed by ", dim),
+        Span::styled(format!("  {}", t("Developed by ", lang)), dim),
+        // Company name stays in its canonical form.
         Span::styled("Strange Days Tech, S.A.S.", text),
     ]));
     lines.push(Line::from(vec![

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -6,8 +6,20 @@ use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 
 use crate::tui::app::{ActivePanel, App, MetaSelection};
 use crate::tui::document::{ConfidenceLevel, DocStatus, RiskLevel};
+use crate::tui::i18n_strings::t;
 use crate::tui::theme;
-use crate::utils::truncate_visual;
+use crate::utils::{pad_right_visual, truncate_visual};
+
+/// Visual columns reserved for the field label + colon. Sized to fit the
+/// widest English label ("Confidence:" = 11 cols) plus a small gutter.
+/// Spanish ("Confianza:") and zh-CN labels (≤ 6 cols) all fit comfortably.
+const LABEL_WIDTH: usize = 13;
+
+/// Render a metadata field label padded to LABEL_WIDTH visual columns so
+/// values stay aligned across all locales.
+fn label_block(label: &str, style: ratatui::style::Style) -> ratatui::text::Span<'static> {
+    ratatui::text::Span::styled(format!(" {}", pad_right_visual(label, LABEL_WIDTH)), style)
+}
 
 pub struct MetadataPanel<'a> {
     app: &'a App,
@@ -22,6 +34,7 @@ impl<'a> MetadataPanel<'a> {
 impl Widget for MetadataPanel<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let is_active = self.app.active_panel == ActivePanel::Metadata;
+        let lang = self.app.language.as_str();
         let border_style = if is_active {
             Style::default().fg(theme::BORDER_ACTIVE)
         } else {
@@ -29,7 +42,7 @@ impl Widget for MetadataPanel<'_> {
         };
 
         let block = Block::default()
-            .title(" Metadata ")
+            .title(format!(" {} ", t("Metadata", lang)))
             .title_style(if is_active {
                 Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)
             } else {
@@ -47,7 +60,7 @@ impl Widget for MetadataPanel<'_> {
             Some(d) => d,
             None => {
                 let line = Line::from(Span::styled(
-                    " No document selected",
+                    format!(" {}", t("No document selected", lang)),
                     Style::default().fg(theme::TEXT_DIM),
                 ));
                 Paragraph::new(vec![line]).render(inner, buf);
@@ -60,11 +73,14 @@ impl Widget for MetadataPanel<'_> {
             None => {
                 let lines = vec![
                     Line::from(vec![
-                        Span::styled(" File:  ", Style::default().fg(theme::TEXT_DIM)),
+                        Span::styled(
+                            format!(" {}  ", t("File:", lang)),
+                            Style::default().fg(theme::TEXT_DIM),
+                        ),
                         Span::styled(doc.filename.clone(), Style::default().fg(theme::TEXT)),
                     ]),
                     Line::from(Span::styled(
-                        " No frontmatter",
+                        format!(" {}", t("No frontmatter", lang)),
                         Style::default().fg(theme::TEXT_DIM),
                     )),
                 ];
@@ -83,7 +99,7 @@ impl Widget for MetadataPanel<'_> {
         if let Some(ref status) = fm.status {
             let (indicator, color) = status_style(status);
             lines.push(Line::from(vec![
-                Span::styled(" Status:      ", l),
+                label_block(t("Status:", lang), l),
                 Span::styled(
                     format!("{indicator} {status}"),
                     Style::default().fg(color).add_modifier(Modifier::BOLD),
@@ -94,7 +110,7 @@ impl Widget for MetadataPanel<'_> {
         // Created
         if let Some(ref created) = fm.created {
             lines.push(Line::from(vec![
-                Span::styled(" Created:     ", l),
+                label_block(t("Created:", lang), l),
                 Span::styled(created.clone(), v),
             ]));
         }
@@ -102,7 +118,7 @@ impl Widget for MetadataPanel<'_> {
         // Agent
         if let Some(ref agent) = fm.agent {
             lines.push(Line::from(vec![
-                Span::styled(" Agent:       ", l),
+                label_block(t("Agent:", lang), l),
                 Span::styled(agent.clone(), v),
             ]));
         }
@@ -111,7 +127,7 @@ impl Widget for MetadataPanel<'_> {
         if let Some(ref confidence) = fm.confidence {
             let (filled, total, color, label) = confidence_bar(confidence);
             lines.push(Line::from(vec![
-                Span::styled(" Confidence:  ", l),
+                label_block(t("Confidence:", lang), l),
                 Span::styled(
                     format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
                     Style::default().fg(color),
@@ -124,7 +140,7 @@ impl Widget for MetadataPanel<'_> {
         if let Some(ref risk) = fm.risk_level {
             let (filled, total, color, label) = risk_bar(risk);
             lines.push(Line::from(vec![
-                Span::styled(" Risk:        ", l),
+                label_block(t("Risk:", lang), l),
                 Span::styled(
                     format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
                     Style::default().fg(color),
@@ -136,9 +152,9 @@ impl Widget for MetadataPanel<'_> {
         // Review required
         if let Some(true) = fm.review_required {
             lines.push(Line::from(vec![
-                Span::styled(" Review:      ", l),
+                label_block(t("Review:", lang), l),
                 Span::styled(
-                    "⚠ REQUIRED",
+                    t("⚠ REQUIRED", lang).to_string(),
                     Style::default()
                         .fg(theme::YELLOW)
                         .add_modifier(Modifier::BOLD),
@@ -149,12 +165,12 @@ impl Widget for MetadataPanel<'_> {
         // Tags
         if !fm.tags.is_empty() {
             let tag_hint = match self.app.meta_selection {
-                Some(MetaSelection::Tag(_)) => " (Enter: search)",
+                Some(MetaSelection::Tag(_)) => t(" (Enter: search)", lang),
                 _ => "",
             };
             lines.push(Line::from(vec![
-                Span::styled(" Tags:", l),
-                Span::styled(tag_hint, Style::default().fg(theme::TEXT_DIM)),
+                Span::styled(format!(" {}", t("Tags:", lang)), l),
+                Span::styled(tag_hint.to_string(), Style::default().fg(theme::TEXT_DIM)),
             ]));
             let tag_style = Style::default()
                 .fg(theme::TEXT_DIM)
@@ -183,12 +199,12 @@ impl Widget for MetadataPanel<'_> {
             )));
 
             let hint = match self.app.meta_selection {
-                Some(MetaSelection::Related(_)) => " (Enter: follow)",
+                Some(MetaSelection::Related(_)) => t(" (Enter: follow)", lang),
                 _ => "",
             };
             lines.push(Line::from(vec![
-                Span::styled(" Related:", l),
-                Span::styled(hint, Style::default().fg(theme::TEXT_DIM)),
+                Span::styled(format!(" {}", t("Related:", lang)), l),
+                Span::styled(hint.to_string(), Style::default().fg(theme::TEXT_DIM)),
             ]));
 
             let max_link_width = inner.width.saturating_sub(4) as usize;

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.3.0` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.5.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.5.1` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 ```
 
 ---
@@ -143,11 +143,11 @@ Use `--method` to override auto-detection: `--method=github` or `--method=cargo`
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.3.0                 │
-  │ CLI       │ cli-3.5.0                │
+  │ CLI       │ cli-3.5.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -643,7 +643,7 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 |------|---------|-------------|
 | `--lang <code>` | resolved from project (see below) | Display language for the TUI shell and framework governance docs (`en`, `es`, `zh-CN`). Falls back silently to English when a translation is missing. |
 
-**Language resolution order** (since cli-3.5.0):
+**Language resolution order** (since cli-3.5.1):
 
 1. `--lang <code>` flag, when provided
 2. `language` field in `.devtrail/config.yml`, when the file exists (an explicit value — even `language: en` — is treated as a deliberate user choice)
@@ -695,7 +695,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.5.0
+  CLI version:       cli-3.5.1
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -150,7 +150,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.3.0` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.5.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.5.1` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.3.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.5.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.5.1` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 ```
 
 ---
@@ -142,11 +142,11 @@ Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 ```
 
 ---
@@ -204,7 +204,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.3.0
-CLI version:       cli-3.5.0
+CLI version:       cli-3.5.1
 Language:          en
 Structure:         ✔ Complete
 
@@ -515,7 +515,7 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 |------|---------|-------------|
 | `--lang <código>` | resuelto desde el proyecto (ver abajo) | Idioma del shell del TUI y los docs de gobernanza del framework (`en`, `es`, `zh-CN`). Cae silenciosamente al inglés si falta la traducción. |
 
-**Orden de resolución del idioma** (desde cli-3.5.0):
+**Orden de resolución del idioma** (desde cli-3.5.1):
 
 1. Flag `--lang <código>`, cuando se especifica
 2. Campo `language` en `.devtrail/config.yml`, cuando el archivo existe (un valor explícito — incluso `language: en` — se respeta como una decisión deliberada del usuario)
@@ -567,7 +567,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.5.0
+  CLI version:       cli-3.5.1
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -150,7 +150,7 @@ DevTrail 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.3.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.5.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.5.1` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.3.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.5.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.5.1` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 ```
 
 ---
@@ -143,11 +143,11 @@ $ devtrail update-framework
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.5.0
+✔ CLI updated to cli-3.5.1
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.3.0                 │
-  │ CLI       │ cli-3.5.0                │
+  │ CLI       │ cli-3.5.1                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -636,7 +636,7 @@ $ devtrail audit --output markdown
 |------|--------|------|
 | `--lang <代码>` | 从项目解析（见下方） | TUI 界面与框架治理文档的显示语言（`en`、`es`、`zh-CN`）。缺少翻译时静默回退到英文。 |
 
-**语言解析顺序**（自 cli-3.5.0 起）：
+**语言解析顺序**（自 cli-3.5.1 起）：
 
 1. 提供 `--lang <代码>` 标志时优先
 2. `.devtrail/config.yml` 文件存在时使用其中的 `language` 字段（即便是显式的 `language: en` 也视为用户的明确选择）
@@ -688,7 +688,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.5.0
+  CLI version:       cli-3.5.1
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary
- Cierra dos huecos de i18n que quedaron tras cli-3.5.0: el panel **Metadata** y el welcome screen del panel **Document** seguían en inglés.
- Agrega ~25 entradas a `tui::i18n_strings::t` para: título del panel Metadata, estado vacío, etiquetas de campo (Status, Created, Agent, Confidence, Risk, Review, Tags, Related), hints `(Enter: search/follow)`, `⚠ REQUIRED`, título del panel Document, y todo el welcome screen (descripción del proyecto, "Total documents:", "Quick start", descripciones de teclas, "Developed by").
- Etiquetas del panel Metadata se padean a un ancho visual fijo (`LABEL_WIDTH = 13`) usando `pad_right_visual`, así los valores quedan alineados en `en`/`es`/`zh-CN` aunque el ancho del label cambie.
- "DevTrail Explorer" y "Strange Days Tech, S.A.S." se dejan en su forma canónica intencionalmente (brand/company names).
- Patch bump 3.5.0 → 3.5.1.

**Sobre el frontmatter**: los valores (status, tags, related, dates) se leen verbatim del archivo markdown — son contenido autoral del adopter, no strings de UI, así que no pasan por `t()`. Cuando cambias a zh-CN, el path mismo del archivo se intercambia por la versión `i18n/zh-CN/`, así que los valores que ves vienen del frontmatter del archivo traducido.

## Test plan
- [x] `cargo test` — 142 unit + 86 integ verde.
- [x] `cargo check --all-targets` limpio.
- [ ] Manual: `devtrail explore --lang zh-CN` → panel Metadata muestra `元数据`, `未选择文档`, `状态:`, `创建:`, `可信度:`, etc. Welcome screen muestra `快速开始`, `文档总数：`, `由 Strange Days Tech, S.A.S.`.
- [ ] Manual: `--lang es` → `Metadatos`, `Sin documento seleccionado`, `Estado:`, `Confianza:`, `Inicio rápido`, `Total de documentos: `.
- [ ] Verificar que con `L` (switcher) los valores siguen alineados al cambiar idioma sin redimensionar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)