### PR TITLE
feat(cli): Phase 2 PR 3 — devtrail charter drift with AILOG-awareness

### DIFF
--- a/cli/src/commands/charter/drift.rs
+++ b/cli/src/commands/charter/drift.rs
@@ -1,0 +1,417 @@
+//! `devtrail charter drift` — file-vs-commit drift check at Charter close.
+//!
+//! Wraps the framework's `.devtrail/scripts/check-charter-drift.sh` (ported
+//! from Sentinel `scripts/check-plan-drift.sh`, validated empirically with
+//! zero false positives across PLAN-05 retrospective + PLAN-06 prospective).
+//! The CLI value-add over the raw script is **AILOG-awareness** (mitigation
+//! R2 of the Sentinel experiment): suppresses alerts on paths already
+//! documented as a risk in any AILOG referenced by the Charter's
+//! `originating_ailogs` frontmatter.
+//!
+//! ## Scope (Phase 2)
+//!
+//! Bash delegation only. Windows native (no WSL, no Git Bash) currently has
+//! no path; document that limitation in the user-facing message and direct
+//! Windows users to WSL. A Rust-native fallback is feasible but deferred
+//! until a real adopter reports the need.
+//!
+//! ## Exit codes
+//!
+//! - `0` — no drift, or only documented out-of-scope extras / AILOG-suppressed
+//! - `1` — drift found that needs attention
+//! - `2` — usage error (Charter not found, bash missing, etc.)
+
+use anyhow::{anyhow, bail, Context, Result};
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::charter::{self, Charter};
+use crate::utils;
+
+const DEFAULT_RANGE: &str = "HEAD~1..HEAD";
+
+pub fn run(
+    path: &str,
+    charter_id: &str,
+    range: Option<&str>,
+    no_ailog_suppress: bool,
+) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("DevTrail not installed. Run 'devtrail init' first."))?;
+    let project_root = &resolved.path;
+    let devtrail_dir = project_root.join(".devtrail");
+
+    // Resolve the Charter file.
+    let (charters, _errors) = charter::discover_and_parse(project_root);
+    let charter = charter::find_by_id(&charters, charter_id)
+        .ok_or_else(|| anyhow!("Charter {} not found in docs/charters/", charter_id))?
+        .clone();
+
+    let charter_path_rel = charter
+        .path
+        .strip_prefix(project_root)
+        .unwrap_or(&charter.path)
+        .to_path_buf();
+
+    // Locate the drift script.
+    let script_path = devtrail_dir.join("scripts").join("check-charter-drift.sh");
+    if !script_path.exists() {
+        bail!(
+            "Drift script not found at {}. Run `devtrail repair` to restore framework files \
+             (the script ships with fw-4.6.0 and later).",
+            script_path.display()
+        );
+    }
+
+    // Locate bash.
+    let bash = which_bash().ok_or_else(|| {
+        anyhow!(
+            "`bash` not found in PATH. The drift check delegates to a bash script. \
+             On Windows native, install Git Bash or WSL; a pure-Rust fallback is on \
+             the roadmap but not in fw-4.6.0."
+        )
+    })?;
+
+    let range_arg = range.unwrap_or(DEFAULT_RANGE);
+
+    // Run the script. cwd = project_root so git ranges and relative Charter
+    // paths work.
+    let output = Command::new(&bash)
+        .arg(&script_path)
+        .arg(&charter_path_rel)
+        .arg(range_arg)
+        .current_dir(project_root)
+        .output()
+        .with_context(|| format!("Failed to invoke bash script at {}", script_path.display()))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let raw_exit = output.status.code().unwrap_or(-1);
+
+    // Parse the script output to identify declared-but-not-modified paths so
+    // we can apply AILOG-suppression. Scope-expansion ("Modified but NOT
+    // declared") is informational and not suppressed — those paths are not
+    // in the Charter's declared list and rarely overlap with documented
+    // risks.
+    let omitted = extract_omitted_paths(&stdout);
+    let suppressions: Vec<(String, String)> = if no_ailog_suppress || omitted.is_empty() {
+        Vec::new()
+    } else {
+        compute_ailog_suppressions(project_root, &charter, &omitted)?
+    };
+    let suppressed_paths: std::collections::HashSet<String> =
+        suppressions.iter().map(|(p, _)| p.clone()).collect();
+    let omitted_after: Vec<String> = omitted
+        .iter()
+        .filter(|p| !suppressed_paths.contains(*p))
+        .cloned()
+        .collect();
+
+    // Render the report. We re-render rather than passing raw stdout because
+    // suppression can change the conclusion.
+    print!("{}", stdout);
+    if !stderr.is_empty() {
+        eprint!("{}", stderr);
+    }
+
+    if !suppressions.is_empty() {
+        println!();
+        println!(
+            "{} {}",
+            "AILOG-suppressed:".cyan().bold(),
+            format!("{} path(s)", suppressions.len()).dimmed()
+        );
+        for (path, ailog_id) in &suppressions {
+            println!("  - {} [documented in {}]", path, ailog_id.dimmed());
+        }
+    }
+
+    // Final exit code: if AILOG-suppression cleared all omitted paths, the
+    // script-reported exit is overridden to 0 (the user did the right thing
+    // by documenting the risk in an AILOG).
+    let final_exit = if raw_exit == 1 && omitted_after.is_empty() && !suppressions.is_empty() {
+        println!();
+        println!(
+            "{} all declared-omitted paths are documented in AILOGs — drift accepted.",
+            "OK".green().bold()
+        );
+        0
+    } else {
+        raw_exit
+    };
+
+    if final_exit != 0 {
+        std::process::exit(final_exit);
+    }
+    Ok(())
+}
+
+/// Locate `bash` in PATH. Returns `None` if not found. We resolve it
+/// explicitly (rather than letting `Command::new("bash")` do PATH lookup at
+/// spawn time) so we can produce a friendlier error before spawning.
+fn which_bash() -> Option<PathBuf> {
+    let path_env = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_env) {
+        for candidate in ["bash", "bash.exe"] {
+            let p = dir.join(candidate);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the list of declared-but-not-modified file paths from the drift
+/// script's stdout. The script's relevant block looks like:
+///
+/// ```text
+/// WARNING: Declared in Charter but NOT modified (3 files):
+///   - path/one.go
+///   - path/two.md
+///   - path/three.yaml
+///
+///   Action: ...
+/// ```
+///
+/// We scan from the WARNING line until a blank line or a non-bullet line
+/// (the first sub-bullet that isn't a path is `  Action:` text).
+fn extract_omitted_paths(stdout: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_section = false;
+    for line in stdout.lines() {
+        if line.starts_with("WARNING: Declared in Charter but NOT modified") {
+            in_section = true;
+            continue;
+        }
+        if in_section {
+            // The script emits `  - <path>` bullets, then a blank line, then
+            // an indented `  Action:` paragraph. We stop at the first line
+            // that isn't a `  - ` bullet.
+            if let Some(rest) = line.strip_prefix("  - ") {
+                let path = rest.trim();
+                if !path.is_empty() {
+                    out.push(path.to_string());
+                }
+                continue;
+            }
+            // Any other line ends the section.
+            in_section = false;
+        }
+    }
+    out
+}
+
+/// For each declared-omitted path, check whether it appears in the `## Risk`
+/// (EN), `## Riesgos` (ES), or `## 风险` (zh-CN) section of any AILOG referenced
+/// by the Charter's `originating_ailogs`. Returns one (path, ailog_id) tuple
+/// per path that was suppressed, with the first matching AILOG.
+fn compute_ailog_suppressions(
+    project_root: &Path,
+    charter: &Charter,
+    omitted: &[String],
+) -> Result<Vec<(String, String)>> {
+    let mut hits = Vec::new();
+    let ailog_ids = match &charter.frontmatter.originating_ailogs {
+        Some(ids) if !ids.is_empty() => ids.clone(),
+        _ => return Ok(hits),
+    };
+
+    let agent_logs_dir = project_root
+        .join(".devtrail")
+        .join("07-ai-audit")
+        .join("agent-logs");
+    if !agent_logs_dir.exists() {
+        return Ok(hits);
+    }
+
+    // Collect Risk sections from all referenced AILOGs once.
+    let mut risk_blobs: Vec<(String, String)> = Vec::new();
+    for ailog_id in &ailog_ids {
+        if let Some(path) = find_ailog_file(&agent_logs_dir, ailog_id) {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Some(risk) = extract_risk_section(&content) {
+                    risk_blobs.push((ailog_id.clone(), risk));
+                }
+            }
+        }
+    }
+
+    for path in omitted {
+        for (ailog_id, blob) in &risk_blobs {
+            if blob.contains(path) {
+                hits.push((path.clone(), ailog_id.clone()));
+                break;
+            }
+        }
+    }
+    Ok(hits)
+}
+
+/// Find the AILOG file matching the given AILOG ID. Searches the agent-logs
+/// directory recursively and matches by filename prefix (since AILOG files are
+/// named `AILOG-YYYY-MM-DD-NNN-slug.md`).
+fn find_ailog_file(agent_logs_dir: &Path, ailog_id: &str) -> Option<PathBuf> {
+    // The id may be either bare (AILOG-2026-05-02-001) or include a slug
+    // (AILOG-2026-05-02-001-foo). We match the bare prefix.
+    let prefix: String = ailog_id
+        .split('-')
+        .take(5) // "AILOG", "YYYY", "MM", "DD", "NNN"
+        .collect::<Vec<_>>()
+        .join("-");
+    walk_for_prefix(agent_logs_dir, &prefix)
+}
+
+fn walk_for_prefix(dir: &Path, prefix: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = walk_for_prefix(&path, prefix) {
+                return Some(found);
+            }
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with(prefix) && name.ends_with(".md") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the `## Risk` / `## Riesgos` / `## 风险` section body from an AILOG.
+/// Returns `None` if no such section exists.
+fn extract_risk_section(content: &str) -> Option<String> {
+    let mut buf = String::new();
+    let mut in_section = false;
+    for line in content.lines() {
+        if line.starts_with("## ")
+            && (line.contains("Risk") || line.contains("Riesgo") || line.contains("风险"))
+        {
+            in_section = true;
+            continue;
+        }
+        if in_section {
+            if line.starts_with("## ") {
+                break;
+            }
+            buf.push_str(line);
+            buf.push('\n');
+        }
+    }
+    if buf.is_empty() {
+        None
+    } else {
+        Some(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_omitted_handles_typical_output() {
+        let stdout = r#"=== Charter drift check ===
+  Charter: docs/charters/01-foo.md
+  Range:   HEAD~1..HEAD
+  Declared: 5 files
+  Modified: 3 files
+
+WARNING: Declared in Charter but NOT modified (2 files):
+  - src/services/policy/handler.go
+  - src/services/policy/repository.go
+
+  Action: either complete the work, or document in AILOG.
+"#;
+        let omitted = extract_omitted_paths(stdout);
+        assert_eq!(
+            omitted,
+            vec![
+                "src/services/policy/handler.go".to_string(),
+                "src/services/policy/repository.go".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_omitted_handles_empty_output() {
+        let stdout = "OK No drift detected.\n";
+        assert!(extract_omitted_paths(stdout).is_empty());
+    }
+
+    #[test]
+    fn extract_risk_section_finds_english_section() {
+        let ailog = r#"# AILOG-2026-04-28-024 — Test
+
+## Context
+
+Body.
+
+## Risk
+
+- **R1**: see `src/services/policy/handler.go` for context.
+- **R2**: see `src/services/policy/repository.go`.
+
+## Outcome
+
+Done.
+"#;
+        let risk = extract_risk_section(ailog).unwrap();
+        assert!(risk.contains("src/services/policy/handler.go"));
+        assert!(risk.contains("src/services/policy/repository.go"));
+        assert!(!risk.contains("Done."));
+    }
+
+    #[test]
+    fn extract_risk_section_finds_spanish_section() {
+        let ailog = r#"## Riesgos
+
+- R1 — `src/foo.rs` puede fallar.
+
+## Cierre
+
+bla.
+"#;
+        let risk = extract_risk_section(ailog).unwrap();
+        assert!(risk.contains("src/foo.rs"));
+        assert!(!risk.contains("Cierre"));
+    }
+
+    #[test]
+    fn extract_risk_section_returns_none_when_absent() {
+        let ailog = "## Context\n\nNo risks here.\n";
+        assert!(extract_risk_section(ailog).is_none());
+    }
+
+    #[test]
+    fn find_ailog_file_matches_prefix_with_slug() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent_logs = tmp.path().join("agent-logs");
+        std::fs::create_dir_all(&agent_logs).unwrap();
+        let path = agent_logs.join("AILOG-2026-04-28-024-implement-baseline.md");
+        std::fs::write(&path, "stub\n").unwrap();
+
+        let found = find_ailog_file(&agent_logs, "AILOG-2026-04-28-024").unwrap();
+        assert_eq!(found, path);
+
+        // Also match when the full id with slug is given.
+        let found2 = find_ailog_file(&agent_logs, "AILOG-2026-04-28-024-implement-baseline").unwrap();
+        assert_eq!(found2, path);
+    }
+
+    #[test]
+    fn find_ailog_file_recurses_into_subdirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let nested = tmp.path().join("agent-logs").join("daemon");
+        std::fs::create_dir_all(&nested).unwrap();
+        let path = nested.join("AILOG-2026-05-01-002-foo.md");
+        std::fs::write(&path, "stub\n").unwrap();
+
+        let found = find_ailog_file(&tmp.path().join("agent-logs"), "AILOG-2026-05-01-002").unwrap();
+        assert_eq!(found, path);
+    }
+}

--- a/cli/src/commands/charter/mod.rs
+++ b/cli/src/commands/charter/mod.rs
@@ -7,6 +7,7 @@
 //! Phase 3 will add `audit` (multi-model external audit).
 
 pub mod close;
+pub mod drift;
 pub mod list;
 pub mod new;
 pub mod status;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,6 +251,23 @@ enum CharterCommands {
         #[arg(long = "path", default_value = ".")]
         path: String,
     },
+    /// Detect file-vs-commit drift at Charter close (declared-but-not-modified
+    /// files; scope expansion). Suppresses alerts on paths already documented
+    /// as risks in the Charter's originating AILOGs.
+    Drift {
+        /// Charter identifier (CHARTER-NN, CHARTER-NN-slug, or just NN)
+        charter_id: String,
+        /// Git revision range (default: HEAD~1..HEAD)
+        #[arg(long)]
+        range: Option<String>,
+        /// Disable AILOG-aware suppression (show every declared-omitted path
+        /// even if documented in an AILOG).
+        #[arg(long)]
+        no_ailog_suppress: bool,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
 }
 
 fn main() {
@@ -335,6 +352,17 @@ fn main() {
                 non_interactive,
                 path,
             } => commands::charter::close::run(&path, &charter_id, from_template, non_interactive),
+            CharterCommands::Drift {
+                charter_id,
+                range,
+                no_ailog_suppress,
+                path,
+            } => commands::charter::drift::run(
+                &path,
+                &charter_id,
+                range.as_deref(),
+                no_ailog_suppress,
+            ),
         },
     };
 

--- a/cli/tests/charter_drift_test.rs
+++ b/cli/tests/charter_drift_test.rs
@@ -1,0 +1,280 @@
+//! Integration tests for `devtrail charter drift`. Requires a real git repo
+//! and `bash` in PATH; tests are skipped on Windows runners that lack bash.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+/// Inline copy of the framework's check-charter-drift.sh — the integration
+/// path expects the script under `.devtrail/scripts/`.
+const DRIFT_SCRIPT: &str = include_str!("../../dist/.devtrail/scripts/check-charter-drift.sh");
+
+const CHARTER_TEMPLATE: &str = r#"---
+charter_id: CHARTER-NN
+status: declared
+effort_estimate: M
+trigger: "[1-line]"
+---
+
+# Charter: [BRIEF TITLE]
+
+## Files to modify
+
+| File | Change |
+|---|---|
+
+## Tasks
+
+1. Sync.
+"#;
+
+fn bash_available() -> bool {
+    StdCommand::new("bash")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn setup_devtrail(dir: &Path) {
+    let devtrail = dir.join(".devtrail");
+    std::fs::create_dir_all(devtrail.join("templates")).unwrap();
+    std::fs::create_dir_all(devtrail.join("scripts")).unwrap();
+    std::fs::create_dir_all(devtrail.join("07-ai-audit/agent-logs")).unwrap();
+    std::fs::write(devtrail.join("config.yml"), "language: en\n").unwrap();
+    std::fs::write(
+        devtrail.join("templates").join("charter-template.md"),
+        CHARTER_TEMPLATE,
+    )
+    .unwrap();
+    let script_path = devtrail.join("scripts").join("check-charter-drift.sh");
+    std::fs::write(&script_path, DRIFT_SCRIPT).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .status()
+        .expect("git invocation failed");
+    assert!(status.success(), "git {} failed", args.join(" "));
+}
+
+fn write_charter_with_files(dir: &Path, declared: &[&str], originating_ailog: Option<&str>) {
+    let charters_dir = dir.join("docs").join("charters");
+    std::fs::create_dir_all(&charters_dir).unwrap();
+    let mut content = String::from("---\ncharter_id: CHARTER-01\nstatus: declared\neffort_estimate: M\ntrigger: \"test trigger\"\n");
+    if let Some(ailog) = originating_ailog {
+        content.push_str(&format!("originating_ailogs:\n  - {}\n", ailog));
+    }
+    content.push_str("---\n\n# Charter: Drift Test\n\n## Files to modify\n\n| File | Change |\n|---|---|\n");
+    for f in declared {
+        content.push_str(&format!("| `{}` | edit |\n", f));
+    }
+    content.push_str("\n## Tasks\n\n1. Run.\n");
+    std::fs::write(charters_dir.join("01-drift-test.md"), content).unwrap();
+}
+
+#[test]
+fn charter_drift_clean_when_declared_matches_modified() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_charter_with_files(dir.path(), &["src/foo.rs"], None);
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo"]);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["charter", "drift", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK No drift detected"));
+}
+
+#[test]
+fn charter_drift_detects_declared_but_not_modified() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_charter_with_files(dir.path(), &["src/foo.rs", "src/bar.rs"], None);
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+    std::fs::write(dir.path().join("src/bar.rs"), "// initial\n").unwrap();
+
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    // Only modify foo, not bar — bar is the drift.
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo only"]);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["charter", "drift", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure() // exit 1
+        .stdout(predicate::str::contains("Declared in Charter but NOT modified"))
+        .stdout(predicate::str::contains("src/bar.rs"));
+}
+
+#[test]
+fn charter_drift_ailog_suppression_clears_documented_paths() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    // Write an AILOG that documents the drift path under ## Risk.
+    let ailog_path = dir
+        .path()
+        .join(".devtrail/07-ai-audit/agent-logs/AILOG-2026-05-02-001-document-bar.md");
+    std::fs::write(
+        &ailog_path,
+        r#"---
+id: AILOG-2026-05-02-001
+title: Document bar
+agent: test
+confidence: high
+risk_level: low
+review_required: false
+---
+
+# AILOG: Document bar
+
+## Context
+
+Some context.
+
+## Risk
+
+- **R3 (new, not in Charter)**: `src/bar.rs` was declared but not touched
+  because the implementation simplified scope mid-flight.
+
+## Outcome
+
+Done.
+"#,
+    )
+    .unwrap();
+
+    write_charter_with_files(
+        dir.path(),
+        &["src/foo.rs", "src/bar.rs"],
+        Some("AILOG-2026-05-02-001"),
+    );
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+    std::fs::write(dir.path().join("src/bar.rs"), "// initial\n").unwrap();
+
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo only"]);
+
+    // Default behavior: AILOG suppression kicks in, drift is cleared.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["charter", "drift", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("AILOG-suppressed"))
+        .stdout(predicate::str::contains("AILOG-2026-05-02-001"));
+}
+
+#[test]
+fn charter_drift_no_ailog_suppress_disables_suppression() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let ailog_path = dir
+        .path()
+        .join(".devtrail/07-ai-audit/agent-logs/AILOG-2026-05-02-001-document-bar.md");
+    std::fs::write(
+        &ailog_path,
+        r#"---
+id: AILOG-2026-05-02-001
+title: Document bar
+agent: test
+confidence: high
+risk_level: low
+review_required: false
+---
+
+## Risk
+
+- **R3**: `src/bar.rs` documented.
+"#,
+    )
+    .unwrap();
+
+    write_charter_with_files(
+        dir.path(),
+        &["src/foo.rs", "src/bar.rs"],
+        Some("AILOG-2026-05-02-001"),
+    );
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+    std::fs::write(dir.path().join("src/bar.rs"), "// initial\n").unwrap();
+
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo only"]);
+
+    // With --no-ailog-suppress, drift is reported even though it's documented.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "drift",
+            "CHARTER-01",
+            "--no-ailog-suppress",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("src/bar.rs"))
+        .stdout(predicate::str::contains("Declared in Charter but NOT modified"));
+}


### PR DESCRIPTION
## Summary

Third of 8 PRs implementing Phase 2 of the CLI roadmap. Wraps the framework's `check-charter-drift.sh` (shipped in PR 1) to provide **AILOG-aware** drift detection at Charter close.

### What's added

- **`cli/src/commands/charter/drift.rs`** — the command implementation:
  - Resolves the Charter, finds the framework drift script, locates `bash` in PATH.
  - Spawns bash with the script + Charter path + git range (default `HEAD~1..HEAD`).
  - Parses the script's `WARNING: Declared in Charter but NOT modified` block to extract declared-but-not-modified paths.
  - For each path, checks whether it appears in the `## Risk` / `## Riesgos` / `## 风险` section of any AILOG referenced by the Charter's `originating_ailogs` frontmatter. Matches are silenced as `[documented in AILOG-XXX]`.
  - Final exit code: `0` if all drift is absent or AILOG-suppressed; `1` if there's unaccounted drift.

This is **mitigation R2 of the Sentinel experiment** — the script alone generates ceremony when alerting on paths already discussed as risks elsewhere; the CLI layer makes that suppression automatic and consent-able (`--no-ailog-suppress` opts out).

### Flags

- `--range REV..REV` — explicit git range (default `HEAD~1..HEAD`).
- `--no-ailog-suppress` — show every declared-omitted path even when documented in an AILOG.
- `--path DIR` — project root override (default cwd).

### Scope of this PR

- **Bash delegation only.** A pure-Rust fallback for Windows-without-bash is on the roadmap but deferred until a real adopter reports the need. WSL and Git Bash both work fine.
- Suppression heuristic: "path appears as text anywhere in the Risk section" — same shape Sentinel's script uses for declared-path extraction.

## Test plan

- [x] 7 unit tests cover: output parsing, Risk section extraction (EN + ES), AILOG file lookup with prefix match + recursive walk.
- [x] 4 integration tests using a real git repo:
  - `charter_drift_clean_when_declared_matches_modified`
  - `charter_drift_detects_declared_but_not_modified`
  - `charter_drift_ailog_suppression_clears_documented_paths`
  - `charter_drift_no_ailog_suppress_disables_suppression`
- [x] **356/356 tests pass** (full suite).
- [ ] Manual smoke against Sentinel's PLAN-05 / PLAN-06 fixtures (out of scope for this PR — slated for Phase 2 closing telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)