### PR TITLE
feat(cli): Phase 2 PR 5 — devtrail approve command

### DIFF
--- a/cli/src/commands/approve.rs
+++ b/cli/src/commands/approve.rs
@@ -1,0 +1,427 @@
+//! `devtrail approve` — record a formal human approval on a `review_required`
+//! document. Implements the closure signal canonized in DOCUMENTATION-POLICY
+//! §3.5 (added in fw-4.6.0): writes the `reviewed_by` / `reviewed_at` /
+//! `review_outcome` frontmatter fields and appends the canonical `## Approval`
+//! body section in one atomic edit.
+//!
+//! Two operating modes:
+//! - **Flag-driven** (CI / scripted): `devtrail approve <doc-id> --outcome
+//!   approved --reviewer <id> [--notes "..."] [--at YYYY-MM-DD]`. Fully
+//!   non-interactive when all required flags are present.
+//! - **Interactive fallback**: when `--outcome` or `--reviewer` is missing
+//!   and stdin is a TTY, prompt for them. Bails on non-TTY missing flags.
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Local;
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+
+use crate::document;
+use crate::prompts;
+use crate::utils;
+
+const VALID_OUTCOMES: &[&str] = &["approved", "revisions_requested", "rejected"];
+
+pub fn run(
+    path: &str,
+    doc_id: &str,
+    outcome: Option<&str>,
+    reviewer: Option<&str>,
+    at: Option<&str>,
+    notes: Option<&str>,
+) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("DevTrail not installed. Run 'devtrail init' first."))?;
+    let project_root = &resolved.path;
+    let devtrail_dir = project_root.join(".devtrail");
+
+    // Locate the document.
+    let doc_path = find_document_by_id(&devtrail_dir, doc_id)?;
+
+    // Resolve outcome + reviewer (flags or prompts).
+    let outcome = resolve_outcome(outcome)?;
+    let reviewer = resolve_reviewer(reviewer)?;
+    let at = at
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| Local::now().format("%Y-%m-%d").to_string());
+
+    // Validate outcome is in the allowed enum.
+    if !VALID_OUTCOMES.contains(&outcome.as_str()) {
+        bail!(
+            "invalid --outcome '{}': must be one of {}",
+            outcome,
+            VALID_OUTCOMES.join(" | ")
+        );
+    }
+
+    // Read + edit the document.
+    let raw = std::fs::read_to_string(&doc_path)
+        .with_context(|| format!("Failed to read {}", doc_path.display()))?;
+
+    // Warn if the doc didn't actually need review (approving an unrequired
+    // doc is unusual but allowed — common case is retroactive sign-off).
+    if let Ok(parsed) = document::parse_document(&doc_path) {
+        if !parsed.frontmatter.review_required.unwrap_or(false) {
+            eprintln!(
+                "{} document does not have `review_required: true`; recording approval anyway.",
+                "warning:".yellow().bold()
+            );
+        }
+    }
+
+    let updated = apply_approval(&raw, &reviewer, &at, &outcome, notes)?;
+    std::fs::write(&doc_path, &updated)
+        .with_context(|| format!("Failed to write {}", doc_path.display()))?;
+
+    println!(
+        "{} {} marked as {}.",
+        "✔".green().bold(),
+        doc_id.bold(),
+        outcome.bold()
+    );
+    println!("  Reviewer: {}", reviewer);
+    println!("  Date:     {}", at);
+    println!("  File:     {}", doc_path.display());
+    Ok(())
+}
+
+/// Search `.devtrail/` for a document whose filename starts with the given ID.
+/// The ID may be the bare prefix (`AIDEC-2026-05-02-001`) or include the slug
+/// (`AIDEC-2026-05-02-001-foo`); both forms resolve to the same file.
+fn find_document_by_id(devtrail_dir: &Path, doc_id: &str) -> Result<PathBuf> {
+    let docs = document::discover_documents(devtrail_dir);
+    // Strip optional slug to get canonical prefix (TYPE-YYYY-MM-DD-NNN).
+    let prefix = canonical_prefix(doc_id);
+    for path in docs {
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with(&prefix) {
+                return Ok(path);
+            }
+        }
+    }
+    bail!(
+        "document {} not found under .devtrail/. Run `devtrail validate` to see all documents.",
+        doc_id
+    )
+}
+
+fn canonical_prefix(doc_id: &str) -> String {
+    // Take the first 5 hyphen-separated segments: TYPE, YYYY, MM, DD, NNN.
+    doc_id
+        .splitn(6, '-')
+        .take(5)
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn resolve_outcome(flag: Option<&str>) -> Result<String> {
+    if let Some(o) = flag {
+        return Ok(o.to_string());
+    }
+    prompts::require_interactive()?;
+    prompts::prompt_enum(
+        "Review outcome",
+        &["approved", "revisions_requested", "rejected"],
+        0,
+    )
+}
+
+fn resolve_reviewer(flag: Option<&str>) -> Result<String> {
+    if let Some(r) = flag {
+        if r.trim().is_empty() {
+            bail!("--reviewer cannot be empty");
+        }
+        return Ok(r.to_string());
+    }
+    prompts::require_interactive()?;
+    prompts::prompt_string("Reviewer (email | github-handle | DID)", None, false)
+}
+
+/// Apply the approval edit to the raw document text. Returns the updated text.
+///
+/// Mutations:
+/// - Frontmatter: insert/update the three approval fields (after
+///   `review_required:` or, lacking that line, before the closing `---`).
+/// - Body: append a `## Approval` section near the end (before any final
+///   HTML comment marker, e.g., `<!-- Template: DevTrail | ... -->`).
+fn apply_approval(
+    raw: &str,
+    reviewer: &str,
+    at: &str,
+    outcome: &str,
+    notes: Option<&str>,
+) -> Result<String> {
+    let updated_fm = update_frontmatter(raw, reviewer, at, outcome)?;
+    let with_section = append_body_section(&updated_fm, reviewer, at, outcome, notes);
+    Ok(with_section)
+}
+
+/// Replace existing approval frontmatter fields, or insert them if absent.
+/// We operate on text rather than re-serializing YAML to preserve comments,
+/// field order, and any project-specific extensions the framework doesn't
+/// know about.
+fn update_frontmatter(raw: &str, reviewer: &str, at: &str, outcome: &str) -> Result<String> {
+    let (frontmatter, rest) = split_frontmatter(raw)?;
+    let new_fm = upsert_approval_fields(&frontmatter, reviewer, at, outcome);
+    Ok(format!("---\n{}---{}", new_fm, rest))
+}
+
+/// Returns (frontmatter_body, rest_of_document) from a `---\n…\n---\n…` file.
+fn split_frontmatter(raw: &str) -> Result<(String, String)> {
+    let trimmed = raw.trim_start_matches('\u{feff}');
+    let after_first = trimmed
+        .strip_prefix("---\n")
+        .ok_or_else(|| anyhow!("document does not start with `---` frontmatter delimiter"))?;
+    let end = after_first
+        .find("\n---")
+        .ok_or_else(|| anyhow!("frontmatter is not terminated by `---`"))?;
+    let fm_body = &after_first[..end + 1]; // include trailing newline
+    let rest_start = end + 4; // skip "\n---"
+    let rest = if rest_start < after_first.len() {
+        after_first[rest_start..].to_string()
+    } else {
+        String::new()
+    };
+    Ok((fm_body.to_string(), rest))
+}
+
+/// Upsert the three approval fields into a frontmatter body. If a field is
+/// already present (uncommented), replace its value. Otherwise, insert all
+/// three after the `review_required:` line, or at the end of the frontmatter
+/// if `review_required:` is absent.
+fn upsert_approval_fields(fm: &str, reviewer: &str, at: &str, outcome: &str) -> String {
+    let fields = [
+        ("reviewed_by", reviewer.to_string()),
+        ("reviewed_at", at.to_string()),
+        ("review_outcome", outcome.to_string()),
+    ];
+
+    let mut lines: Vec<String> = fm.lines().map(|s| s.to_string()).collect();
+
+    // Pass 1: replace any existing uncommented field.
+    let mut applied = std::collections::HashMap::new();
+    for line in lines.iter_mut() {
+        for (key, value) in &fields {
+            if applied.contains_key(*key) {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix(&format!("{key}:")) {
+                let _ = rest;
+                *line = format!("{}: {}", key, yaml_scalar(value));
+                applied.insert(*key, ());
+            }
+        }
+    }
+
+    // Pass 2: insert missing fields. Insertion point: after `review_required:`
+    // (commented or not), or at the end of the frontmatter.
+    let missing: Vec<(&str, String)> = fields
+        .iter()
+        .filter(|(k, _)| !applied.contains_key(*k))
+        .map(|(k, v)| (*k, v.clone()))
+        .collect();
+
+    if !missing.is_empty() {
+        let insertion_idx = lines
+            .iter()
+            .position(|l| l.trim_start().starts_with("review_required:"))
+            .map(|i| i + 1);
+        let new_lines: Vec<String> = missing
+            .into_iter()
+            .map(|(k, v)| format!("{}: {}", k, yaml_scalar(&v)))
+            .collect();
+
+        match insertion_idx {
+            Some(i) => {
+                for (offset, l) in new_lines.into_iter().enumerate() {
+                    lines.insert(i + offset, l);
+                }
+            }
+            None => {
+                lines.extend(new_lines);
+            }
+        }
+    }
+
+    let mut out = lines.join("\n");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Render a string as a YAML scalar. Quote if the value contains characters
+/// that YAML would otherwise misinterpret. Conservative: quote when in doubt.
+fn yaml_scalar(value: &str) -> String {
+    let needs_quote = value.is_empty()
+        || value.contains(':')
+        || value.contains('#')
+        || value.contains('\n')
+        || value.contains('"')
+        || value.contains('\'')
+        || value.starts_with(' ')
+        || value.ends_with(' ');
+    if needs_quote {
+        format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        value.to_string()
+    }
+}
+
+/// Append a `## Approval` section to the body. Inserts before any trailing
+/// HTML comment marker (e.g., `<!-- Template: DevTrail | ... -->`) so the
+/// canonical signature stays at the very bottom.
+fn append_body_section(
+    raw: &str,
+    reviewer: &str,
+    at: &str,
+    outcome: &str,
+    notes: Option<&str>,
+) -> String {
+    let outcome_label = match outcome {
+        "approved" => "Approved",
+        "revisions_requested" => "Revisions requested",
+        "rejected" => "Rejected",
+        other => other,
+    };
+    let mut block = format!("\n## Approval\n\n**{}**: {} by `{}`.\n", outcome_label, at, reviewer);
+    if let Some(n) = notes {
+        let trimmed = n.trim();
+        if !trimmed.is_empty() {
+            block.push('\n');
+            block.push_str(trimmed);
+            block.push('\n');
+        }
+    }
+
+    // Find a trailing HTML comment marker (the template signature) and
+    // insert the block immediately before it. If absent, append at end.
+    let needle = "<!-- Template: DevTrail";
+    if let Some(pos) = raw.rfind(needle) {
+        // Ensure we land at the start of the line containing the marker.
+        let line_start = raw[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let mut out = String::with_capacity(raw.len() + block.len());
+        out.push_str(&raw[..line_start]);
+        out.push_str(&block);
+        out.push('\n');
+        out.push_str(&raw[line_start..]);
+        return out;
+    }
+
+    let mut out = raw.to_string();
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&block);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_prefix_strips_slug() {
+        assert_eq!(canonical_prefix("AIDEC-2026-05-02-001"), "AIDEC-2026-05-02-001");
+        assert_eq!(
+            canonical_prefix("AIDEC-2026-05-02-001-foo-bar"),
+            "AIDEC-2026-05-02-001"
+        );
+    }
+
+    #[test]
+    fn yaml_scalar_quotes_when_needed() {
+        assert_eq!(yaml_scalar("plain"), "plain");
+        assert_eq!(yaml_scalar("user@example.com"), "user@example.com");
+        assert_eq!(yaml_scalar("has: colon"), "\"has: colon\"");
+        assert_eq!(yaml_scalar("needs # comment"), "\"needs # comment\"");
+        assert_eq!(yaml_scalar(""), "\"\"");
+    }
+
+    #[test]
+    fn upsert_inserts_after_review_required() {
+        let fm = "id: AIDEC-2026-05-02-001\nstatus: accepted\nreview_required: true\nrisk_level: medium\n";
+        let updated = upsert_approval_fields(fm, "pepe@example.com", "2026-05-02", "approved");
+        let expected = "id: AIDEC-2026-05-02-001\nstatus: accepted\nreview_required: true\nreviewed_by: pepe@example.com\nreviewed_at: 2026-05-02\nreview_outcome: approved\nrisk_level: medium\n";
+        assert_eq!(updated, expected);
+    }
+
+    #[test]
+    fn upsert_replaces_existing_fields() {
+        let fm = "review_required: true\nreviewed_by: stale@old.com\nreviewed_at: 2026-04-01\nreview_outcome: revisions_requested\n";
+        let updated = upsert_approval_fields(fm, "fresh@new.com", "2026-05-02", "approved");
+        assert!(updated.contains("reviewed_by: fresh@new.com"));
+        assert!(updated.contains("reviewed_at: 2026-05-02"));
+        assert!(updated.contains("review_outcome: approved"));
+        assert!(!updated.contains("stale@old.com"));
+        assert!(!updated.contains("revisions_requested"));
+    }
+
+    #[test]
+    fn upsert_appends_when_review_required_absent() {
+        let fm = "id: AIDEC-x\nstatus: accepted\n";
+        let updated = upsert_approval_fields(fm, "pepe", "2026-05-02", "approved");
+        assert!(updated.contains("reviewed_by: pepe"));
+        assert!(updated.ends_with("review_outcome: approved\n"));
+    }
+
+    #[test]
+    fn append_body_section_inserts_before_template_marker() {
+        let body = "\n# Body\n\nContent.\n\n---\n\n<!-- Template: DevTrail | https://strangedays.tech -->\n";
+        let out = append_body_section(body, "pepe", "2026-05-02", "approved", None);
+        let approval_pos = out.find("## Approval").unwrap();
+        let marker_pos = out.find("<!-- Template: DevTrail").unwrap();
+        assert!(approval_pos < marker_pos, "Approval should land before signature");
+        assert!(out.contains("**Approved**: 2026-05-02 by `pepe`."));
+    }
+
+    #[test]
+    fn append_body_section_includes_notes_when_provided() {
+        let body = "# Body\n";
+        let out = append_body_section(
+            body,
+            "pepe",
+            "2026-05-02",
+            "approved",
+            Some("Looks good. Ship it."),
+        );
+        assert!(out.contains("Looks good. Ship it."));
+    }
+
+    #[test]
+    fn append_body_section_handles_revisions_requested() {
+        let body = "# Body\n";
+        let out = append_body_section(body, "pepe", "2026-05-02", "revisions_requested", None);
+        assert!(out.contains("**Revisions requested**: 2026-05-02"));
+    }
+
+    #[test]
+    fn split_frontmatter_round_trips() {
+        let raw = "---\nid: x\nstatus: accepted\n---\n\n# Body\n";
+        let (fm, rest) = split_frontmatter(raw).unwrap();
+        assert_eq!(fm, "id: x\nstatus: accepted\n");
+        assert_eq!(rest, "\n\n# Body\n");
+    }
+
+    #[test]
+    fn apply_approval_full_pipeline() {
+        let raw = "---\nid: AIDEC-2026-05-02-001\ntitle: Test\nstatus: accepted\nreview_required: true\nrisk_level: medium\n---\n\n# AIDEC\n\nBody.\n";
+        let out = apply_approval(raw, "pepe@example.com", "2026-05-02", "approved", None).unwrap();
+        // Frontmatter has the three new fields.
+        assert!(out.contains("reviewed_by: pepe@example.com"));
+        assert!(out.contains("reviewed_at: 2026-05-02"));
+        assert!(out.contains("review_outcome: approved"));
+        // Body has the section.
+        assert!(out.contains("## Approval"));
+        assert!(out.contains("**Approved**: 2026-05-02 by `pepe@example.com`."));
+        // Round-trips through YAML parser.
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            out.split("---\n").nth(1).unwrap().split("\n---").next().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            parsed.get("review_outcome").and_then(|v| v.as_str()),
+            Some("approved")
+        );
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod about;
 #[cfg(feature = "analyze")]
 pub mod analyze;
+pub mod approve;
 pub mod audit;
 pub mod charter;
 pub mod compliance;

--- a/cli/src/document.rs
+++ b/cli/src/document.rs
@@ -190,6 +190,14 @@ pub struct Frontmatter {
     pub agent: Option<String>,
     pub confidence: Option<String>,
     pub review_required: Option<bool>,
+    /// Reviewer identity (email | github-handle | DID). Set by `devtrail approve`
+    /// and by `## 3.5 Recording Approval` of the framework's documentation policy.
+    pub reviewed_by: Option<String>,
+    /// Date of formal approval (must be >= `created`).
+    pub reviewed_at: Option<String>,
+    /// Closure signal — one of: `approved | revisions_requested | rejected`.
+    /// Presence of this field is the canonical "human has reviewed" signal.
+    pub review_outcome: Option<String>,
     pub risk_level: Option<String>,
     pub eu_ai_act_risk: Option<String>,
     pub nist_genai_risks: Option<Vec<String>>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -156,6 +156,28 @@ enum Commands {
     },
     /// Show version, author, and license information
     About,
+    /// Record a formal human approval on a `review_required: true` document.
+    /// Writes the reviewed_by/reviewed_at/review_outcome frontmatter fields
+    /// and appends the canonical `## Approval` body section in one edit.
+    Approve {
+        /// Document ID (e.g., AIDEC-2026-05-02-001 or with slug)
+        doc_id: String,
+        /// Outcome of the review
+        #[arg(long, value_parser = ["approved", "revisions_requested", "rejected"])]
+        outcome: Option<String>,
+        /// Reviewer identity: email | github-handle | DID
+        #[arg(long)]
+        reviewer: Option<String>,
+        /// Approval date (default: today, format YYYY-MM-DD)
+        #[arg(long)]
+        at: Option<String>,
+        /// Optional reviewer notes (appended in the body section)
+        #[arg(long)]
+        notes: Option<String>,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
     /// Analyze code complexity using cognitive and cyclomatic metrics
     #[cfg(feature = "analyze")]
     Analyze {
@@ -315,6 +337,21 @@ fn main() {
         Commands::Status { path } => commands::status::run(&path),
         Commands::Repair { path } => commands::repair::run(&path),
         Commands::About => commands::about::run(),
+        Commands::Approve {
+            doc_id,
+            outcome,
+            reviewer,
+            at,
+            notes,
+            path,
+        } => commands::approve::run(
+            &path,
+            &doc_id,
+            outcome.as_deref(),
+            reviewer.as_deref(),
+            at.as_deref(),
+            notes.as_deref(),
+        ),
         #[cfg(feature = "analyze")]
         Commands::Analyze {
             path,

--- a/cli/tests/approve_test.rs
+++ b/cli/tests/approve_test.rs
@@ -1,0 +1,251 @@
+//! Integration tests for `devtrail approve`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn setup_devtrail(dir: &Path) {
+    let devtrail = dir.join(".devtrail");
+    std::fs::create_dir_all(devtrail.join("07-ai-audit/decisions")).unwrap();
+    std::fs::write(devtrail.join("config.yml"), "language: en\n").unwrap();
+}
+
+fn write_aidec(dir: &Path, id: &str, review_required: bool) -> std::path::PathBuf {
+    let path = dir.join(format!(
+        ".devtrail/07-ai-audit/decisions/{}-test-decision.md",
+        id
+    ));
+    let body = format!(
+        r#"---
+id: {id}
+title: Test decision
+status: accepted
+created: 2026-04-23
+agent: test-v1.0
+confidence: high
+review_required: {rq}
+risk_level: medium
+---
+
+# AIDEC: Test decision
+
+## Context
+
+Body.
+
+## References
+
+- (none)
+
+<!-- Template: DevTrail | https://strangedays.tech -->
+"#,
+        id = id,
+        rq = if review_required { "true" } else { "false" }
+    );
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+#[test]
+fn approve_requires_devtrail_installed() {
+    let dir = TempDir::new().unwrap();
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-001",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not installed"));
+}
+
+#[test]
+fn approve_unknown_doc_fails_clearly() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-999",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "AIDEC-2026-05-02-999 not found",
+        ));
+}
+
+#[test]
+fn approve_writes_frontmatter_and_body() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    let aidec = write_aidec(dir.path(), "AIDEC-2026-05-02-001", true);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-001",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--at",
+            "2026-05-02",
+            "--notes",
+            "Looks good. Ship it.",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("approved"))
+        .stdout(predicate::str::contains("pepe@example.com"));
+
+    let content = std::fs::read_to_string(&aidec).unwrap();
+
+    // Frontmatter has the three new fields.
+    assert!(content.contains("reviewed_by: pepe@example.com"), "{content}");
+    assert!(content.contains("reviewed_at: 2026-05-02"), "{content}");
+    assert!(content.contains("review_outcome: approved"), "{content}");
+
+    // Body has the section, before the template signature.
+    assert!(content.contains("## Approval"), "{content}");
+    assert!(
+        content.contains("**Approved**: 2026-05-02 by `pepe@example.com`."),
+        "{content}"
+    );
+    assert!(content.contains("Looks good. Ship it."), "{content}");
+
+    // Approval section appears BEFORE the template signature line.
+    let approval_pos = content.find("## Approval").unwrap();
+    let signature_pos = content.find("<!-- Template: DevTrail").unwrap();
+    assert!(approval_pos < signature_pos);
+
+    // Original frontmatter and body are preserved.
+    assert!(content.contains("review_required: true"));
+    assert!(content.contains("risk_level: medium"));
+    assert!(content.contains("# AIDEC: Test decision"));
+    assert!(content.contains("## References"));
+}
+
+#[test]
+fn approve_warns_when_review_not_required_but_succeeds() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec(dir.path(), "AIDEC-2026-05-02-002", false);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-002",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--at",
+            "2026-05-02",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("does not have `review_required: true`"));
+}
+
+#[test]
+fn approve_replaces_existing_approval_fields() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    let aidec = write_aidec(dir.path(), "AIDEC-2026-05-02-003", true);
+
+    // First approval.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-003",
+            "--outcome",
+            "revisions_requested",
+            "--reviewer",
+            "first@example.com",
+            "--at",
+            "2026-05-01",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    // Second approval (overrides the first in frontmatter).
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-003",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "second@example.com",
+            "--at",
+            "2026-05-02",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&aidec).unwrap();
+
+    // Frontmatter shows the LATEST approval only.
+    assert!(content.contains("reviewed_by: second@example.com"), "{content}");
+    assert!(content.contains("reviewed_at: 2026-05-02"), "{content}");
+    assert!(content.contains("review_outcome: approved"), "{content}");
+    assert!(!content.contains("reviewed_by: first@example.com"), "{content}");
+
+    // Body contains BOTH approval blocks chronologically (multi-reviewer
+    // convention from DOCUMENTATION-POLICY §3.5).
+    let approval_count = content.matches("## Approval").count();
+    assert_eq!(approval_count, 2, "expected 2 approval blocks, got:\n{content}");
+}
+
+#[test]
+fn approve_invalid_outcome_rejected_by_clap() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec(dir.path(), "AIDEC-2026-05-02-004", true);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-02-004",
+            "--outcome",
+            "totally-invalid",
+            "--reviewer",
+            "pepe@example.com",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}


### PR DESCRIPTION
## Summary

Fifth of 8 PRs implementing Phase 2. The CLI counterpart to PR 4 — writes the three approval frontmatter fields and appends the canonical `## Approval` body section in one atomic edit.

### Command

```
devtrail approve <doc-id>
  --outcome approved | revisions_requested | rejected
  --reviewer <email|github-handle|DID>
  [--at YYYY-MM-DD]                  # default: today
  [--notes "..."]                    # optional reviewer notes
  [--path DIR]                       # default: cwd
```

Falls back to interactive prompts for `--outcome` and `--reviewer` if missing and stdin is a TTY; bails on non-TTY missing flags (CI-friendly).

### Behavior

- **Document resolution** via `document::discover_documents` (any DocType), matching by canonical prefix `TYPE-YYYY-MM-DD-NNN`; slug suffix is optional in the input.
- **Warns** (does not fail) if the document doesn't have `review_required: true` — retroactive sign-off is a real use case.
- **Frontmatter mutation**: replaces existing `reviewed_by/_at/outcome` if present (latest-wins per the multi-reviewer convention in DOCUMENTATION-POLICY §3.5); inserts after `review_required:` when absent, falls back to end of frontmatter otherwise.
- **Body mutation**: appends `## Approval` block before any trailing template signature comment (`<!-- Template: DevTrail ... -->`), preserving multiple chronological approvals when the doc was re-approved.
- **YAML scalar quoting** is conservative: any value with `:`, `#`, newlines, quotes, or leading/trailing whitespace gets quoted to prevent ambiguity with the `document::Frontmatter` deserializer.

### Frontmatter struct

Adds `reviewed_by` / `reviewed_at` / `review_outcome` as `Option<String>` on `document::Frontmatter` so PR 6 (`validate --check-pending-reviews`) can read them.

## Test plan

- [x] 10 unit tests cover: `canonical_prefix`, `yaml_scalar` quoting, upsert insertion/replacement/append behavior, body section placement (before template signature, with and without notes), and full pipeline round-tripping through the YAML parser.
- [x] 6 integration tests using a real AIDEC:
  - `approve_requires_devtrail_installed`
  - `approve_unknown_doc_fails_clearly`
  - `approve_writes_frontmatter_and_body` (full happy path with notes)
  - `approve_warns_when_review_not_required_but_succeeds`
  - `approve_replaces_existing_approval_fields` (multi-approval body preservation)
  - `approve_invalid_outcome_rejected_by_clap`
- [x] **372/372 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)