### PR TITLE
feat(framework): Phase 2 PR 1 — telemetry schema + drift script artifacts

### DIFF
--- a/dist/.devtrail/schemas/charter-telemetry.schema.v0.json
+++ b/dist/.devtrail/schemas/charter-telemetry.schema.v0.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devtrail.dev/schemas/charter-telemetry.schema.v0.json",
+  "title": "DevTrail Charter Telemetry (experimental v0)",
+  "description": "Schema for the post-execution telemetry recorded at Charter close. See Propuesta/devtrail-charter-telemetry.md v0.3 for the questions this instrumentation is designed to answer and the empirical evidence behind each field.",
+  "$comment": "EXPERIMENTAL v0. Derived from 5 PLAN-NN.telemetry.yaml files in Sentinel (one project, Go backend) — same N=1-domain caveat as charter.schema.v0.json. Will not stabilize to v1.0 until validated in a second domain. The 4 fields refined by Sentinel relative to v0.1 of the doc are: external_audit as array (dual-audit calibration), outcome.scope_change_notes with F1...FN encoding, agent_quality.r_n_plus_one_emergent_count, qualitative.format_iteration. Adopters: this schema is for the YAML inside the top-level `charter_telemetry:` key in .devtrail/charters/CHARTER-NN.telemetry.yaml — not for the file itself.",
+  "type": "object",
+  "required": ["charter_telemetry"],
+  "additionalProperties": false,
+  "properties": {
+    "charter_telemetry": {
+      "type": "object",
+      "required": ["charter_id", "charter_title", "closed_at", "effort", "outcome"],
+      "additionalProperties": false,
+      "properties": {
+        "charter_id": {
+          "type": "string",
+          "pattern": "^CHARTER-[0-9]{2,}(-[a-z0-9-]+)?$",
+          "description": "Charter identifier this telemetry corresponds to. Must match the charter_id of an existing Charter file in docs/charters/."
+        },
+        "charter_title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short title of the Charter, copied for human-readability in the telemetry file."
+        },
+        "closed_at": {
+          "type": "string",
+          "format": "date",
+          "description": "Date when the Charter was closed (YYYY-MM-DD). Conventionally the same date as the closing commit."
+        },
+
+        "originating_ailogs": {
+          "type": "array",
+          "description": "AILOGs that motivated the Charter, with retrospective notes on whether they remained relevant at execution time.",
+          "items": {
+            "type": "object",
+            "required": ["ailog_id", "still_relevant_at_execution"],
+            "additionalProperties": false,
+            "properties": {
+              "ailog_id": {
+                "type": "string",
+                "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}(-[a-z0-9-]+)?$"
+              },
+              "still_relevant_at_execution": { "type": "boolean" },
+              "relevance_notes": { "type": "string" }
+            }
+          }
+        },
+
+        "trigger": {
+          "type": "object",
+          "description": "Whether the declared trigger fired cleanly. Sentinel observed that declared triggers were prescriptive, not predictive (5/5 Plans fired on meta-experiment signal). Capturing the gap is the point.",
+          "additionalProperties": false,
+          "properties": {
+            "declared_kind": {
+              "type": "string",
+              "enum": ["event_trigger", "date", "metric_threshold", "infrastructure_milestone"]
+            },
+            "declared_description": { "type": "string" },
+            "fired_at": { "type": "string", "format": "date" },
+            "fire_clarity": {
+              "type": "string",
+              "enum": ["clear", "ambiguous", "manually_decided"]
+            },
+            "fire_clarity_notes": { "type": "string" }
+          }
+        },
+
+        "pre_work": {
+          "type": "object",
+          "description": "Whether the §Pre-trabajo section in the Charter was honored. items_discovered_during_planning being high signals the field is not doing its job.",
+          "additionalProperties": false,
+          "properties": {
+            "items_declared": { "type": "integer", "minimum": 0 },
+            "items_completed_before_planning": { "type": "integer", "minimum": 0 },
+            "items_skipped": { "type": "integer", "minimum": 0 },
+            "items_discovered_during_planning": { "type": "integer", "minimum": 0 },
+            "pre_work_quality": { "type": "string", "enum": ["high", "medium", "low"] },
+            "pre_work_notes": { "type": "string" }
+          }
+        },
+
+        "planning_session": {
+          "type": "object",
+          "description": "Optional — many Charters execute without a formal planning session. Set occurred:false to skip the rest.",
+          "additionalProperties": false,
+          "required": ["occurred"],
+          "properties": {
+            "occurred": { "type": "boolean" },
+            "duration_minutes": { "type": "integer", "minimum": 0 },
+            "participants": { "type": "integer", "minimum": 0 },
+            "decisions_made": { "type": "integer", "minimum": 0 },
+            "decisions_deferred": { "type": "integer", "minimum": 0 },
+            "notes": { "type": "string" }
+          }
+        },
+
+        "effort": {
+          "type": "object",
+          "description": "Estimation accuracy — TIME only. Line-count was retired in Sentinel (drift 1.0x to 8.1x; not predictive).",
+          "required": ["estimated_effort", "actual_effort"],
+          "additionalProperties": false,
+          "properties": {
+            "started_at": { "type": "string", "format": "date" },
+            "finished_at": { "type": "string", "format": "date" },
+            "estimated_effort": {
+              "type": "string",
+              "pattern": "^(XS|S|M|L)( \\(~.+\\))?$",
+              "description": "XS/S/M/L bucket plus optional ~time hint, e.g., 'M (~1.5h)'."
+            },
+            "actual_effort": {
+              "type": "string",
+              "pattern": "^(XS|S|M|L)( \\(~.+\\))?$"
+            },
+            "estimation_drift_factor": {
+              "type": "number",
+              "minimum": 0,
+              "description": "actual / estimated TIME ratio. 1.0 = perfect estimate."
+            },
+            "estimation_drift_reason": { "type": "string" }
+          }
+        },
+
+        "agent_quality": {
+          "type": "object",
+          "description": "Signal about the agent's behavior during execution, not just deliverables.",
+          "additionalProperties": false,
+          "properties": {
+            "sessions_count": { "type": "integer", "minimum": 0 },
+            "hallucinations_caught": { "type": "integer", "minimum": 0 },
+            "hallucination_categories": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "decisions_contradicting_prior_adrs": { "type": "integer", "minimum": 0 },
+            "contradiction_notes": { "type": "string" },
+            "context_loaded_was_sufficient": { "type": "boolean" },
+            "additional_context_loaded_manually": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Files the operator had to load manually mid-execution because the initial context was insufficient. PLAN-06 = 6."
+            },
+            "r_n_plus_one_emergent_count": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Risks named explicitly during execution that were not in the declared §Risks list. Validated in 4/4 Sentinel cycles as cross-agent signal."
+            },
+            "skill_prompts_used": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+
+        "external_audit": {
+          "type": "array",
+          "description": "Array (not single object) — Sentinel validated dual-audit (Copilot + Gemini) as cross-model calibration. The categorization delta between auditors is itself signal.",
+          "items": {
+            "type": "object",
+            "required": ["auditor", "findings_total"],
+            "additionalProperties": false,
+            "properties": {
+              "auditor": { "type": "string", "minLength": 1 },
+              "findings_total": { "type": "integer", "minimum": 0 },
+              "findings_by_category": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "hallucination": { "type": "integer", "minimum": 0 },
+                  "implementation_gap": { "type": "integer", "minimum": 0 },
+                  "real_debt": { "type": "integer", "minimum": 0 },
+                  "false_positive": { "type": "integer", "minimum": 0 }
+                }
+              },
+              "audit_quality": { "type": "string", "enum": ["high", "medium", "low"] },
+              "audit_notes": { "type": "string" }
+            }
+          }
+        },
+
+        "outcome": {
+          "type": "object",
+          "required": ["completed_as_planned", "scope_changes"],
+          "additionalProperties": false,
+          "properties": {
+            "completed_as_planned": { "type": "boolean" },
+            "scope_changes": { "type": "string", "enum": ["ninguno", "menor", "mayor"] },
+            "scope_change_notes": {
+              "type": "string",
+              "description": "Free text. Convention: F1...FN encoding consistent with claude-analisis output, with optional category tag — e.g. 'F1 (IG): drift declared-vs-implemented in handler.go'. IG=implementation gap, FP=false positive."
+            },
+            "new_followups_generated": { "type": "integer", "minimum": 0 },
+            "new_charters_created": { "type": "integer", "minimum": 0 },
+            "charters_invalidated": { "type": "integer", "minimum": 0 },
+            "associated_stage_id": { "type": "string" }
+          }
+        },
+
+        "qualitative": {
+          "type": "object",
+          "description": "Where the insight usually lives. Quantitative fields show what happened; qualitative shows what to change.",
+          "additionalProperties": false,
+          "properties": {
+            "format_iteration": {
+              "type": "string",
+              "description": "Which format version of the Charter template was used (e.g., v3, v4). Self-evolving: each Charter refines the format of the next."
+            },
+            "friction_points": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "wins": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "overall_satisfaction": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "description": "1-5 score for how useful the Charter format was in this case."
+            },
+            "would_repeat_format": { "type": "boolean" },
+            "proposed_format_changes": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/dist/.devtrail/scripts/check-charter-drift.sh
+++ b/dist/.devtrail/scripts/check-charter-drift.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# check-charter-drift.sh — flag declared-but-not-modified files at Charter close.
+#
+# Ported from Sentinel scripts/check-plan-drift.sh (validated empirically with
+# zero false positives across PLAN-05 retrospective + PLAN-06 prospective).
+# DevTrail surface: docs/charters/CHARTER-NN.md instead of docs/plans/NN-*.md.
+#
+# This script catches drifts of OMISSION (file declared in Charter, never touched)
+# and SCOPE EXPANSION (file modified but not declared). Both kinds were caught by
+# external auditors in PLAN-05 (F4 evaluator_test gap, F5 architectural hallucination,
+# modified extras like wire_gen.go).
+#
+# Usage:
+#   .devtrail/scripts/check-charter-drift.sh <charter-file> <git-range>
+#
+# Examples:
+#   .devtrail/scripts/check-charter-drift.sh docs/charters/01-format-v4.md fd65e87..473f6e0
+#   .devtrail/scripts/check-charter-drift.sh docs/charters/01-format-v4.md HEAD~1..HEAD
+#
+# Exit codes:
+#   0 — no drift detected (or only documented out-of-scope extras)
+#   1 — drift found that needs attention (declared-but-not-modified or
+#       undocumented scope expansion)
+#   2 — usage error
+#
+# Output is human-readable; the agent reading this should take action by either
+# completing the missing work or documenting the drift in the AILOG under
+# "## Risk" as `R<N+1> (new, not in Charter)`.
+#
+# Note: `devtrail charter drift` (cli-3.7.0+) wraps this script and adds
+# AILOG-awareness — it suppresses alerts on paths already documented as R<N>
+# in any AILOG referenced by the Charter's `originating_ailogs` frontmatter.
+# Invoking this script directly is fine but you'll see those documented-drift
+# alerts as well; use the CLI for the de-noised view.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <charter-file> <git-range>" >&2
+  echo "Example: $0 docs/charters/01-format-v4.md fd65e87..473f6e0" >&2
+  exit 2
+fi
+
+CHARTER_FILE="$1"
+GIT_RANGE="$2"
+
+if [ ! -f "$CHARTER_FILE" ]; then
+  echo "ERROR: Charter file not found: $CHARTER_FILE" >&2
+  exit 2
+fi
+
+# Extract declared files from the "## Files to modify" / "## Archivos a modificar" section.
+# Reads the section delimited by the heading and the next `## ` heading.
+# Then extracts backtick-quoted paths that look like real files (have a known
+# extension or `.devtrail/` prefix).
+declared=$(awk '
+    /^## (Files to modify|Archivos a modificar|要修改的文件)/ { in_table=1; next }
+    in_table && /^## / { in_table=0 }
+    in_table { print }
+' "$CHARTER_FILE" | grep -oP '`\K[^`]+(?=`)' | grep -E '\.(go|sql|yaml|yml|md|sh|ts|tsx|js|jsx|rs|py|java|kt|rb|cs|cpp|c|h|hpp|swift|toml|json|tf)$|\.devtrail/' | sort -u)
+
+if [ -z "$declared" ]; then
+  echo "WARN: no files extracted from §Files to modify in $CHARTER_FILE" >&2
+  echo "  Either the section is missing, the table format is unusual, or the" >&2
+  echo "  declared paths don't have recognized extensions. Script can't help — exit clean." >&2
+  exit 0
+fi
+
+# Get files actually modified in the range.
+modified=$(git diff --name-only "$GIT_RANGE" 2>/dev/null | sort -u)
+
+if [ -z "$modified" ]; then
+  echo "WARN: no files modified in range $GIT_RANGE — Charter may not have executed." >&2
+  exit 0
+fi
+
+# Set diff: declared but not modified.
+# Note: AILOG paths in the Charter often have wildcards (e.g. AILOG-...md), so
+# we compare on basename match too — if the Charter declared an AILOG path with
+# wildcards, any AILOG that matches the prefix is considered "fulfilled".
+declared_omitted=""
+while IFS= read -r decl; do
+  # If declared path has '...', try a prefix match.
+  if [[ "$decl" == *...* ]]; then
+    prefix="${decl%...*}"
+    if echo "$modified" | grep -q "^${prefix}"; then
+      continue  # any match satisfies the wildcard.
+    fi
+    declared_omitted+="$decl"$'\n'
+    continue
+  fi
+  if ! echo "$modified" | grep -qx "$decl"; then
+    declared_omitted+="$decl"$'\n'
+  fi
+done <<< "$declared"
+declared_omitted=$(echo "$declared_omitted" | sed '/^$/d')
+
+# Set diff: modified but not declared (scope expansion).
+modified_extra=""
+while IFS= read -r mod; do
+  # Allow Charter-doc and AILOG paths through without alarm — those are always
+  # in scope when the Charter itself or the AILOG of execution gets touched.
+  if [[ "$mod" == docs/charters/* || "$mod" == .devtrail/07-ai-audit/* ]]; then
+    continue
+  fi
+  if ! echo "$declared" | grep -qx "$mod"; then
+    # Also allow if the declared list has a wildcard prefix that matches.
+    matched_wildcard=0
+    while IFS= read -r decl; do
+      if [[ "$decl" == *...* ]]; then
+        prefix="${decl%...*}"
+        if [[ "$mod" == ${prefix}* ]]; then
+          matched_wildcard=1
+          break
+        fi
+      fi
+    done <<< "$declared"
+    if [ $matched_wildcard -eq 0 ]; then
+      modified_extra+="$mod"$'\n'
+    fi
+  fi
+done <<< "$modified"
+modified_extra=$(echo "$modified_extra" | sed '/^$/d')
+
+# --- Report ---
+
+echo "=== Charter drift check ==="
+echo "  Charter: $CHARTER_FILE"
+echo "  Range:   $GIT_RANGE"
+echo "  Declared: $(echo "$declared" | wc -l) files"
+echo "  Modified: $(echo "$modified" | wc -l) files"
+echo ""
+
+exit_code=0
+
+if [ -n "$declared_omitted" ]; then
+  echo "WARNING: Declared in Charter but NOT modified ($(echo "$declared_omitted" | wc -l) files):"
+  echo "$declared_omitted" | sed 's/^/  - /'
+  echo ""
+  echo "  Action: either complete the work, or document in AILOG under '## Risk'"
+  echo "  as 'R<N+1> (new, not in Charter)' explaining why this file did not need"
+  echo "  changes (Charter was wrong, scope simplified, etc.)."
+  echo ""
+  exit_code=1
+fi
+
+if [ -n "$modified_extra" ]; then
+  echo "INFO: Modified but NOT declared ($(echo "$modified_extra" | wc -l) files, scope expansion):"
+  echo "$modified_extra" | sed 's/^/  - /'
+  echo ""
+  echo "  Action: if intentional, document the scope expansion in AILOG."
+  echo "  Common reasons: mock updates after interface change, generated"
+  echo "  files (e.g. wire_gen.go), pre-existing drift fix needed to unblock work."
+  echo ""
+  # Scope expansion is informational, not a hard failure — exit_code stays.
+fi
+
+if [ -z "$declared_omitted" ] && [ -z "$modified_extra" ]; then
+  echo "OK No drift detected. Charter and execution are in sync."
+fi
+
+exit $exit_code

--- a/dist/.devtrail/templates/charter-telemetry-template.yaml
+++ b/dist/.devtrail/templates/charter-telemetry-template.yaml
@@ -1,0 +1,125 @@
+# DevTrail Charter telemetry — fill at Charter close.
+#
+# Schema:        .devtrail/schemas/charter-telemetry.schema.v0.json
+# Conceptual:    Propuesta/devtrail-charter-telemetry.md (in the upstream repo)
+# Storage path:  .devtrail/charters/CHARTER-NN.telemetry.yaml
+#
+# Fill time target: 5-10 minutes per Charter. The point is signal, not exhaustiveness —
+# leave a field blank or omit it if you don't have honest data for it. Honest gaps
+# are more useful than invented numbers.
+
+charter_telemetry:
+  # ---------- Identification ----------
+  charter_id: "CHARTER-NN"               # match the charter_id of the Charter file
+  charter_title: "<short title>"
+  closed_at: "YYYY-MM-DD"                # date of the closing commit / merge
+
+  # ---------- Origin & activation ----------
+  # Which AILOGs (if any) motivated this Charter, and were they still useful when
+  # execution actually happened? still_relevant_at_execution captures whether the
+  # AILOG content lined up with reality, not whether it merely existed.
+  originating_ailogs:
+    - ailog_id: "AILOG-YYYY-MM-DD-NNN"
+      still_relevant_at_execution: true  # bool
+      relevance_notes: ""                # optional — explain partial / shifted relevance
+
+  # The trigger as declared in the Charter, plus what actually fired the Charter
+  # in practice. Sentinel found that declared triggers tend to be prescriptive
+  # (when SHOULD this run) while the effective trigger was usually meta — the
+  # delta between the two is the interesting datum.
+  trigger:
+    declared_kind: ""                    # event_trigger | date | metric_threshold | infrastructure_milestone
+    declared_description: ""
+    fired_at: "YYYY-MM-DD"
+    fire_clarity: ""                     # clear | ambiguous | manually_decided
+    fire_clarity_notes: ""
+
+  # ---------- Pre-work ----------
+  # Whether the Charter's §Pre-trabajo section did its job. If items_discovered_during_planning
+  # is high, the field is not protecting you — flag it.
+  pre_work:
+    items_declared: 0
+    items_completed_before_planning: 0
+    items_skipped: 0
+    items_discovered_during_planning: 0
+    pre_work_quality: ""                 # high | medium | low
+    pre_work_notes: ""
+
+  # ---------- Planning session (if any) ----------
+  # Many Charters execute without a formal planning session. If so, set occurred:false
+  # and skip the rest of this block.
+  planning_session:
+    occurred: false
+    duration_minutes: 0
+    participants: 0
+    decisions_made: 0
+    decisions_deferred: 0
+    notes: ""
+
+  # ---------- Effort ----------
+  # TIME only. Sentinel's data showed lines-changed is not predictive (1.0x to 8.1x drift);
+  # do NOT attempt to capture it. Estimation is one of the questions this telemetry exists
+  # to answer.
+  effort:
+    started_at: "YYYY-MM-DD"
+    finished_at: "YYYY-MM-DD"
+    estimated_effort: "M (~1.5h)"        # XS/S/M/L bucket + optional ~time
+    actual_effort: "M (~1.5h)"
+    estimation_drift_factor: 1.0         # actual / estimated TIME ratio
+    estimation_drift_reason: ""
+
+  # ---------- Agent quality during execution ----------
+  # r_n_plus_one_emergent_count is the field most worth your time: risks named
+  # during execution that weren't in §Risks. Sentinel validated this as the
+  # cross-agent signal of disciplined execution.
+  agent_quality:
+    sessions_count: 0
+    hallucinations_caught: 0
+    hallucination_categories: []
+    decisions_contradicting_prior_adrs: 0
+    contradiction_notes: ""
+    context_loaded_was_sufficient: true
+    additional_context_loaded_manually: 0
+    r_n_plus_one_emergent_count: 0
+    skill_prompts_used: []
+
+  # ---------- External audit ----------
+  # ARRAY, not a single object — dual-audit (e.g. Copilot + Gemini) gives you
+  # cross-model calibration. The categorization DELTA between auditors is signal:
+  # if Copilot calls something "implementation_gap" and Gemini calls the same
+  # finding "false_positive", that disagreement is itself useful data.
+  external_audit:
+    - auditor: "<auditor-id-and-version>"
+      findings_total: 0
+      findings_by_category:
+        hallucination: 0
+        implementation_gap: 0
+        real_debt: 0
+        false_positive: 0
+      audit_quality: ""                  # high | medium | low (your judgment as the calibrator)
+      audit_notes: ""
+
+  # ---------- Outcome & follow-ups ----------
+  # scope_change_notes uses F1...FN encoding consistent with claude-analisis output.
+  # Optional category suffix: IG (implementation gap), FP (false positive), HALL (hallucination).
+  # Example: "F1 (IG): handler.go declared but not modified — scope simplified mid-flight."
+  outcome:
+    completed_as_planned: true
+    scope_changes: "ninguno"             # ninguno | menor | mayor
+    scope_change_notes: ""
+    new_followups_generated: 0
+    new_charters_created: 0
+    charters_invalidated: 0
+    associated_stage_id: ""
+
+  # ---------- Qualitative (where insight usually lives) ----------
+  # Quantitative fields tell you what happened; qualitative tells you what to change.
+  # The format_iteration field is part of the self-evolving feedback loop: each
+  # Charter refines the format of the next.
+  qualitative:
+    format_iteration: "v4"
+    friction_points: []
+    wins: []
+    overall_satisfaction: 0              # 1-5
+    would_repeat_format: true
+    proposed_format_changes: ""


### PR DESCRIPTION
## Summary

First of 8 PRs implementing Phase 2 of the CLI roadmap (telemetry, drift, approval workflow). **Framework-only** — no CLI code yet — so the artifacts are reviewable in isolation.

### What's added

- **`dist/.devtrail/schemas/charter-telemetry.schema.v0.json`** — JSON Schema Draft 2020-12 derived from `Propuesta/devtrail-charter-telemetry.md` v0.3, with the 4 fields refined by Sentinel: `external_audit` as array (dual-audit calibration), `outcome.scope_change_notes` with F1...FN encoding, `agent_quality.r_n_plus_one_emergent_count`, `qualitative.format_iteration`. Marked **experimental v0** — same N=1-domain caveat as `charter.schema.v0.json`.

- **`dist/.devtrail/templates/charter-telemetry-template.yaml`** — commented YAML skeleton mirroring the schema, with adoption notes inline. Will be the starting point for `devtrail charter close --from-template` (PR 2).

- **`dist/.devtrail/scripts/check-charter-drift.sh`** — ported from Sentinel `scripts/check-plan-drift.sh` (153 lines, awk + grep + git, validated empirically with zero false positives across PLAN-05 retrospective + PLAN-06 prospective). Adaptations:
  - Path surface: `docs/plans/` → `docs/charters/`.
  - Section heading detection extended to EN/ES/zh-CN (`## Files to modify` / `## Archivos a modificar` / `## 要修改的文件`).
  - File-extension whitelist broadened beyond the Go-centric Sentinel set (rust, python, java, kotlin, swift, ruby, etc.).

The CLI wrapper with AILOG-awareness lands in **PR 3** — invoking this script directly works but you'll see documented-drift alerts that the CLI suppresses based on `originating_ailogs`.

### What's NOT in this PR

No version bump. The fw-4.6.0 / cli-3.7.0 release ships at PR 8 once all framework artifacts and CLI code are in main. Adopters get the new artifacts at that release tag, not before.

## Test plan

- [x] Bash script passes `bash -n` syntax check.
- [x] Schema is valid JSON.
- [x] No `dist-manifest.yml` change needed — `.devtrail/` is already declared recursively.
- [ ] PR 2 will validate the schema against a real `charter close` flow.
- [ ] PR 3 will validate the script against PLAN-05 + PLAN-06 fixtures (golden tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)