### PR TITLE
chore: Phase 2 PR 8 — bump cli-3.7.0 / fw-4.6.0 + docs + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.6.0 / CLI 3.7.0 — Phase 2: telemetry, drift, approval workflow
+
+The first feature-bearing release since the repositioning (fw-4.5.x). Phase 2 of `Propuesta/devtrail-cli-roadmap.md` lands as 7 bisect-safe PRs (#73–#79), grouped here for reviewers. The release closes the empirical loop the Sentinel experiment opened: telemetry at Charter close, drift detection at Charter close, and a canonical approval signal for `review_required: true` documents (resolving issue #67).
+
+**Compatibility.** No breaking changes. Existing Charters, AILOGs, AIDECs, and templates remain valid. New CLI commands and framework artifacts are additive; new template fields ship as commented YAML so existing documents continue to validate. Adopters pick up the changes via `devtrail update-framework` + `devtrail update-cli`.
+
+### Added (Framework)
+
+- **`dist/.devtrail/schemas/charter-telemetry.schema.v0.json`** — JSON Schema Draft 2020-12 for the post-execution telemetry recorded at Charter close. Derived from `Propuesta/devtrail-charter-telemetry.md` v0.3 with the 4 fields refined by Sentinel: `external_audit` as array (dual-audit calibration), `outcome.scope_change_notes` with F1...FN encoding, `agent_quality.r_n_plus_one_emergent_count`, `qualitative.format_iteration`. Marked **experimental v0** — same N=1-domain caveat as `charter.schema.v0.json`. (PR #73)
+- **`dist/.devtrail/templates/charter-telemetry-template.yaml`** — commented YAML skeleton mirroring the schema. Used by `devtrail charter close --from-template` as the starting point for manual edits. (PR #73)
+- **`dist/.devtrail/scripts/check-charter-drift.sh`** — bash script (~165 lines) ported from Sentinel `scripts/check-plan-drift.sh`. Detects declared-but-not-modified files and undocumented scope expansion. Validated empirically with zero false positives across PLAN-05 retrospective + PLAN-06 prospective in Sentinel. Path surface adapted (`docs/plans/` → `docs/charters/`) and section heading detection extended to EN/ES/zh-CN. (PR #73)
+- **`dist/.devtrail/hooks/pre-pr.sh`** — opt-in pre-push hook that runs `devtrail charter drift` automatically on Charters with `status: in-progress`. Per principle #6 (cognitive discipline > raw productivity), the hook is virtuous when consented to and never installed by default. Manual install: `cp .devtrail/hooks/pre-pr.sh .git/hooks/pre-push`. CLI flag: `devtrail init --hooks`. (PR #79)
+- **Approval workflow canonization** (PR #76, closes issue #67): 3 optional frontmatter fields (`reviewed_by`, `reviewed_at`, `review_outcome`) added to all 11 templates that need formal approval (AIDEC, ETH, MCARD, ADR, DPIA, INC, SEC + China: PIPIA, CACFILE, TC260RA, AILABEL) across EN, ES, and zh-CN — **33 template files**. Fields ship as commented YAML so existing documents continue to validate. The presence of `review_outcome` is the canonical "human has reviewed" signal; `review_required: true` remains as historical record after approval (it's not toggled to `false`).
+
+### Changed (Framework)
+
+- **`dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md`** (EN + ES + zh-CN):
+  - §2 Optional Fields extended with `reviewed_by`, `reviewed_at`, `review_outcome`.
+  - New §3.5 "Recording Approval" section explaining closure semantics, body section format (compatible with existing `## Approval` tables in 7 templates), the multi-reviewer convention for v1 (chronological body blocks; structured array deferred), and the CLI tooling.
+
+### Added (CLI)
+
+- **`devtrail charter close <CHARTER-ID>`** (PR #74) — record post-execution telemetry and bump status to `closed`. Two modes:
+  - **Interactive** (default): walks the schema field by field — trigger, effort, agent quality, outcome, qualitative — rendering YAML directly so the output is stable, comment-free, and validated against the schema before disk write. Target time: 5–10 min.
+  - **`--from-template [--non-interactive]`**: copies the YAML skeleton next to the Charter for manual editing (CI / scripted use). Pre-fills `charter_id`, title, and `closed_at`. Idempotent.
+  - Telemetry storage: `.devtrail/charters/CHARTER-NN.telemetry.yaml` (lateral file, not embedded in Charter frontmatter — per roadmap §A2: frontmatter is declarative ex-ante, telemetry is voluminous ex-post).
+- **`devtrail charter drift <CHARTER-ID>`** (PR #75) — wraps `check-charter-drift.sh` with **AILOG-awareness**: paths reported as "declared but not modified" are silenced when they appear in the `## Risk` / `## Riesgos` / `## 风险` section of any AILOG referenced by the Charter's `originating_ailogs`. This is mitigation R2 of the Sentinel experiment — friction was virtuous when emitting cross-agent signal, ceremony when alerting on already-documented risks. Flags: `--range REV..REV` (default `HEAD~1..HEAD`), `--no-ailog-suppress` (disable suppression), `--path DIR`. Bash delegation only; pure-Rust fallback for Windows-without-bash deferred until requested.
+- **`devtrail approve <doc-id>`** (PR #77) — record a formal human approval. Writes the three approval frontmatter fields and appends the canonical `## Approval` body section in one atomic edit. Flag-driven for CI (`--outcome <approved|revisions_requested|rejected> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."]`); falls back to interactive prompts on TTY when flags are absent. Resolves any DocType by canonical prefix, supports re-approval (latest-wins in frontmatter, both blocks preserved chronologically in body for the multi-reviewer convention).
+- **`devtrail validate --check-pending-reviews [--max-pending-days N]`** (PR #78) — surfaces documents with `review_required: true` and no `review_outcome` older than the threshold. **Warn-only** (never errors): per principle #6, useful for CI dashboards of the approval backlog without blocking unrelated PRs. Default threshold: 14 days.
+- **`devtrail init --hooks`** (PR #79) — copies `.devtrail/hooks/pre-pr.sh` to `.git/hooks/pre-push` after init. Refuses to overwrite existing hooks; skips silently if not a git repo.
+
+### Changed (CLI)
+
+- New shared module `cli/src/prompts.rs` — interactive helpers (string, u32, bool, enum, comma-separated array, multiline) with `require_interactive()` guard, used by `charter close` and `approve`.
+- New `cli/src/telemetry_schema.rs` — JSON Schema validator for telemetry YAML, mirroring `charter_schema.rs`.
+- New `cli/src/charter_schema.rs::yaml_to_json_value` — exposed as `pub` (renamed from private `yaml_to_json`) so `telemetry_schema` and other future schema validators can reuse the conversion without duplication.
+- `cli/src/document.rs::Frontmatter` — added `reviewed_by`, `reviewed_at`, `review_outcome` as `Option<String>` so `validate --check-pending-reviews` can read them.
+
+### Notes
+
+- **No schema changes to `charter.schema.v0.json`** — Phase 2 is additive in the Charter ecosystem, not breaking.
+- **Empirical validation gate** — Sentinel's PLAN-05 + PLAN-06 fixtures (zero false positives) are the contractual reference for `charter drift`. The integration tests in PR #75 reproduce the equivalent shape against a real git repo. The Sentinel-side telemetry artifacts (5 PLAN-NN.telemetry.yaml files) are the cross-validation set for the schema crystallized here.
+- **i18n parity** — DOCUMENTATION-POLICY §3.5 ships in all three languages this release; CLI-REFERENCE EN gets the new command sections in this release, ES + zh-CN command-section translations are deferred to fw-4.6.x (the EN canonical surface advances first, ES + zh-CN translations of the command tables stay at the current command list with a brief note).
+
+### Test plan summary
+
+**382/382 tests pass** across 15 test groups: 4 hook-install unit tests, 6 approve integration tests, 4 drift integration tests, 5 charter-close integration tests, 4 pending-review integration tests, plus the existing 359 covering the rest of the CLI. Manual smoke of the interactive `charter close` flow remains an open item before tag.
+
+---
+
 ## Framework 4.5.1 — i18n catch-up + ADOPTION-GUIDE reframe (ES + zh-CN follow up to fw-4.5.0)
 
 Completes the repositioning shipped in `fw-4.5.0` for the Spanish and Simplified Chinese surfaces, and reframes `docs/adopters/ADOPTION-GUIDE.md` (English) — which had been overlooked in `fw-4.5.0` and was still leading with the *"ISO 42001-aligned AI governance platform"* framing. After this release, the canonical engineering-discipline-first positioning is consistent across all three languages.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ Built-in safeguards ensure humans stay in control:
 
 Built-in commands that turn the discipline into actionable feedback:
 
-- **`devtrail charter <new|list|status>`** — Bounded units of work declared ex-ante, audited ex-post (the unit of agent execution)
-- **`devtrail validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `docs/charters/`
+- **`devtrail charter <new|list|status|close|drift>`** — Bounded units of work declared ex-ante, audited ex-post (the unit of agent execution). `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression.
+- **`devtrail approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
+- **`devtrail validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `docs/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
 - **`devtrail metrics`** — Governance KPIs, review rates, risk distribution, trends
 - **`devtrail analyze`** — Code complexity analysis (cognitive + cyclomatic) powered by [arborist-metrics](https://github.com/StrangeDaysTech/arborist), our open-source Rust library for multi-language code metrics
 - **`devtrail audit`** — Audit trail reports with timeline, traceability maps, and HTML export
@@ -258,8 +259,8 @@ DevTrail uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.5.1` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.6.1` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.6.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.7.0` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 
@@ -274,8 +275,9 @@ Check installed versions with `devtrail status` or `devtrail about`.
 | `devtrail remove [--full]` | Remove DevTrail from project |
 | `devtrail status [path]` | Show installation health and doc stats |
 | `devtrail repair [path]` | Restore missing directories and framework files |
-| `devtrail validate [path]` | Validate documents for compliance and correctness (use `--include-charters` to also check `docs/charters/`) |
-| `devtrail charter <subcommand>` | Manage Charters: `new`, `list`, `status` (bounded units of work declared ex-ante, audited ex-post) |
+| `devtrail validate [path]` | Validate documents for compliance and correctness (use `--include-charters` for Charters, `--check-pending-reviews` for approval backlog) |
+| `devtrail charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness) |
+| `devtrail approve <doc-id>` | Record a formal human approval on a `review_required: true` document (frontmatter + canonical body section) |
 | `devtrail compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
 | `devtrail metrics [path]` | Show governance metrics and documentation statistics |
 | `devtrail analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
@@ -290,7 +292,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/a
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/devtrail/releases
-# and download the latest fw-* release (e.g., fw-4.5.1)
+# and download the latest fw-* release (e.g., fw-4.6.0)
 
 # Extract and copy to your project
 unzip devtrail-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.6.1"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.6.1"
+version = "3.7.0"
 edition = "2021"
 description = "CLI for DevTrail — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -270,4 +270,4 @@ When a change modifies API endpoints:
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
@@ -307,4 +307,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -213,4 +213,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -270,4 +270,4 @@ Cuando un cambio modifica endpoints de API:
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -300,4 +300,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -270,4 +270,4 @@ confidence: high | medium | low
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -299,4 +299,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*DevTrail v4.5.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/QUICK-REFERENCE.md
+++ b/dist/.devtrail/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.5.1 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.0 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.5.1"
+version: "4.6.0"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.5.1`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.6.0`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.5.1` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.6.1` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.6.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.7.0` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -64,15 +64,16 @@ devtrail status   # Shows full installation health including versions
 
 ## Commands
 
-### `devtrail init [path]`
+### `devtrail init [path] [--hooks]`
 
 Initialize DevTrail in a project directory.
 
-**Arguments:**
+**Arguments and flags:**
 
-| Argument | Default | Description |
-|----------|---------|-------------|
+| Argument/Flag | Default | Description |
+|---|---|---|
 | `path` | `.` (current directory) | Target project directory |
+| `--hooks` *(cli-3.7.0+)* | off | After init, install the framework's pre-PR hook (`.devtrail/hooks/pre-pr.sh`) as `.git/hooks/pre-push`. Runs `devtrail charter drift` automatically before each push. Opt-in per principle #6 (cognitive discipline > raw productivity). Refuses to overwrite an existing `pre-push` hook; skips silently if not a git repo. |
 
 **What it does:**
 
@@ -81,12 +82,13 @@ Initialize DevTrail in a project directory.
 3. Creates `DEVTRAIL.md` with governance rules
 4. Configures AI agent directive files (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 5. Copies CI/CD workflows
+6. *(`--hooks`)* installs the pre-PR hook
 
 **Example:**
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.5.1
+✔ Downloaded DevTrail fw-4.6.0
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +110,7 @@ If `.devtrail/` does not exist in the current directory, the framework update is
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.5.1
+✔ Framework updated to fw-4.6.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -125,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.5.1
+✔ Framework updated to fw-4.6.0
 ```
 
 ---
@@ -209,7 +211,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.5.1                 │
+  │ Framework │ fw-4.6.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -266,7 +268,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.5.1
+  Using version: fw-4.6.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -275,7 +277,7 @@ Repairing DevTrail in /home/user/my-project
 
 ---
 
-### `devtrail validate [path] [--fix] [--staged] [--include-charters]`
+### `devtrail validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
 
 Validate DevTrail documents for compliance and correctness.
 
@@ -286,7 +288,9 @@ Validate DevTrail documents for compliance and correctness.
 | `path` | `.` (current directory) | Target project directory |
 | `--fix` | — | Automatically fix simple issues (e.g., missing `review_required: true` for high-risk docs) |
 | `--staged` | — | Validate only staged (git-added) files. Ideal for pre-commit hooks. |
-| `--include-charters` | — | Also validate Charters in `docs/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Opt-in so projects that don't yet use the Charter pattern are unaffected. Currently honored only without `--staged` — Charter validation in staged mode lands in cli-3.7.0. |
+| `--include-charters` | — | Also validate Charters in `docs/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Opt-in so projects that don't yet use the Charter pattern are unaffected. |
+| `--check-pending-reviews` *(cli-3.7.0+)* | off | List documents with `review_required: true` and no `review_outcome` older than `--max-pending-days`. **Warn-only** — never fails the validate exit code; useful for CI dashboards of the approval backlog. |
+| `--max-pending-days` *(cli-3.7.0+)* | `14` | Threshold in days for `--check-pending-reviews` |
 
 **What it checks:**
 
@@ -312,6 +316,56 @@ $ devtrail validate --fix
   Auto-fixing 2 issue(s)...
   ✓ Fixed 2 issue(s)
 ```
+
+---
+
+### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
+
+*Available since **cli-3.7.0** + **fw-4.6.0**.*
+
+Record a formal human approval on a `review_required: true` document. Writes the three approval frontmatter fields (`reviewed_by`, `reviewed_at`, `review_outcome`) **and** appends the canonical `## Approval` body section in one atomic edit. Implements the closure signal canonized in `DOCUMENTATION-POLICY.md §3.5`.
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `<doc-id>` | — | Document ID. Accepts the bare prefix (`AIDEC-2026-05-02-001`) or full ID with slug (`AIDEC-2026-05-02-001-foo`). |
+| `--outcome` | — | One of `approved`, `revisions_requested`, `rejected`. Prompts on TTY if absent. |
+| `--reviewer` | — | Reviewer identity: email, GitHub handle, or DID. Prompts on TTY if absent. |
+| `--at` | today | Approval date (`YYYY-MM-DD`) |
+| `--notes` | — | Optional reviewer notes (appended in the body section) |
+| `--path` | `.` | Target project directory |
+
+**Behavior:**
+
+- Warns (does not fail) if the document doesn't have `review_required: true` — retroactive sign-off is a real use case.
+- **Frontmatter mutation** (latest-wins): replaces existing `reviewed_by/_at/outcome` if present; otherwise inserts after `review_required:`. This implements the multi-reviewer convention from §3.5: frontmatter holds the *latest* approval.
+- **Body mutation** (chronological): appends a new `## Approval` block before any trailing template signature. Re-running `approve` preserves earlier blocks so the body shows the full review history.
+- `review_required: true` is **not** toggled to `false` after approval — it remains as historical record of why review was needed.
+
+**Examples:**
+
+```bash
+# Flag-driven (CI / scripts)
+$ devtrail approve AIDEC-2026-05-02-001 \
+    --outcome approved \
+    --reviewer pepe@example.com \
+    --notes "Reviewed against ADR-007. LGTM."
+
+  ✔ AIDEC-2026-05-02-001 marked as approved.
+    Reviewer: pepe@example.com
+    Date:     2026-05-02
+    File:     .devtrail/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
+
+# Iterative review cycle: revisions_requested → re-approve
+$ devtrail approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
+# (author iterates)
+$ devtrail approve AIDEC-... --outcome approved --reviewer reviewer@x.io
+# Frontmatter shows the latest (approved); body shows BOTH blocks chronologically.
+
+# Backlog visibility
+$ devtrail validate --check-pending-reviews --max-pending-days 14
+```
+
+> See `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval" for the canonical workflow definition (closure semantics, body format, multi-reviewer convention).
 
 ---
 
@@ -367,8 +421,10 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 - `devtrail charter new` — scaffold a new Charter from the framework template
 - `devtrail charter list` — enumerate Charters with optional filters
 - `devtrail charter status` — show Charter detail, or the most recent 5 Charters
+- `devtrail charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.0+)*
+- `devtrail charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.0+)*
 
-Phase 2 of the CLI roadmap will add `charter close` (interactive telemetry) and `charter drift` (file-vs-commit drift check). Phase 3 adds `charter audit` (multi-model external audit).
+Phase 3 will add `charter audit` (multi-model external audit).
 
 #### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
@@ -453,6 +509,79 @@ $ devtrail charter status CHARTER-02-baseline-recompute
 $ devtrail charter status CHARTER-02
 $ devtrail charter status 2
 ```
+
+#### `devtrail charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
+
+Record the post-execution telemetry and bump the Charter's status to `closed`. Telemetry is written to `.devtrail/charters/CHARTER-NN.telemetry.yaml` (lateral file, **not** embedded in Charter frontmatter — frontmatter is declarative ex-ante; telemetry is voluminous ex-post). The shape is validated against `.devtrail/schemas/charter-telemetry.schema.v0.json`.
+
+Two modes:
+
+| Mode | Flag combination | When to use |
+|---|---|---|
+| **Interactive** (default) | (none) | Walks the schema field by field with prompts. Target time: 5–10 min. |
+| **From template** | `--from-template` | Copies the YAML skeleton next to the Charter for manual editing. Pre-fills `charter_id`, title, `closed_at`. |
+| **From template, scripted** | `--from-template --non-interactive` | CI / batch use. Skips prompts entirely; idempotent on re-run. |
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `CHARTER-ID` | — | Same resolution rules as `charter status` |
+| `--from-template` | false | Copy the template skeleton instead of running the interactive flow |
+| `--non-interactive` | false | Skip all prompts. Requires `--from-template`. |
+| `--path` | `.` | Target project directory |
+
+**Example:**
+
+```bash
+$ devtrail charter close CHARTER-01
+
+  Closing CHARTER-01-test-charter
+    Title: Test charter
+  Press Enter to accept defaults; type to override.
+
+  ── Trigger ──
+  Declared trigger kind › event_trigger
+  Declared trigger description › first false-positive ticket
+  Fired at (YYYY-MM-DD) [2026-05-02]:
+  ...
+
+  ✔ Charter CHARTER-01 closed.
+    Telemetry: .devtrail/charters/CHARTER-01.telemetry.yaml
+    Status updated: in-progress/declared → closed
+```
+
+#### `devtrail charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+
+Detect file-vs-commit drift at Charter close. Wraps the framework's `.devtrail/scripts/check-charter-drift.sh` (zero false positives validated empirically across PLAN-05 retrospective + PLAN-06 prospective in Sentinel). The CLI value-add over the raw script is **AILOG-awareness**: paths reported as "declared but not modified" are silenced when they appear in the `## Risk` / `## Riesgos` / `## 风险` section of any AILOG referenced by the Charter's `originating_ailogs`. Use `--no-ailog-suppress` to disable.
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `CHARTER-ID` | — | Same resolution rules as `charter status` |
+| `--range` | `HEAD~1..HEAD` | Git revision range to check |
+| `--no-ailog-suppress` | false | Disable AILOG-aware suppression (show every declared-omitted path) |
+| `--path` | `.` | Target project directory |
+
+**Exit codes:** `0` if no drift (or only AILOG-suppressed); `1` if there's unaccounted drift; `2` for usage errors (Charter not found, bash missing, etc.).
+
+**Example:**
+
+```bash
+$ devtrail charter drift CHARTER-01 --range origin/main..HEAD
+=== Charter drift check ===
+  Charter: docs/charters/01-test.md
+  Range:   origin/main..HEAD
+  Declared: 5 files
+  Modified: 3 files
+
+WARNING: Declared in Charter but NOT modified (1 files):
+  - src/services/policy/repository.go
+
+AILOG-suppressed: 1 path(s)
+  - src/services/policy/repository.go [documented in AILOG-2026-05-02-001]
+
+OK all declared-omitted paths are documented in AILOGs — drift accepted.
+```
+
+> **Platform note.** The drift check delegates to `bash`. On Linux/macOS/WSL/Git Bash this works out of the box. On Windows native without WSL, install Git Bash; a pure-Rust fallback is on the roadmap but not in fw-4.6.0.
 
 ---
 
@@ -797,7 +926,7 @@ Show version, authorship, and license information.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.5.1
+  Framework version: fw-4.6.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -125,8 +125,9 @@ Salvaguardas incorporadas que aseguran que los humanos mantengan el control:
 
 Comandos integrados que convierten la disciplina en feedback accionable:
 
-- **`devtrail charter <new|list|status>`** — Unidades acotadas de trabajo declaradas ex-ante, auditadas ex-post (la unidad de ejecución del agente)
-- **`devtrail validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `docs/charters/`
+- **`devtrail charter <new|list|status|close|drift>`** — Unidades acotadas de trabajo declaradas ex-ante, auditadas ex-post (la unidad de ejecución del agente). `close` registra telemetría post-ejecución; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware.
+- **`devtrail approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
+- **`devtrail validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `docs/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
 - **`devtrail metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
 - **`devtrail analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) impulsado por [arborist-metrics](https://github.com/StrangeDaysTech/arborist), nuestra librería open-source en Rust para métricas de código multi-lenguaje
 - **`devtrail audit`** — Reportes de auditoría con línea temporal, mapas de trazabilidad y exportación HTML
@@ -221,8 +222,8 @@ DevTrail usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.5.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.6.1` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.6.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.7.0` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 
@@ -237,8 +238,9 @@ Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 | `devtrail remove [--full]` | Eliminar DevTrail del proyecto |
 | `devtrail status [path]` | Mostrar estado de la instalación y estadísticas |
 | `devtrail repair [path]` | Restaurar directorios y archivos del framework faltantes |
-| `devtrail validate [path]` | Validar documentos por cumplimiento y corrección (use `--include-charters` para validar también `docs/charters/`) |
-| `devtrail charter <subcomando>` | Gestionar Charters: `new`, `list`, `status` (unidades acotadas de trabajo declaradas ex-ante, auditadas ex-post) |
+| `devtrail validate [path]` | Validar documentos por cumplimiento y corrección (use `--include-charters` para Charters, `--check-pending-reviews` para el backlog de aprobaciones) |
+| `devtrail charter <subcomando>` | Gestionar Charters: `new`, `list`, `status`, `close` (registra telemetría), `drift` (drift archivos-vs-commit con AILOG-awareness) |
+| `devtrail approve <doc-id>` | Registra una aprobación humana formal en un documento `review_required: true` (frontmatter + sección body canónica) |
 | `devtrail compliance [path]` | Verificar cumplimiento regulatorio (EU AI Act, ISO 42001, NIST) |
 | `devtrail metrics [path]` | Mostrar métricas de gobernanza y estadísticas |
 | `devtrail analyze [path]` | Analizar complejidad de código (métricas cognitiva + ciclomática) |
@@ -253,7 +255,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/devtrail/releases
-# y descarga el último release fw-* (ej. fw-4.5.1)
+# y descarga el último release fw-* (ej. fw-4.6.0)
 
 # Extraer y copiar a tu proyecto
 unzip devtrail-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.5.1`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.6.0`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.5.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.6.1` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.6.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.7.0` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -86,7 +86,7 @@ Inicializa DevTrail en un directorio de proyecto.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.5.1
+✔ Downloaded DevTrail fw-4.6.0
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -107,7 +107,7 @@ Si `.devtrail/` no existe en el directorio actual, la actualización del framewo
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.5.1
+✔ Framework updated to fw-4.6.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -124,7 +124,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.5.1
+✔ Framework updated to fw-4.6.0
 ```
 
 ---
@@ -203,7 +203,7 @@ $ devtrail status
 DevTrail Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.5.1
+Framework version: fw-4.6.0
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -633,7 +633,7 @@ Muestra información de versión, autoría y licencia.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.5.1
+  Framework version: fw-4.6.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -125,8 +125,9 @@ DevTrail 的产品决策基于十二条明确的原则。它们按层级排序�
 
 将纪律转化为可执行反馈的内置命令：
 
-- **`devtrail charter <new|list|status>`** — 事前声明、事后审计的有界工作单元（Agent 执行的单位）
-- **`devtrail validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `docs/charters/`
+- **`devtrail charter <new|list|status|close|drift>`** — 事前声明、事后审计的有界工作单元（Agent 执行的单位）。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差。
+- **`devtrail approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
+- **`devtrail validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `docs/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
 - **`devtrail metrics`** — 治理 KPI、审查率、风险分布、趋势
 - **`devtrail analyze`** — 代码复杂度分析（认知复杂度 + 圈复杂度），由 [arborist-metrics](https://github.com/StrangeDaysTech/arborist) 驱动——我们的开源 Rust 多语言代码度量库
 - **`devtrail audit`** — 审计跟踪报告，含时间线、可追溯性映射和 HTML 导出
@@ -239,8 +240,8 @@ DevTrail 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.5.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.6.1` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.6.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.7.0` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 
@@ -255,8 +256,9 @@ DevTrail 为每个组件使用独立的版本标签：
 | `devtrail remove [--full]` | 从项目中移除 DevTrail |
 | `devtrail status [path]` | 显示安装状态和文档统计 |
 | `devtrail repair [path]` | 恢复缺失的目录和框架文件 |
-| `devtrail validate [path]` | 验证文档的合规性和正确性（使用 `--include-charters` 同时验证 `docs/charters/`） |
-| `devtrail charter <子命令>` | 管理章程：`new`、`list`、`status`（事前声明、事后审计的有界工作单元） |
+| `devtrail validate [path]` | 验证文档的合规性和正确性（`--include-charters` 同时校验 Charter；`--check-pending-reviews` 列出审批积压） |
+| `devtrail charter <子命令>` | 管理章程：`new`、`list`、`status`、`close`（记录遥测）、`drift`（带 AILOG-awareness 的偏差检测） |
+| `devtrail approve <doc-id>` | 在 `review_required: true` 的文档上记录一次正式的人工审批（frontmatter + 规范的 body 章节） |
 | `devtrail compliance [path]` | 检查法规合规（EU AI Act、ISO 42001、NIST） |
 | `devtrail metrics [path]` | 显示治理指标和文档统计 |
 | `devtrail analyze [path]` | 分析代码复杂度（认知复杂度 + 圈复杂度指标） |
@@ -271,7 +273,7 @@ DevTrail 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/devtrail/releases
-# 下载最新的 fw-* 发布（例如 fw-4.5.1）
+# 下载最新的 fw-* 发布（例如 fw-4.6.0）
 
 # 解压并复制到你的项目
 unzip devtrail-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.5.1`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.6.0`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.5.1` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.6.1` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.6.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.7.0` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -86,7 +86,7 @@ devtrail status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.5.1
+✔ Downloaded DevTrail fw-4.6.0
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +108,7 @@ Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.5.1
+✔ Framework updated to fw-4.6.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -125,7 +125,7 @@ Updating CLI...
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.5.1
+✔ Framework updated to fw-4.6.0
 ```
 
 ---
@@ -209,7 +209,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.5.1                 │
+  │ Framework │ fw-4.6.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -266,7 +266,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.5.1
+  Using version: fw-4.6.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -741,7 +741,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.5.1
+  Framework version: fw-4.6.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail


### PR DESCRIPTION
## Summary

Eighth and final PR of Phase 2. Lifts the version footers and example outputs across the canonical surface, adds CLI-REFERENCE entries for the new commands shipped in PRs 1-7, and writes the consolidated CHANGELOG entry that lists all 7 PRs as one release.

### Version bumps

- `cli/Cargo.toml`: 3.6.1 → **3.7.0** (Cargo.lock auto-updated)
- `dist/dist-manifest.yml`: 4.5.1 → **4.6.0**
- 13 governance footers (5 EN + 4 ES + 4 zh-CN): `v4.5.1` → `v4.6.0`
- README.md (3 langs) + CLI-REFERENCE.md (3 langs) versioning tables and example outputs

### Documentation

- **README.md** (3 langs): commands tables list `charter close`, `charter drift`, `approve`, `validate --check-pending-reviews`.
- **docs/adopters/CLI-REFERENCE.md** (EN canonical):
  - `devtrail init [--hooks]` — flag documented.
  - `devtrail validate` — `--check-pending-reviews` + `--max-pending-days` flags documented; warn-only behavior called out.
  - `devtrail charter close` — full subsection: two modes, pre-fills, target time, schema validation.
  - `devtrail charter drift` — full subsection: AILOG-aware suppression, exit codes, platform note about bash dependency.
  - `devtrail approve` — **new top-level section**: behavior, flags, multi-reviewer convention, pointer to DOCUMENTATION-POLICY §3.5.
- ES + zh-CN CLI-REFERENCE keep the version-footer bumps; the command-section translations are deferred to `fw-4.6.x` (CHANGELOG notes the deferral explicitly).

### CHANGELOG

New `## Framework 4.6.0 / CLI 3.7.0` consolidated section listing all 7 Phase 2 PRs grouped by feature (Added Framework, Changed Framework, Added CLI, Changed CLI, Notes, Test plan summary). Compatibility statement: **no breaking changes** — new commands and fields are additive.

## Test plan

- [x] **382/382 tests pass** with the new versions.
- [x] No `4.5.1` / `cli-3.6.1` references remain in the canonical surface.
- [ ] Post-merge: tag `fw-4.6.0` and `cli-3.7.0`; verify both release workflows publish their assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)