### PR TITLE
fix: O3 — charter drift --no-ailog-suppress always emits INFO line (cli-3.8.1 + fw-4.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.7.1 / CLI 3.8.1 — O3 resolved (`--no-ailog-suppress` always emits INFO line)
+
+Closes the last `pending design discussion` carried forward from issue #81:
+**O3** — when `devtrail charter drift --no-ailog-suppress` was passed and there
+was nothing for the AILOG-aware filter to suppress (N=0), the output was
+**byte-identical** to the default. Operators couldn't tell whether the
+suppression logic ran and found nothing, or whether the flag was wired
+incorrectly.
+
+Resolution voted by Sentinel CHARTER-06 telemetry on issue #91 (option (c)
+"--no-ailog-suppress only", with the N=0 confirming-line extension):
+
+- Default mode stays silent at N=0 — no new noise in the common case.
+- `--no-ailog-suppress` always emits at least one line confirming dispatch:
+  - At N=0: `INFO: AILOG-aware suppression bypassed (would have suppressed: 0 paths)`
+  - At N>0: `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s) listed above as drift)` followed by a per-path list with the AILOG ID that documents the risk.
+
+The asymmetry matches the `git diff --stat` shape — silent default, signal on
+explicit opt-in. Operators with dispatch suspicion now have a one-flag debug
+path that always says something.
+
+### Fixed (CLI)
+
+- **`devtrail charter drift --no-ailog-suppress`** — emits a confirming
+  `INFO:` line at end of output regardless of N. The line names the count
+  and (when N>0) lists each path that would have been suppressed with its
+  documenting AILOG ID. Default mode (suppression on) is unchanged: silent
+  at N=0, existing `AILOG-suppressed: N path(s)` block at N>0.
+
+  Implementation: `compute_ailog_suppressions` now runs unconditionally so
+  the count is available regardless of whether suppression is applied. The
+  flag controls only whether the suppression mutates the rendered drift
+  list.
+
+### Tests
+
+- 3 new integration tests:
+  - `charter_drift_no_ailog_suppress_emits_info_line_when_n_zero` (the
+    primary case the issue is about).
+  - `charter_drift_no_ailog_suppress_emits_info_line_when_n_nonzero`
+    (count + per-path listing).
+  - `charter_drift_default_stays_silent_when_n_zero` (negative test:
+    confirms we did NOT add noise to the common case).
+- 414/414 tests pass (3 new on top of 411 from cli-3.8.0).
+
+### Empirical signal that drove this decision
+
+Sentinel CHARTER-06 was constructed deliberately to exercise the
+N>0 path (`subscriber.go` declared in the Charter, named in
+AILOG-2026-05-03-034's `## Risk` section, not modified during execution).
+The captured outputs confirmed the byte-identical-at-N=0 ambiguity and
+voted for option (c) with a one-line N=0 confirmation. Full telemetry is
+on issue #91.
+
+A secondary observation from the same run — that paths in the WARNING
+block don't carry an inline `[suppressed]` annotation, forcing the reader
+to scan top-to-bottom to know a WARNING was OK'd — is **not bundled here**.
+It's a UX polish item flagged for separate validation; tracked in a
+follow-up issue rather than rolled into this patch to keep the change
+surgical.
+
+### What's NOT in this release
+
+- Inline `[suppressed]` annotation on WARNING block items (separate issue).
+- HTTP API clients for `charter audit` (Phase 3 v1).
+- Inter-family heterogeneity auto-enforcement.
+
+---
+
 ## Framework 4.7.0 / CLI 3.8.0 — Phase 3 (multi-model external audit, orchestration-only) + open frictions F2/F5/F7
 
 The first feature-bearing release since Phase 2 (fw-4.6.0/cli-3.7.0). Lands the

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ DevTrail uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.7.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.8.0` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.7.1` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.8.1` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 
@@ -292,7 +292,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/a
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/devtrail/releases
-# and download the latest fw-* release (e.g., fw-4.7.0)
+# and download the latest fw-* release (e.g., fw-4.7.1)
 
 # Extract and copy to your project
 unzip devtrail-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.8.0"
+version = "3.8.1"
 edition = "2021"
 description = "CLI for DevTrail — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/commands/charter/drift.rs
+++ b/cli/src/commands/charter/drift.rs
@@ -89,16 +89,27 @@ pub fn run(
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let raw_exit = output.status.code().unwrap_or(-1);
 
-    // Parse the script output to identify declared-but-not-modified paths so
-    // we can apply AILOG-suppression. Scope-expansion ("Modified but NOT
-    // declared") is informational and not suppressed — those paths are not
-    // in the Charter's declared list and rarely overlap with documented
-    // risks.
+    // Parse the script output to identify declared-but-not-modified paths.
+    // Scope-expansion ("Modified but NOT declared") is informational and not
+    // suppressed — those paths are not in the Charter's declared list and
+    // rarely overlap with documented risks.
     let omitted = extract_omitted_paths(&stdout);
-    let suppressions: Vec<(String, String)> = if no_ailog_suppress || omitted.is_empty() {
+
+    // O3 (cli-3.8.1, issue #91): always compute what AILOG-aware suppression
+    // would have done, regardless of the flag. The flag only controls
+    // whether to APPLY that suppression to the rendered output. This lets us
+    // emit a confirming INFO line when --no-ailog-suppress is passed (the
+    // operator opted into the diagnostic mode and deserves visible signal,
+    // even when N=0).
+    let would_have_suppressed: Vec<(String, String)> = if omitted.is_empty() {
         Vec::new()
     } else {
         compute_ailog_suppressions(project_root, &charter, &omitted)?
+    };
+    let suppressions: Vec<(String, String)> = if no_ailog_suppress {
+        Vec::new()
+    } else {
+        would_have_suppressed.clone()
     };
     let suppressed_paths: std::collections::HashSet<String> =
         suppressions.iter().map(|(p, _)| p.clone()).collect();
@@ -124,6 +135,35 @@ pub fn run(
         );
         for (path, ailog_id) in &suppressions {
             println!("  - {} [documented in {}]", path, ailog_id.dimmed());
+        }
+    }
+
+    // O3 (cli-3.8.1): when --no-ailog-suppress is passed, always emit at
+    // least one line confirming dispatch — closes the "default and
+    // --no-ailog-suppress produce byte-identical output at N=0" ambiguity
+    // reported in Sentinel CHARTER-02 telemetry. Issue #91 vote: option
+    // (c) "--no-ailog-suppress only", with explicit confirmation when N=0.
+    if no_ailog_suppress {
+        println!();
+        let n = would_have_suppressed.len();
+        if n == 0 {
+            println!(
+                "{} AILOG-aware suppression bypassed (would have suppressed: 0 paths)",
+                "INFO:".cyan().bold()
+            );
+        } else {
+            println!(
+                "{} AILOG-aware suppression bypassed (would have suppressed: {} path(s) listed above as drift)",
+                "INFO:".cyan().bold(),
+                n
+            );
+            for (path, ailog_id) in &would_have_suppressed {
+                println!(
+                    "  - {} [would suppress: {}]",
+                    path,
+                    ailog_id.dimmed()
+                );
+            }
         }
     }
 

--- a/cli/tests/charter_drift_test.rs
+++ b/cli/tests/charter_drift_test.rs
@@ -279,6 +279,149 @@ review_required: false
         .stdout(predicate::str::contains("Declared in Charter but NOT modified"));
 }
 
+// ── O3 (cli-3.8.1): --no-ailog-suppress always emits INFO line ──────
+
+#[test]
+fn charter_drift_no_ailog_suppress_emits_info_line_when_n_zero() {
+    // O3 (issue #91): when --no-ailog-suppress is passed AND there's
+    // nothing the AILOG-aware filter would have suppressed (N=0), we
+    // still emit one INFO line confirming the flag was honored. Closes
+    // the byte-identical-output ambiguity Sentinel CHARTER-02 reported.
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_charter_with_files(dir.path(), &["src/foo.rs"], None);
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo"]);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "drift",
+            "CHARTER-01",
+            "--no-ailog-suppress",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "AILOG-aware suppression bypassed (would have suppressed: 0 paths)",
+        ));
+}
+
+#[test]
+fn charter_drift_no_ailog_suppress_emits_info_line_when_n_nonzero() {
+    // When --no-ailog-suppress is passed AND there's something the filter
+    // would have suppressed (N>0), the INFO line names the count and
+    // lists each path that was bypassed (with the AILOG ID that documents
+    // the risk). The drift itself is still surfaced as failure exit.
+    if !bash_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    let ailog_path = dir
+        .path()
+        .join(".devtrail/07-ai-audit/agent-logs/AILOG-2026-05-03-001-document-bar.md");
+    std::fs::write(
+        &ailog_path,
+        r#"---
+id: AILOG-2026-05-03-001
+title: Document bar
+agent: test
+confidence: high
+risk_level: low
+review_required: false
+---
+
+## Risk
+
+- **R3**: `src/bar.rs` documented as scope-simplified.
+"#,
+    )
+    .unwrap();
+
+    write_charter_with_files(
+        dir.path(),
+        &["src/foo.rs", "src/bar.rs"],
+        Some("AILOG-2026-05-03-001"),
+    );
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+    std::fs::write(dir.path().join("src/bar.rs"), "// initial\n").unwrap();
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo only"]);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "drift",
+            "CHARTER-01",
+            "--no-ailog-suppress",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        // INFO line names the count.
+        .stdout(predicate::str::contains(
+            "AILOG-aware suppression bypassed (would have suppressed: 1 path(s)",
+        ))
+        // And lists each would-have-been-suppressed path.
+        .stdout(predicate::str::contains("src/bar.rs"))
+        .stdout(predicate::str::contains("would suppress: AILOG-2026-05-03-001"));
+}
+
+#[test]
+fn charter_drift_default_stays_silent_when_n_zero() {
+    // The flip side of O3: the DEFAULT (suppression on) must NOT emit
+    // an INFO line when there's nothing to suppress. The common-case
+    // output stays minimal — adding ceremony there is what (a)
+    // "always-on" would have done, which we explicitly rejected per
+    // the Sentinel CHARTER-06 vote.
+    if !bash_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+    write_charter_with_files(dir.path(), &["src/foo.rs"], None);
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/foo.rs"), "// initial\n").unwrap();
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/foo.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit foo"]);
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["charter", "drift", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK No drift detected"))
+        // No INFO line in default mode at N=0.
+        .stdout(predicate::str::contains("AILOG-aware suppression bypassed").not());
+}
+
 #[test]
 fn charter_drift_resolves_glob_wildcards_in_declared_paths() {
     // fw-4.6.2: bulk Charters can declare `prefix*suffix` glob patterns

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -270,4 +270,4 @@ When a change modifies API endpoints:
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
@@ -307,4 +307,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -213,4 +213,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -270,4 +270,4 @@ Cuando un cambio modifica endpoints de API:
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -300,4 +300,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -270,4 +270,4 @@ confidence: high | medium | low
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -299,4 +299,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -188,4 +188,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*DevTrail v4.7.0 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/QUICK-REFERENCE.md
+++ b/dist/.devtrail/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.7.0 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.7.1 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.7.0"
+version: "4.7.1"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.7.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.7.1`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.7.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.8.0` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.7.1` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.8.1` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize DevTrail in a project directory.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.7.0
+✔ Downloaded DevTrail fw-4.7.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.devtrail/` does not exist in the current directory, the framework update is
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.7.0
+✔ Framework updated to fw-4.7.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.7.0
+✔ Framework updated to fw-4.7.1
 ```
 
 ---
@@ -211,7 +211,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.7.0                 │
+  │ Framework │ fw-4.7.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.7.0
+  Using version: fw-4.7.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -321,7 +321,7 @@ $ devtrail validate --fix
 
 ### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
 
-*Available since **cli-3.8.0** + **fw-4.7.0**.*
+*Available since **cli-3.7.0** + **fw-4.6.0**. `--quiet` and high-risk warning added in cli-3.8.0.*
 
 Record a formal human approval on a `review_required: true` document. Writes the three approval frontmatter fields (`reviewed_by`, `reviewed_at`, `review_outcome`) **and** appends the canonical `## Approval` body section in one atomic edit. Implements the closure signal canonized in `DOCUMENTATION-POLICY.md §3.5`.
 
@@ -423,7 +423,7 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 - `devtrail charter status` — show Charter detail, or the most recent 5 Charters
 - `devtrail charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.0+)*
 - `devtrail charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.0+)*
-- `devtrail charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.7.0+)*
+- `devtrail charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.7.1+)*
 
 #### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
@@ -582,14 +582,14 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 > **Platform note.** The drift check delegates to `bash`. On Linux/macOS/WSL/Git Bash this works out of the box. On Windows native without WSL, install Git Bash; a pure-Rust fallback is on the roadmap but not in fw-4.6.x.
 
-#### Wildcard support in declared paths *(fw-4.7.0+)*
+#### Wildcard support in declared paths *(fw-4.7.1+)*
 
 The drift check resolves two forms of wildcard in `## Files to modify`:
 
 | Form | Example | Use case |
 |---|---|---|
 | Ellipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Any modified path with that prefix satisfies the wildcard. Used historically when an unknown number of AILOGs would be created during execution. |
-| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.7.0 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.7.1 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
 
 Both forms are handled in both directions: a declared wildcard suppresses both "declared but not modified" warnings (when at least one matching file was modified) and "modified but not declared" warnings (when a modified path matches a declared wildcard).
 
@@ -1048,7 +1048,7 @@ Show version, authorship, and license information.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.7.0
+  Framework version: fw-4.7.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -222,8 +222,8 @@ DevTrail usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.7.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.8.0` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.7.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.8.1` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 
@@ -255,7 +255,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/devtrail/releases
-# y descarga el último release fw-* (ej. fw-4.7.0)
+# y descarga el último release fw-* (ej. fw-4.7.1)
 
 # Extraer y copiar a tu proyecto
 unzip devtrail-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.7.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.7.1`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.7.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.8.0` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.7.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.8.1` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -86,7 +86,7 @@ Inicializa DevTrail en un directorio de proyecto.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.7.0
+✔ Downloaded DevTrail fw-4.7.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -107,7 +107,7 @@ Si `.devtrail/` no existe en el directorio actual, la actualización del framewo
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.7.0
+✔ Framework updated to fw-4.7.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -124,7 +124,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.7.0
+✔ Framework updated to fw-4.7.1
 ```
 
 ---
@@ -203,7 +203,7 @@ $ devtrail status
 DevTrail Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.7.0
+Framework version: fw-4.7.1
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -267,7 +267,7 @@ Valida documentos DevTrail verificando cumplimiento y corrección.
 | `path` | `.` (directorio actual) | Directorio del proyecto |
 | `--fix` | — | Corregir automáticamente problemas simples |
 | `--staged` | — | Validar solo archivos staged en Git (ideal para hooks pre-commit) |
-| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.8.0. |
+| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.8.1. |
 
 **Reglas de validación:**
 
@@ -633,7 +633,7 @@ Muestra información de versión, autoría y licencia.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.7.0
+  Framework version: fw-4.7.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -240,8 +240,8 @@ DevTrail 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.7.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.8.0` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.7.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.8.1` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 
@@ -273,7 +273,7 @@ DevTrail 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/devtrail/releases
-# 下载最新的 fw-* 发布（例如 fw-4.7.0）
+# 下载最新的 fw-* 发布（例如 fw-4.7.1）
 
 # 解压并复制到你的项目
 unzip devtrail-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.7.0`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.7.1`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.7.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.8.0` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.7.1` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.8.1` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -86,7 +86,7 @@ devtrail status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.7.0
+✔ Downloaded DevTrail fw-4.7.1
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -108,7 +108,7 @@ Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.7.0
+✔ Framework updated to fw-4.7.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -125,7 +125,7 @@ Updating CLI...
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.7.0
+✔ Framework updated to fw-4.7.1
 ```
 
 ---
@@ -209,7 +209,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.7.0                 │
+  │ Framework │ fw-4.7.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -266,7 +266,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.7.0
+  Using version: fw-4.7.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -286,7 +286,7 @@ Repairing DevTrail in /home/user/my-project
 | `path` | `.`（当前目录） | 目标项目目录 |
 | `--fix` | — | 自动修复简单问题（例如为高风险文档添加缺失的 `review_required: true`） |
 | `--staged` | — | 仅验证已暂存（git add）的文件。适合 pre-commit 钩子。 |
-| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.8.0 中加入。 |
+| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.8.1 中加入。 |
 
 **检查项目：**
 
@@ -741,7 +741,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.7.0
+  Framework version: fw-4.7.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail


### PR DESCRIPTION
## Summary

Closes the last pending design discussion from issue #81. Resolution voted by Sentinel CHARTER-06 telemetry on [issue #91](https://github.com/StrangeDaysTech/devtrail/issues/91): option **(c) `--no-ailog-suppress` only**, with the N=0 confirming-line extension.

### Behavior matrix

| Mode | N | Output |
|---|---|---|
| Default (suppression on) | 0 | silent — no new noise in the common case |
| Default | >0 | existing `AILOG-suppressed: N path(s)` block (no change) |
| `--no-ailog-suppress` | 0 | `INFO: AILOG-aware suppression bypassed (would have suppressed: 0 paths)` |
| `--no-ailog-suppress` | >0 | `INFO:` line with count + per-path list including the documenting AILOG ID |

The asymmetry matches `git diff --stat` — silent default, signal on explicit opt-in.

### Implementation

`compute_ailog_suppressions` now runs **unconditionally** so the count is available regardless of whether suppression is applied to the output. The flag controls only whether suppression mutates the rendered drift list.

## Test plan

- [x] **3 new integration tests**:
  - `charter_drift_no_ailog_suppress_emits_info_line_when_n_zero` (the primary case the issue is about)
  - `charter_drift_no_ailog_suppress_emits_info_line_when_n_nonzero` (count + per-path listing)
  - `charter_drift_default_stays_silent_when_n_zero` (negative test: confirms we did NOT add noise to the common case)
- [x] **414/414 tests pass**.

## What's NOT in this release

- Inline `[suppressed]` annotation on WARNING block items (separate observation from Sentinel CHARTER-06 telemetry; tracked as follow-up issue, deferred for empirical confirmation in a future cycle before changing).
- HTTP API clients for `charter audit` (Phase 3 v1 if a real adopter requires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)