### PR TITLE
fix(framework): docs-validation.yml recognizes all DocTypes (fw-4.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.4.1 — `docs-validation.yml` workflow recognizes all DocTypes and recent governance files
+
+### Fixed (Framework)
+
+- `dist/.github/workflows/docs-validation.yml` had three pre-existing divergences that surfaced once Charters Phase 1 made adopters revisit the framework:
+  - **`VALID_PATTERN` regex** missed the four China-specific DocTypes (`PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`) that shipped earlier and incorrectly listed two stale prefixes (`OPS`, `DOC`) that aren't real DocType variants. A China-region adopter creating `PIPIA-2026-01-15-001-foo.md` would have the workflow reject it as "Invalid naming".
+  - **`TYPES` array in the `governance-metrics` job** was a 12-element list missing the same four China DocTypes. The metrics summary on `$GITHUB_STEP_SUMMARY` always reported zero PIPIA/CACFILE/TC260RA/AILABEL counts, even when those documents existed.
+  - **`EXCLUDED` regex** (referenced in 5 places) listed only 8 framework files but the framework now ships ~18 additional governance / reference files at the root of `00-governance/` and `03-implementation/` (C4-DIAGRAM-GUIDE, MANAGEMENT-REVIEW-TEMPLATE, AI-KPIS, AI-LIFECYCLE-TRACKER, AI-RISK-CATALOG, AI-GOVERNANCE-POLICY, CHINA-REGULATORY-FRAMEWORK, CAC-FILING-GUIDE, GB-45438-LABELING-GUIDE, PIPL-PIPIA-GUIDE, ISO-25010-2023-REFERENCE, OBSERVABILITY-GUIDE, TC260-IMPLEMENTATION-GUIDE, the four NIST-AI-RMF guides). When an adopter ran `devtrail update-framework` on a tracked checkout, the workflow flagged each of these as "Invalid naming" and the job failed.
+
+### Changed (Framework)
+
+- The workflow now uses a **whitelist approach** instead of the blacklist. A new top-level `env: DOC_TYPE_PREFIXES` enumerates the 16 canonical DocType prefixes (in sync with `cli/src/document.rs::DocType::ALL_PREFIXES`); per-step checks skip files whose basename does not start with one of those prefixes. Framework / governance / template files are silently skipped with no manual exclude list to maintain. The `governance-metrics` job derives its `TYPES` array from the same env var.
+- `cli/src/document.rs::ALL_PREFIXES` gains a doc-comment pointing at the workflow's env var, and the workflow's env var has a comment pointing back. Adding a new DocType still requires updating both sides, but the bidirectional pointer makes the obligation discoverable from either entry point.
+
+### Notes
+
+- This is a Framework-only patch. CLI behavior is unchanged; `cli-3.6.0` is unaffected. Existing adopters can pick up the fix with `devtrail update-framework`.
+- Charter validation in CI is intentionally still out of scope for this workflow — the `--include-charters` flag on `devtrail validate` is opt-in and the workflow's path filter (`.devtrail/**`) does not cover `docs/charters/`. Adding Charter validation to CI is queued for cli-3.7.0 along with `--include-charters --staged` integration.
+
+---
+
 ## Framework 4.4.0 / CLI 3.6.0 — Charters as a first-class entity
 
 The first user-visible step of the post-Sentinel roadmap (`Propuesta/devtrail-cli-roadmap.md` Fase 1). Crystallizes the Charter pattern — bounded, auditable units of work declared ex-ante and validated ex-post — that emerged from the 6-cycle Sentinel `/plan-audit` experiment. The artifact was historically called "Plan" in Sentinel; renamed to **Charter** to disambiguate from GitHub SpecKit's `plan.md`. Sentinel's historical files preserve "Plan"; everything DevTrail ships from this release on uses "Charter".

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ DevTrail uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.4.0` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.4.1` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.6.0` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
@@ -238,7 +238,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/a
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/devtrail/releases
-# and download the latest fw-* release (e.g., fw-4.4.0)
+# and download the latest fw-* release (e.g., fw-4.4.1)
 
 # Extract and copy to your project
 unzip devtrail-fw-*.zip -d your-project/

--- a/cli/src/document.rs
+++ b/cli/src/document.rs
@@ -71,7 +71,13 @@ impl DocType {
         }
     }
 
-    /// All valid prefixes
+    /// All valid prefixes.
+    ///
+    /// Adding a DocType? Update BOTH this array and the
+    /// `DOC_TYPE_PREFIXES` env var at the top of
+    /// `dist/.github/workflows/docs-validation.yml`. The CI workflow uses
+    /// that env var as its single source of truth for valid type prefixes,
+    /// but it cannot import from Rust — the two must be kept in manual sync.
     pub const ALL_PREFIXES: &'static [&'static str] = &[
         "AILOG", "AIDEC", "ADR", "ETH", "REQ", "TES", "INC", "TDE",
         "SEC", "MCARD", "SBOM", "DPIA",

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -270,4 +270,4 @@ When a change modifies API endpoints:
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
@@ -257,4 +257,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -213,4 +213,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -270,4 +270,4 @@ Cuando un cambio modifica endpoints de API:
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -249,4 +249,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -270,4 +270,4 @@ confidence: high | medium | low
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -249,4 +249,4 @@ draft ──────► accepted ──────► deprecated
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*DevTrail v4.4.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/QUICK-REFERENCE.md
+++ b/dist/.devtrail/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.4.0 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.4.1 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.github/workflows/docs-validation.yml
+++ b/dist/.github/workflows/docs-validation.yml
@@ -27,6 +27,15 @@ on:
     paths:
       - '.devtrail/**'
 
+# Single source of truth for the DocType prefixes the workflow recognizes.
+# Adding a new DocType requires updating BOTH this list and
+# `cli/src/document.rs::DocType::ALL_PREFIXES`. Keep them in sync.
+# Files whose basename does not start with one of these prefixes followed by
+# `-` are treated as framework / governance / template files and are silently
+# skipped from the per-document checks (no manual exclude list needed).
+env:
+  DOC_TYPE_PREFIXES: "AILOG|AIDEC|ADR|ETH|REQ|TES|INC|TDE|SEC|MCARD|SBOM|DPIA|PIPIA|CACFILE|TC260RA|AILABEL"
+
 jobs:
   validate-docs:
     name: Validate Documentation
@@ -71,23 +80,28 @@ jobs:
           echo "📋 Validating file naming convention..."
           ERRORS=0
 
-          # Canonical source of valid types: cli/src/document.rs::DocType::ALL_PREFIXES
-          VALID_PATTERN="^(ADR|REQ|TES|OPS|INC|TDE|AILOG|AIDEC|ETH|DOC|SEC|MCARD|SBOM|DPIA)-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}-[a-z0-9-]+\.md$"
-          EXCLUDED="PRINCIPLES.md|DOCUMENTATION-POLICY.md|AGENT-RULES.md|TEMPLATE-.*\.md|README.md|QUICK-REFERENCE.md|INDEX.md|GIT-BRANCHING-STRATEGY.md"
+          # Whitelist approach: only files whose basename starts with one of
+          # the known DocType prefixes are validated. Framework / governance /
+          # template files (e.g., AGENT-RULES.md, AI-KPIS.md, NIST-AI-RMF-*)
+          # don't match any prefix and are silently skipped — no manual
+          # exclude list to maintain.
+          PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
+          VALID_PATTERN="^(${DOC_TYPE_PREFIXES})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}-[a-z0-9-]+\.md$"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             filename=$(basename "$file")
 
-            # Skip excluded files
-            if echo "$filename" | grep -qE "$EXCLUDED"; then
-              echo "  ⊘ Excluded: $filename"
+            # Skip files that are not adopter-created typed documents.
+            if ! echo "$filename" | grep -qE "$PREFIX_RE"; then
+              echo "  ⊘ Skipped (framework / non-typed): $filename"
               continue
             fi
 
-            # Validate naming convention
+            # File starts with a DocType prefix — validate the full pattern.
             if ! echo "$filename" | grep -qE "$VALID_PATTERN"; then
               echo "  ✗ Invalid naming: $filename"
               echo "    Expected: [TYPE]-[YYYY-MM-DD]-[NNN]-[description].md"
+              echo "    Valid TYPEs: ${DOC_TYPE_PREFIXES//|/, }"
               ERRORS=$((ERRORS + 1))
             else
               echo "  ✓ $filename"
@@ -110,14 +124,14 @@ jobs:
           echo "📋 Validating metadata..."
           ERRORS=0
 
-          EXCLUDED="PRINCIPLES.md|DOCUMENTATION-POLICY.md|AGENT-RULES.md|TEMPLATE-.*\.md|README.md|QUICK-REFERENCE.md|INDEX.md|GIT-BRANCHING-STRATEGY.md"
+          PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
           REQUIRED_FIELDS="id title status created"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             filename=$(basename "$file")
 
-            # Skip excluded files
-            if echo "$filename" | grep -qE "$EXCLUDED"; then
+            # Only validate adopter-created typed documents.
+            if ! echo "$filename" | grep -qE "$PREFIX_RE"; then
               continue
             fi
 
@@ -153,13 +167,13 @@ jobs:
           echo "📋 Validating risk_level and review_required..."
           ERRORS=0
 
-          EXCLUDED="PRINCIPLES.md|DOCUMENTATION-POLICY.md|AGENT-RULES.md|TEMPLATE-.*\.md|README.md|QUICK-REFERENCE.md|INDEX.md|GIT-BRANCHING-STRATEGY.md"
+          PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             filename=$(basename "$file")
 
-            # Skip excluded files
-            if echo "$filename" | grep -qE "$EXCLUDED"; then
+            # Only validate adopter-created typed documents.
+            if ! echo "$filename" | grep -qE "$PREFIX_RE"; then
               continue
             fi
 
@@ -314,12 +328,12 @@ jobs:
           echo "📋 Checking compliance: high-risk documents must reference an ETH..."
           ERRORS=0
 
-          EXCLUDED="PRINCIPLES.md|DOCUMENTATION-POLICY.md|AGENT-RULES.md|TEMPLATE-.*\.md|README.md|QUICK-REFERENCE.md|INDEX.md|GIT-BRANCHING-STRATEGY.md"
+          PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             filename=$(basename "$file")
 
-            if echo "$filename" | grep -qE "$EXCLUDED"; then
+            if ! echo "$filename" | grep -qE "$PREFIX_RE"; then
               continue
             fi
 
@@ -347,12 +361,12 @@ jobs:
         run: |
           echo "📋 Checking EU AI Act compliance..."
 
-          EXCLUDED="PRINCIPLES.md|DOCUMENTATION-POLICY.md|AGENT-RULES.md|TEMPLATE-.*\.md|README.md|QUICK-REFERENCE.md|INDEX.md|GIT-BRANCHING-STRATEGY.md"
+          PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             filename=$(basename "$file")
 
-            if echo "$filename" | grep -qE "$EXCLUDED"; then
+            if ! echo "$filename" | grep -qE "$PREFIX_RE"; then
               continue
             fi
 
@@ -391,7 +405,9 @@ jobs:
           echo "📊 Generating governance metrics..."
 
           DEVTRAIL_DIR=".devtrail"
-          TYPES=("AILOG" "AIDEC" "ADR" "ETH" "REQ" "TES" "INC" "TDE" "SEC" "MCARD" "SBOM" "DPIA")
+          # Derive the types array from the workflow-level env var so we never
+          # have to maintain it in two places.
+          IFS='|' read -ra TYPES <<< "$DOC_TYPE_PREFIXES"
 
           # Header
           echo "## DevTrail Governance Metrics" >> "$GITHUB_STEP_SUMMARY"

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.4.0"
+version: "4.4.1"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -226,7 +226,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.4.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.4.1`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ DevTrail uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.4.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.4.1` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.6.0` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -86,7 +86,7 @@ Initialize DevTrail in a project directory.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.4.0
+✔ Downloaded DevTrail fw-4.4.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +108,7 @@ If `.devtrail/` does not exist in the current directory, the framework update is
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.4.0
+✔ Framework updated to fw-4.4.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -125,7 +125,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.4.0
+✔ Framework updated to fw-4.4.1
 ```
 
 ---
@@ -209,7 +209,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.4.0                 │
+  │ Framework │ fw-4.4.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -266,7 +266,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.4.0
+  Using version: fw-4.4.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -797,7 +797,7 @@ Show version, authorship, and license information.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.4.0
+  Framework version: fw-4.4.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -149,7 +149,7 @@ DevTrail usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.4.0` | Plantillas (12 tipos), gobernanza, directivas |
+| Framework | `fw-` | `fw-4.4.1` | Plantillas (12 tipos), gobernanza, directivas |
 | CLI | `cli-` | `cli-3.6.0` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
@@ -181,7 +181,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/devtrail/releases
-# y descarga el último release fw-* (ej. fw-4.4.0)
+# y descarga el último release fw-* (ej. fw-4.4.1)
 
 # Extraer y copiar a tu proyecto
 unzip devtrail-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -217,7 +217,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.4.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.4.1`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ DevTrail usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.4.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.4.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.6.0` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -86,7 +86,7 @@ Inicializa DevTrail en un directorio de proyecto.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.4.0
+✔ Downloaded DevTrail fw-4.4.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -107,7 +107,7 @@ Si `.devtrail/` no existe en el directorio actual, la actualización del framewo
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.4.0
+✔ Framework updated to fw-4.4.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -124,7 +124,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.4.0
+✔ Framework updated to fw-4.4.1
 ```
 
 ---
@@ -203,7 +203,7 @@ $ devtrail status
 DevTrail Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.4.0
+Framework version: fw-4.4.1
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -633,7 +633,7 @@ Muestra información de versión, autoría y licencia.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.4.0
+  Framework version: fw-4.4.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -149,7 +149,7 @@ DevTrail 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.4.0` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.4.1` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.6.0` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
@@ -181,7 +181,7 @@ DevTrail 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/devtrail/releases
-# 下载最新的 fw-* 发布（例如 fw-4.4.0）
+# 下载最新的 fw-* 发布（例如 fw-4.4.1）
 
 # 解压并复制到你的项目
 unzip devtrail-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -226,7 +226,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.4.0`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.4.1`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ DevTrail 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.4.0` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.4.1` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.6.0` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -86,7 +86,7 @@ devtrail status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.4.0
+✔ Downloaded DevTrail fw-4.4.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +108,7 @@ Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.4.0
+✔ Framework updated to fw-4.4.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -125,7 +125,7 @@ Updating CLI...
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.4.0
+✔ Framework updated to fw-4.4.1
 ```
 
 ---
@@ -209,7 +209,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.4.0                 │
+  │ Framework │ fw-4.4.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -266,7 +266,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.4.0
+  Using version: fw-4.4.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -741,7 +741,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.4.0
+  Framework version: fw-4.4.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail


### PR DESCRIPTION
## Summary

- The workflow shipped at `dist/.github/workflows/docs-validation.yml` had three pre-existing divergences that surfaced during the post-Charters review:
  - `VALID_PATTERN` missed the 4 China-specific DocTypes (`PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`) and incorrectly listed 2 stale prefixes (`OPS`, `DOC`).
  - `governance-metrics` job's `TYPES` array had the same 12-element gap.
  - `EXCLUDED` blacklist missed ~18 framework / governance / NIST guide files added in later releases — `devtrail update-framework` on a tracked checkout would fail every file as "Invalid naming".
- Refactored to a **whitelist** approach: a single workflow-level `env: DOC_TYPE_PREFIXES` is the canonical 16-prefix list. Per-step checks skip files whose basename doesn't start with one of those prefixes (no manual exclude list).
- `cli/src/document.rs::ALL_PREFIXES` gains a doc-comment pointing at the workflow's env var so the manual sync requirement is discoverable from either side.

## Scope

- Framework-only patch. CLI behavior unchanged; `cli-3.6.0` unaffected.
- 26 files changed (+105 / −62). Most of the diff is the 13 governance footers and the 9 docs-versioning lines getting bumped from `fw-4.4.0` → `fw-4.4.1`. The substantive change is in the workflow YAML.

## Test plan

- [ ] CI on tag `fw-4.4.1` (release-framework.yml) packages and publishes the new ZIP.
- [ ] Manual: in a clean adopter project, copy `dist/.github/workflows/docs-validation.yml` to `.github/workflows/`, push a commit that touches a `PIPIA-*.md` file → workflow accepts it (previously rejected).
- [ ] Manual: same workflow on a commit that touches `AGENT-RULES.md` → workflow silently skips it (previously rejected after the file count grew beyond the EXCLUDED list).
- [ ] `cargo check` / `cargo test`: unchanged green (the only `cli/` edit is a doc-comment).

## Post-merge

```
git tag fw-4.4.1 && git push origin fw-4.4.1
```

Triggers `release-framework.yml`; CLI is unaffected so no `cli-*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)