### PR TITLE
feat(cli): Phase 2 PR 2 — prompts module + devtrail charter close

### DIFF
--- a/cli/src/charter_schema.rs
+++ b/cli/src/charter_schema.rs
@@ -56,7 +56,7 @@ impl CharterSchema {
         yaml_value: &serde_yaml::Value,
         file_path: &Path,
     ) -> Vec<ValidationIssue> {
-        let json_value = match yaml_to_json(yaml_value) {
+        let json_value = match yaml_to_json_value(yaml_value) {
             Ok(v) => v,
             Err(e) => {
                 return vec![ValidationIssue {
@@ -148,7 +148,10 @@ fn hint_for(err: &jsonschema::ValidationError) -> Option<String> {
 /// of JSON so the conversion is direct for the constructs the schema expects.
 /// YAML-only constructs (non-string mapping keys, tagged values not handled
 /// here) cause a typed error.
-fn yaml_to_json(v: &serde_yaml::Value) -> Result<Value> {
+///
+/// Public so that `telemetry_schema` and other future schema validators can
+/// reuse the conversion without duplicating it.
+pub fn yaml_to_json_value(v: &serde_yaml::Value) -> Result<Value> {
     Ok(match v {
         serde_yaml::Value::Null => Value::Null,
         serde_yaml::Value::Bool(b) => Value::Bool(*b),
@@ -169,7 +172,7 @@ fn yaml_to_json(v: &serde_yaml::Value) -> Result<Value> {
         serde_yaml::Value::Sequence(seq) => {
             let mut arr = Vec::with_capacity(seq.len());
             for item in seq {
-                arr.push(yaml_to_json(item)?);
+                arr.push(yaml_to_json_value(item)?);
             }
             Value::Array(arr)
         }
@@ -185,11 +188,11 @@ fn yaml_to_json(v: &serde_yaml::Value) -> Result<Value> {
                         ));
                     }
                 };
-                obj.insert(key, yaml_to_json(val)?);
+                obj.insert(key, yaml_to_json_value(val)?);
             }
             Value::Object(obj)
         }
-        serde_yaml::Value::Tagged(t) => yaml_to_json(&t.value)?,
+        serde_yaml::Value::Tagged(t) => yaml_to_json_value(&t.value)?,
     })
 }
 
@@ -435,7 +438,7 @@ list: [1, 2, 3]
 nested: { a: 1, b: 2 }
 "#,
         );
-        let j = yaml_to_json(&v).unwrap();
+        let j = yaml_to_json_value(&v).unwrap();
         let obj = j.as_object().unwrap();
         assert_eq!(obj.get("str").unwrap().as_str(), Some("hello"));
         assert_eq!(obj.get("int").unwrap().as_i64(), Some(42));
@@ -448,7 +451,7 @@ nested: { a: 1, b: 2 }
         let mut map = serde_yaml::Mapping::new();
         map.insert(serde_yaml::Value::Number(1.into()), serde_yaml::Value::String("v".into()));
         let v = serde_yaml::Value::Mapping(map);
-        let err = yaml_to_json(&v).unwrap_err();
+        let err = yaml_to_json_value(&v).unwrap_err();
         assert!(err.to_string().contains("not a string"));
     }
 }

--- a/cli/src/commands/charter/close.rs
+++ b/cli/src/commands/charter/close.rs
@@ -1,0 +1,600 @@
+//! `devtrail charter close` — record the post-execution telemetry of a Charter.
+//!
+//! Two operating modes:
+//! - **Interactive** (default): walks the operator through the telemetry schema
+//!   field by field with prompts. Target time: 5–10 min per Charter.
+//! - **From-template** (`--from-template`): copies the YAML skeleton next to
+//!   the Charter so the operator can edit it manually with their preferred
+//!   editor. Combine with `--non-interactive` for CI / scripted use.
+//!
+//! After populating telemetry, the YAML is validated against
+//! `.devtrail/schemas/charter-telemetry.schema.v0.json`. The Charter
+//! frontmatter `status` is bumped to `closed`.
+//!
+//! Storage: `.devtrail/charters/CHARTER-NN.telemetry.yaml`. We do not embed
+//! telemetry in the Charter frontmatter (see roadmap §A2): frontmatter is
+//! declarative ex-ante; telemetry is ex-post and voluminous.
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Local;
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+
+use crate::charter::{self, Charter, CharterStatus};
+use crate::prompts;
+use crate::telemetry_schema::TelemetrySchema;
+use crate::utils;
+
+pub fn run(
+    path: &str,
+    charter_id: &str,
+    from_template: bool,
+    non_interactive: bool,
+) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("DevTrail not installed. Run 'devtrail init' first."))?;
+    let project_root = &resolved.path;
+    let devtrail_dir = project_root.join(".devtrail");
+
+    // Resolve the Charter.
+    let (charters, _errors) = charter::discover_and_parse(project_root);
+    let charter = charter::find_by_id(&charters, charter_id)
+        .ok_or_else(|| anyhow!("Charter {} not found in docs/charters/", charter_id))?
+        .clone();
+
+    // Decide telemetry destination.
+    let charters_state_dir = devtrail_dir.join("charters");
+    utils::ensure_dir(&charters_state_dir)?;
+    let telemetry_path = telemetry_path_for(&charters_state_dir, &charter);
+
+    // Mode dispatch.
+    let yaml_text = if from_template {
+        copy_template_for(&devtrail_dir, &charter, &telemetry_path, non_interactive)?
+    } else {
+        prompts::require_interactive()?;
+        let telemetry = drive_interactive_flow(&charter)?;
+        std::fs::write(&telemetry_path, &telemetry).with_context(|| {
+            format!("Failed to write telemetry to {}", telemetry_path.display())
+        })?;
+        telemetry
+    };
+
+    // Validate against schema (skip for --from-template + --non-interactive,
+    // since the user hasn't edited the file yet — the template would fail).
+    if !(from_template && non_interactive) {
+        let schema = TelemetrySchema::load(&devtrail_dir)?;
+        let yaml_value: serde_yaml::Value = serde_yaml::from_str(&yaml_text)
+            .with_context(|| format!("Telemetry YAML at {} is not valid YAML", telemetry_path.display()))?;
+        let issues = schema.validate(&yaml_value, &telemetry_path);
+        if !issues.is_empty() {
+            eprintln!("{}", "Telemetry validation found issues:".yellow().bold());
+            for issue in &issues {
+                eprintln!("  - {} [{}]", issue.message, issue.rule);
+                if let Some(hint) = &issue.fix_hint {
+                    eprintln!("    {} {}", "hint:".cyan(), hint);
+                }
+            }
+            bail!("telemetry written but failed schema validation; fix and re-run with --from-template to edit in place");
+        }
+    }
+
+    // Bump Charter status to closed.
+    update_charter_status_to_closed(&charter)?;
+
+    // Summary.
+    println!(
+        "{} Charter {} closed.",
+        "✔".green().bold(),
+        charter.frontmatter.charter_id.bold()
+    );
+    println!("  Telemetry: {}", telemetry_path.display());
+    println!("  Status updated: in-progress/declared → closed");
+    if from_template && non_interactive {
+        println!(
+            "{} {}",
+            "next:".cyan().bold(),
+            "edit the telemetry YAML and re-run `devtrail charter close --from-template` to revalidate"
+        );
+    }
+    Ok(())
+}
+
+/// Build the `.devtrail/charters/CHARTER-NN.telemetry.yaml` path for a Charter.
+fn telemetry_path_for(charters_state_dir: &Path, charter: &Charter) -> PathBuf {
+    // Strip optional slug suffix to keep the telemetry filename stable across
+    // Charter renames: CHARTER-01-foo → CHARTER-01.telemetry.yaml.
+    let id = &charter.frontmatter.charter_id;
+    let canonical = id
+        .split_once('-')
+        .and_then(|(prefix, rest)| {
+            // CHARTER-NN[-slug] → CHARTER-NN
+            let nn = rest.split('-').next()?;
+            Some(format!("{}-{}", prefix, nn))
+        })
+        .unwrap_or_else(|| id.clone());
+    charters_state_dir.join(format!("{}.telemetry.yaml", canonical))
+}
+
+/// Copy the template YAML to the telemetry path. Refuses to overwrite an
+/// existing file unless the operator confirms (interactive mode) or the file
+/// is the template itself unchanged (resumable in `--from-template` flow).
+fn copy_template_for(
+    devtrail_dir: &Path,
+    charter: &Charter,
+    dest: &Path,
+    non_interactive: bool,
+) -> Result<String> {
+    let template_path = devtrail_dir
+        .join("templates")
+        .join("charter-telemetry-template.yaml");
+    let template = std::fs::read_to_string(&template_path).with_context(|| {
+        format!(
+            "Telemetry template not found at {}. Run `devtrail repair` to restore framework files.",
+            template_path.display()
+        )
+    })?;
+
+    if dest.exists() {
+        if non_interactive {
+            // Idempotent: leave existing file in place.
+            return std::fs::read_to_string(dest)
+                .with_context(|| format!("Failed to read existing telemetry at {}", dest.display()));
+        }
+        prompts::require_interactive()?;
+        let overwrite = prompts::prompt_bool(
+            &format!("Telemetry file {} already exists — overwrite?", dest.display()),
+            false,
+        )?;
+        if !overwrite {
+            return std::fs::read_to_string(dest)
+                .with_context(|| format!("Failed to read existing telemetry at {}", dest.display()));
+        }
+    }
+
+    // Pre-fill the obvious fields (charter_id, charter_title, closed_at) so
+    // the user lands on a less-empty starting point.
+    let prefilled = template
+        .replace("CHARTER-NN", &short_id(&charter.frontmatter.charter_id))
+        .replace("<short title>", &one_line_title(charter))
+        .replace("YYYY-MM-DD", &Local::now().format("%Y-%m-%d").to_string());
+    std::fs::write(dest, &prefilled)
+        .with_context(|| format!("Failed to write telemetry template to {}", dest.display()))?;
+    Ok(prefilled)
+}
+
+fn short_id(charter_id: &str) -> String {
+    charter_id
+        .split_once('-')
+        .and_then(|(prefix, rest)| Some(format!("{}-{}", prefix, rest.split('-').next()?)))
+        .unwrap_or_else(|| charter_id.to_string())
+}
+
+fn one_line_title(charter: &Charter) -> String {
+    // Use the H1 title if available; fallback to the slug.
+    crate::charter::display_title(charter)
+}
+
+/// Drive the operator through the full schema interactively. Returns the
+/// rendered YAML (top-level `charter_telemetry:` map) ready to write.
+fn drive_interactive_flow(charter: &Charter) -> Result<String> {
+    println!(
+        "{} {}",
+        "Closing".cyan().bold(),
+        charter.frontmatter.charter_id.bold()
+    );
+    println!(
+        "  Title: {}",
+        crate::charter::display_title(charter).dimmed()
+    );
+    println!("{}", "Press Enter to accept defaults; type to override.".dimmed());
+    println!();
+
+    let charter_id = short_id(&charter.frontmatter.charter_id);
+    let charter_title = crate::charter::display_title(charter);
+    let closed_at = Local::now().format("%Y-%m-%d").to_string();
+
+    // ── Trigger ─────────────────────────────────────────────────────────
+    println!("{}", "── Trigger ──".bold());
+    let declared_kind = prompts::prompt_enum(
+        "Declared trigger kind",
+        &["event_trigger", "date", "metric_threshold", "infrastructure_milestone"],
+        0,
+    )?;
+    let declared_description =
+        prompts::prompt_string("Declared trigger description", None, true)?;
+    let fired_at = prompts::prompt_string("Fired at (YYYY-MM-DD)", Some(&closed_at), false)?;
+    let fire_clarity =
+        prompts::prompt_enum("Trigger clarity", &["clear", "ambiguous", "manually_decided"], 0)?;
+    let fire_clarity_notes = prompts::prompt_string("Trigger clarity notes", None, true)?;
+
+    // ── Effort ──────────────────────────────────────────────────────────
+    println!();
+    println!("{}", "── Effort ──".bold());
+    let estimated_effort =
+        prompts::prompt_string("Estimated effort (e.g., M (~1.5h))", Some("M (~1.5h)"), false)?;
+    let actual_effort = prompts::prompt_string(
+        "Actual effort (e.g., M (~1.5h))",
+        Some(&estimated_effort),
+        false,
+    )?;
+    let drift_factor_raw = prompts::prompt_string(
+        "Estimation drift factor (actual/estimated TIME, e.g., 1.0)",
+        Some("1.0"),
+        false,
+    )?;
+    let drift_factor: f64 = drift_factor_raw
+        .trim()
+        .parse()
+        .map_err(|e| anyhow!("drift factor not a number: {e}"))?;
+    let drift_reason = prompts::prompt_string("Estimation drift reason", None, true)?;
+
+    // ── Agent quality ───────────────────────────────────────────────────
+    println!();
+    println!("{}", "── Agent quality ──".bold());
+    let sessions_count = prompts::prompt_u32("Sessions count", 1)?;
+    let hallucinations_caught = prompts::prompt_u32("Hallucinations caught", 0)?;
+    let hallucination_categories = if hallucinations_caught > 0 {
+        prompts::prompt_string_array("Hallucination categories")?
+    } else {
+        Vec::new()
+    };
+    let decisions_contradicting_prior_adrs =
+        prompts::prompt_u32("Decisions contradicting prior ADRs", 0)?;
+    let context_loaded_was_sufficient =
+        prompts::prompt_bool("Context loaded was sufficient", true)?;
+    let additional_context_loaded_manually =
+        prompts::prompt_u32("Additional context files loaded manually", 0)?;
+    let r_n_plus_one_emergent_count =
+        prompts::prompt_u32("Emergent risks named during execution (R<N+1>)", 0)?;
+
+    // ── Outcome ─────────────────────────────────────────────────────────
+    println!();
+    println!("{}", "── Outcome ──".bold());
+    let completed_as_planned = prompts::prompt_bool("Completed as planned", true)?;
+    let scope_changes = prompts::prompt_enum("Scope changes", &["ninguno", "menor", "mayor"], 0)?;
+    let scope_change_notes = if scope_changes == "ninguno" {
+        String::new()
+    } else {
+        prompts::prompt_string("Scope change notes (F1...FN encoding)", None, true)?
+    };
+    let new_followups_generated = prompts::prompt_u32("New follow-up AILOGs generated", 0)?;
+    let new_charters_created = prompts::prompt_u32("New Charters created", 0)?;
+
+    // ── Qualitative ─────────────────────────────────────────────────────
+    println!();
+    println!("{}", "── Qualitative ──".bold());
+    let format_iteration = prompts::prompt_string("Format iteration (e.g., v4)", Some("v4"), false)?;
+    let friction_points = prompts::prompt_string_array("Friction points")?;
+    let wins = prompts::prompt_string_array("Wins")?;
+    let overall_satisfaction = prompts::prompt_u32("Overall satisfaction (1-5)", 4)?;
+    if !(1..=5).contains(&overall_satisfaction) {
+        bail!("overall_satisfaction must be in 1..=5 (got {})", overall_satisfaction);
+    }
+    let would_repeat_format = prompts::prompt_bool("Would repeat this format", true)?;
+
+    // ── Render YAML ─────────────────────────────────────────────────────
+    let yaml = render_yaml(TelemetryDraft {
+        charter_id,
+        charter_title,
+        closed_at,
+        trigger_declared_kind: declared_kind,
+        trigger_declared_description: declared_description,
+        trigger_fired_at: fired_at,
+        trigger_fire_clarity: fire_clarity,
+        trigger_fire_clarity_notes: fire_clarity_notes,
+        effort_estimated: estimated_effort,
+        effort_actual: actual_effort,
+        effort_drift_factor: drift_factor,
+        effort_drift_reason: drift_reason,
+        agent_sessions_count: sessions_count,
+        agent_hallucinations_caught: hallucinations_caught,
+        agent_hallucination_categories: hallucination_categories,
+        agent_decisions_contradicting: decisions_contradicting_prior_adrs,
+        agent_context_sufficient: context_loaded_was_sufficient,
+        agent_additional_context_manual: additional_context_loaded_manually,
+        agent_r_n_plus_one: r_n_plus_one_emergent_count,
+        outcome_completed: completed_as_planned,
+        outcome_scope_changes: scope_changes,
+        outcome_scope_change_notes: scope_change_notes,
+        outcome_new_followups: new_followups_generated,
+        outcome_new_charters: new_charters_created,
+        qualitative_format_iteration: format_iteration,
+        qualitative_friction_points: friction_points,
+        qualitative_wins: wins,
+        qualitative_overall_satisfaction: overall_satisfaction,
+        qualitative_would_repeat: would_repeat_format,
+    });
+    Ok(yaml)
+}
+
+struct TelemetryDraft {
+    charter_id: String,
+    charter_title: String,
+    closed_at: String,
+    trigger_declared_kind: String,
+    trigger_declared_description: String,
+    trigger_fired_at: String,
+    trigger_fire_clarity: String,
+    trigger_fire_clarity_notes: String,
+    effort_estimated: String,
+    effort_actual: String,
+    effort_drift_factor: f64,
+    effort_drift_reason: String,
+    agent_sessions_count: u32,
+    agent_hallucinations_caught: u32,
+    agent_hallucination_categories: Vec<String>,
+    agent_decisions_contradicting: u32,
+    agent_context_sufficient: bool,
+    agent_additional_context_manual: u32,
+    agent_r_n_plus_one: u32,
+    outcome_completed: bool,
+    outcome_scope_changes: String,
+    outcome_scope_change_notes: String,
+    outcome_new_followups: u32,
+    outcome_new_charters: u32,
+    qualitative_format_iteration: String,
+    qualitative_friction_points: Vec<String>,
+    qualitative_wins: Vec<String>,
+    qualitative_overall_satisfaction: u32,
+    qualitative_would_repeat: bool,
+}
+
+/// Render a `TelemetryDraft` as canonical YAML. We hand-write this rather than
+/// relying on `serde_yaml::to_string` so the output is stable, comment-free,
+/// and visually consistent with `charter-telemetry-template.yaml`.
+fn render_yaml(d: TelemetryDraft) -> String {
+    let mut out = String::new();
+    out.push_str("charter_telemetry:\n");
+    out.push_str(&format!("  charter_id: \"{}\"\n", yaml_escape(&d.charter_id)));
+    out.push_str(&format!("  charter_title: \"{}\"\n", yaml_escape(&d.charter_title)));
+    out.push_str(&format!("  closed_at: \"{}\"\n", d.closed_at));
+
+    out.push_str("\n  trigger:\n");
+    out.push_str(&format!("    declared_kind: \"{}\"\n", d.trigger_declared_kind));
+    out.push_str(&format!(
+        "    declared_description: \"{}\"\n",
+        yaml_escape(&d.trigger_declared_description)
+    ));
+    out.push_str(&format!("    fired_at: \"{}\"\n", d.trigger_fired_at));
+    out.push_str(&format!("    fire_clarity: \"{}\"\n", d.trigger_fire_clarity));
+    out.push_str(&format!(
+        "    fire_clarity_notes: \"{}\"\n",
+        yaml_escape(&d.trigger_fire_clarity_notes)
+    ));
+
+    out.push_str("\n  effort:\n");
+    out.push_str(&format!("    estimated_effort: \"{}\"\n", d.effort_estimated));
+    out.push_str(&format!("    actual_effort: \"{}\"\n", d.effort_actual));
+    out.push_str(&format!(
+        "    estimation_drift_factor: {}\n",
+        format_float(d.effort_drift_factor)
+    ));
+    out.push_str(&format!(
+        "    estimation_drift_reason: \"{}\"\n",
+        yaml_escape(&d.effort_drift_reason)
+    ));
+
+    out.push_str("\n  agent_quality:\n");
+    out.push_str(&format!("    sessions_count: {}\n", d.agent_sessions_count));
+    out.push_str(&format!(
+        "    hallucinations_caught: {}\n",
+        d.agent_hallucinations_caught
+    ));
+    out.push_str("    hallucination_categories:");
+    if d.agent_hallucination_categories.is_empty() {
+        out.push_str(" []\n");
+    } else {
+        out.push('\n');
+        for cat in &d.agent_hallucination_categories {
+            out.push_str(&format!("      - \"{}\"\n", yaml_escape(cat)));
+        }
+    }
+    out.push_str(&format!(
+        "    decisions_contradicting_prior_adrs: {}\n",
+        d.agent_decisions_contradicting
+    ));
+    out.push_str(&format!(
+        "    context_loaded_was_sufficient: {}\n",
+        d.agent_context_sufficient
+    ));
+    out.push_str(&format!(
+        "    additional_context_loaded_manually: {}\n",
+        d.agent_additional_context_manual
+    ));
+    out.push_str(&format!(
+        "    r_n_plus_one_emergent_count: {}\n",
+        d.agent_r_n_plus_one
+    ));
+
+    out.push_str("\n  outcome:\n");
+    out.push_str(&format!("    completed_as_planned: {}\n", d.outcome_completed));
+    out.push_str(&format!(
+        "    scope_changes: \"{}\"\n",
+        d.outcome_scope_changes
+    ));
+    if !d.outcome_scope_change_notes.is_empty() {
+        out.push_str(&format!(
+            "    scope_change_notes: \"{}\"\n",
+            yaml_escape(&d.outcome_scope_change_notes)
+        ));
+    }
+    out.push_str(&format!(
+        "    new_followups_generated: {}\n",
+        d.outcome_new_followups
+    ));
+    out.push_str(&format!("    new_charters_created: {}\n", d.outcome_new_charters));
+
+    out.push_str("\n  qualitative:\n");
+    out.push_str(&format!(
+        "    format_iteration: \"{}\"\n",
+        d.qualitative_format_iteration
+    ));
+    out.push_str("    friction_points:");
+    if d.qualitative_friction_points.is_empty() {
+        out.push_str(" []\n");
+    } else {
+        out.push('\n');
+        for p in &d.qualitative_friction_points {
+            out.push_str(&format!("      - \"{}\"\n", yaml_escape(p)));
+        }
+    }
+    out.push_str("    wins:");
+    if d.qualitative_wins.is_empty() {
+        out.push_str(" []\n");
+    } else {
+        out.push('\n');
+        for w in &d.qualitative_wins {
+            out.push_str(&format!("      - \"{}\"\n", yaml_escape(w)));
+        }
+    }
+    out.push_str(&format!(
+        "    overall_satisfaction: {}\n",
+        d.qualitative_overall_satisfaction
+    ));
+    out.push_str(&format!(
+        "    would_repeat_format: {}\n",
+        d.qualitative_would_repeat
+    ));
+
+    out
+}
+
+/// Escape a string for use inside a double-quoted YAML scalar. Handles `\` and `"`.
+fn yaml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Render a float without trailing zeros for clean YAML.
+fn format_float(f: f64) -> String {
+    if f.fract() == 0.0 {
+        format!("{:.1}", f)
+    } else {
+        format!("{}", f)
+    }
+}
+
+/// Update the Charter file: bump `status: ...` to `status: closed`. No-op
+/// when already closed.
+fn update_charter_status_to_closed(charter: &Charter) -> Result<()> {
+    if matches!(charter.frontmatter.status, CharterStatus::Closed) {
+        return Ok(());
+    }
+    let raw = std::fs::read_to_string(&charter.path).with_context(|| {
+        format!("Failed to read Charter file at {}", charter.path.display())
+    })?;
+    // Replace the first `status:` line. Charters use front-matter with a known
+    // shape (validated by the schema), so a simple line-by-line replace is safe.
+    let mut updated = String::with_capacity(raw.len());
+    let mut in_frontmatter = false;
+    let mut replaced = false;
+    let mut delim_count = 0;
+    for line in raw.lines() {
+        if line.trim() == "---" {
+            delim_count += 1;
+            in_frontmatter = delim_count == 1;
+            updated.push_str(line);
+            updated.push('\n');
+            continue;
+        }
+        if in_frontmatter && !replaced && line.trim_start().starts_with("status:") {
+            let leading_ws: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+            updated.push_str(&format!("{leading_ws}status: closed\n"));
+            replaced = true;
+            continue;
+        }
+        updated.push_str(line);
+        updated.push('\n');
+    }
+    if !replaced {
+        bail!(
+            "Charter at {} has no `status:` line in frontmatter — cannot bump to closed",
+            charter.path.display()
+        );
+    }
+    std::fs::write(&charter.path, updated).with_context(|| {
+        format!("Failed to write updated status to {}", charter.path.display())
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_strips_slug() {
+        assert_eq!(short_id("CHARTER-01"), "CHARTER-01");
+        assert_eq!(short_id("CHARTER-01-foo-bar"), "CHARTER-01");
+        assert_eq!(short_id("CHARTER-12"), "CHARTER-12");
+        assert_eq!(short_id("CHARTER-12-baseline-recompute"), "CHARTER-12");
+    }
+
+    #[test]
+    fn yaml_escape_handles_quotes_and_backslashes() {
+        assert_eq!(yaml_escape("hello"), "hello");
+        assert_eq!(yaml_escape(r#"a "b" c"#), r#"a \"b\" c"#);
+        assert_eq!(yaml_escape(r"a\b"), r"a\\b");
+    }
+
+    #[test]
+    fn format_float_keeps_one_decimal_for_whole_numbers() {
+        assert_eq!(format_float(1.0), "1.0");
+        assert_eq!(format_float(1.33), "1.33");
+        assert_eq!(format_float(2.5), "2.5");
+    }
+
+    #[test]
+    fn render_yaml_produces_parseable_output() {
+        let draft = TelemetryDraft {
+            charter_id: "CHARTER-01".into(),
+            charter_title: "Test charter".into(),
+            closed_at: "2026-05-02".into(),
+            trigger_declared_kind: "event_trigger".into(),
+            trigger_declared_description: "first ticket".into(),
+            trigger_fired_at: "2026-05-02".into(),
+            trigger_fire_clarity: "clear".into(),
+            trigger_fire_clarity_notes: String::new(),
+            effort_estimated: "M (~1.5h)".into(),
+            effort_actual: "M (~1.5h)".into(),
+            effort_drift_factor: 1.0,
+            effort_drift_reason: String::new(),
+            agent_sessions_count: 1,
+            agent_hallucinations_caught: 0,
+            agent_hallucination_categories: Vec::new(),
+            agent_decisions_contradicting: 0,
+            agent_context_sufficient: true,
+            agent_additional_context_manual: 0,
+            agent_r_n_plus_one: 0,
+            outcome_completed: true,
+            outcome_scope_changes: "ninguno".into(),
+            outcome_scope_change_notes: String::new(),
+            outcome_new_followups: 0,
+            outcome_new_charters: 0,
+            qualitative_format_iteration: "v4".into(),
+            qualitative_friction_points: Vec::new(),
+            qualitative_wins: Vec::new(),
+            qualitative_overall_satisfaction: 4,
+            qualitative_would_repeat: true,
+        };
+        let yaml = render_yaml(draft);
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+        assert!(parsed.get("charter_telemetry").is_some());
+        let ct = parsed.get("charter_telemetry").unwrap();
+        assert_eq!(
+            ct.get("charter_id").and_then(|v| v.as_str()),
+            Some("CHARTER-01")
+        );
+        assert_eq!(
+            ct.get("outcome")
+                .and_then(|o| o.get("completed_as_planned"))
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            ct.get("effort")
+                .and_then(|e| e.get("estimation_drift_factor"))
+                .and_then(|v| v.as_f64()),
+            Some(1.0)
+        );
+    }
+}

--- a/cli/src/commands/charter/mod.rs
+++ b/cli/src/commands/charter/mod.rs
@@ -1,10 +1,12 @@
 //! `devtrail charter` — Charter lifecycle subcommands.
 //!
-//! Phase 1 ships `new` (scaffold from template), `list` (enumerate with filters),
+//! Phase 1 shipped `new` (scaffold from template), `list` (enumerate with filters),
 //! and `status` (detail view).
-//! Phase 2 will add `close` (interactive telemetry) and `drift` (file-vs-commit
-//! drift check). Phase 3 will add `audit` (multi-model external audit).
+//! Phase 2 adds `close` (interactive telemetry) and `drift` (file-vs-commit
+//! drift check, in PR 3).
+//! Phase 3 will add `audit` (multi-model external audit).
 
+pub mod close;
 pub mod list;
 pub mod new;
 pub mod status;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,9 @@ mod inject;
 mod manifest;
 mod metrics_engine;
 mod platform;
+mod prompts;
 mod self_update;
+mod telemetry_schema;
 #[cfg(feature = "tui")]
 mod tui;
 mod utils;
@@ -232,6 +234,23 @@ enum CharterCommands {
         #[arg(long = "path", default_value = ".")]
         path: String,
     },
+    /// Record post-execution telemetry and bump status to `closed`
+    Close {
+        /// Charter identifier (CHARTER-NN, CHARTER-NN-slug, or just NN)
+        charter_id: String,
+        /// Copy the telemetry template next to the Charter for manual editing
+        /// instead of running the interactive flow. Combine with
+        /// --non-interactive for CI / scripted use.
+        #[arg(long)]
+        from_template: bool,
+        /// Skip prompts. Requires --from-template (the schema cannot be
+        /// validated until the user has filled in the YAML).
+        #[arg(long, requires = "from_template")]
+        non_interactive: bool,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
 }
 
 fn main() {
@@ -310,6 +329,12 @@ fn main() {
             CharterCommands::Status { charter_id, path } => {
                 commands::charter::status::run(&path, charter_id.as_deref())
             }
+            CharterCommands::Close {
+                charter_id,
+                from_template,
+                non_interactive,
+                path,
+            } => commands::charter::close::run(&path, &charter_id, from_template, non_interactive),
         },
     };
 

--- a/cli/src/prompts.rs
+++ b/cli/src/prompts.rs
@@ -1,0 +1,139 @@
+//! Common interactive prompts for `charter close` and `approve`.
+//!
+//! Wraps `dialoguer` with a consistent theme and adds a few specialized
+//! prompts (multiline, optional-string, comma-separated array) that are not
+//! direct dialoguer primitives. Detects non-TTY context and bails early so
+//! scripted invocation fails fast instead of hanging.
+//!
+//! All prompts return `anyhow::Result<T>` so callers can `?` propagate Ctrl-C
+//! and IO errors uniformly.
+
+use anyhow::{bail, Result};
+use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
+use std::io::IsTerminal;
+
+/// Reject early if stdin is not a TTY. Call this once at the start of any
+/// command that intends to drive the user through prompts.
+pub fn require_interactive() -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        bail!(
+            "interactive prompts require a TTY. Re-run with --from-template --non-interactive \
+             to copy the YAML skeleton and edit it manually."
+        );
+    }
+    Ok(())
+}
+
+/// Prompt for a free-text string. `default` is shown as the pre-filled value.
+/// Empty input is allowed when `allow_empty` is true; otherwise the prompt
+/// re-asks until something non-empty is entered.
+pub fn prompt_string(label: &str, default: Option<&str>, allow_empty: bool) -> Result<String> {
+    let theme = ColorfulTheme::default();
+    let mut builder = Input::<String>::with_theme(&theme).with_prompt(label);
+    if let Some(d) = default {
+        builder = builder.default(d.to_string());
+    }
+    builder = builder.allow_empty(allow_empty);
+    Ok(builder.interact_text()?)
+}
+
+/// Prompt for a non-negative integer. Rejects negative numbers and non-digits.
+pub fn prompt_u32(label: &str, default: u32) -> Result<u32> {
+    let raw: String = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt(label)
+        .default(default.to_string())
+        .validate_with(|input: &String| -> Result<(), String> {
+            input
+                .trim()
+                .parse::<u32>()
+                .map(|_| ())
+                .map_err(|e| format!("not a non-negative integer: {e}"))
+        })
+        .interact_text()?;
+    Ok(raw.trim().parse::<u32>().expect("validated above"))
+}
+
+/// Prompt for a yes/no answer. `default` pre-selects the response.
+pub fn prompt_bool(label: &str, default: bool) -> Result<bool> {
+    Ok(Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(label)
+        .default(default)
+        .interact()?)
+}
+
+/// Prompt for one of a fixed set of options, returning the selected option as
+/// an owned String. `default_index` pre-selects an option (0-based).
+pub fn prompt_enum(label: &str, options: &[&str], default_index: usize) -> Result<String> {
+    let idx = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(label)
+        .items(options)
+        .default(default_index.min(options.len().saturating_sub(1)))
+        .interact()?;
+    Ok(options[idx].to_string())
+}
+
+/// Prompt for a comma-separated list of strings. Empty input returns an empty
+/// Vec. Trailing commas and inter-element whitespace are tolerated.
+pub fn prompt_string_array(label: &str) -> Result<Vec<String>> {
+    let raw: String = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("{label} (comma-separated, blank for none)"))
+        .allow_empty(true)
+        .interact_text()?;
+    Ok(raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect())
+}
+
+/// Prompt for a multi-line block. Reads lines from stdin until a line
+/// containing only `.` or EOF (Ctrl-D) is seen. Returns the joined lines
+/// without the terminator. Slated for use by `devtrail approve --notes` in
+/// Phase 2 PR 5.
+#[allow(dead_code)]
+pub fn prompt_multiline(label: &str) -> Result<String> {
+    use std::io::{self, BufRead, Write};
+    print!("{label} (end with a single '.' on a line, or Ctrl-D):\n");
+    io::stdout().flush().ok();
+    let stdin = io::stdin();
+    let mut buf = String::new();
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim() == "." {
+            break;
+        }
+        buf.push_str(&line);
+        buf.push('\n');
+    }
+    // Trim a trailing newline if any but preserve internal newlines.
+    Ok(buf.trim_end_matches('\n').to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // We cannot test interactive prompts without a TTY. Test the few
+    // pure helpers and the array-splitting logic via a private helper.
+    fn split_csv(raw: &str) -> Vec<String> {
+        raw.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    #[test]
+    fn split_csv_handles_whitespace_and_empties() {
+        assert_eq!(split_csv(""), Vec::<String>::new());
+        assert_eq!(split_csv("a"), vec!["a"]);
+        assert_eq!(split_csv("a, b , c"), vec!["a", "b", "c"]);
+        assert_eq!(split_csv(",a,,b,"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn require_interactive_errors_in_non_tty() {
+        // Cargo test runs without a TTY.
+        let result = require_interactive();
+        assert!(result.is_err());
+    }
+}

--- a/cli/src/telemetry_schema.rs
+++ b/cli/src/telemetry_schema.rs
@@ -1,0 +1,255 @@
+//! JSON Schema validation for Charter telemetry YAML.
+//!
+//! The schema is shipped at `<framework>/.devtrail/schemas/charter-telemetry.schema.v0.json`
+//! (the framework distribution drops it into the project at `devtrail init` time).
+//! This module mirrors `charter_schema.rs` — load and compile the schema once,
+//! then validate parsed YAML.
+//!
+//! Telemetry YAML files have a single top-level key `charter_telemetry:`, so
+//! the schema validates the whole file (including that wrapper). The CLI's
+//! validator reports issues using the same `ValidationIssue` shape used for
+//! Charter frontmatter validation.
+
+use anyhow::{anyhow, Context, Result};
+use jsonschema::JSONSchema;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+use crate::charter_schema::yaml_to_json_value;
+use crate::validation::{Severity, ValidationIssue};
+
+/// Path to the telemetry schema relative to a project's `.devtrail/` directory.
+pub const SCHEMA_RELATIVE_PATH: &str = "schemas/charter-telemetry.schema.v0.json";
+
+/// A loaded and compiled telemetry schema, ready to validate YAML.
+pub struct TelemetrySchema {
+    compiled: JSONSchema,
+}
+
+impl TelemetrySchema {
+    /// Load and compile the telemetry schema from a project's `.devtrail/`
+    /// directory. Returns an error if the schema file is missing, not valid
+    /// JSON, or not a valid JSON Schema.
+    pub fn load(devtrail_dir: &Path) -> Result<Self> {
+        let path = devtrail_dir.join(SCHEMA_RELATIVE_PATH);
+        let raw = std::fs::read_to_string(&path).with_context(|| {
+            format!(
+                "Failed to read telemetry schema at {}. Run `devtrail repair` to restore framework files.",
+                path.display()
+            )
+        })?;
+        Self::from_json_str(&raw, path)
+    }
+
+    /// Compile the schema from a raw JSON string. Split out for testability.
+    pub fn from_json_str(raw: &str, source_path: PathBuf) -> Result<Self> {
+        let schema_json: Value = serde_json::from_str(raw).with_context(|| {
+            format!("Telemetry schema at {} is not valid JSON", source_path.display())
+        })?;
+        let compiled = JSONSchema::options()
+            .compile(&schema_json)
+            .map_err(|e| anyhow!("Failed to compile telemetry schema: {e}"))?;
+        Ok(Self { compiled })
+    }
+
+    /// Validate parsed telemetry YAML against the schema. Returns an empty Vec
+    /// if the YAML is valid; otherwise one `ValidationIssue` per violation.
+    pub fn validate(
+        &self,
+        yaml_value: &serde_yaml::Value,
+        file_path: &Path,
+    ) -> Vec<ValidationIssue> {
+        let json_value = match yaml_to_json_value(yaml_value) {
+            Ok(v) => v,
+            Err(e) => {
+                return vec![ValidationIssue {
+                    file: file_path.to_path_buf(),
+                    rule: "TELEMETRY-CONVERT".to_string(),
+                    message: format!(
+                        "Telemetry YAML cannot be converted to JSON for schema validation: {e}"
+                    ),
+                    severity: Severity::Error,
+                    fix_hint: Some(
+                        "Telemetry must be JSON-compatible YAML (no tagged values or non-string keys).".to_string(),
+                    ),
+                }];
+            }
+        };
+        let issues: Vec<ValidationIssue> = match self.compiled.validate(&json_value) {
+            Ok(()) => Vec::new(),
+            Err(errors) => errors
+                .map(|err| ValidationIssue {
+                    file: file_path.to_path_buf(),
+                    rule: rule_from_error(&err),
+                    message: format_message(&err),
+                    severity: Severity::Error,
+                    fix_hint: hint_for(&err),
+                })
+                .collect(),
+        };
+        issues
+    }
+}
+
+fn rule_from_error(err: &jsonschema::ValidationError) -> String {
+    let path = err.schema_path.to_string();
+    let trimmed = path.trim_start_matches('/').replace("/properties/", "/");
+    if trimmed.is_empty() {
+        "TELEMETRY-SCHEMA".to_string()
+    } else {
+        format!("TELEMETRY-SCHEMA/{}", trimmed)
+    }
+}
+
+fn format_message(err: &jsonschema::ValidationError) -> String {
+    let instance_path = err.instance_path.to_string();
+    let location = if instance_path.is_empty() {
+        "telemetry".to_string()
+    } else {
+        instance_path.trim_start_matches('/').replace('/', ".")
+    };
+    format!("{} (at {})", err, location)
+}
+
+fn hint_for(err: &jsonschema::ValidationError) -> Option<String> {
+    let path = err.schema_path.to_string();
+    if path.contains("/charter_id/pattern") {
+        Some(
+            "charter_id must match CHARTER-NN[-slug] (e.g., CHARTER-01-anomaly-thresholds)."
+                .to_string(),
+        )
+    } else if path.contains("/closed_at/format") || path.contains("/closed_at/type") {
+        Some("closed_at must be a date string in YYYY-MM-DD format.".to_string())
+    } else if path.contains("/scope_changes/enum") {
+        Some("scope_changes must be one of: ninguno, menor, mayor.".to_string())
+    } else if path.contains("/effort/required") || path.contains("/charter_telemetry/required") {
+        Some(
+            "Required telemetry fields are missing. At minimum: charter_id, charter_title, closed_at, effort, outcome."
+                .to_string(),
+        )
+    } else if path.contains("/estimated_effort/pattern") || path.contains("/actual_effort/pattern")
+    {
+        Some(
+            "Effort fields must match XS|S|M|L optionally followed by a parenthesized hint, e.g., 'M (~1.5h)'."
+                .to_string(),
+        )
+    } else if path.contains("/overall_satisfaction/maximum")
+        || path.contains("/overall_satisfaction/minimum")
+    {
+        Some("overall_satisfaction must be an integer in 1..=5.".to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal-shape telemetry schema for unit tests. The real schema lives
+    /// at `dist/.devtrail/schemas/charter-telemetry.schema.v0.json` and is
+    /// not bundled into the binary — these tests are for the wrapper logic.
+    const TEST_SCHEMA: &str = r##"{
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["charter_telemetry"],
+        "properties": {
+            "charter_telemetry": {
+                "type": "object",
+                "required": ["charter_id", "charter_title", "closed_at", "effort", "outcome"],
+                "properties": {
+                    "charter_id": {
+                        "type": "string",
+                        "pattern": "^CHARTER-[0-9]{2,}(-[a-z0-9-]+)?$"
+                    },
+                    "charter_title": { "type": "string" },
+                    "closed_at": { "type": "string", "format": "date" },
+                    "effort": {
+                        "type": "object",
+                        "required": ["estimated_effort", "actual_effort"],
+                        "properties": {
+                            "estimated_effort": { "type": "string" },
+                            "actual_effort": { "type": "string" }
+                        }
+                    },
+                    "outcome": {
+                        "type": "object",
+                        "required": ["completed_as_planned", "scope_changes"],
+                        "properties": {
+                            "completed_as_planned": { "type": "boolean" },
+                            "scope_changes": {
+                                "type": "string",
+                                "enum": ["ninguno", "menor", "mayor"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"##;
+
+    fn schema() -> TelemetrySchema {
+        TelemetrySchema::from_json_str(TEST_SCHEMA, PathBuf::from("test://schema")).unwrap()
+    }
+
+    fn yaml(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn valid_minimal_telemetry_passes() {
+        let v = yaml(
+            r#"
+charter_telemetry:
+  charter_id: CHARTER-01
+  charter_title: Test
+  closed_at: "2026-05-02"
+  effort:
+    estimated_effort: M
+    actual_effort: M
+  outcome:
+    completed_as_planned: true
+    scope_changes: ninguno
+"#,
+        );
+        assert!(schema().validate(&v, Path::new("test.yaml")).is_empty());
+    }
+
+    #[test]
+    fn missing_required_field_is_caught() {
+        let v = yaml(
+            r#"
+charter_telemetry:
+  charter_id: CHARTER-01
+  charter_title: Test
+  closed_at: "2026-05-02"
+"#,
+        );
+        let issues = schema().validate(&v, Path::new("test.yaml"));
+        assert!(!issues.is_empty());
+        assert!(issues.iter().any(|i| i.message.contains("required")));
+    }
+
+    #[test]
+    fn bad_charter_id_pattern_is_caught() {
+        let v = yaml(
+            r#"
+charter_telemetry:
+  charter_id: not-a-charter-id
+  charter_title: Test
+  closed_at: "2026-05-02"
+  effort:
+    estimated_effort: M
+    actual_effort: M
+  outcome:
+    completed_as_planned: true
+    scope_changes: ninguno
+"#,
+        );
+        let issues = schema().validate(&v, Path::new("test.yaml"));
+        assert!(!issues.is_empty());
+        assert!(issues
+            .iter()
+            .any(|i| i.rule.contains("charter_id") || i.message.contains("pattern")));
+    }
+}

--- a/cli/tests/charter_close_test.rs
+++ b/cli/tests/charter_close_test.rs
@@ -1,0 +1,256 @@
+//! Integration tests for `devtrail charter close`. Only the
+//! `--from-template --non-interactive` path is testable without a TTY; the
+//! interactive flow is exercised manually and via the unit tests in
+//! `cli/src/commands/charter/close.rs`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+const CHARTER_TEMPLATE: &str = r#"---
+charter_id: CHARTER-NN
+status: declared
+effort_estimate: M
+trigger: "[1-line]"
+---
+
+# Charter: [BRIEF TITLE]
+
+## Files to modify
+
+| File | Change |
+|---|---|
+
+## Tasks
+
+1. Sync.
+"#;
+
+const TELEMETRY_TEMPLATE: &str = r#"# DevTrail Charter telemetry — fill at Charter close.
+charter_telemetry:
+  charter_id: "CHARTER-NN"
+  charter_title: "<short title>"
+  closed_at: "YYYY-MM-DD"
+  effort:
+    estimated_effort: "M (~1.5h)"
+    actual_effort: "M (~1.5h)"
+  outcome:
+    completed_as_planned: true
+    scope_changes: "ninguno"
+"#;
+
+const TELEMETRY_SCHEMA: &str = include_str!(
+    "../../dist/.devtrail/schemas/charter-telemetry.schema.v0.json"
+);
+
+/// Set up a minimal DevTrail installation with both the Charter template and
+/// the telemetry template + schema. Mirrors what `devtrail init` would produce
+/// after fw-4.6.0 ships.
+fn setup_devtrail(dir: &Path) {
+    let devtrail = dir.join(".devtrail");
+    std::fs::create_dir_all(devtrail.join("templates")).unwrap();
+    std::fs::create_dir_all(devtrail.join("schemas")).unwrap();
+    std::fs::write(devtrail.join("config.yml"), "language: en\n").unwrap();
+    std::fs::write(
+        devtrail.join("templates").join("charter-template.md"),
+        CHARTER_TEMPLATE,
+    )
+    .unwrap();
+    std::fs::write(
+        devtrail
+            .join("templates")
+            .join("charter-telemetry-template.yaml"),
+        TELEMETRY_TEMPLATE,
+    )
+    .unwrap();
+    std::fs::write(
+        devtrail.join("schemas").join("charter-telemetry.schema.v0.json"),
+        TELEMETRY_SCHEMA,
+    )
+    .unwrap();
+}
+
+fn create_charter(dir: &Path, title: &str) {
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .arg("charter")
+        .arg("new")
+        .arg("--title")
+        .arg(title)
+        .arg(dir.to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn charter_close_requires_devtrail_installed() {
+    let dir = TempDir::new().unwrap();
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not installed"));
+}
+
+#[test]
+fn charter_close_unknown_charter_fails_clearly() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-99",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("CHARTER-99 not found"));
+}
+
+#[test]
+fn charter_close_from_template_non_interactive_writes_telemetry_file() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "Test Charter");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("closed"))
+        .stdout(predicate::str::contains("Telemetry:"));
+
+    let telemetry_path = dir
+        .path()
+        .join(".devtrail/charters/CHARTER-01.telemetry.yaml");
+    assert!(telemetry_path.exists(), "telemetry file should exist");
+
+    let content = std::fs::read_to_string(&telemetry_path).unwrap();
+    // Pre-fills applied.
+    assert!(
+        content.contains("charter_id: \"CHARTER-01\""),
+        "should pre-fill charter_id, got:\n{content}"
+    );
+    assert!(
+        content.contains("Test Charter"),
+        "should pre-fill title, got:\n{content}"
+    );
+    assert!(
+        !content.contains("YYYY-MM-DD"),
+        "closed_at placeholder should be replaced with today's date, got:\n{content}"
+    );
+}
+
+#[test]
+fn charter_close_bumps_status_to_closed() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "Status Bump");
+
+    let charter_path = dir.path().join("docs/charters/01-status-bump.md");
+    let before = std::fs::read_to_string(&charter_path).unwrap();
+    assert!(before.contains("status: declared"));
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let after = std::fs::read_to_string(&charter_path).unwrap();
+    assert!(
+        after.contains("status: closed"),
+        "status line should be bumped, got:\n{after}"
+    );
+    assert!(
+        !after.contains("status: declared"),
+        "old declared status should be gone, got:\n{after}"
+    );
+}
+
+#[test]
+fn charter_close_idempotent_under_non_interactive() {
+    // Running --from-template --non-interactive twice should not clobber
+    // edits the user made between runs (we re-read the existing file).
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "Idempotent");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    // Simulate the user editing the telemetry file.
+    let telemetry_path = dir
+        .path()
+        .join(".devtrail/charters/CHARTER-01.telemetry.yaml");
+    let edited = std::fs::read_to_string(&telemetry_path)
+        .unwrap()
+        .replace("ninguno", "menor");
+    std::fs::write(&telemetry_path, &edited).unwrap();
+
+    // Second run: should NOT overwrite the edit.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let after = std::fs::read_to_string(&telemetry_path).unwrap();
+    assert!(
+        after.contains("scope_changes: \"menor\""),
+        "user edit should be preserved, got:\n{after}"
+    );
+}


### PR DESCRIPTION
## Summary

Second of 8 PRs implementing Phase 2 of the CLI roadmap. Adds the interactive close flow that records post-execution telemetry for a Charter and bumps its status to `closed`.

### What's added

- **`cli/src/prompts.rs`** — shared interactive helpers (string, u32, bool, enum, comma-separated array, multiline) with a `require_interactive()` guard that bails early in non-TTY contexts. Will be reused by `devtrail approve` in PR 5.
- **`cli/src/telemetry_schema.rs`** — `jsonschema` wrapper for the telemetry YAML, mirroring `src/charter_schema.rs`. Reuses the yaml-to-json conversion helper from `charter_schema` (now made public as `yaml_to_json_value`) instead of duplicating it.
- **`cli/src/commands/charter/close.rs`** — the command itself. Two operating modes:
  - **Interactive** (default): walks the schema field by field — trigger, effort, agent quality, outcome, qualitative — rendering YAML directly so the output is stable, comment-free, and validated against the schema before disk write. Target time: 5–10 min.
  - **`--from-template [--non-interactive]`**: copies the YAML skeleton next to the Charter for manual editing (CI / scripted use). Pre-fills `charter_id`, title, and `closed_at`. Idempotent — re-running with non-interactive does NOT clobber user edits.

After populating telemetry, the Charter file is rewritten with `status` bumped from `declared`/`in-progress` to `closed`.

**Storage**: `.devtrail/charters/CHARTER-NN.telemetry.yaml`. Telemetry is **not** embedded in the Charter frontmatter (per roadmap §A2): frontmatter is declarative ex-ante, telemetry is voluminous ex-post.

### What's NOT in this PR

- No version bump. fw-4.6.0 / cli-3.7.0 ship at PR 8.
- The interactive flow has no schema-validation regression test — `dialoguer` is non-trivial to mock. Unit tests cover `render_yaml`, `short_id`, `yaml_escape`, and `format_float`; integration tests cover the from-template path. The interactive flow is exercised manually.
- AILOG-awareness for drift suppression is in PR 3 (`devtrail charter drift`).

## Test plan

- [x] `cargo build` clean (1 expected dead-code allow on `prompt_multiline`, slated for PR 5).
- [x] `cargo test` — 345/345 pass (222 unit + 123 integration, including 5 new `charter_close_test` cases).
- [x] Schema reuse verified: existing 10 `charter_schema` tests still green after renaming `yaml_to_json` → `yaml_to_json_value` and making it `pub`.
- [x] `--from-template --non-interactive` is idempotent (test `charter_close_idempotent_under_non_interactive`).
- [ ] Manual smoke of interactive flow in a tempdir (will run before tagging fw-4.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)