### PR TITLE
fix: Phase 2 patches part 2 — F1 / F8 / drift wildcard glob (cli-3.7.2 + fw-4.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,103 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.6.2 / CLI 3.7.2 — Phase 2 patches part 2 (F1, F8 + wildcard glob from issue #81 update)
+
+Second round of patches surfaced by Sentinel CHARTER-02..05 telemetry
+([issue #81 update](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)).
+After fw-4.6.1 / cli-3.7.1 fixed F3 / F4 / F6, executing four more
+Charters in Sentinel re-prioritized the remaining frictions: **F1
+(slug truncation) reproduced 4/4 times consecutively** — was UX
+polish in the original report, now the most consistently reproducing
+friction in the CLI. **F8 (closed_at)** required manual workaround on
+every Charter close (4× consecutive). **Wildcard glob in drift script**
+was a new finding from CHARTER-04 that any future bulk Charter would
+hit. Plus **observation O1** validated empirically as a feature
+(governance paths always-in-scope correctly suppressed governance
+noise without hiding a stray `git add -A` of project files).
+
+**Compatibility.** No breaking changes. New behavior is additive
+(`--slug` flag, automatic `closed_at` writing, glob resolution in drift).
+
+### Fixed (CLI)
+
+- **F1 — `devtrail charter new` mid-word slug truncation.** A title that
+  overflows the 50-char slug limit by 1-2 chars used to produce a partial
+  word fragment (Sentinel CHARTER-04: title ending in `... true` →
+  filename `…-required-t.md`). Two changes:
+  - `slugify` now backs up to the last `-` boundary at-or-before the
+    limit and drops any partial token, never producing a mid-word cut.
+    Conservative: when the next char in the original is a `-` (or
+    end-of-string), the truncated view is already at a complete
+    boundary and is kept verbatim.
+  - New `--slug <value>` flag lets the operator override the
+    title-derived slug entirely (Sentinel CHARTER-05: title with a
+    meaningful `… Plan 04 F3` suffix that otherwise gets lost). The
+    override is normalized through the same slugifier so it cannot
+    smuggle in characters that break the filename.
+
+- **F8 — `devtrail charter close` did not auto-write `closed_at`.** Per
+  Sentinel CHARTER-02..05 telemetry, the field had to be added manually
+  4× consecutively. The CLI now writes `closed_at: <today>` to the
+  frontmatter alongside the `status: closed` bump. If the Charter
+  already had a `closed_at` (e.g., a prior close that was reverted),
+  the value is refreshed to today rather than left stale.
+
+### Fixed (Framework)
+
+- **Drift script wildcard glob resolution.** The bash drift script
+  already supported the historical `prefix...suffix` ellipsis
+  wildcard. Now it also resolves the more conventional
+  `prefix*suffix` glob form: `*` is converted to `.*` for the regex
+  match, and the same logic applies in both directions (declared
+  glob suppresses "declared but not modified" when at least one
+  matching file was modified, and suppresses "modified but not
+  declared" when a modified path matches a declared glob).
+  Sentinel CHARTER-04 declared `AILOG-*.md` for a parameterized bulk
+  set; pre-fix the script extracted the literal string and reported
+  spurious drift.
+
+### Documented (Framework)
+
+- **O1 ("always in scope" rule for governance paths) is a designed
+  feature, not a bug.** Empirically validated in Sentinel CHARTER-04:
+  a stray `git add -A` staged unrelated user-untracked files
+  (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly
+  suppressed governance noise without hiding the genuine project-file
+  expansion. CLI-REFERENCE.md `devtrail charter drift` section now
+  has explicit subsections for "Wildcard support" and "Designed:
+  governance paths are always in scope", with the empirical citation
+  to issue #81 W2. A `--strict-scope` flag that disables the rule
+  remains on the table for cli-3.8.0 if a real adopter reports the
+  asymmetry as friction.
+
+### Tests
+
+- 4 new unit tests for the F1 slug helper (mid-word truncation
+  reproduction, hard-cut fallback for hyphenless slugs, trailing-`-`
+  trim, helper purity).
+- 4 new integration tests for `devtrail charter new` (word-boundary
+  truncation end-to-end, `--slug` override, `--slug` normalized
+  through slugifier, empty `--slug` falls back to title).
+- 2 new integration tests for F8 (`closed_at` auto-write when
+  absent, refresh of stale `closed_at` to today).
+- 1 new integration test for the drift wildcard glob (real git repo,
+  Charter declares `component-*.rs`, all matching modified files
+  satisfy the glob).
+- All 16/16 test groups pass (393 individual tests, 11 new on top of
+  the 382 carried forward from cli-3.7.1).
+
+### What's NOT in this release
+
+- F2 (AILOG context backfill in Origin line) — bundled for cli-3.8.0.
+- F5 (high-risk approve warning + verbose) — bundled for cli-3.8.0.
+- F7 (charter close output differentiation first-run vs revalidation)
+  — bundled for cli-3.8.0.
+- O3 (`INFO: 0 paths suppressed` always-on log) — pending design discussion.
+- Phase 3 (multi-model external audit) — separately scoped.
+
+---
+
 ## Framework 4.6.1 / CLI 3.7.1 — Phase 2 patches (F3, F4, F6 from issue #81)
 
 Empirical validation of fw-4.6.0 / cli-3.7.0 in Sentinel CHARTER-02

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ DevTrail uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.6.1` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.7.1` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.6.2` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.7.2` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 
@@ -292,7 +292,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/a
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/devtrail/releases
-# and download the latest fw-* release (e.g., fw-4.6.1)
+# and download the latest fw-* release (e.g., fw-4.6.2)
 
 # Extract and copy to your project
 unzip devtrail-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2021"
 description = "CLI for DevTrail — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/commands/charter/close.rs
+++ b/cli/src/commands/charter/close.rs
@@ -489,10 +489,22 @@ fn update_charter_status_to_closed(charter: &Charter) -> Result<()> {
         format!("Failed to read Charter file at {}", charter.path.display())
     })?;
 
-    // Replace the first frontmatter `status:` line.
-    let mut updated = String::with_capacity(raw.len());
+    // F8 (cli-3.7.2): also write closed_at: <today> alongside status: closed.
+    // Per Sentinel CHARTER-02..05 telemetry the field had to be added manually
+    // 4× consecutively. Schema permits arbitrary additional fields; the test
+    // suite for fw-4.6.0 confirmed the validator passes through unknown keys.
+    let today = Local::now().format("%Y-%m-%d").to_string();
+
+    // Walk the frontmatter in a single pass:
+    //   - Replace the first `status:` line with `status: closed`.
+    //   - Replace an existing `closed_at:` line with today's date, if present.
+    //   - If `closed_at:` is absent, queue it for insertion right after the
+    //     replaced `status:` line so it sits in a logical place.
+    let mut updated = String::with_capacity(raw.len() + 32);
     let mut in_frontmatter = false;
-    let mut replaced = false;
+    let mut status_replaced = false;
+    let mut closed_at_replaced = false;
+    let mut closed_at_indent: Option<String> = None;
     let mut delim_count = 0;
     for line in raw.lines() {
         if line.trim() == "---" {
@@ -502,21 +514,52 @@ fn update_charter_status_to_closed(charter: &Charter) -> Result<()> {
             updated.push('\n');
             continue;
         }
-        if in_frontmatter && !replaced && line.trim_start().starts_with("status:") {
+        if in_frontmatter && !status_replaced && line.trim_start().starts_with("status:") {
             let leading_ws: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+            closed_at_indent = Some(leading_ws.clone());
             updated.push_str(&format!("{leading_ws}status: closed\n"));
-            replaced = true;
+            status_replaced = true;
+            continue;
+        }
+        if in_frontmatter && !closed_at_replaced && line.trim_start().starts_with("closed_at:") {
+            let leading_ws: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+            updated.push_str(&format!("{leading_ws}closed_at: {today}\n"));
+            closed_at_replaced = true;
             continue;
         }
         updated.push_str(line);
         updated.push('\n');
     }
-    if !replaced {
+    if !status_replaced {
         bail!(
             "Charter at {} has no `status:` line in frontmatter — cannot bump to closed",
             charter.path.display()
         );
     }
+
+    // If closed_at was absent in the original frontmatter, insert it right
+    // after the replaced status line. We rebuild `updated` rather than tracking
+    // an insertion point above, since insertion at arbitrary line indices is
+    // simpler than splicing an index.
+    let updated = if !closed_at_replaced {
+        let indent = closed_at_indent.unwrap_or_default();
+        let needle = format!("{indent}status: closed\n");
+        let insert = format!("{indent}closed_at: {today}\n");
+        match updated.find(&needle) {
+            Some(pos) => {
+                let after = pos + needle.len();
+                let mut out = String::with_capacity(updated.len() + insert.len());
+                out.push_str(&updated[..after]);
+                out.push_str(&insert);
+                out.push_str(&updated[after..]);
+                out
+            }
+            // Defensive — shouldn't happen since we just wrote it.
+            None => updated,
+        }
+    } else {
+        updated
+    };
 
     // Sync the body status mirror line. Best-effort: if the line is absent or
     // has been edited beyond recognition, we leave it alone — the schema has

--- a/cli/src/commands/charter/new.rs
+++ b/cli/src/commands/charter/new.rs
@@ -28,6 +28,7 @@ pub fn run(
     from_ailog: Option<&str>,
     from_spec: Option<&str>,
     title_arg: Option<&str>,
+    slug_arg: Option<&str>,
 ) -> Result<()> {
     // clap enforces mutual exclusion via conflicts_with — keep this assertion
     // as a defense against direct programmatic invocation.
@@ -75,12 +76,20 @@ pub fn run(
     })?;
 
     // Build identifiers.
+    // F1 (cli-3.7.2): `--slug` lets the operator override the title-derived
+    // slug when the auto-derivation drops meaningful suffixes (e.g.
+    // `…-plan-04-f3` → cut to `…-plan` because the limit hit). The override
+    // is normalized through the same slugifier so it cannot smuggle in
+    // characters that break the filename.
     let nn = next_charter_number(project_root);
-    let slug = slugify(&title);
+    let slug = match slug_arg {
+        Some(s) if !s.trim().is_empty() => slugify(s),
+        _ => slugify(&title),
+    };
     if slug.is_empty() {
         bail!(
-            "Title '{}' produces an empty slug — titles must contain at least one alphanumeric character",
-            title
+            "{} produces an empty slug — must contain at least one alphanumeric character",
+            if slug_arg.is_some() { "--slug" } else { "Title" }
         );
     }
     let charter_id = format!("CHARTER-{:02}-{}", nn, slug);
@@ -247,6 +256,13 @@ fn validate_spec_path(project_root: &Path, spec_path: &str) -> Result<()> {
 /// Slugify a title for use in a Charter filename. Mirrors the implementation
 /// in `commands::new::slugify` (kept private there — duplicated here to avoid
 /// touching the existing command in this PR; consolidate to `utils` later).
+///
+/// F1 (cli-3.7.2): truncation now respects word boundaries. The previous
+/// implementation cut at the 50-char limit and only trimmed a trailing `-`,
+/// which produced mid-word slugs like `…-required-t` (truncating "true" to "t"
+/// in Sentinel CHARTER-04). The fix is to back up to the last `-` boundary
+/// at-or-before the limit, never producing a partial word fragment. Operators
+/// who want a fully custom slug pass `--slug` to override this function entirely.
 fn slugify(title: &str) -> String {
     let lower = title.to_lowercase();
     let parts: Vec<&str> = lower
@@ -255,11 +271,40 @@ fn slugify(title: &str) -> String {
         .collect();
     let slug = parts.join("-");
     if slug.chars().count() > 50 {
-        let truncated: String = slug.chars().take(50).collect();
-        truncated.trim_end_matches('-').to_string()
+        truncate_slug_at_word_boundary(&slug, 50)
     } else {
         slug
     }
+}
+
+/// Truncate `slug` at-or-before `max_chars`, never splitting a word.
+///
+/// The function works in two cases:
+/// - If `slug[max_chars]` is `-` or end-of-string, then `slug[..max_chars]`
+///   already ends on a complete word — we keep the full prefix (after
+///   trimming any trailing `-`).
+/// - Otherwise, `slug[..max_chars]` ends mid-word; we back up to the last
+///   `-` boundary inside the truncated view and drop the partial token.
+///
+/// Falls back to a hard cut when the truncated view contains no hyphen at
+/// all (single very long token).
+fn truncate_slug_at_word_boundary(slug: &str, max_chars: usize) -> String {
+    let truncated: String = slug.chars().take(max_chars).collect();
+
+    let next_is_boundary = slug
+        .chars()
+        .nth(max_chars)
+        .map(|c| c == '-')
+        .unwrap_or(true);
+    if next_is_boundary {
+        return truncated.trim_end_matches('-').to_string();
+    }
+
+    let cut = match truncated.rfind('-') {
+        Some(idx) => &truncated[..idx],
+        None => truncated.as_str(),
+    };
+    cut.trim_end_matches('-').to_string()
 }
 
 #[cfg(test)]
@@ -385,6 +430,57 @@ Body content.
         let long = "a".repeat(100);
         let s = slugify(&long);
         assert!(s.len() <= 50);
+    }
+
+    // ── F1 (cli-3.7.2): word-boundary truncation ─────────────────────────
+
+    #[test]
+    fn slugify_truncates_at_word_boundary_not_mid_word() {
+        // CHARTER-04 reproduction case from issue #81: title that overflows
+        // 50 chars by 1-2 chars used to produce a mid-word fragment like
+        // "…required-t" (cutting "true" to "t"). Now the truncation backs up
+        // to the last `-` boundary and drops the partial token entirely.
+        let title = "Approve retroactivo bulk de docs review_required: true";
+        let s = slugify(title);
+        assert!(s.len() <= 50, "slug must fit limit, got {}: {s}", s.len());
+        assert!(
+            !s.ends_with("-t") && !s.ends_with("-tr") && !s.ends_with("-tru"),
+            "slug must not end with a partial word fragment, got: {s}"
+        );
+        // Last completed word should be preserved.
+        assert!(s.ends_with("required"), "got: {s}");
+    }
+
+    #[test]
+    fn slugify_handles_no_hyphen_in_truncated_window() {
+        // Single very long token: no hyphens to back up to. We hard-cut.
+        let title = "supercalifragilisticexpialidocious".repeat(3);
+        let s = slugify(&title);
+        assert!(s.len() <= 50);
+        assert!(!s.contains('-'));
+    }
+
+    #[test]
+    fn slugify_strips_trailing_hyphens_after_word_boundary_cut() {
+        // If the cut lands such that a trailing `-` survives, we trim it.
+        let title = "abc-def-ghi-jkl-mno-pqr-stu-vwx-yz1-2345-6789-extra";
+        let s = slugify(title);
+        assert!(!s.ends_with('-'), "got: {s}");
+    }
+
+    #[test]
+    fn truncate_slug_at_word_boundary_helper_is_pure() {
+        // Direct unit test of the helper: cut at last `-` ≤ max_chars.
+        assert_eq!(
+            truncate_slug_at_word_boundary("foo-bar-baz-qux", 11),
+            "foo-bar-baz"
+        );
+        assert_eq!(
+            truncate_slug_at_word_boundary("foo-bar-baz-qux", 10),
+            "foo-bar"
+        );
+        // No hyphen within window → hard cut.
+        assert_eq!(truncate_slug_at_word_boundary("supercalifragilistic", 10), "supercalif");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,6 +251,12 @@ enum CharterCommands {
         /// Charter title (used to build the slug and filename)
         #[arg(long)]
         title: Option<String>,
+        /// Explicit slug override (cli-3.7.2+). Use when the title-derived
+        /// slug would lose meaningful context (e.g., a long title with a
+        /// trailing reference like `… Plan 04 F3` whose suffix would be
+        /// truncated). Input is normalized through the slugifier.
+        #[arg(long)]
+        slug: Option<String>,
         /// Project directory (default: current directory)
         #[arg(default_value = ".")]
         path: String,
@@ -399,6 +405,7 @@ fn main() {
                 from_ailog,
                 from_spec,
                 title,
+                slug,
                 path,
             } => commands::charter::new::run(
                 &path,
@@ -406,6 +413,7 @@ fn main() {
                 from_ailog.as_deref(),
                 from_spec.as_deref(),
                 title.as_deref(),
+                slug.as_deref(),
             ),
             CharterCommands::List {
                 status,

--- a/cli/tests/charter_close_test.rs
+++ b/cli/tests/charter_close_test.rs
@@ -217,6 +217,103 @@ fn charter_close_syncs_body_status_mirror_line() {
 }
 
 #[test]
+fn charter_close_writes_closed_at_when_absent() {
+    // F8 (cli-3.7.2): every closed Charter should carry a closed_at:
+    // YYYY-MM-DD line in frontmatter. Sentinel CHARTER-02..05 telemetry had
+    // to add it manually 4× consecutively. The CLI now does it on close.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "Closed At Test");
+    let charter_path = dir.path().join("docs/charters/01-closed-at-test.md");
+    let before = std::fs::read_to_string(&charter_path).unwrap();
+    assert!(!before.contains("closed_at:"), "scaffold should not pre-write closed_at");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let after = std::fs::read_to_string(&charter_path).unwrap();
+    assert!(after.contains("closed_at:"), "closed_at must be written on close, got:\n{after}");
+    // Today's date.
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    assert!(
+        after.contains(&format!("closed_at: {today}")),
+        "closed_at should be today ({today}), got:\n{after}"
+    );
+    // Closed-at sits adjacent to the bumped status line for readability.
+    let status_pos = after.find("status: closed").expect("status: closed");
+    let closed_at_pos = after.find("closed_at:").expect("closed_at line");
+    let between = &after[status_pos..closed_at_pos];
+    assert!(
+        between.lines().count() <= 2,
+        "closed_at should be on the line right after status: closed, got intervening:\n{between}"
+    );
+}
+
+#[test]
+fn charter_close_replaces_existing_closed_at_with_today() {
+    // If a Charter was previously closed with a stale closed_at (manual
+    // edit, or a re-close after status got reverted), the date should be
+    // refreshed to today rather than left stale.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let charter_path = dir.path().join("docs/charters/01-stale.md");
+    let stale = r#"---
+charter_id: CHARTER-01
+status: in-progress
+closed_at: 2020-01-01
+effort_estimate: M
+trigger: "test"
+---
+
+# Charter: Stale
+
+> **Status (mirrored from frontmatter — source of truth is above):** in-progress. Effort: M.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+
+## Tasks
+
+1. ok.
+"#;
+    std::fs::create_dir_all(dir.path().join("docs/charters")).unwrap();
+    std::fs::write(&charter_path, stale).unwrap();
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let after = std::fs::read_to_string(&charter_path).unwrap();
+    assert!(!after.contains("closed_at: 2020-01-01"), "stale date should be replaced");
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    assert!(after.contains(&format!("closed_at: {today}")));
+}
+
+#[test]
 fn charter_close_bumps_status_to_closed() {
     let dir = TempDir::new().unwrap();
     setup_devtrail(dir.path());

--- a/cli/tests/charter_drift_test.rs
+++ b/cli/tests/charter_drift_test.rs
@@ -280,6 +280,67 @@ review_required: false
 }
 
 #[test]
+fn charter_drift_resolves_glob_wildcards_in_declared_paths() {
+    // fw-4.6.2: bulk Charters can declare `prefix*suffix` glob patterns
+    // (e.g. `AILOG-*.md` for parameterized sets). Pre-fix the script
+    // extracted the literal "AILOG-*.md" and reported it as drift; now
+    // it expands `*` to a regex match against the modified files.
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    // Build a Charter that declares a glob.
+    let charters_dir = dir.path().join("docs").join("charters");
+    std::fs::create_dir_all(&charters_dir).unwrap();
+    let charter = r#"---
+charter_id: CHARTER-01
+status: declared
+effort_estimate: XS
+trigger: "bulk"
+---
+
+# Charter: glob test
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `src/handler.rs` | edit |
+| `src/things/component-*.rs` | bulk edit |
+
+## Tasks
+
+1. Run.
+"#;
+    std::fs::write(charters_dir.join("01-glob.md"), charter).unwrap();
+
+    std::fs::create_dir_all(dir.path().join("src/things")).unwrap();
+    std::fs::write(dir.path().join("src/handler.rs"), "// initial\n").unwrap();
+    std::fs::write(dir.path().join("src/things/component-a.rs"), "// initial\n").unwrap();
+    std::fs::write(dir.path().join("src/things/component-b.rs"), "// initial\n").unwrap();
+
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/handler.rs"), "// edited\n").unwrap();
+    std::fs::write(dir.path().join("src/things/component-a.rs"), "// edited\n").unwrap();
+    std::fs::write(dir.path().join("src/things/component-b.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit all"]);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["charter", "drift", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK No drift detected"));
+}
+
+#[test]
 fn charter_drift_ignores_path_references_in_change_column() {
     // F3 (cli-3.7.1 / fw-4.6.1): the drift script's regex used to extract
     // backtick-quoted paths from ANY column of the table, including the

--- a/cli/tests/charter_test.rs
+++ b/cli/tests/charter_test.rs
@@ -897,3 +897,110 @@ fn charter_new_does_not_overwrite_existing_file() {
         .success();
     assert!(charters_dir.join("02-foo.md").exists());
 }
+
+// ── F1 (cli-3.7.2): word-boundary slug truncation + --slug override ──
+
+#[test]
+fn charter_new_truncates_long_title_at_word_boundary() {
+    // CHARTER-04 reproduction (issue #81): title that overflowed 50 chars
+    // by 1-2 chars used to produce a mid-word fragment like "…required-t"
+    // (cutting "true" to "t"). The fix truncates at the last `-` boundary.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail_with_charter_template(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .arg("charter")
+        .arg("new")
+        .arg("--title")
+        .arg("Approve retroactivo bulk de docs review_required: true")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    // The slug should not include a partial "true" fragment.
+    let charters_dir = dir.path().join("docs/charters");
+    let entries: Vec<_> = std::fs::read_dir(&charters_dir).unwrap().flatten().collect();
+    assert_eq!(entries.len(), 1);
+    let filename = entries[0]
+        .path()
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        !filename.ends_with("-t.md") && !filename.ends_with("-tr.md") && !filename.ends_with("-tru.md"),
+        "filename must not end with a partial word, got: {filename}"
+    );
+    assert!(filename.contains("required"), "should preserve last full word, got: {filename}");
+}
+
+#[test]
+fn charter_new_slug_flag_overrides_title_derivation() {
+    // CHARTER-05 reproduction (issue #81): the title-derived slug dropped a
+    // meaningful trailing reference (e.g. "-04-f3"). The --slug flag lets
+    // the operator provide an explicit short slug that preserves context.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail_with_charter_template(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .arg("charter")
+        .arg("new")
+        .arg("--title")
+        .arg("Batching ListTimeSeries para N≥500 servicios — Plan 04 F3")
+        .arg("--slug")
+        .arg("batching-listtimeseries-04-f3")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let charters_dir = dir.path().join("docs/charters");
+    assert!(charters_dir.join("01-batching-listtimeseries-04-f3.md").exists());
+}
+
+#[test]
+fn charter_new_slug_flag_normalizes_through_slugifier() {
+    // The override is normalized through the same slugifier so the operator
+    // cannot smuggle in characters that would break the filename.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail_with_charter_template(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .arg("charter")
+        .arg("new")
+        .arg("--title")
+        .arg("Whatever")
+        .arg("--slug")
+        .arg("UPPER and SPECIAL!!!")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let charters_dir = dir.path().join("docs/charters");
+    assert!(charters_dir.join("01-upper-and-special.md").exists());
+}
+
+#[test]
+fn charter_new_empty_slug_flag_falls_back_to_title() {
+    // An empty --slug "" should be ignored (not treated as a hard error),
+    // falling back to the title-derived slug.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail_with_charter_template(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .arg("charter")
+        .arg("new")
+        .arg("--title")
+        .arg("Hello World")
+        .arg("--slug")
+        .arg("")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("docs/charters/01-hello-world.md").exists());
+}

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -270,4 +270,4 @@ When a change modifies API endpoints:
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
@@ -307,4 +307,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -213,4 +213,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -270,4 +270,4 @@ Cuando un cambio modifica endpoints de API:
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -300,4 +300,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -270,4 +270,4 @@ confidence: high | medium | low
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -299,4 +299,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*DevTrail v4.6.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/QUICK-REFERENCE.md
+++ b/dist/.devtrail/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.6.1 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.6.2 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/scripts/check-charter-drift.sh
+++ b/dist/.devtrail/scripts/check-charter-drift.sh
@@ -102,12 +102,18 @@ if [ -z "$modified" ]; then
 fi
 
 # Set diff: declared but not modified.
-# Note: AILOG paths in the Charter often have wildcards (e.g. AILOG-...md), so
-# we compare on basename match too — if the Charter declared an AILOG path with
-# wildcards, any AILOG that matches the prefix is considered "fulfilled".
+#
+# Two wildcard forms are supported in declared paths:
+#   1. Ellipsis form `prefix...suffix` — any modified file with that prefix
+#      satisfies the wildcard. Used historically in AILOG references like
+#      `.devtrail/07-ai-audit/agent-logs/AILOG-...md`.
+#   2. Glob form `prefix*suffix` (added fw-4.6.2): any modified file whose
+#      path matches the glob (`*` → `.*` regex) satisfies the wildcard.
+#      Used for bulk Charter declarations like `AILOG-*.md`. Reported as the
+#      new finding in CHARTER-04 of issue #81.
 declared_omitted=""
 while IFS= read -r decl; do
-  # If declared path has '...', try a prefix match.
+  # 1. Ellipsis wildcard.
   if [[ "$decl" == *...* ]]; then
     prefix="${decl%...*}"
     if echo "$modified" | grep -q "^${prefix}"; then
@@ -116,6 +122,16 @@ while IFS= read -r decl; do
     declared_omitted+="$decl"$'\n'
     continue
   fi
+  # 2. Glob wildcard. Convert `*` → `.*` and escape `.` for the regex match.
+  if [[ "$decl" == *\** ]]; then
+    glob_re=$(printf '%s' "$decl" | sed 's/\./\\./g; s/\*/.*/g')
+    if echo "$modified" | grep -qE "^${glob_re}$"; then
+      continue
+    fi
+    declared_omitted+="$decl"$'\n'
+    continue
+  fi
+  # 3. Literal path.
   if ! echo "$modified" | grep -qx "$decl"; then
     declared_omitted+="$decl"$'\n'
   fi
@@ -132,11 +148,18 @@ while IFS= read -r mod; do
   fi
   if ! echo "$declared" | grep -qx "$mod"; then
     # Also allow if the declared list has a wildcard prefix that matches.
+    # Recognizes both forms: `prefix...suffix` and `prefix*suffix` (fw-4.6.2).
     matched_wildcard=0
     while IFS= read -r decl; do
       if [[ "$decl" == *...* ]]; then
         prefix="${decl%...*}"
         if [[ "$mod" == ${prefix}* ]]; then
+          matched_wildcard=1
+          break
+        fi
+      elif [[ "$decl" == *\** ]]; then
+        glob_re=$(printf '%s' "$decl" | sed 's/\./\\./g; s/\*/.*/g')
+        if echo "$mod" | grep -qE "^${glob_re}$"; then
           matched_wildcard=1
           break
         fi

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.6.1"
+version: "4.6.2"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.6.1`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.6.2`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.6.1` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.7.1` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.6.2` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.7.2` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -73,7 +73,7 @@ Initialize DevTrail in a project directory.
 | Argument/Flag | Default | Description |
 |---|---|---|
 | `path` | `.` (current directory) | Target project directory |
-| `--hooks` *(cli-3.7.1+)* | off | After init, install the framework's pre-PR hook (`.devtrail/hooks/pre-pr.sh`) as `.git/hooks/pre-push`. Runs `devtrail charter drift` automatically before each push. Opt-in per principle #6 (cognitive discipline > raw productivity). Refuses to overwrite an existing `pre-push` hook; skips silently if not a git repo. |
+| `--hooks` *(cli-3.7.0+)* | off | After init, install the framework's pre-PR hook (`.devtrail/hooks/pre-pr.sh`) as `.git/hooks/pre-push`. Runs `devtrail charter drift` automatically before each push. Opt-in per principle #6 (cognitive discipline > raw productivity). Refuses to overwrite an existing `pre-push` hook; skips silently if not a git repo. |
 
 **What it does:**
 
@@ -88,7 +88,7 @@ Initialize DevTrail in a project directory.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.6.1
+✔ Downloaded DevTrail fw-4.6.2
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.devtrail/` does not exist in the current directory, the framework update is
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.6.1
+✔ Framework updated to fw-4.6.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.6.1
+✔ Framework updated to fw-4.6.2
 ```
 
 ---
@@ -211,7 +211,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.6.1                 │
+  │ Framework │ fw-4.6.2                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.6.1
+  Using version: fw-4.6.2
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -289,8 +289,8 @@ Validate DevTrail documents for compliance and correctness.
 | `--fix` | — | Automatically fix simple issues (e.g., missing `review_required: true` for high-risk docs) |
 | `--staged` | — | Validate only staged (git-added) files. Ideal for pre-commit hooks. |
 | `--include-charters` | — | Also validate Charters in `docs/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Opt-in so projects that don't yet use the Charter pattern are unaffected. |
-| `--check-pending-reviews` *(cli-3.7.1+)* | off | List documents with `review_required: true` and no `review_outcome` older than `--max-pending-days`. **Warn-only** — never fails the validate exit code; useful for CI dashboards of the approval backlog. |
-| `--max-pending-days` *(cli-3.7.1+)* | `14` | Threshold in days for `--check-pending-reviews` |
+| `--check-pending-reviews` *(cli-3.7.0+)* | off | List documents with `review_required: true` and no `review_outcome` older than `--max-pending-days`. **Warn-only** — never fails the validate exit code; useful for CI dashboards of the approval backlog. |
+| `--max-pending-days` *(cli-3.7.0+)* | `14` | Threshold in days for `--check-pending-reviews` |
 
 **What it checks:**
 
@@ -321,7 +321,7 @@ $ devtrail validate --fix
 
 ### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
 
-*Available since **cli-3.7.1** + **fw-4.6.1**.*
+*Available since **cli-3.7.2** + **fw-4.6.2**.*
 
 Record a formal human approval on a `review_required: true` document. Writes the three approval frontmatter fields (`reviewed_by`, `reviewed_at`, `review_outcome`) **and** appends the canonical `## Approval` body section in one atomic edit. Implements the closure signal canonized in `DOCUMENTATION-POLICY.md §3.5`.
 
@@ -421,8 +421,8 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 - `devtrail charter new` — scaffold a new Charter from the framework template
 - `devtrail charter list` — enumerate Charters with optional filters
 - `devtrail charter status` — show Charter detail, or the most recent 5 Charters
-- `devtrail charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.1+)*
-- `devtrail charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.1+)*
+- `devtrail charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.2+)*
+- `devtrail charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.2+)*
 
 Phase 3 will add `charter audit` (multi-model external audit).
 
@@ -581,7 +581,24 @@ AILOG-suppressed: 1 path(s)
 OK all declared-omitted paths are documented in AILOGs — drift accepted.
 ```
 
-> **Platform note.** The drift check delegates to `bash`. On Linux/macOS/WSL/Git Bash this works out of the box. On Windows native without WSL, install Git Bash; a pure-Rust fallback is on the roadmap but not in fw-4.6.1.
+> **Platform note.** The drift check delegates to `bash`. On Linux/macOS/WSL/Git Bash this works out of the box. On Windows native without WSL, install Git Bash; a pure-Rust fallback is on the roadmap but not in fw-4.6.x.
+
+#### Wildcard support in declared paths *(fw-4.6.2+)*
+
+The drift check resolves two forms of wildcard in `## Files to modify`:
+
+| Form | Example | Use case |
+|---|---|---|
+| Ellipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Any modified path with that prefix satisfies the wildcard. Used historically when an unknown number of AILOGs would be created during execution. |
+| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.6.2 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+
+Both forms are handled in both directions: a declared wildcard suppresses both "declared but not modified" warnings (when at least one matching file was modified) and "modified but not declared" warnings (when a modified path matches a declared wildcard).
+
+#### Designed: governance paths are always in scope
+
+Paths under `docs/charters/*` and `.devtrail/07-ai-audit/*` are **never** reported as "modified but not declared". This is opinionated by design — those paths are always legitimate when the Charter itself or the AILOG of execution is touched. Empirically validated in Sentinel CHARTER-04: a stray `git add -A` staged unrelated user-untracked files (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly suppressed the governance noise without hiding the genuine project-file expansion ([issue #81 W2](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)).
+
+If you're running a Charter whose explicit scope is governance churn (e.g., a bulk approval Charter touching only `.devtrail/07-ai-audit/`), the drift check will report 0 modified files and you'll need to verify scope by reading the AILOG. A `--strict-scope` flag that disables the always-in-scope rule is on the table for cli-3.8.0 if a real adopter reports the asymmetry as a friction.
 
 ---
 
@@ -926,7 +943,7 @@ Show version, authorship, and license information.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.6.1
+  Framework version: fw-4.6.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -222,8 +222,8 @@ DevTrail usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.6.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.7.1` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.6.2` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.7.2` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 
@@ -255,7 +255,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/devtrail/releases
-# y descarga el último release fw-* (ej. fw-4.6.1)
+# y descarga el último release fw-* (ej. fw-4.6.2)
 
 # Extraer y copiar a tu proyecto
 unzip devtrail-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.6.1`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.6.2`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.6.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.7.1` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.6.2` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.7.2` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -86,7 +86,7 @@ Inicializa DevTrail en un directorio de proyecto.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.6.1
+✔ Downloaded DevTrail fw-4.6.2
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -107,7 +107,7 @@ Si `.devtrail/` no existe en el directorio actual, la actualización del framewo
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.6.1
+✔ Framework updated to fw-4.6.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -124,7 +124,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.6.1
+✔ Framework updated to fw-4.6.2
 ```
 
 ---
@@ -203,7 +203,7 @@ $ devtrail status
 DevTrail Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.6.1
+Framework version: fw-4.6.2
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -267,7 +267,7 @@ Valida documentos DevTrail verificando cumplimiento y corrección.
 | `path` | `.` (directorio actual) | Directorio del proyecto |
 | `--fix` | — | Corregir automáticamente problemas simples |
 | `--staged` | — | Validar solo archivos staged en Git (ideal para hooks pre-commit) |
-| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.7.1. |
+| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.7.2. |
 
 **Reglas de validación:**
 
@@ -633,7 +633,7 @@ Muestra información de versión, autoría y licencia.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.6.1
+  Framework version: fw-4.6.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -240,8 +240,8 @@ DevTrail 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.6.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.7.1` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.6.2` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.7.2` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 
@@ -273,7 +273,7 @@ DevTrail 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/devtrail/releases
-# 下载最新的 fw-* 发布（例如 fw-4.6.1）
+# 下载最新的 fw-* 发布（例如 fw-4.6.2）
 
 # 解压并复制到你的项目
 unzip devtrail-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.6.1`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.6.2`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.6.1` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.7.1` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.6.2` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.7.2` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -86,7 +86,7 @@ devtrail status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.6.1
+✔ Downloaded DevTrail fw-4.6.2
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +108,7 @@ Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.6.1
+✔ Framework updated to fw-4.6.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -125,7 +125,7 @@ Updating CLI...
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.6.1
+✔ Framework updated to fw-4.6.2
 ```
 
 ---
@@ -209,7 +209,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.6.1                 │
+  │ Framework │ fw-4.6.2                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -266,7 +266,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.6.1
+  Using version: fw-4.6.2
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -286,7 +286,7 @@ Repairing DevTrail in /home/user/my-project
 | `path` | `.`（当前目录） | 目标项目目录 |
 | `--fix` | — | 自动修复简单问题（例如为高风险文档添加缺失的 `review_required: true`） |
 | `--staged` | — | 仅验证已暂存（git add）的文件。适合 pre-commit 钩子。 |
-| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.7.1 中加入。 |
+| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.7.2 中加入。 |
 
 **检查项目：**
 
@@ -741,7 +741,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.6.1
+  Framework version: fw-4.6.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail


### PR DESCRIPTION
## Summary

Second round of patches surfaced by [Sentinel CHARTER-02..05 telemetry](https://github.com/StrangeDaysTech/devtrail/issues/81). After fw-4.6.1 / cli-3.7.1 fixed F3 / F4 / F6, executing four more Charters re-prioritized the remaining frictions:

- **F1 reproduced 4/4× consecutively** — was UX polish in the original report, now the top-reproducibility friction.
- **F8 required manual workaround on every Charter close** (4× consecutive).
- **NEW: wildcard glob in drift script** — finding from CHARTER-04 that any future bulk Charter would hit.
- **O1 validated empirically as a feature** in CHARTER-04 (caught real scope expansion).

### F1 — `devtrail charter new` mid-word slug truncation

A title overflowing the 50-char limit by 1-2 chars used to produce a partial word fragment (CHARTER-04: `… true` → `…-required-t.md`).

- `slugify` now backs up to the last `-` boundary at-or-before the limit. Conservative — when the next char in the original is `-` (or end), the truncated view is already at a complete boundary and is kept verbatim.
- New **`--slug <value>`** flag for explicit override (CHARTER-05 case where a meaningful `… Plan 04 F3` suffix gets lost). Override is normalized through the same slugifier.

### F8 — `devtrail charter close` did not auto-write `closed_at`

`charter close` now writes `closed_at: <today>` alongside `status: closed`. If a stale `closed_at` was already present, it's refreshed.

### Drift wildcard glob *(framework)*

Bash drift script already supported `prefix...suffix` ellipsis wildcards. Now also resolves `prefix*suffix` glob form (`*` → `.*` regex). Symmetric in both directions: declared glob suppresses missing-file warnings, modified path matching declared glob suppresses scope-expansion warnings.

### O1 documented as feature

CLI-REFERENCE.md now has explicit "Wildcard support" and "Designed: governance paths are always in scope" subsections in the drift section, citing CHARTER-04 W2 as the empirical validation.

## Test plan

- [x] 4 unit tests for the slug helper (mid-word reproduction, hard-cut fallback, trailing-`-` trim, helper purity).
- [x] 4 integration tests for `charter new` (word-boundary truncation, `--slug` override, `--slug` normalized through slugifier, empty `--slug` falls back).
- [x] 2 integration tests for F8 (auto-write, refresh stale).
- [x] 1 integration test for the drift wildcard glob.
- [x] **393/393 tests pass** (11 new on top of 382 from cli-3.7.1).

## Compatibility

**No breaking changes.** New behavior is additive: `--slug` is opt-in, `closed_at` auto-write is automatic but adopters who previously wrote it manually still get the same final state, glob resolution only fires for paths containing `*` (existing literal paths unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)