### PR TITLE
docs: bump roadmap to v0.3 + ship anonymized AILOG example

### DIFF
--- a/Propuesta/devtrail-cli-roadmap.md
+++ b/Propuesta/devtrail-cli-roadmap.md
@@ -1,10 +1,57 @@
 # DevTrail CLI — Roadmap hacia la tesis (post-Sentinel)
 
-**Versión:** 0.2 (rename Plan → Charter para evitar colisión con SpecKit)
-**Fecha:** 30 de abril de 2026
+**Versión:** 0.3 (post-implementación de las 3 fases — A1 orchestration-only documentada para Fase 3; RFCs #67/#82/#91 cerradas; frictions F1-F8 + observación O3 resueltos; CHARTER-01/02 + AILOG-01 ejemplos shipped en `dist/docs/examples/`)
+**Fecha:** 3 de mayo de 2026
 **Autor:** Jose Villaseñor Montfort — StrangeDaysTech
 **Propósito:** Traducir los hallazgos validados de Sentinel en una secuencia accionable de cambios al CLI Rust y al framework, manteniendo el principio #12 (cristalización experimental, no estable).
-**Documentos relacionados:** `devtrail-thesis-validation.md` (evidencia que justifica el roadmap), `devtrail-design-principles.md` (anotaciones v0.2 sobre #6, #9, #12), `devtrail-cloud-proposal.md` §4.5 y §8 (Charters en Cloud, Q3), `devtrail-charter-telemetry.md` v0.2 (schema de telemetría refinado), `que-es-un-charter.md` (alcance conceptual del artefacto Charter y coexistencia con SpecKit).
+**Documentos relacionados:** `devtrail-thesis-validation.md` (evidencia que justifica el roadmap), `devtrail-design-principles.md` (anotaciones v0.2 sobre #6, #9, #12), `devtrail-cloud-proposal.md` §4.5 y §8 (Charters en Cloud, Q3), `devtrail-charter-telemetry.md` v0.3 (schema de telemetría refinado), `que-es-un-charter.md` (alcance conceptual del artefacto Charter y coexistencia con SpecKit).
+
+---
+
+## 0. Estado de implementación (al 3 de mayo de 2026)
+
+Las tres fases del roadmap están shippeadas. El gate de cristalización `v0 → v1` (segundo dominio) sigue abierto porque Sentinel es el único adoptante hasta hoy y es Go-backend; el siguiente experimento en un subproyecto de frontend está agendado y abre la puerta a evaluar la promoción a v1 estable.
+
+**Releases shipped:**
+
+| Fase | Release | Issues / RFCs cerradas en este release |
+|---|---|---|
+| 1 — Charters como entidad de primera clase | `fw-4.4.0` / `cli-3.6.0` (PR #65) | — |
+| 1 patches | `fw-4.4.1` (#66), `fw-4.4.2` (#68 format v4 atomic Charter closure), `cli-3.6.1` (#69 charter new numbering F1) | — |
+| Reposicionamiento canónico | `fw-4.5.0` (#71), `fw-4.5.1` (#72 i18n + ADOPTION-GUIDE reframe) | — |
+| 2 — Telemetría + drift + approval workflow | `fw-4.6.0` / `cli-3.7.0` (PR #80) | RFC #67 (canonical approval workflow) |
+| 2 patches part 1 | `fw-4.6.1` / `cli-3.7.1` (PR #83) | F3 / F4 / F6 de issue #81 |
+| 2 patches part 2 | `fw-4.6.2` / `cli-3.7.2` (PR #84) | F1 / F8 + drift wildcard glob |
+| 3 — Auditoría externa multi-modelo (orchestration-only) + open frictions | `fw-4.7.0` / `cli-3.8.0` (PR #90) | RFC #82 (audit visibility) + frictions F2 / F5 / F7 |
+| 3 patches | `fw-4.7.1` / `cli-3.8.1` (PR #92) | Observación O3 (`--no-ailog-suppress` always emits INFO line) |
+
+**Decisiones arquitectónicas que divergen del roadmap original:**
+
+- **A1 (Phase 3): orchestration-only, no HTTP API clients en v0.** El roadmap §5.4 originalmente sugería "soportar OpenAI/Google/Anthropic en v0" con manejo de API keys. La realidad implementada es que el CLI prepara prompts, valida outputs contra schema, e integra con telemetría — pero NO invoca APIs. El operador pega los prompts en su auditor de elección manualmente. Razones documentadas en el commit message de PR #85: implementar 3 clientes HTTP es 1-2 semanas + mantenimiento perpetuo cuando cambian las APIs (premature para una v0 *experimental*); el patrón humano-en-el-loop coincide con `/plan-audit` de Sentinel; cumple principio #10 ("no es un LLM gateway"); cierra RFC #82 por diseño. Los HTTP clients se reabren en v1 cuando un adoptante real lo justifique con datos.
+
+**Diferencias entre §5.5 como escrito y §5.5 como entregado:**
+
+- §5.5 criterio 4 dice "una configuración monocromática es rechazada con error claro; una heterogénea procede sin advertencia". Como shippeado, la heterogeneidad inter-familia es **recomendación documentada** (CLI-REFERENCE.md `devtrail charter audit` section), **no auto-enforcement**. El criterio depende de A1: sin invocación de APIs, el CLI no sabe qué modelo usará el operador, así que no hay punto de inyección donde validar la heterogeneidad. Auto-enforcement queda como gate v1 cuando los HTTP clients se justifiquen.
+
+**Items §6 (mapping Sentinel → CLI) shipped:**
+
+- `dist/docs/examples/charters/CHARTER-01-anomaly-thresholds.md` (anonimizado de PLAN-05 de Sentinel) — ✅
+- `dist/docs/examples/charters/CHARTER-02-baseline-recompute.md` (anonimizado de PLAN-06 de Sentinel) — ✅
+- `dist/docs/examples/ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md` (anonimizado del AILOG originador de CHARTER-01) — ✅
+
+Estos viven fuera del manifest de `devtrail init` por diseño (decisión A6 del plan original): adopters los browse en GitHub o vía clone, no se auto-instalan como artefactos del framework.
+
+**Open issues a la fecha:**
+
+- **#93** — UX polish: inline `[suppressed]` annotation en bloque WARNING de drift. Abierto pendiente de validación empírica (próximo cycle de Sentinel).
+
+**Items diferidos a v1 con criterio de salida explícito** (de §8 + de las decisiones de A1):
+
+- HTTP API clients (Phase 3 v1, gated en demanda real de adopter).
+- Auto-enforcement de heterogeneidad inter-familia (Phase 3 v1, dependiente de los HTTP clients).
+- `--strict-scope` flag en drift (gated en fricción reportada por adopter).
+- Forma estructurada multi-revisor `review:` array (gated en flujo multi-actor real).
+- `charter.schema.v1.0` estable (gated en adopter de segundo dominio — el siguiente cycle de Sentinel en frontend toca exactamente este criterio).
 
 ---
 
@@ -76,9 +123,9 @@ DevTrail llamó originalmente a este artefacto "Plan" durante el experimento Sen
 
 ### 3.6 Criterios de salida de la Fase 1
 
-- `devtrail charter new` genera un Charter compatible con `check-plan-drift.sh` (Sentinel) ejecutado manualmente — la compatibilidad sintáctica se preserva aunque cambien los nombres canónicos en el framework. Se valida en ambos modos (`--from-ailog` y `--from-spec`).
-- Al menos 1 adoptante (idealmente fuera de Go) ha creado un Charter completo con `devtrail charter` y reportado sobre la experiencia.
-- Schema `charter.schema.v0.json` no ha requerido breaking changes en 2 ciclos de release.
+- ✅ `devtrail charter new` genera un Charter compatible con `check-plan-drift.sh` (Sentinel) ejecutado manualmente — la compatibilidad sintáctica se preserva aunque cambien los nombres canónicos en el framework. Se valida en ambos modos (`--from-ailog` y `--from-spec`). *Validado empíricamente por Sentinel CHARTER-02..06.*
+- ⏳ Al menos 1 adoptante (idealmente fuera de Go) ha creado un Charter completo con `devtrail charter` y reportado sobre la experiencia. *Sentinel (Go-backend) ha cerrado 6 Charters; el siguiente cycle se realizará en un subproyecto de frontend, abriendo el segundo-dominio.*
+- ✅ Schema `charter.schema.v0.json` no ha requerido breaking changes en 2 ciclos de release. *Cumplido — 0 breaking changes a través de fw-4.4.0 → fw-4.7.1.*
 
 ## 4. Fase 2 — Telemetría y drift-check ejecutable
 
@@ -105,9 +152,9 @@ DevTrail llamó originalmente a este artefacto "Plan" durante el experimento Sen
 
 ### 4.5 Criterios de salida de la Fase 2
 
-- Al menos 2 adoptantes han usado `devtrail charter close` y producido telemetría YAML válida.
-- `devtrail charter drift` mantiene la propiedad de 0 falsos positivos en proyectos adoptantes.
-- AILOG-awareness reduce el triage manual a cero en al menos 1 caso real reportado.
+- ⏳ Al menos 2 adoptantes han usado `devtrail charter close` y producido telemetría YAML válida. *Solo Sentinel hasta hoy (6 telemetrías cerradas: CHARTER-01..06). Se cumple cuando un adopter de segundo dominio cierre al menos 1 Charter.*
+- ✅ `devtrail charter drift` mantiene la propiedad de 0 falsos positivos en proyectos adoptantes. *Validado empíricamente por Sentinel CHARTER-02..06; el único falso positivo histórico (F3 — regex column-1) se cerró en `fw-4.6.1`.*
+- ✅ AILOG-awareness reduce el triage manual a cero en al menos 1 caso real reportado. *Validado por Sentinel CHARTER-06 (ver issue #91 para evidencia: drift detectó `subscriber.go` declarado pero no modificado, y la supresión AILOG-aware eliminó el triage manual al 100%).*
 
 ## 5. Fase 3 — Auditoría externa multi-modelo
 
@@ -148,25 +195,27 @@ La auditoría externa **no es sustituible por auto-auditoría del mismo modelo**
 
 Decisión abierta: qué APIs/modelos soportar. Recomendación inicial: usar el patrón "user provides the API key" (similar a herramientas como `aichat`), no acoplar el CLI a un proveedor específico. Soportar al menos OpenAI (Copilot stand-in), Google (Gemini), Anthropic (Claude) en v0.
 
+> **Decisión arquitectónica A1 al implementar (ver §0):** los HTTP clients se difirieron a v1 — la versión shippeada (`fw-4.7.0`/`cli-3.8.0`) es **orchestration-only**: el CLI prepara prompts, valida outputs contra schema, e integra con telemetría, pero no invoca APIs. El operador pega los prompts en su auditor de elección manualmente. El flag `--implementer-family` y la heterogeneidad inter-familia descritos arriba quedan como recomendación documentada en CLI-REFERENCE.md hasta que los HTTP clients aterricen en v1.
+
 ### 5.5 Criterios de salida de la Fase 3
 
-- Al menos 1 ciclo de auditoría externa multi-modelo ejecutada en un proyecto adoptante con resultados consistentes con la calibración cross-modelo observada en Sentinel.
-- El calibrador-reconciliador produce findings en formato compatible con el array `external_audit` de la telemetría.
-- Documentación clara de que el CLI orquesta pero no provee modelos; el usuario controla qué APIs usar.
-- La restricción de heterogeneidad inter-familia se ejercita en los tests integration: una configuración monocromática es rechazada con error claro; una heterogénea procede sin advertencia.
+- ⏳ Al menos 1 ciclo de auditoría externa multi-modelo ejecutada en un proyecto adoptante con resultados consistentes con la calibración cross-modelo observada en Sentinel. *Pendiente — Sentinel todavía no ejercita `devtrail charter audit` sobre la nueva versión `fw-4.7.x`. El próximo cycle de telemetría (frontend) lo cubre.*
+- ✅ El calibrador-reconciliador produce findings en formato compatible con el array `external_audit` de la telemetría. *Schema `audit-output.schema.v0.json` enforza compatibilidad por construcción; integración con telemetry validated por la integration test del 3-step flow.*
+- ✅ Documentación clara de que el CLI orquesta pero no provee modelos; el usuario controla qué APIs usar. *CLI-REFERENCE.md `### devtrail charter audit` lo declara explícito; CHANGELOG fw-4.7.0 documenta la decisión A1.*
+- ⏳ La restricción de heterogeneidad inter-familia se ejercita en los tests integration: una configuración monocromática es rechazada con error claro; una heterogénea procede sin advertencia. *Diferido a v1 por la decisión A1 (orchestration-only) — sin invocación de APIs, el CLI no conoce los modelos del operador, así que no hay punto de inyección donde validar. La heterogeneidad queda como recomendación documentada (CLI-REFERENCE.md) hasta que los HTTP clients aterricen.*
 
 ## 6. Mapeo artefactos Sentinel → CLI
 
 Tabla de referencia rápida que conecta cada artefacto validado en Sentinel con su destino en el CLI/framework. La columna izquierda preserva el vocabulario histórico de Sentinel ("Plan"); la columna derecha usa el vocabulario DevTrail going-forward ("Charter").
 
-| Artefacto Sentinel (vocabulario "Plan") | Ruta absoluta de origen | Fase | Destino DevTrail (vocabulario "Charter") |
-|---------------------|--------------------------|------|---------|
-| `TEMPLATE.md` v3 | `sentinel/docs/plans/TEMPLATE.md` | 1 | `dist/.devtrail/templates/charter-template.md` |
-| Plan-docs canónicos | `sentinel/docs/plans/{05,06}-*.md` | 1 | `dist/docs/examples/charters/` (anonimizados, renombrados a `CHARTER-NN`) |
-| Telemetrías YAML | `sentinel/.devtrail/plans/PLAN-{05,06}.telemetry.yaml` | 2 | Schema validador para `devtrail charter close` output |
-| `check-plan-drift.sh` | `sentinel/scripts/check-plan-drift.sh` | 2 | `devtrail charter drift` (invocar bash o reimplementar) |
-| Reportes auditoría dual | `sentinel/audit/plans/{05,06}/{copilot,gemini,claude-analisis}.md` | 3 | Output canónico de `devtrail charter audit` (en `audit/charters/`) |
-| AILOGs 020-024 | `sentinel/.devtrail/07-ai-audit/agent-logs/AILOG-2026-04-28-{020..024}-*.md` | Referencia transversal | `dist/docs/examples/ailogs/` (anonimizados, 1-2 ejemplos) |
+| Artefacto Sentinel (vocabulario "Plan") | Ruta absoluta de origen | Fase | Destino DevTrail (vocabulario "Charter") | Estado |
+|---------------------|--------------------------|------|---------|---|
+| `TEMPLATE.md` v3 | `sentinel/docs/plans/TEMPLATE.md` | 1 | `dist/.devtrail/templates/charter-template.md` | ✅ shipped (`fw-4.4.0`) |
+| Plan-docs canónicos | `sentinel/docs/plans/{05,06}-*.md` | 1 | `dist/docs/examples/charters/CHARTER-{01,02}-*.md` (anonimizados) | ✅ shipped |
+| Telemetrías YAML | `sentinel/.devtrail/plans/PLAN-{05,06}.telemetry.yaml` | 2 | Schema validador para `devtrail charter close` output | ✅ shipped (`fw-4.6.0`) |
+| `check-plan-drift.sh` | `sentinel/scripts/check-plan-drift.sh` | 2 | `devtrail charter drift` (reimplementación nativa Rust) | ✅ shipped (`cli-3.7.0`) |
+| Reportes auditoría dual | `sentinel/audit/plans/{05,06}/{copilot,gemini,claude-analisis}.md` | 3 | Output canónico de `devtrail charter audit` (orchestration-only en v0; ver A1 §0) | ✅ shipped (`cli-3.8.0`) |
+| AILOG canónico originador | `sentinel/.devtrail/07-ai-audit/agent-logs/AILOG-2026-04-24-010-pm008-anomaly-detector.md` | Referencia transversal | `dist/docs/examples/ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md` (anonimizado, par de `CHARTER-01`) | ✅ shipped |
 
 ## 7. Verificación end-to-end de cada fase
 
@@ -203,4 +252,4 @@ Cada uno de estos puntos tiene un criterio de salida explícito en `devtrail-the
 
 ---
 
-*Este roadmap es el primer artefacto que traduce evidencia empírica en código accionable para DevTrail. Su evolución sigue el patrón auto-evolutivo observado en Sentinel: cada fase ejecutada genera datos que refinan el roadmap del próximo ciclo. La versión 0.3 de este documento se escribirá tras completar al menos la Fase 1 con un adoptante real.*
+*Este roadmap es el primer artefacto que traduce evidencia empírica en código accionable para DevTrail. Su evolución sigue el patrón auto-evolutivo observado en Sentinel: cada fase ejecutada genera datos que refinan el roadmap del próximo ciclo. La versión 0.3 (este documento) se escribió tras completar las 3 fases en `fw-4.4.0` → `fw-4.7.1` con Sentinel como adoptante único; la próxima versión (0.4) se escribirá cuando el segundo dominio (subproyecto frontend de Sentinel, agendado) cierre al menos 1 Charter completo y aporte señal sobre qué del schema `v0` debe promoverse a `v1`, qué frictions emergen en un stack distinto a Go, y si los HTTP clients se justifican antes de v1 estable.*

--- a/dist/docs/examples/ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md
+++ b/dist/docs/examples/ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md
@@ -1,0 +1,191 @@
+<!--
+Anonymized example derived from a real AILOG that documented the
+introduction of an anomaly detector to a Go backend service. This is
+the AILOG referenced as `originating_ailogs` by CHARTER-01-anomaly-thresholds.md
+in the same examples directory — the pair illustrates the canonical
+"Charter as follow-up of an AILOG" pattern.
+
+Sentinel-specific identifiers (module names, internal issue numbers,
+PR refs, infrastructure hostnames, reviewer emails, dates) have been
+replaced with generic placeholders. Technical reasoning, the Decision
+section structure, the Risk numbering, and the Verification commands
+are preserved verbatim per the example-anonymization rules in
+devtrail-cli-roadmap.md §3.1.
+
+For browsing only — `devtrail init` does not install this file. Adopters
+who want a starting AILOG scaffold use `devtrail new --doc-type ailog`
+against TEMPLATE-AILOG.md.
+-->
+
+---
+id: AILOG-2026-01-15-001
+title: "AnomalyDetector + Activity Baselines (statistical RPM anomaly detection)"
+status: accepted
+created: 2026-01-15
+agent: claude-code-v1.0
+confidence: high
+review_required: true
+reviewed_by: reviewer@example.com
+reviewed_at: 2026-01-28
+review_outcome: approved
+risk_level: medium
+eu_ai_act_risk: minimal
+nist_genai_risks: [confabulation, information_integrity]
+iso_42001_clause: [6, 8]
+lines_changed: 450
+files_modified:
+  - db/migrations/008_activity_baselines_rls.sql
+  - db/queries/monitor/baselines.sql
+  - db/generated/baselines.sql.go
+  - db/generated/models.go
+  - src/core/config.<ext>
+  - src/services/monitor/anomaly_detector.go
+  - src/services/monitor/anomaly_detector_test.go
+  - src/services/monitor/job_baseline.go
+  - src/services/monitor/models.go
+  - src/services/monitor/repository.go
+  - src/services/monitor/service.go
+  - src/services/monitor/wire.go
+  - src/main.<ext>
+  - src/main.<ext> (DI wiring)
+  - .env.example
+  - specs/001-service-mvp/post-mvp-backlog.md
+observability_scope: event:status.anomaly_detected event:status.anomaly_critical
+tags: [post-mvp, anomaly, statistics, rpm, feature]
+related:
+  - specs/001-service-mvp/post-mvp-backlog.md
+  - specs/001-service-mvp/data-model.md
+  - specs/001-service-mvp/contracts/events.md
+---
+
+# AILOG: AnomalyDetector + Activity Baselines
+
+## Summary
+
+Closes the upstream issue. Activates for the first time the `activity_baselines` table that existed as a skeleton since an earlier migration, and turns on statistical anomaly detection over the RPM reported by services in their heartbeats.
+
+Components:
+
+- **`AnomalyDetector`** (`src/services/monitor/anomaly_detector.go`): evaluates each heartbeat against the baseline for its `(service_id, day_of_week, hour_of_day)` bucket and publishes events `status.anomaly_detected` (z ≥ 3σ) and `status.anomaly_critical` (z ≥ 5σ). Stateless, nil-receiver-safe, best-effort (errors never block ingestion).
+- **`StartActivityBaselineJob`** (`job_baseline.go`): daily goroutine that invokes `repo.RefreshActivityBaselines`, an UPSERT that recomputes `(avg_rpm, stddev_pop, sample_count)` per bucket over the last 7 days of heartbeats with `jsonb_typeof(checks->'rpm') = 'number'`.
+- **Migration 008** (`db/migrations/008_activity_baselines_rls.sql`): closes two gaps detected when reviewing the original migration against `data-model.md §3.8` — missing RLS and missing `updated_at` column.
+- **3 anomaly types**: `rpm_drop`, `rpm_spike`, `zero_activity`. All three modeled as string constants to avoid magic strings.
+- **Configuration via env vars**: `ANOMALY_DETECTION_ENABLED`, `ANOMALY_DEVIATION_FACTOR`, `ANOMALY_CRITICAL_FACTOR`, `ANOMALY_MIN_SAMPLES`, `ANOMALY_ZERO_ACTIVITY_MIN_AVG`. Defaults 3.0 / 5.0 / 7 / 1.0.
+
+## Context
+
+Origin: `specs/001-service-mvp/data-model.md` (the `activity_baselines` table declared as "Future Phase"), `plan.md` (`AnomalyDetector` component), `contracts/events.md` (events `status.anomaly_detected` and `status.anomaly_critical` with schemas already defined). The post-MVP backlog marked the item as "define when prioritized"; the operator prioritized it today.
+
+## Decision
+
+### Data source assumption
+
+The principal design decision was where the detector takes the "observed RPM" from. The service only persists heartbeats (presence, not volume); there is no MetricsPoller and no integration with a cloud monitoring backend (those live in a deferred upstream issue).
+
+Agreed with the operator (2026-01-15): assume services report `rpm` as a key inside `IncomingHeartbeat.Checks` (which is `map[string]any`). Services that don't report it are exempt without error. This decision:
+
+- Zero new infra (heartbeats already carry `checks` JSONB).
+- Lets a future deferred upstream issue replace the source without touching the detector.
+- False positives are impossible by design for silent services (no `rpm` reported → detector skips).
+
+### Daily refresh vs incremental
+
+Welford on-line (incremental per heartbeat) is more reactive but introduces race conditions and complicates the empty-first-boot case. Chose UPSERT daily over a rolling window:
+
+```sql
+INSERT INTO activity_baselines (...)
+SELECT service_id, EXTRACT(DOW...), EXTRACT(HOUR...),
+       AVG((checks->>'rpm')::numeric),
+       COALESCE(STDDEV_POP(...), 0),
+       COUNT(*)::INT, NOW()
+FROM heartbeats
+WHERE received_at >= NOW() - INTERVAL '7 days'
+  AND jsonb_typeof(checks->'rpm') = 'number'
+GROUP BY ...
+ON CONFLICT (service_id, day_of_week, hour_of_day) DO UPDATE ...
+```
+
+`STDDEV_POP` (population stddev) instead of `STDDEV_SAMP` because we are describing observed historical behavior, not extrapolating to a larger population. It matters when `sample_count` is small (n=2 gives var=2 vs var=4).
+
+`jsonb_typeof(checks->'rpm') = 'number'` filters non-numeric values before the `::numeric` cast, preventing a malformed value in one heartbeat from breaking the refresh for all services.
+
+### Thresholds via env vars (not per-service)
+
+`PolicyEngine` already exposes `RateLimits` per-service in `src/core/interfaces/policy.<ext>`, but extending it for anomaly thresholds expands surface without proven demand. Defaults of 3σ / 5σ are industry-standard (>99.7% / >99.99994% intervals); the operator can tune via env vars without recompiling. Per-service is a follow-up when there's signal of real use.
+
+> *Note: this follow-up materialized later as CHARTER-01-anomaly-thresholds (see the Charter examples directory) — exactly the pattern of "AILOG observes a constraint, a Charter eventually addresses it" the framework is designed to capture.*
+
+### `DurationMinutes = 0`
+
+`AnomalyCriticalData.DurationMinutes` is in the event schema from `events.md`. Real tracking (how many minutes the anomaly has been ongoing) requires per-service in-memory state that survives between heartbeats and clears on return-to-normal. For the MVP version of this feature I left it at 0 with a TODO documented in this AILOG. The principal info travels in `status.anomaly_detected`, which does carry `DeviationFactor` and baseline.
+
+### Migration 008
+
+When inspecting the earlier migration against `data-model.md §3.8` I found two gaps:
+
+1. The `activity_baselines` table did not have RLS, even though `service_id` is a pivot column and the doc lists it.
+2. `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` was missing in the DDL even though the doc lists it.
+
+Migration 008 closes both before the detector consumes the table in production. Idempotent via `ADD COLUMN IF NOT EXISTS`.
+
+### Event schema preserved
+
+`AnomalyDetectedData` and `AnomalyCriticalData` are modeled in `monitor/models.go` with the contract's exact field names (`current_value`, `baseline_avg`, `baseline_stddev`, etc.). This lets a future consumer (e.g., the audit module's universal consumer) deserialize without coupling to the package.
+
+## Verification
+
+```bash
+sqlc generate                                              # OK (generates baselines.sql.go)
+go build ./...                                             # OK
+go vet ./...                                               # OK
+go test -short ./src/services/monitor/...                  # 13 unit tests green (TestAnomalyDetector_*)
+go test -short ./...                                       # full suite green
+go test -tags=integration -run 'TestIntegration_RefreshActivityBaselines|TestIntegration_AnomalyDetectorEndToEnd' \
+        -timeout 5m ./src/services/monitor/...             # 3/3 green
+<security-scanner> --exclude-generated ./...               # 0 issues, 5 nosec
+```
+
+Unit coverage (`monitor/anomaly_detector_test.go`):
+
+- Nil receiver no panic.
+- Disabled cfg emits nothing, no lookup performed.
+- No `rpm` in checks → silent skip (no lookup).
+- `baseline == nil` → silent skip.
+- `sample_count < min_samples` → silent skip.
+- Lookup error → log warn, no panic, no events.
+- Reading inside the envelope → no events.
+- Spike (z=4) → `rpm_spike` only.
+- Drop (z=-4) → `rpm_drop` only.
+- Critical spike (z=10) → both events.
+- `zero_activity` with historical avg > 1 → emits (even with stddev=0).
+- `zero_activity` with avg < `ZeroActivityMinAvg` → skip.
+- Bucket key correctly derived from `received_at` (DOW + hour).
+- `extractRPM` accepts float64/int/int64/json.Number; rejects string/bool.
+
+Integration coverage:
+
+- 7 heartbeats across 7 distinct DOWs → 7 baseline rows with `sample_count=1` each; today's bucket has avg=100, stddev=0.
+- 5 heartbeats in the same bucket → 1 baseline row with avg=100, stddev_pop=√50 ≈ 7.0711, sample_count=5.
+- `ProcessHeartbeat` with a pinned baseline and anomalous rpm → both events reach the bus subscriber.
+
+## Risk
+
+- **R1 — False positives in seasonal services**: static thresholds (3σ/5σ) don't understand deploy ramps or maintenance windows. *Mitigation*: env vars allow trivial tuning; events go to the audit module with WARNING, not direct paging. Per-service is a follow-up.
+- **R2 — Refresh cost over large N**: scanning 7 days × `jsonb_typeof()` × `STDDEV_POP` per (service, dow, hour) could become noticeable when N > 50 services and heartbeats are dense. *Mitigation*: the `jsonb_typeof(checks->'rpm') = 'number'` filter enables a future expression index. Documented as a follow-up in the backlog.
+- **R3 — Heartbeats without RPM**: most MVP services don't report RPM today (only cpu/memory/latency/error_rate). The detector emits nothing for them, which is correct but invisible. Observability metric pending as follow-up.
+- **R4 — RLS added late to the table**: migration 008 turns on RLS over a table that was open until today. Zero existing rows (the table wasn't being filled in MVP), so no risk of historical exposure.
+- **R5 — Nil detector in legacy tests**: updated `newTestService` in `service_test.go` to pass `nil` as the detector, and added a test `TestAnomalyDetector_NilReceiverIsNoOp` that protects that path. Existing heartbeat tests stay green.
+
+## Follow-ups
+
+- **Metric `service.anomaly_evaluations_total{outcome}`** (skipped / detected / critical) — operational observability over how many heartbeats activate the detector vs how many it skips for missing RPM or baseline. Trivial to add.
+- **Real `DurationMinutes`** — per-service in-memory tracking of the first anomalous heartbeat with cleanup on return-to-normal. Allows reporting real duration in `AnomalyCriticalData`.
+- **Per-service thresholds via PolicyEngine config** — useful when a critical service (e.g., billing) needs stricter gates than the global default. *(This follow-up was eventually picked up as CHARTER-01-anomaly-thresholds, see the Charter examples directory.)*
+- **Expression index on `heartbeats.checks`** — `CREATE INDEX ... ON heartbeats USING GIN ((checks->'rpm'))` only if the refresh cost becomes noticeable.
+- **Switch to cloud-monitoring source** — when a deferred MetricsPoller upstream issue lands, the detector can consume RPM observed by the poller without changing its interfaces.
+
+## Approval
+
+**Approved**: 2026-01-28 by `reviewer@example.com`.
+
+Approved retroactively as part of a housekeeping bulk-approval cycle. Code shipped to main on or before AILOG creation date; behavior validated by elapsed operation without incidents reported.


### PR DESCRIPTION
## Summary

Docs-only PR closing the v0.3 cycle of the roadmap and shipping the third (and final, for now) anonymized example from Sentinel.

- **`Propuesta/devtrail-cli-roadmap.md` v0.2 → v0.3** — adds new §0 with the full implementation status (8 releases shipped through `fw-4.7.1`/`cli-3.8.1`, RFCs #67/#82/#91 closed, frictions F1-F8 + observation O3 resolved). Documents architectural decision **A1** (Phase 3 v0 is orchestration-only — no HTTP API clients — operator pastes prompts manually) and the §5.5 criterion 4 divergence (heterogeneity inter-familia is recommendation, not auto-enforcement, gated on A1). Adds ✅/⏳ status markers on the exit criteria of §3.6, §4.5, §5.5. Marks `dist/docs/examples/` artifacts as shipped in the §6 mapping table. Footer rewritten to reflect that v0.3 is current and v0.4 is gated on the second-domain cycle (Sentinel frontend subproject, scheduled).
- **`dist/docs/examples/ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md`** — anonymized from Sentinel `AILOG-2026-04-24-010`. Paired with the existing `CHARTER-01-anomaly-thresholds.md` as the canonical "Charter as follow-up of an AILOG" example. Per A6 of the Phase 1 plan, lives in `dist/docs/examples/` for browsing on GitHub or via clone — **not auto-installed via `dist-manifest.yml`**.

No version bump for either component, since neither file is in the auto-distributed manifest paths.

## Test plan

- [x] Roadmap renders correctly on GitHub (markdown tables + status markers)
- [x] AILOG example anonymization is complete (no `Sentinel`, no `internal/modules/`, no `gosec`, no `pepemontfort@gmail.com`, no `cmd/sentinel/...`)
- [x] AILOG example cross-references `CHARTER-01-anomaly-thresholds.md` correctly
- [x] No code, schema, or manifest changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)