### PR TITLE
chore(cli): remove undocumented vim aliases l and h (cli-3.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.5.2 — Remove Undocumented Vim-Style Aliases (`l`, `h`)
+
+### Changed (CLI)
+- `devtrail explore` no longer treats lowercase `l` as a synonym for `Enter` / `Right` (open document / expand group) and no longer treats lowercase `h` as a synonym for `Esc` / `Left` (back / collapse). These bindings were never documented in the `?` help popup nor the status bar, and `l` clashed with the language switcher key `L` introduced in cli-3.5.0 — users pressing `L` could land on `l` if Shift slipped, accidentally opening a document instead of cycling languages. The documented `j` / `k`, `g` / `G`, and `n` / `N` keys (all listed in the help popup) remain unchanged.
+- "Fullscreen document mode, vim-style keybindings" is now described as "alternate `j` / `k` keys for `↓` / `↑`" in `docs/adopters/CLI-REFERENCE.md` (EN / ES / zh-CN). DevTrail no longer claims vim compatibility — only specific documented alternates.
+
+---
+
 ## CLI 3.5.1 — Metadata Panel and Welcome Screen i18n Coverage
 
 ### Fixed (CLI)

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ DevTrail uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.3.0` | Templates (12 types), governance, directives |
-| CLI | `cli-` | `cli-3.5.1` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.5.2` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.5.1"
+version = "3.5.2"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.5.1"
+version = "3.5.2"
 edition = "2021"
 description = "CLI tool for DevTrail - Documentation Governance for AI-Assisted Development"
 license = "MIT"

--- a/cli/src/tui/event.rs
+++ b/cli/src/tui/event.rs
@@ -75,7 +75,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         },
 
         // Enter: open/expand or follow selected related link
-        KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => {
+        KeyCode::Enter | KeyCode::Right => {
             if app.active_panel == ActivePanel::Navigation {
                 app.nav_enter();
             } else if app.active_panel == ActivePanel::Metadata
@@ -86,7 +86,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         }
 
         // Back: collapse/go back / clear search
-        KeyCode::Esc | KeyCode::Char('h') | KeyCode::Left => {
+        KeyCode::Esc | KeyCode::Left => {
             match app.active_panel {
                 ActivePanel::Document if key.code == KeyCode::Esc => {
                     if app.view_mode == ViewMode::Fullscreen {

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.3.0` | Templates (12 types), governance docs, directives |
-| CLI | `cli-` | `cli-3.5.1` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.5.2` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 ```
 
 ---
@@ -143,11 +143,11 @@ Use `--method` to override auto-detection: `--method=github` or `--method=cargo`
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.3.0                 │
-  │ CLI       │ cli-3.5.1                │
+  │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -643,7 +643,7 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 |------|---------|-------------|
 | `--lang <code>` | resolved from project (see below) | Display language for the TUI shell and framework governance docs (`en`, `es`, `zh-CN`). Falls back silently to English when a translation is missing. |
 
-**Language resolution order** (since cli-3.5.1):
+**Language resolution order** (since cli-3.5.2):
 
 1. `--lang <code>` flag, when provided
 2. `language` field in `.devtrail/config.yml`, when the file exists (an explicit value — even `language: en` — is treated as a deliberate user choice)
@@ -657,7 +657,7 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 - Markdown rendering with colors, tables, code blocks, and heading indentation
 - Navigate between related documents via hyperlinks
 - Search by filename, title, tags, or date
-- Fullscreen document mode, vim-style keybindings
+- Fullscreen document mode, with `j` / `k` as alternate keys for `↓` / `↑`
 - Localization-aware: framework docs (`QUICK-REFERENCE`, `AGENT-RULES`, China regulatory guides, etc.) are served in the language set by `language` in `.devtrail/config.yml` or by `--lang`
 
 **Key bindings:**
@@ -695,7 +695,7 @@ Show version, authorship, and license information.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.5.1
+  CLI version:       cli-3.5.2
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -150,7 +150,7 @@ DevTrail usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.3.0` | Plantillas (12 tipos), gobernanza, directivas |
-| CLI | `cli-` | `cli-3.5.1` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.5.2` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.3.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.5.1` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.5.2` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -109,7 +109,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 ```
 
 ---
@@ -142,11 +142,11 @@ Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 ```
 
 ---
@@ -204,7 +204,7 @@ DevTrail Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.3.0
-CLI version:       cli-3.5.1
+CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
 
@@ -515,7 +515,7 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 |------|---------|-------------|
 | `--lang <código>` | resuelto desde el proyecto (ver abajo) | Idioma del shell del TUI y los docs de gobernanza del framework (`en`, `es`, `zh-CN`). Cae silenciosamente al inglés si falta la traducción. |
 
-**Orden de resolución del idioma** (desde cli-3.5.1):
+**Orden de resolución del idioma** (desde cli-3.5.2):
 
 1. Flag `--lang <código>`, cuando se especifica
 2. Campo `language` en `.devtrail/config.yml`, cuando el archivo existe (un valor explícito — incluso `language: en` — se respeta como una decisión deliberada del usuario)
@@ -529,7 +529,7 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 - Renderizado de Markdown con colores, tablas, bloques de código e indentación por niveles
 - Navegación entre documentos relacionados mediante hipervínculos
 - Búsqueda por nombre de archivo, título, tags o fecha
-- Modo pantalla completa, atajos estilo vim
+- Modo pantalla completa, con `j` / `k` como teclas alternas para `↓` / `↑`
 - Consciente de localización: los docs del framework (`QUICK-REFERENCE`, `AGENT-RULES`, guías regulatorias de China, etc.) se sirven en el idioma definido por `language` en `.devtrail/config.yml` o por `--lang`
 
 **Atajos de teclado:**
@@ -567,7 +567,7 @@ Muestra información de versión, autoría y licencia.
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.5.1
+  CLI version:       cli-3.5.2
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -150,7 +150,7 @@ DevTrail 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.3.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.5.1` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.5.2` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ DevTrail 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.3.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.5.1` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.5.2` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -110,7 +110,7 @@ $ devtrail update
 Updating framework...
 ✔ Framework updated to fw-4.3.0
 Updating CLI...
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 ```
 
 ---
@@ -143,11 +143,11 @@ $ devtrail update-framework
 
 ```bash
 $ devtrail update-cli
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 
 $ devtrail update-cli --method=cargo
 Compiling from source, this may take a few minutes...
-✔ CLI updated to cli-3.5.1
+✔ CLI updated to cli-3.5.2
 ```
 
 ---
@@ -210,7 +210,7 @@ $ devtrail status
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
   │ Framework │ fw-4.3.0                 │
-  │ CLI       │ cli-3.5.1                │
+  │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
 
@@ -636,7 +636,7 @@ $ devtrail audit --output markdown
 |------|--------|------|
 | `--lang <代码>` | 从项目解析（见下方） | TUI 界面与框架治理文档的显示语言（`en`、`es`、`zh-CN`）。缺少翻译时静默回退到英文。 |
 
-**语言解析顺序**（自 cli-3.5.1 起）：
+**语言解析顺序**（自 cli-3.5.2 起）：
 
 1. 提供 `--lang <代码>` 标志时优先
 2. `.devtrail/config.yml` 文件存在时使用其中的 `language` 字段（即便是显式的 `language: en` 也视为用户的明确选择）
@@ -650,7 +650,7 @@ $ devtrail audit --output markdown
 - Markdown 渲染，支持颜色、表格、代码块和标题缩进
 - 通过超链接在关联文档间导航
 - 按文件名、标题、标签或日期搜索
-- 全屏文档模式，vim 风格快捷键
+- 全屏文档模式，`j` / `k` 作为 `↓` / `↑` 的替代按键
 - 本地化感知：框架文档（`QUICK-REFERENCE`、`AGENT-RULES`、中国合规指南等）按 `.devtrail/config.yml` 中的 `language` 或 `--lang` 提供对应语言版本
 
 **快捷键：**
@@ -688,7 +688,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 ```bash
 $ devtrail about
 DevTrail CLI
-  CLI version:       cli-3.5.1
+  CLI version:       cli-3.5.2
   Framework version: fw-4.3.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT


### PR DESCRIPTION
## Summary
- The TUI silently treated lowercase `l` as a synonym for `Enter` / `Right` (open document / expand group) and lowercase `h` as a synonym for `Esc` / `Left` (back / collapse). Neither alias was listed in the `?` help popup or the status bar, and `l` clashed with the **language switcher** `L` introduced in cli-3.5.0 — pressing `L` with Shift slipping dropped you into "open document" instead of cycling languages.
- Drop both. The documented alternates (`j` / `k` for navigation/scroll, `g` / `G` for doc top/bottom, `n` / `N` for next/previous doc) stay untouched.
- Update CLI-REFERENCE.md (EN / ES / zh-CN): "vim-style keybindings" → "alternate `j` / `k` keys for `↓` / `↑`". DevTrail no longer claims vim compatibility — only specific documented alternates.
- Patch bump 3.5.1 → 3.5.2.

## Test plan
- [x] `cargo test` — 142 unit + 86 integ verde.
- [x] `cargo check --all-targets` limpio.
- [ ] Manual: in `devtrail explore`, pressing lowercase `l` no longer opens documents (no-op). Pressing `L` reliably triggers the language switcher. `j` / `k` / `g` / `G` / `n` / `N` continue to work as documented in the `?` popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)