### PR TITLE
feat(cli): Phase 3 PR 5 — F7 charter close output differentiation

### DIFF
--- a/cli/src/commands/charter/close.rs
+++ b/cli/src/commands/charter/close.rs
@@ -47,6 +47,11 @@ pub fn run(
     utils::ensure_dir(&charters_state_dir)?;
     let telemetry_path = telemetry_path_for(&charters_state_dir, &charter);
 
+    // F7 (cli-3.8.0): differentiate first-run vs subsequent-run output.
+    // Pre-existence check happens BEFORE any write so we can report
+    // accurately even though copy_template_for is idempotent.
+    let telemetry_existed_before = telemetry_path.exists();
+
     // Mode dispatch.
     let yaml_text = if from_template {
         copy_template_for(&devtrail_dir, &charter, &telemetry_path, non_interactive)?
@@ -59,9 +64,12 @@ pub fn run(
         telemetry
     };
 
-    // Validate against schema (skip for --from-template + --non-interactive,
-    // since the user hasn't edited the file yet — the template would fail).
-    if !(from_template && non_interactive) {
+    // Validate against schema. F7: on a subsequent --from-template run the
+    // user has presumably edited the file, so we DO validate; only a true
+    // first-run with --non-interactive (where the user hasn't seen the
+    // template yet) skips validation since the placeholders would fail.
+    let is_first_run_template = from_template && non_interactive && !telemetry_existed_before;
+    if !is_first_run_template {
         let schema = TelemetrySchema::load(&devtrail_dir)?;
         let yaml_value: serde_yaml::Value = serde_yaml::from_str(&yaml_text)
             .with_context(|| format!("Telemetry YAML at {} is not valid YAML", telemetry_path.display()))?;
@@ -81,7 +89,15 @@ pub fn run(
     // Bump Charter status to closed.
     update_charter_status_to_closed(&charter)?;
 
-    // Summary.
+    // Summary. F7 (cli-3.8.0): differentiate the three operationally
+    // distinct cases instead of printing identical output for all three:
+    //
+    //  - Interactive flow → telemetry was filled directly via prompts;
+    //    print the standard "closed + telemetry path + status" trio.
+    //  - --from-template, FIRST run: template was just dropped on disk
+    //    with placeholders; user needs to edit + re-run. Tell them so.
+    //  - --from-template, SUBSEQUENT run: schema passed; the file is
+    //    valid telemetry. Charter close is finalized.
     println!(
         "{} Charter {} closed.",
         "✔".green().bold(),
@@ -90,11 +106,27 @@ pub fn run(
     println!("  Telemetry: {}", telemetry_path.display());
     println!("  Status updated: in-progress/declared → closed");
     if from_template && non_interactive {
-        println!(
-            "{} {}",
-            "next:".cyan().bold(),
-            "edit the telemetry YAML and re-run `devtrail charter close --from-template` to revalidate"
-        );
+        if is_first_run_template {
+            println!();
+            println!(
+                "  {} Telemetry template created with prefilled charter_id, title, and closed_at.",
+                "→".blue().bold()
+            );
+            println!(
+                "  {} Edit the YAML to fill in trigger, effort, agent_quality, outcome,",
+                "→".blue().bold()
+            );
+            println!(
+                "    and qualitative sections. Then re-run the same command to validate"
+            );
+            println!("    against the schema and finalize the close.");
+        } else {
+            println!();
+            println!(
+                "  {} Telemetry schema validation passed. Charter close finalized.",
+                "✔".green().bold()
+            );
+        }
     }
     Ok(())
 }

--- a/cli/tests/charter_close_test.rs
+++ b/cli/tests/charter_close_test.rs
@@ -400,3 +400,156 @@ fn charter_close_idempotent_under_non_interactive() {
         "user edit should be preserved, got:\n{after}"
     );
 }
+
+// ── F7 (cli-3.8.0): output differentiation first-run vs subsequent-run ──
+
+#[test]
+fn charter_close_first_run_prints_template_created_message() {
+    // F7: first --from-template --non-interactive invocation writes the
+    // template skeleton; output should tell the operator to edit and re-run,
+    // NOT pretend the close is finalized.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "F7 First Run");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Telemetry template created"))
+        .stdout(predicate::str::contains("Edit the YAML"))
+        // The "finalized" message is only printed on subsequent runs.
+        .stdout(predicate::str::contains("finalized").not());
+}
+
+#[test]
+fn charter_close_subsequent_run_prints_finalized_message() {
+    // F7: subsequent invocation (telemetry already exists, presumably edited)
+    // should run schema validation and report "finalized" on success.
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "F7 Subsequent Run");
+
+    // First invocation: writes the template.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    // Simulate the operator editing the telemetry file with valid content.
+    let telemetry_path = dir
+        .path()
+        .join(".devtrail/charters/CHARTER-01.telemetry.yaml");
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let valid_yaml = format!(
+        r#"charter_telemetry:
+  charter_id: "CHARTER-01"
+  charter_title: "F7 Subsequent Run"
+  closed_at: "{today}"
+  effort:
+    estimated_effort: "M (~1.5h)"
+    actual_effort: "M (~1.5h)"
+  outcome:
+    completed_as_planned: true
+    scope_changes: "ninguno"
+"#
+    );
+    std::fs::write(&telemetry_path, valid_yaml).unwrap();
+
+    // Second invocation: schema validates, output says finalized.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("validation passed"))
+        .stdout(predicate::str::contains("finalized"))
+        // The first-run "Edit the YAML" guidance should NOT appear here.
+        .stdout(predicate::str::contains("Edit the YAML").not())
+        .stdout(predicate::str::contains("Telemetry template created").not());
+}
+
+#[test]
+fn charter_close_subsequent_run_with_invalid_yaml_fails_clearly() {
+    // F7: subsequent invocation that fails schema validation should bail
+    // with a clear message, not silently print "finalized".
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    create_charter(dir.path(), "F7 Invalid Telemetry");
+
+    // First invocation drops the template.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    // Now break the telemetry file (invalid scope_changes value).
+    let telemetry_path = dir
+        .path()
+        .join(".devtrail/charters/CHARTER-01.telemetry.yaml");
+    std::fs::write(
+        &telemetry_path,
+        r#"charter_telemetry:
+  charter_id: "CHARTER-01"
+  charter_title: "test"
+  closed_at: "2026-05-03"
+  effort:
+    estimated_effort: "M"
+    actual_effort: "M"
+  outcome:
+    completed_as_planned: true
+    scope_changes: "MAJOR_INVALID"
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "close",
+            "CHARTER-01",
+            "--from-template",
+            "--non-interactive",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("validation"));
+}


### PR DESCRIPTION
## Summary

Closes **F7** from issue #81. Pre-fix, every `charter close --from-template --non-interactive` invocation printed the same "next: edit the telemetry YAML and re-run..." message regardless of whether this was the first run (template just dropped) or a subsequent run (validating an edited file).

### After

| Case | Output suffix |
|---|---|
| **First run** (telemetry didn't exist before) | `Telemetry template created…` + `Edit the YAML…` |
| **Subsequent run** (telemetry exists, user has edited) | `Telemetry schema validation passed. Charter close finalized.` |

### Implementation

- Detect `telemetry_path.exists()` **before** `copy_template_for` runs (which is idempotent on existing files).
- A "first run" = `--from-template + --non-interactive + file didn't exist before`. Skip schema validation in that case (placeholders would fail).
- A "subsequent run" runs schema validation just like the interactive flow does. Success → "finalized" message; failure bails with a clear validation-issues report (existing behavior preserved).

## Test plan

- [x] 3 new integration tests:
  - `charter_close_first_run_prints_template_created_message` (first-run guidance + no "finalized")
  - `charter_close_subsequent_run_prints_finalized_message` ("validation passed" + "finalized" + no first-run guidance)
  - `charter_close_subsequent_run_with_invalid_yaml_fails_clearly`
- [x] **411/411 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)