### PR TITLE
feat(cli): Phase 2 PR 6 — devtrail validate --check-pending-reviews

### DIFF
--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -6,7 +6,14 @@ use std::path::PathBuf;
 use crate::utils;
 use crate::validation::{self, Severity, ValidationIssue};
 
-pub fn run(path: &str, fix: bool, staged: bool, include_charters: bool) -> Result<()> {
+pub fn run(
+    path: &str,
+    fix: bool,
+    staged: bool,
+    include_charters: bool,
+    check_pending_reviews: bool,
+    max_pending_days: i64,
+) -> Result<()> {
     let resolved = match utils::resolve_project_root(path) {
         Some(r) => r,
         None => {
@@ -55,6 +62,12 @@ pub fn run(path: &str, fix: bool, staged: bool, include_charters: bool) -> Resul
         doc_count += charter_count;
     }
 
+    if check_pending_reviews {
+        for issue in validation::check_pending_reviews(&devtrail_dir, max_pending_days) {
+            result.warnings.push(issue);
+        }
+    }
+
     if doc_count == 0 {
         utils::info("No documents found to validate.");
         println!(
@@ -77,6 +90,11 @@ pub fn run(path: &str, fix: bool, staged: bool, include_charters: bool) -> Resul
                 validation::validate_charters(&target, &devtrail_dir);
             result.merge(charter_result);
             doc_count += charter_count;
+        }
+        if check_pending_reviews {
+            for issue in validation::check_pending_reviews(&devtrail_dir, max_pending_days) {
+                result.warnings.push(issue);
+            }
         }
         print_results(&result, doc_count);
         return exit_with_code(&result);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,6 +89,15 @@ enum Commands {
         /// projects that don't yet use the Charter pattern.
         #[arg(long)]
         include_charters: bool,
+        /// Surface documents with `review_required: true` and no
+        /// `review_outcome` that are older than --max-pending-days. Warn-only
+        /// (never fails the validate exit code); useful for CI dashboards of
+        /// the approval backlog. See DOCUMENTATION-POLICY.md §3.5.
+        #[arg(long)]
+        check_pending_reviews: bool,
+        /// Threshold for --check-pending-reviews (default: 14 days).
+        #[arg(long, default_value_t = 14)]
+        max_pending_days: i64,
     },
     /// Check regulatory compliance (EU, NIST, ISO; China standards opt-in via regional_scope)
     Compliance {
@@ -309,7 +318,16 @@ fn main() {
             fix,
             staged,
             include_charters,
-        } => commands::validate::run(&path, fix, staged, include_charters),
+            check_pending_reviews,
+            max_pending_days,
+        } => commands::validate::run(
+            &path,
+            fix,
+            staged,
+            include_charters,
+            check_pending_reviews,
+            max_pending_days,
+        ),
         Commands::Audit {
             path,
             from,

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -260,6 +260,69 @@ pub fn validate_all(devtrail_dir: &Path) -> (ValidationResult, usize) {
 
 /// Validate a specific set of document paths (used for --staged mode).
 /// Skips orphan document checking since that is not meaningful for partial validation.
+/// Surface documents whose `review_required: true` is older than a threshold
+/// and still has no `review_outcome`. Per DOCUMENTATION-POLICY §3.5: warn-only,
+/// never errors. Adopters opt in via `devtrail validate --check-pending-reviews`.
+///
+/// Returns one `ValidationIssue` per pending document, all `Severity::Warning`.
+pub fn check_pending_reviews(devtrail_dir: &Path, max_pending_days: i64) -> Vec<ValidationIssue> {
+    use chrono::{Local, NaiveDate};
+
+    let mut issues = Vec::new();
+    let today = Local::now().date_naive();
+    let paths = document::discover_documents(devtrail_dir);
+
+    for path in paths {
+        let doc = match document::parse_document(&path) {
+            Ok(d) => d,
+            Err(_) => continue, // parse errors surface via the regular validate path
+        };
+        if !doc.frontmatter.review_required.unwrap_or(false) {
+            continue;
+        }
+        if doc.frontmatter.review_outcome.is_some() {
+            continue; // already reviewed
+        }
+        let created = match doc
+            .frontmatter
+            .created
+            .as_deref()
+            .and_then(|s| NaiveDate::parse_from_str(s.trim(), "%Y-%m-%d").ok())
+        {
+            Some(d) => d,
+            None => continue, // missing/invalid created date is a separate validate rule
+        };
+        let age_days = (today - created).num_days();
+        if age_days < max_pending_days {
+            continue;
+        }
+        let id = doc
+            .frontmatter
+            .id
+            .clone()
+            .unwrap_or_else(|| {
+                path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(String::from)
+                    .unwrap_or_default()
+            });
+        issues.push(ValidationIssue {
+            file: path,
+            rule: "REVIEW-PENDING".to_string(),
+            message: format!(
+                "{} has `review_required: true` and no `review_outcome` ({} days since creation)",
+                id, age_days
+            ),
+            severity: Severity::Warning,
+            fix_hint: Some(format!(
+                "Run `devtrail approve {} --outcome <approved|revisions_requested|rejected> --reviewer <id>` once a human has reviewed.",
+                id
+            )),
+        });
+    }
+    issues
+}
+
 pub fn validate_paths(paths: &[PathBuf], devtrail_dir: &Path) -> (ValidationResult, usize) {
     let mut result = ValidationResult::default();
     let mut doc_count = 0;

--- a/cli/tests/validate_test.rs
+++ b/cli/tests/validate_test.rs
@@ -451,6 +451,163 @@ fn test_validate_staged_no_git_repo() {
         .stderr(predicates::str::contains("git"));
 }
 
+// ── --check-pending-reviews (Phase 2 / fw-4.6.0) ─────────────────────────
+
+/// Today minus N days as a YYYY-MM-DD string.
+fn days_ago(n: i64) -> String {
+    use chrono::{Duration, Local};
+    (Local::now().date_naive() - Duration::days(n))
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+#[test]
+fn test_check_pending_reviews_flags_old_pending_aidec() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let created = days_ago(30);
+    create_doc(
+        dir.path(),
+        "07-ai-audit/decisions",
+        "AIDEC-2026-04-01-001-old.md",
+        &format!(
+            r#"id: AIDEC-2026-04-01-001
+title: Old decision
+status: accepted
+created: {created}
+agent: test
+confidence: high
+review_required: true
+risk_level: medium"#,
+            created = created
+        ),
+    );
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "validate",
+            "--check-pending-reviews",
+            "--max-pending-days",
+            "14",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        // Warn-only: success exit code even with the warning.
+        .success()
+        .stdout(predicate::str::contains("REVIEW-PENDING"))
+        .stdout(predicate::str::contains("AIDEC-2026-04-01-001"));
+}
+
+#[test]
+fn test_check_pending_reviews_silent_when_outcome_set() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let created = days_ago(30);
+    create_doc(
+        dir.path(),
+        "07-ai-audit/decisions",
+        "AIDEC-2026-04-01-002-approved.md",
+        &format!(
+            r#"id: AIDEC-2026-04-01-002
+title: Approved decision
+status: accepted
+created: {created}
+agent: test
+confidence: high
+review_required: true
+reviewed_by: pepe@example.com
+reviewed_at: {created}
+review_outcome: approved
+risk_level: medium"#,
+            created = created
+        ),
+    );
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "validate",
+            "--check-pending-reviews",
+            "--max-pending-days",
+            "14",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("REVIEW-PENDING").not());
+}
+
+#[test]
+fn test_check_pending_reviews_threshold_respected() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let recent = days_ago(5); // newer than the default 14-day threshold
+    create_doc(
+        dir.path(),
+        "07-ai-audit/decisions",
+        "AIDEC-2026-05-01-001-recent.md",
+        &format!(
+            r#"id: AIDEC-2026-05-01-001
+title: Recent decision
+status: accepted
+created: {created}
+agent: test
+confidence: high
+review_required: true
+risk_level: medium"#,
+            created = recent
+        ),
+    );
+
+    // Default max-pending-days = 14, doc is 5 days old → no warning.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["validate", "--check-pending-reviews"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("REVIEW-PENDING").not());
+}
+
+#[test]
+fn test_check_pending_reviews_skipped_without_flag() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let created = days_ago(30);
+    create_doc(
+        dir.path(),
+        "07-ai-audit/decisions",
+        "AIDEC-2026-04-01-003-stale.md",
+        &format!(
+            r#"id: AIDEC-2026-04-01-003
+title: Stale decision
+status: accepted
+created: {created}
+agent: test
+confidence: high
+review_required: true
+risk_level: medium"#,
+            created = created
+        ),
+    );
+
+    // Without --check-pending-reviews, the warning does not appear.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("REVIEW-PENDING").not());
+}
+
+// ── --staged ─────────────────────────────────────────────────────────────
+
 #[test]
 fn test_validate_staged_no_staged_docs() {
     let dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Sixth of 8 PRs implementing Phase 2. Surfaces documents with `review_required: true` and no `review_outcome` that are older than a threshold. Per DOCUMENTATION-POLICY §3.5: **warn-only**, never errors — useful for CI dashboards of the approval backlog without blocking unrelated PRs.

### Flags

```
devtrail validate --check-pending-reviews [--max-pending-days N]
```

Both default off (opt-in). `--max-pending-days` defaults to 14.

### Implementation

- **New `pub fn check_pending_reviews(devtrail_dir, max_pending_days)`** in `src/validation.rs`. Walks `document::discover_documents`, filters by `review_required:true && review_outcome.is_none() && (today - created) >= max_pending_days`. Emits one `ValidationIssue` per pending doc with rule `REVIEW-PENDING`, `Severity::Warning`, and a fix hint that names the exact `devtrail approve` command line.
- Both branches of `commands::validate::run()` (regular path + `--fix` path) honor the new flags so adopters can combine them naturally.
- Documents with malformed/missing `created` are skipped silently (the existing `META-001` rule catches them).

## Test plan

- [x] 4 new integration tests:
  - `test_check_pending_reviews_flags_old_pending_aidec`
  - `test_check_pending_reviews_silent_when_outcome_set`
  - `test_check_pending_reviews_threshold_respected`
  - `test_check_pending_reviews_skipped_without_flag`
- [x] **378/378 tests pass**.
- [x] Warn-only confirmed: tests with pending reviews exit success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)