### PR TITLE
feat(cli): Phase 3 PR 4 — F5 high-risk approve warning + --quiet

### DIFF
--- a/cli/src/commands/approve.rs
+++ b/cli/src/commands/approve.rs
@@ -30,6 +30,7 @@ pub fn run(
     at: Option<&str>,
     notes: Option<&str>,
     force: bool,
+    quiet: bool,
 ) -> Result<()> {
     let resolved = utils::resolve_project_root(path)
         .ok_or_else(|| anyhow!("DevTrail not installed. Run 'devtrail init' first."))?;
@@ -40,34 +41,31 @@ pub fn run(
     let doc_path = find_document_by_id(&devtrail_dir, doc_id)?;
 
     // F4 (cli-3.7.1): detect existing approval before resolving any prompts.
-    // Re-applying approve to an already-approved document silently overwrote
-    // the frontmatter and appended a duplicate `## Approval` block. Now the
-    // default is to skip with a clear message and exit Ok; `--force` is the
-    // explicit gate for the legitimate cases (revisions_requested → approved
-    // iteration, multi-reviewer hand-off).
     if let Ok(parsed) = document::parse_document(&doc_path) {
         if let (Some(prev_outcome), Some(prev_reviewer)) = (
             parsed.frontmatter.review_outcome.as_deref(),
             parsed.frontmatter.reviewed_by.as_deref(),
         ) {
             if !force {
-                let prev_at = parsed
-                    .frontmatter
-                    .reviewed_at
-                    .as_deref()
-                    .unwrap_or("(unknown date)");
-                println!(
-                    "{} {} already has approval on file ({} by `{}` on {}).",
-                    "✓".green().bold(),
-                    doc_id.bold(),
-                    prev_outcome.bold(),
-                    prev_reviewer,
-                    prev_at
-                );
-                println!(
-                    "  Pass {} to overwrite or amend (e.g., revisions_requested → approved).",
-                    "--force".cyan()
-                );
+                if !quiet {
+                    let prev_at = parsed
+                        .frontmatter
+                        .reviewed_at
+                        .as_deref()
+                        .unwrap_or("(unknown date)");
+                    println!(
+                        "{} {} already has approval on file ({} by `{}` on {}).",
+                        "✓".green().bold(),
+                        doc_id.bold(),
+                        prev_outcome.bold(),
+                        prev_reviewer,
+                        prev_at
+                    );
+                    println!(
+                        "  Pass {} to overwrite or amend (e.g., revisions_requested → approved).",
+                        "--force".cyan()
+                    );
+                }
                 return Ok(());
             }
         }
@@ -93,14 +91,29 @@ pub fn run(
     let raw = std::fs::read_to_string(&doc_path)
         .with_context(|| format!("Failed to read {}", doc_path.display()))?;
 
-    // Warn if the doc didn't actually need review (approving an unrequired
-    // doc is unusual but allowed — common case is retroactive sign-off).
+    // F5 (cli-3.8.0): warnings about review_required:false and risk_level.
+    // The high/critical risk warning is INTENTIONALLY not silenceable by
+    // --quiet — bulk-approving high-risk documents without seeing it is
+    // exactly the failure mode --quiet would otherwise enable. The
+    // `review_required: false` info-warning IS silenceable since it just
+    // documents an unusual-but-allowed retroactive sign-off pattern.
     if let Ok(parsed) = document::parse_document(&doc_path) {
-        if !parsed.frontmatter.review_required.unwrap_or(false) {
+        if !parsed.frontmatter.review_required.unwrap_or(false) && !quiet {
             eprintln!(
                 "{} document does not have `review_required: true`; recording approval anyway.",
                 "warning:".yellow().bold()
             );
+        }
+        if let Some(risk) = parsed.frontmatter.risk_level.as_deref() {
+            if matches!(risk, "high" | "critical") {
+                // Always surface — even under --quiet.
+                eprintln!(
+                    "{} {} has `risk_level: {}` — ensure thorough human review (per AGENT-RULES.md §4).",
+                    "WARNING:".red().bold(),
+                    doc_id.bold(),
+                    risk.bold()
+                );
+            }
         }
     }
 
@@ -108,15 +121,17 @@ pub fn run(
     std::fs::write(&doc_path, &updated)
         .with_context(|| format!("Failed to write {}", doc_path.display()))?;
 
-    println!(
-        "{} {} marked as {}.",
-        "✔".green().bold(),
-        doc_id.bold(),
-        outcome.bold()
-    );
-    println!("  Reviewer: {}", reviewer);
-    println!("  Date:     {}", at);
-    println!("  File:     {}", doc_path.display());
+    if !quiet {
+        println!(
+            "{} {} marked as {}.",
+            "✔".green().bold(),
+            doc_id.bold(),
+            outcome.bold()
+        );
+        println!("  Reviewer: {}", reviewer);
+        println!("  Date:     {}", at);
+        println!("  File:     {}", doc_path.display());
+    }
     Ok(())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -196,6 +196,14 @@ enum Commands {
         /// on an already-approved document is a no-op (cli-3.7.1+).
         #[arg(long)]
         force: bool,
+        /// Suppress the per-document success and idempotent-skip messages.
+        /// Useful for bulk approve runs (the operator just wants the
+        /// exit code). High-risk warnings (`risk_level: high|critical`)
+        /// are NOT silenceable by this flag — bulk-approving high-risk
+        /// docs without seeing the warning is exactly the failure mode
+        /// the warning exists to prevent (cli-3.8.0+, F5 of issue #81).
+        #[arg(long)]
+        quiet: bool,
         /// Project directory (default: current directory)
         #[arg(long = "path", default_value = ".")]
         path: String,
@@ -406,6 +414,7 @@ fn main() {
             at,
             notes,
             force,
+            quiet,
             path,
         } => commands::approve::run(
             &path,
@@ -415,6 +424,7 @@ fn main() {
             at.as_deref(),
             notes.as_deref(),
             force,
+            quiet,
         ),
         #[cfg(feature = "analyze")]
         Commands::Analyze {

--- a/cli/tests/approve_test.rs
+++ b/cli/tests/approve_test.rs
@@ -12,6 +12,15 @@ fn setup_devtrail(dir: &Path) {
 }
 
 fn write_aidec(dir: &Path, id: &str, review_required: bool) -> std::path::PathBuf {
+    write_aidec_with_risk(dir, id, review_required, "medium")
+}
+
+fn write_aidec_with_risk(
+    dir: &Path,
+    id: &str,
+    review_required: bool,
+    risk_level: &str,
+) -> std::path::PathBuf {
     let path = dir.join(format!(
         ".devtrail/07-ai-audit/decisions/{}-test-decision.md",
         id
@@ -25,7 +34,7 @@ created: 2026-04-23
 agent: test-v1.0
 confidence: high
 review_required: {rq}
-risk_level: medium
+risk_level: {risk}
 ---
 
 # AIDEC: Test decision
@@ -41,7 +50,8 @@ Body.
 <!-- Template: DevTrail | https://strangedays.tech -->
 "#,
         id = id,
-        rq = if review_required { "true" } else { "false" }
+        rq = if review_required { "true" } else { "false" },
+        risk = risk_level,
     );
     std::fs::write(&path, body).unwrap();
     path
@@ -309,4 +319,184 @@ fn approve_invalid_outcome_rejected_by_clap() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
+}
+
+// ── F5 (cli-3.8.0): high-risk warning + --quiet ──────────────────────
+
+#[test]
+fn approve_warns_on_high_risk_document() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec_with_risk(dir.path(), "AIDEC-2026-05-03-001", true, "high");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-001",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--at",
+            "2026-05-03",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("WARNING"))
+        .stderr(predicate::str::contains("risk_level: high"))
+        .stderr(predicate::str::contains("thorough human review"));
+}
+
+#[test]
+fn approve_warns_on_critical_risk_document() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec_with_risk(dir.path(), "AIDEC-2026-05-03-002", true, "critical");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-002",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--at",
+            "2026-05-03",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("risk_level: critical"));
+}
+
+#[test]
+fn approve_no_warning_for_low_or_medium_risk() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec_with_risk(dir.path(), "AIDEC-2026-05-03-003", true, "low");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-003",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("risk_level").not());
+}
+
+#[test]
+fn approve_quiet_suppresses_normal_output_but_keeps_high_risk_warning() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec_with_risk(dir.path(), "AIDEC-2026-05-03-004", true, "high");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-004",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--at",
+            "2026-05-03",
+            "--quiet",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        // Normal success message is suppressed.
+        .stdout(predicate::str::contains("marked as").not())
+        // But the high-risk warning still surfaces — that's the whole point
+        // of F5 not being silenceable by --quiet.
+        .stderr(predicate::str::contains("WARNING"))
+        .stderr(predicate::str::contains("risk_level: high"));
+}
+
+#[test]
+fn approve_quiet_suppresses_idempotent_skip_message() {
+    // Re-approving an already-approved document under --quiet should still
+    // be an idempotent no-op, but with no console output.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec(dir.path(), "AIDEC-2026-05-03-005", true);
+
+    // First approval — verbose so we know the file is set up.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-005",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "first@example.com",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    // Second invocation — quiet, should produce no stdout.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-005",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "first@example.com",
+            "--quiet",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn approve_quiet_suppresses_review_required_false_warning() {
+    // The "document does not have review_required:true" info-warning IS
+    // silenceable by --quiet (it documents an unusual-but-allowed pattern).
+    // High-risk warning is NOT silenceable; this test only covers the
+    // info-warning path.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_aidec(dir.path(), "AIDEC-2026-05-03-006", false);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "approve",
+            "AIDEC-2026-05-03-006",
+            "--outcome",
+            "approved",
+            "--reviewer",
+            "pepe@example.com",
+            "--quiet",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("review_required").not())
+        .stdout(predicate::str::is_empty());
 }


### PR DESCRIPTION
## Summary

Closes **F5** from issue #81. Two changes to `devtrail approve`:

1. **WARNING for `risk_level: high|critical`.** Per AGENT-RULES.md §4 those triggers require thorough human review; flag-driven mode previously swallowed that. Now stderr surfaces `WARNING: <id> has risk_level: <level> — ensure thorough human review` before the mutation. Defense-in-depth, not enforcement — approval still proceeds.

2. **New `--quiet` flag** for bulk approve runs. Suppresses:
   - The success message + Reviewer/Date/File lines.
   - The F4 idempotent-skip message.
   - The `review_required: false` info-warning.

   `--quiet` does **NOT** silence the high/critical risk warning. Sentinel CHARTER-04 bulk-approved 13 medium-risk AILOGs in <100ms with zero indicator at scale — the high-risk warning is **intentionally always-on**, otherwise `--quiet` re-introduces the exact signal-loss failure mode F5 exists to prevent.

## Test plan

- [x] 6 new integration tests covering: WARNING on `high`, WARNING on `critical`, no warning on `low`/`medium`, `--quiet` suppresses normal output but keeps WARNING, `--quiet` suppresses idempotent-skip message, `--quiet` suppresses `review_required:false` info-warning.
- [x] **408/408 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)