### PR TITLE
docs: sync ES + zh-CN CLI-REFERENCE with shipped state, add examples index

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Built-in commands that turn the discipline into actionable feedback:
 - **`devtrail analyze`** — Code complexity analysis (cognitive + cyclomatic) powered by [arborist-metrics](https://github.com/StrangeDaysTech/arborist), our open-source Rust library for multi-language code metrics
 - **`devtrail audit`** — Audit trail reports with timeline, traceability maps, and HTML export
 - **`devtrail compliance`** — Regulatory compliance scoring as a side effect of the documented work (EU AI Act, ISO 42001, NIST AI RMF; six Chinese frameworks opt-in via `--region china`)
-- **`devtrail explore`** — Interactive TUI for navigating the project's documentation graph
+- **`devtrail explore`** — Interactive TUI for navigating the project's documentation graph, including a Charter view (lifecycle status, origin AILOG/spec, file location)
 - **Pre-commit hooks** + **GitHub Actions** for CI/CD validation
 
 ---

--- a/dist/docs/examples/README.md
+++ b/dist/docs/examples/README.md
@@ -1,0 +1,33 @@
+# DevTrail examples — browse-only reference
+
+This directory ships a small set of anonymized real-world examples derived from the Sentinel `/plan-audit` experiment that originated the Charter pattern. They exist for **browsing** — not as scaffolding templates.
+
+`devtrail init` does **not** copy these into adopter projects. The auto-installed manifest paths are `.devtrail/`, `DEVTRAIL.md`, agent skills, and the docs-validation workflow (see `dist/dist-manifest.yml`); `dist/docs/` is excluded by design. To scaffold a real document in your project, use:
+
+- `devtrail new --doc-type ailog --title "..."` → AILOG
+- `devtrail charter new --type S|M|L --title "..."` → Charter
+
+## What's here
+
+| File | Type | Effort | Status | Pairs with |
+|---|---|---|---|---|
+| [`charters/CHARTER-01-anomaly-thresholds.md`](charters/CHARTER-01-anomaly-thresholds.md) | Charter | M | closed | `AILOG-2026-01-15-001` (origin) |
+| [`charters/CHARTER-02-baseline-recompute.md`](charters/CHARTER-02-baseline-recompute.md) | Charter | XS | closed | — |
+| [`ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md`](ailogs/AILOG-2026-01-15-001-anomaly-detector-introduction.md) | AILOG | — | accepted | `CHARTER-01-anomaly-thresholds.md` (follow-up) |
+
+## The canonical "Charter as follow-up of an AILOG" pattern
+
+`AILOG-2026-01-15-001` documents the introduction of an anomaly detector to a Go backend service. Its Risk section flagged static thresholds (3σ/5σ) as a tradeoff acceptable for the MVP, with per-service thresholds recorded as a follow-up. That follow-up later materialized as `CHARTER-01-anomaly-thresholds`, whose `originating_ailogs` frontmatter field references the AILOG.
+
+This pair illustrates the loop the framework is built to capture:
+
+1. An AI-implemented change is logged as an AILOG (ex-post).
+2. The AILOG identifies a constraint or follow-up.
+3. A Charter declares the bounded follow-up work (ex-ante).
+4. The Charter closes with telemetry that, when external audit is run, references the calibrated findings.
+
+`CHARTER-02-baseline-recompute` is a smaller, independent example (XS effort) that does not have a paired AILOG — useful as a reference for the minimal-Charter shape.
+
+## Anonymization
+
+Sentinel-specific identifiers (module names, internal issue numbers, PR refs, infrastructure hostnames, reviewer emails, dates) have been replaced with generic placeholders. Technical reasoning, the Decision section structure, the Risk numbering, and the Verification commands are preserved verbatim per the example-anonymization rules in `Propuesta/devtrail-cli-roadmap.md` §3.1.

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -556,7 +556,7 @@ Detect file-vs-commit drift at Charter close. Wraps the framework's `.devtrail/s
 |---|---|---|
 | `CHARTER-ID` | — | Same resolution rules as `charter status` |
 | `--range` | `HEAD~1..HEAD` | Git revision range to check |
-| `--no-ailog-suppress` | false | Disable AILOG-aware suppression (show every declared-omitted path) |
+| `--no-ailog-suppress` *(cli-3.8.1+ always emits a confirming INFO line)* | false | Disable AILOG-aware suppression (show every declared-omitted path). When passed, the CLI always prints an `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` line — including when N=0 — so that the diagnostic mode is visible in output even on a clean run. |
 | `--path` | `.` | Target project directory |
 
 **Exit codes:** `0` if no drift (or only AILOG-suppressed); `1` if there's unaccounted drift; `2` for usage errors (Charter not found, bash missing, etc.).

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -132,7 +132,7 @@ Comandos integrados que convierten la disciplina en feedback accionable:
 - **`devtrail analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) impulsado por [arborist-metrics](https://github.com/StrangeDaysTech/arborist), nuestra librería open-source en Rust para métricas de código multi-lenguaje
 - **`devtrail audit`** — Reportes de auditoría con línea temporal, mapas de trazabilidad y exportación HTML
 - **`devtrail compliance`** — Puntuación de cumplimiento regulatorio como side effect del trabajo documentado (EU AI Act, ISO 42001, NIST AI RMF; seis frameworks chinos opt-in vía `--region china`)
-- **`devtrail explore`** — TUI interactivo para navegar el grafo de documentación del proyecto
+- **`devtrail explore`** — TUI interactivo para navegar el grafo de documentación del proyecto, incluyendo una vista de Charters (estado del ciclo de vida, AILOG/spec de origen, ubicación del archivo)
 - **Hooks pre-commit** + **GitHub Actions** para validación CI/CD
 
 ---

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -64,15 +64,16 @@ devtrail status   # Muestra estado completo de la instalación incluyendo versio
 
 ## Comandos
 
-### `devtrail init [path]`
+### `devtrail init [path] [--hooks]`
 
 Inicializa DevTrail en un directorio de proyecto.
 
-**Argumentos:**
+**Argumentos y flags:**
 
-| Argumento | Por defecto | Descripción |
-|-----------|-------------|-------------|
+| Argumento/Flag | Por defecto | Descripción |
+|----------------|-------------|-------------|
 | `path` | `.` (directorio actual) | Directorio del proyecto destino |
+| `--hooks` *(cli-3.7.0+)* | off | Tras `init`, instala el hook pre-PR del framework (`.devtrail/hooks/pre-pr.sh`) como `.git/hooks/pre-push`. Ejecuta `devtrail charter drift` automáticamente antes de cada push. Opt-in por principio #6 (disciplina cognitiva > productividad cruda). Se rehúsa a sobreescribir un `pre-push` ya existente; se omite silenciosamente si no es un repositorio git. |
 
 **Qué hace:**
 
@@ -81,6 +82,7 @@ Inicializa DevTrail en un directorio de proyecto.
 3. Crea `DEVTRAIL.md` con las reglas de gobernanza
 4. Configura archivos de directivas de agentes IA (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 5. Copia workflows de CI/CD
+6. *(`--hooks`)* instala el hook pre-PR
 
 **Ejemplo:**
 
@@ -256,7 +258,7 @@ Repairing DevTrail in /home/user/mi-proyecto
 
 ---
 
-### `devtrail validate [path] [--fix] [--staged] [--include-charters]`
+### `devtrail validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
 
 Valida documentos DevTrail verificando cumplimiento y corrección.
 
@@ -268,6 +270,8 @@ Valida documentos DevTrail verificando cumplimiento y corrección.
 | `--fix` | — | Corregir automáticamente problemas simples |
 | `--staged` | — | Validar solo archivos staged en Git (ideal para hooks pre-commit) |
 | `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.8.1. |
+| `--check-pending-reviews` *(cli-3.7.0+)* | off | Lista documentos con `review_required: true` y sin `review_outcome` cuya antigüedad supere `--max-pending-days`. **Solo warn** — nunca falla el exit code de validate; útil para dashboards de CI sobre el backlog de aprobaciones. |
+| `--max-pending-days` *(cli-3.7.0+)* | `14` | Umbral en días para `--check-pending-reviews`. |
 
 **Reglas de validación:**
 
@@ -326,6 +330,56 @@ $ devtrail new -t ailog --title "Refactorizar módulo de pagos"
 
 ---
 
+### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
+
+*Disponible desde **cli-3.7.0** + **fw-4.6.0**. `--quiet` y warning de alto riesgo añadidos en cli-3.8.0.*
+
+Registra una aprobación humana formal sobre un documento con `review_required: true`. Escribe los tres campos de aprobación en el frontmatter (`reviewed_by`, `reviewed_at`, `review_outcome`) **y** añade la sección canónica `## Approval` al cuerpo en una edición atómica. Implementa la señal de cierre canonizada en `DOCUMENTATION-POLICY.md §3.5`.
+
+| Argumento/Flag | Default | Descripción |
+|----------------|---------|-------------|
+| `<doc-id>` | — | ID del documento. Acepta el prefijo (`AIDEC-2026-05-02-001`) o el ID completo con slug (`AIDEC-2026-05-02-001-foo`). |
+| `--outcome` | — | Uno de `approved`, `revisions_requested`, `rejected`. Solicita prompt en TTY si está ausente. |
+| `--reviewer` | — | Identidad del revisor: email, GitHub handle, o DID. Solicita prompt en TTY si está ausente. |
+| `--at` | hoy | Fecha de aprobación (`YYYY-MM-DD`). |
+| `--notes` | — | Notas opcionales del revisor (anexadas en la sección del cuerpo). |
+| `--path` | `.` | Directorio del proyecto. |
+
+**Comportamiento:**
+
+- Advierte (no falla) si el documento no tiene `review_required: true` — el sign-off retroactivo es un caso real.
+- **Mutación de frontmatter** (latest-wins): reemplaza los `reviewed_by/_at/outcome` existentes; si no existen, los inserta tras `review_required:`. Implementa la convención multi-revisor de §3.5: el frontmatter mantiene la *última* aprobación.
+- **Mutación del cuerpo** (cronológica): añade un nuevo bloque `## Approval` antes de cualquier firma de plantilla final. Re-ejecutar `approve` preserva los bloques anteriores, así el cuerpo muestra el historial completo de revisiones.
+- `review_required: true` **no** se cambia a `false` tras la aprobación — permanece como registro histórico de por qué fue necesario revisar.
+
+**Ejemplos:**
+
+```bash
+# Driven por flags (CI / scripts)
+$ devtrail approve AIDEC-2026-05-02-001 \
+    --outcome approved \
+    --reviewer pepe@example.com \
+    --notes "Revisado contra ADR-007. LGTM."
+
+  ✔ AIDEC-2026-05-02-001 marked as approved.
+    Reviewer: pepe@example.com
+    Date:     2026-05-02
+    File:     .devtrail/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
+
+# Ciclo iterativo: revisions_requested → re-aprobación
+$ devtrail approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
+# (autor itera)
+$ devtrail approve AIDEC-... --outcome approved --reviewer reviewer@x.io
+# Frontmatter muestra la última (approved); el cuerpo conserva AMBOS bloques cronológicamente.
+
+# Visibilidad del backlog
+$ devtrail validate --check-pending-reviews --max-pending-days 14
+```
+
+> Ver `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval" para la definición canónica del flujo (semántica de cierre, formato del cuerpo, convención multi-revisor).
+
+---
+
 ### `devtrail charter <subcomando>`
 
 Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-ante y validadas ex-post. Un Charter empareja scope declarativo (archivos a tocar, riesgos, comandos de verificación ejecutables) con el ancla de auditoría ex-post (drift detection, auditoría multi-modelo). Los Charters viven en `docs/charters/NN-slug.md` (a nivel del project root, **no** bajo `.devtrail/`).
@@ -337,8 +391,9 @@ Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-
 - `devtrail charter new` — crea un nuevo Charter desde el template del framework
 - `devtrail charter list` — enumera Charters con filtros opcionales
 - `devtrail charter status` — muestra detalle de un Charter, o los 5 más recientes
-
-La Fase 2 del CLI roadmap añadirá `charter close` (telemetría interactiva) y `charter drift` (chequeo de drift archivo-vs-commit). La Fase 3 añadirá `charter audit` (auditoría externa multi-modelo).
+- `devtrail charter close` *(cli-3.7.0+)* — registra la telemetría post-ejecución y mueve el Charter a `closed`
+- `devtrail charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware
+- `devtrail charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
 
 #### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <titulo>] [path]`
 
@@ -381,12 +436,208 @@ Los archivos que no parsean se reportan como warnings en stderr sin abortar el c
 
 #### `devtrail charter status [CHARTER-ID] [--path <dir>]`
 
-Con un ID: imprime el detalle completo del Charter (frontmatter, ubicación del archivo, lista de secciones del cuerpo, placeholders de Fase 2). Sin ID: imprime los 5 Charters más recientes por NN descendente.
+Con un ID: imprime el detalle completo del Charter (frontmatter, ubicación del archivo, lista de secciones del cuerpo). Sin ID: imprime los 5 Charters más recientes por NN descendente.
 
 | Argumento/Flag | Default | Descripción |
 |----------------|---------|-------------|
 | `CHARTER-ID` | — | Identificador del Charter. Acepta el `charter_id` completo (`CHARTER-01-test`), el prefijo `CHARTER-NN` (`CHARTER-01`), o solo el NN numérico (`01` o `1`). El match numérico es permisivo respecto al zero-padding. |
 | `--path` | `.` | Directorio del proyecto. Es flag (no positional) para evitar colisión con el positional opcional `CHARTER-ID`. |
+
+#### `devtrail charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
+
+Registra la telemetría post-ejecución y mueve el status del Charter a `closed`. La telemetría se escribe en `.devtrail/charters/CHARTER-NN.telemetry.yaml` (archivo lateral, **no** embebido en el frontmatter del Charter — el frontmatter es declarativo ex-ante; la telemetría es voluminosa ex-post). El shape se valida contra `.devtrail/schemas/charter-telemetry.schema.v0.json`.
+
+Dos modos:
+
+| Modo | Combinación de flags | Cuándo usar |
+|---|---|---|
+| **Interactivo** (default) | (ninguno) | Recorre el schema campo por campo con prompts. Tiempo objetivo: 5–10 min. |
+| **From template** | `--from-template` | Copia el esqueleto YAML junto al Charter para edición manual. Pre-llena `charter_id`, título, `closed_at`. |
+| **From template, scripted** | `--from-template --non-interactive` | Uso CI / batch. Omite todos los prompts; idempotente al re-ejecutar. |
+
+| Argumento/Flag | Default | Descripción |
+|---|---|---|
+| `CHARTER-ID` | — | Mismas reglas de resolución que `charter status`. |
+| `--from-template` | false | Copia el esqueleto del template en lugar de correr el flujo interactivo. |
+| `--non-interactive` | false | Omite todos los prompts. Requiere `--from-template`. |
+| `--path` | `.` | Directorio del proyecto. |
+
+**Ejemplo:**
+
+```bash
+$ devtrail charter close CHARTER-01
+
+  Closing CHARTER-01-test-charter
+    Title: Test charter
+  Press Enter to accept defaults; type to override.
+
+  ── Trigger ──
+  Declared trigger kind › event_trigger
+  Declared trigger description › first false-positive ticket
+  Fired at (YYYY-MM-DD) [2026-05-02]:
+  ...
+
+  ✔ Charter CHARTER-01 closed.
+    Telemetry: .devtrail/charters/CHARTER-01.telemetry.yaml
+    Status updated: in-progress/declared → closed
+```
+
+#### `devtrail charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+
+Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del framework `.devtrail/scripts/check-charter-drift.sh` (cero falsos positivos validados empíricamente en PLAN-05 retrospectivo + PLAN-06 prospectivo en Sentinel). El valor agregado del CLI sobre el script crudo es la **AILOG-awareness**: los paths reportados como "declarados pero no modificados" se silencian cuando aparecen en la sección `## Risk` / `## Riesgos` / `## 风险` de algún AILOG referenciado por `originating_ailogs` del Charter. Usa `--no-ailog-suppress` para deshabilitarlo.
+
+| Argumento/Flag | Default | Descripción |
+|---|---|---|
+| `CHARTER-ID` | — | Mismas reglas de resolución que `charter status`. |
+| `--range` | `HEAD~1..HEAD` | Rango de revisiones git a chequear. |
+| `--no-ailog-suppress` *(cli-3.8.1+ siempre emite una línea INFO de confirmación)* | false | Deshabilita la supresión AILOG-aware (muestra todo path declarado-omitido). Cuando se pasa el flag, el CLI siempre imprime una línea `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` — incluso cuando N=0 — para que el modo diagnóstico sea visible en la salida aun en una corrida limpia. |
+| `--path` | `.` | Directorio del proyecto. |
+
+**Códigos de salida:** `0` si no hay drift (o solo AILOG-suprimido); `1` si hay drift no contabilizado; `2` para errores de uso (Charter no encontrado, bash ausente, etc.).
+
+**Ejemplo:**
+
+```bash
+$ devtrail charter drift CHARTER-01 --range origin/main..HEAD
+=== Charter drift check ===
+  Charter: docs/charters/01-test.md
+  Range:   origin/main..HEAD
+  Declared: 5 files
+  Modified: 3 files
+
+WARNING: Declared in Charter but NOT modified (1 files):
+  - src/services/policy/repository.go
+
+AILOG-suppressed: 1 path(s)
+  - src/services/policy/repository.go [documented in AILOG-2026-05-02-001]
+
+OK all declared-omitted paths are documented in AILOGs — drift accepted.
+```
+
+> **Nota de plataforma.** El chequeo de drift delega en `bash`. En Linux/macOS/WSL/Git Bash funciona out-of-the-box. En Windows nativo sin WSL, instalar Git Bash; un fallback puro Rust está en el roadmap pero no en fw-4.6.x.
+
+#### Soporte de wildcards en paths declarados *(fw-4.7.1+)*
+
+El chequeo de drift resuelve dos formas de wildcard en `## Files to modify`:
+
+| Forma | Ejemplo | Caso de uso |
+|---|---|---|
+| Elipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Cualquier path modificado con ese prefijo satisface el wildcard. Usado históricamente cuando un número desconocido de AILOGs serían creados durante la ejecución. |
+| Glob | `` `AILOG-*.md` `` o `` `src/services/foo-*.rs` `` | Cualquier path modificado que matchee el glob (`*` → `.*`) satisface el wildcard. Usado para declaraciones bulk de Charter donde un set parametrizado es tocado. Añadido en fw-4.7.1 tras la fricción surgida en Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+
+Ambas formas se manejan en ambas direcciones: un wildcard declarado suprime tanto warnings de "declarado pero no modificado" (cuando al menos un archivo matching fue modificado) como warnings de "modificado pero no declarado" (cuando un path modificado matchea un wildcard declarado).
+
+#### Por diseño: rutas de gobernanza siempre están en scope
+
+Los paths bajo `docs/charters/*` y `.devtrail/07-ai-audit/*` **nunca** se reportan como "modificado pero no declarado". Es opinionated por diseño — esos paths son siempre legítimos cuando el Charter mismo o el AILOG de ejecución son tocados. Validado empíricamente en Sentinel CHARTER-04: un `git add -A` accidental stageó archivos no-tracked del usuario (`.claude/skills/`, `cmd/sentinel/sentinel`); la regla suprimió correctamente el ruido de gobernanza sin esconder la expansión genuina de archivos del proyecto ([issue #81 W2](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)).
+
+Si corres un Charter cuyo scope explícito es churn de gobernanza (p.ej. un Charter de aprobación bulk que toca solo `.devtrail/07-ai-audit/`), el chequeo reportará 0 archivos modificados y necesitarás verificar el scope leyendo el AILOG. Un flag `--strict-scope` que deshabilite la regla "siempre en scope" está sobre la mesa para una minor futura si un adopter real reporta la asimetría como fricción.
+
+#### `devtrail charter audit <CHARTER-ID> [--range <REV..REV>] [--calibrate | --finalize] [--path <dir>]`
+
+*Disponible desde **cli-3.8.0** + **fw-4.7.0** (Fase 3 v0).*
+
+Orquesta una revisión externa multi-modelo de la ejecución de un Charter. **Orchestration-only** — el CLI prepara prompts, valida outputs contra el schema, e imprime findings listos para pegar en la telemetría del Charter. **NO invoca APIs de LLM.** El operador corre los prompts en su auditor de elección (Copilot, Gemini, Claude, etc.) y guarda las respuestas en paths canónicos.
+
+Tres pasos, cada uno invocable independientemente:
+
+| Paso | Flag | Qué pasa |
+|---|---|---|
+| 1. PREPARE | (default) | Resuelve los prompts `auditor-primary` y `auditor-secondary` contra el Charter + git diff + AILOGs originadores. Los escribe bajo `audit/charters/<CHARTER-ID>/prompts/`. |
+| 2. CALIBRATE | `--calibrate` | Lee `auditor-primary.md` y `auditor-secondary.md` (el operador debe guardarlos entre pasos 1 y 2). Los valida contra `audit-output.schema.v0.json`. Resuelve el prompt del calibrador con ambas respuestas embebidas. |
+| 3. FINALIZE | `--finalize` | Lee la respuesta del calibrador. Valida los 3 outputs. Imprime un bloque YAML `external_audit` listo para pegar en la telemetría del Charter. |
+
+| Argumento/Flag | Default | Descripción |
+|---|---|---|
+| `<CHARTER-ID>` | — | Mismas reglas de resolución que `charter status`. |
+| `--range` | `HEAD~1..HEAD` | Rango git que los auditores revisarán. |
+| `--calibrate` | off | Corre el paso 2. Mutuamente excluyente con `--finalize`. |
+| `--finalize` | off | Corre el paso 3. Mutuamente excluyente con `--calibrate`. |
+| `--path` | `.` | Directorio del proyecto. |
+
+##### Recomendación de heterogeneidad (no enforced en v0)
+
+Por la justificación de diseño (`devtrail-cli-roadmap.md` §5.2), el par de auditores debería ser de **familias de modelo distintas**: uno Anthropic + uno Google + uno OpenAI, en cualquier combinación, nunca dos de la misma familia. La heterogeneidad inter-familia es lo que hace que la convergencia en findings sea de alta señal — auditores de la misma familia comparten blind spots.
+
+El calibrador-reconciliador PUEDE ser de cualquier familia (incluida la del implementador) porque su tarea es definicional (aplicar el schema sobre veredictos ya producidos), no de descubrimiento. La heterogeneidad importa para el par auditor, no para el calibrador.
+
+v0 documenta esta recomendación pero no la auto-detecta ni enforza. Un flag `--implementer-family X` con rechazo de configuraciones monocromáticas es candidato v1 cuando un adopter reporte un caso real.
+
+##### Layout producido
+
+```
+audit/charters/CHARTER-NN/
+├── prompts/
+│   ├── auditor-primary.prompt.md      # resuelto por el paso 1, lo que se envió
+│   ├── auditor-secondary.prompt.md    # resuelto por el paso 1
+│   └── calibrator-reconciler.prompt.md  # resuelto por el paso 2
+├── auditor-primary.md                 # el operador pega la respuesta del auditor 1
+├── auditor-secondary.md               # el operador pega la respuesta del auditor 2
+└── calibrator-reconciler.md           # el operador pega la respuesta del calibrador
+```
+
+El subdirectorio `prompts/` persiste lo que se envió a cada auditor *antes* de la API call (cierra [RFC #82](https://github.com/StrangeDaysTech/devtrail/issues/82) sobre visibilidad de auditoría). Los adopters pueden `git add` el directorio entero `audit/` para un audit trail completamente versionado, o `.gitignore` si prefieren un ciclo efímero.
+
+**Ejemplo:**
+
+```bash
+$ devtrail charter audit CHARTER-05
+  Step 1/3: PREPARE (CHARTER-05)
+  ✔ Wrote audit/charters/CHARTER-05/prompts/auditor-primary.prompt.md
+  ✔ Wrote audit/charters/CHARTER-05/prompts/auditor-secondary.prompt.md
+
+  Next:
+    1. Paste each prompt into your auditor of choice (use a model
+       of a different family per auditor — see CLI-REFERENCE).
+    2. Save the auditor responses to:
+         audit/charters/CHARTER-05/auditor-primary.md
+         audit/charters/CHARTER-05/auditor-secondary.md
+    3. Run: devtrail charter audit CHARTER-05 --calibrate
+
+# (el operador corre auditor 1 en Copilot, guarda respuesta. Corre auditor 2
+# en Gemini, guarda respuesta.)
+
+$ devtrail charter audit CHARTER-05 --calibrate
+  Step 2/3: CALIBRATE (CHARTER-05)
+  ✔ Validated audit/charters/CHARTER-05/auditor-primary.md
+  ✔ Validated audit/charters/CHARTER-05/auditor-secondary.md
+  ✔ Wrote audit/charters/CHARTER-05/prompts/calibrator-reconciler.prompt.md
+
+  Next:
+    1. Run the calibrator prompt in a model of your choice (calibrator
+       may be of any family).
+    2. Save the response to: audit/charters/CHARTER-05/calibrator-reconciler.md
+    3. Run: devtrail charter audit CHARTER-05 --finalize
+
+# (el operador corre el calibrador en Claude, guarda respuesta.)
+
+$ devtrail charter audit CHARTER-05 --finalize
+  Step 3/3: FINALIZE (CHARTER-05)
+  ✔ Validated audit/charters/CHARTER-05/auditor-primary.md (5 findings)
+  ✔ Validated audit/charters/CHARTER-05/auditor-secondary.md (4 findings)
+  ✔ Validated audit/charters/CHARTER-05/calibrator-reconciler.md
+
+  Charter audit complete.
+
+  external_audit YAML — paste into telemetry:
+    - auditor: "copilot-v1.0.37"
+      findings_total: 5
+      findings_by_category:
+        hallucination: 0
+        implementation_gap: 2
+        real_debt: 2
+        false_positive: 1
+      audit_quality: "high"
+      audit_notes: "see audit/charters/<charter-id>/auditor-primary.md"
+    - auditor: "gemini-cli-v1.5"
+      findings_total: 4
+      findings_by_category: ...
+
+  Calibrator summary (copy to outcome.scope_change_notes if relevant):
+    audit/charters/CHARTER-05/calibrator-reconciler.md
+```
+
+> **¿Por qué orchestration-only?** Implementar 3 HTTP clients (OpenAI / Google / Anthropic) son 1-2 semanas + mantenimiento perpetuo cuando las APIs cambian. La Fase 3 v0 es experimental — el valor del CLI es el canon (forma del prompt + schema de output + integración con telemetría), no la API call. v1 puede agregar HTTP clients cuando un adopter reporte una necesidad real; hasta entonces el patrón humano-en-el-loop coincide con el `/plan-audit` empírico de Sentinel que motivó la Fase 3.
 
 ---
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -132,7 +132,7 @@ DevTrail 的产品决策基于十二条明确的原则。它们按层级排序�
 - **`devtrail analyze`** — 代码复杂度分析（认知复杂度 + 圈复杂度），由 [arborist-metrics](https://github.com/StrangeDaysTech/arborist) 驱动——我们的开源 Rust 多语言代码度量库
 - **`devtrail audit`** — 审计跟踪报告，含时间线、可追溯性映射和 HTML 导出
 - **`devtrail compliance`** — 作为已记录工作的副作用产出法规合规评分（EU AI Act、ISO 42001、NIST AI RMF；六项中国框架通过 `--region china` 按选项启用）
-- **`devtrail explore`** — 用于浏览项目文档图谱的交互式 TUI
+- **`devtrail explore`** — 用于浏览项目文档图谱的交互式 TUI，包含章程视图（生命周期状态、来源 AILOG/spec、文件位置）
 - **Pre-commit 钩子** + **GitHub Actions** 用于 CI/CD 验证
 
 ---

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -64,15 +64,16 @@ devtrail status   # 显示完整的安装状态，包括版本
 
 ## 命令
 
-### `devtrail init [path]`
+### `devtrail init [path] [--hooks]`
 
 在项目目录中初始化 DevTrail。
 
-**参数：**
+**参数和标志：**
 
-| 参数 | 默认值 | 描述 |
-|------|--------|------|
+| 参数/标志 | 默认值 | 描述 |
+|-----------|--------|------|
 | `path` | `.`（当前目录） | 目标项目目录 |
+| `--hooks` *(cli-3.7.0+)* | off | 在 `init` 后将框架的 pre-PR 钩子（`.devtrail/hooks/pre-pr.sh`）安装为 `.git/hooks/pre-push`。每次 push 之前自动运行 `devtrail charter drift`。Opt-in，遵循原则 #6（认知纪律 > 原始生产力）。如果已存在 `pre-push` 钩子则拒绝覆盖；非 git 仓库时静默跳过。 |
 
 **功能：**
 
@@ -81,6 +82,7 @@ devtrail status   # 显示完整的安装状态，包括版本
 3. 创建包含治理规则的 `DEVTRAIL.md`
 4. 配置 AI Agent 指令文件（`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
 5. 复制 CI/CD 工作流
+6. *(`--hooks`)* 安装 pre-PR 钩子
 
 **示例：**
 
@@ -275,7 +277,7 @@ Repairing DevTrail in /home/user/my-project
 
 ---
 
-### `devtrail validate [path] [--fix] [--staged] [--include-charters]`
+### `devtrail validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
 
 验证 DevTrail 文档的合规性和正确性。
 
@@ -287,6 +289,8 @@ Repairing DevTrail in /home/user/my-project
 | `--fix` | — | 自动修复简单问题（例如为高风险文档添加缺失的 `review_required: true`） |
 | `--staged` | — | 仅验证已暂存（git add）的文件。适合 pre-commit 钩子。 |
 | `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.8.1 中加入。 |
+| `--check-pending-reviews` *(cli-3.7.0+)* | off | 列出所有 `review_required: true` 且没有 `review_outcome`、年龄超过 `--max-pending-days` 的文档。**仅警告** — 永不影响 validate 的退出码；适合用于 CI 仪表板上的审批积压视图。 |
+| `--max-pending-days` *(cli-3.7.0+)* | `14` | `--check-pending-reviews` 的天数阈值。 |
 
 **检查项目：**
 
@@ -356,6 +360,56 @@ $ devtrail new -t ailog --title "Implement JWT authentication"
 
 ---
 
+### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
+
+*自 **cli-3.7.0** + **fw-4.6.0** 起可用。`--quiet` 与高风险警告于 cli-3.8.0 加入。*
+
+在带 `review_required: true` 的文档上记录正式的人工审批。原子地写入三个 frontmatter 审批字段（`reviewed_by`、`reviewed_at`、`review_outcome`）**并**追加规范的 `## Approval` 正文段落。实现 `DOCUMENTATION-POLICY.md §3.5` 中规范化的关闭信号。
+
+| 参数/标志 | 默认值 | 描述 |
+|-----------|--------|------|
+| `<doc-id>` | — | 文档 ID。接受裸前缀（`AIDEC-2026-05-02-001`）或带 slug 的完整 ID（`AIDEC-2026-05-02-001-foo`）。 |
+| `--outcome` | — | 之一：`approved`、`revisions_requested`、`rejected`。TTY 中缺失时提示。 |
+| `--reviewer` | — | 评审者身份：邮箱、GitHub handle 或 DID。TTY 中缺失时提示。 |
+| `--at` | 今天 | 审批日期（`YYYY-MM-DD`）。 |
+| `--notes` | — | 评审者可选备注（追加到正文段落）。 |
+| `--path` | `.` | 目标项目目录。 |
+
+**行为：**
+
+- 如果文档没有 `review_required: true`，发出警告（不失败）— 追溯式签核是真实用例。
+- **Frontmatter 修改**（最新优先）：替换已存在的 `reviewed_by/_at/outcome`；不存在时插入到 `review_required:` 之后。实现 §3.5 的多评审者约定：frontmatter 持有*最新*审批。
+- **正文修改**（按时间顺序）：在任何模板尾签之前追加新的 `## Approval` 块。重新运行 `approve` 保留之前的块，因此正文显示完整的评审历史。
+- 审批后**不会**将 `review_required: true` 切换为 `false` — 它作为为何需要评审的历史记录保留。
+
+**示例：**
+
+```bash
+# Flag 驱动（CI / 脚本）
+$ devtrail approve AIDEC-2026-05-02-001 \
+    --outcome approved \
+    --reviewer pepe@example.com \
+    --notes "Reviewed against ADR-007. LGTM."
+
+  ✔ AIDEC-2026-05-02-001 marked as approved.
+    Reviewer: pepe@example.com
+    Date:     2026-05-02
+    File:     .devtrail/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
+
+# 迭代评审周期：revisions_requested → 重新批准
+$ devtrail approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
+# (作者迭代)
+$ devtrail approve AIDEC-... --outcome approved --reviewer reviewer@x.io
+# Frontmatter 显示最新（approved）；正文按时间顺序保留两个块。
+
+# 积压可见性
+$ devtrail validate --check-pending-reviews --max-pending-days 14
+```
+
+> 完整流程定义（关闭语义、正文格式、多评审者约定）见 `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval"。
+
+---
+
 ### `devtrail charter <子命令>`
 
 管理**章程（Charter）**：事前声明、事后审计的有界工作单元。一个章程将声明性范围（要修改的文件、风险、可执行的验证命令）与事后审计锚点（漂移检测、多模型审计）配对。章程位于 `docs/charters/NN-slug.md`（项目根目录级别，**不在** `.devtrail/` 之下）。
@@ -367,8 +421,9 @@ $ devtrail new -t ailog --title "Implement JWT authentication"
 - `devtrail charter new` — 从框架模板创建新的章程
 - `devtrail charter list` — 用可选过滤器枚举章程
 - `devtrail charter status` — 显示章程详情，或最近的 5 个章程
-
-CLI 路线图的第 2 阶段将增加 `charter close`（交互式遥测）和 `charter drift`（文件与提交的漂移检查）。第 3 阶段将增加 `charter audit`（多模型外部审计）。
+- `devtrail charter close` *(cli-3.7.0+)* — 记录执行后遥测并将章程移至 `closed`
+- `devtrail charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制
+- `devtrail charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
 
 #### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
@@ -398,12 +453,207 @@ CLI 路线图的第 2 阶段将增加 `charter close`（交互式遥测）和 `c
 
 #### `devtrail charter status [CHARTER-ID] [--path <dir>]`
 
-带 ID：打印完整的章程详情（前置元数据、文件位置、正文章节列表、第 2 阶段功能占位符）。无 ID：按 NN 降序打印最近的 5 个章程。
+带 ID：打印完整的章程详情（前置元数据、文件位置、正文章节列表）。无 ID：按 NN 降序打印最近的 5 个章程。
 
 | 参数/标志 | 默认值 | 描述 |
 |-----------|--------|------|
 | `CHARTER-ID` | — | 章程标识符。接受完整的 `charter_id`（`CHARTER-01-test`）、`CHARTER-NN` 前缀（`CHARTER-01`），或仅数字 NN（`01` 或 `1`）。数字匹配对零填充宽容。 |
 | `--path` | `.` | 目标项目目录。使用标志（而非位置参数）以避免与可选位置参数 `CHARTER-ID` 混淆。 |
+
+#### `devtrail charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
+
+记录执行后遥测并将章程状态移至 `closed`。遥测被写入 `.devtrail/charters/CHARTER-NN.telemetry.yaml`（独立文件，**不**嵌入到章程的 frontmatter — frontmatter 是事前声明性的；遥测是事后大量数据）。形状根据 `.devtrail/schemas/charter-telemetry.schema.v0.json` 验证。
+
+两种模式：
+
+| 模式 | 标志组合 | 何时使用 |
+|---|---|---|
+| **交互式**（默认） | （无） | 按 schema 字段逐项 prompt。目标时间：5–10 分钟。 |
+| **From template** | `--from-template` | 在章程旁复制 YAML 骨架供手动编辑。预填 `charter_id`、标题、`closed_at`。 |
+| **From template, scripted** | `--from-template --non-interactive` | CI / 批量使用。完全跳过 prompts；重运行幂等。 |
+
+| 参数/标志 | 默认值 | 描述 |
+|---|---|---|
+| `CHARTER-ID` | — | 与 `charter status` 相同的解析规则。 |
+| `--from-template` | false | 复制模板骨架而非运行交互式流程。 |
+| `--non-interactive` | false | 跳过所有 prompt。需要 `--from-template`。 |
+| `--path` | `.` | 目标项目目录。 |
+
+**示例：**
+
+```bash
+$ devtrail charter close CHARTER-01
+
+  Closing CHARTER-01-test-charter
+    Title: Test charter
+  Press Enter to accept defaults; type to override.
+
+  ── Trigger ──
+  Declared trigger kind › event_trigger
+  Declared trigger description › first false-positive ticket
+  Fired at (YYYY-MM-DD) [2026-05-02]:
+  ...
+
+  ✔ Charter CHARTER-01 closed.
+    Telemetry: .devtrail/charters/CHARTER-01.telemetry.yaml
+    Status updated: in-progress/declared → closed
+```
+
+#### `devtrail charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+
+在章程关闭时检测文件 vs 提交漂移。封装框架的 `.devtrail/scripts/check-charter-drift.sh`（在 Sentinel PLAN-05 回顾性 + PLAN-06 前瞻性中实证验证零误报）。CLI 在原始脚本之上的附加价值是 **AILOG 感知**：报告为"已声明但未修改"的路径，如果出现在被章程 `originating_ailogs` 引用的任何 AILOG 的 `## Risk` / `## Riesgos` / `## 风险` 节中，则被静默。使用 `--no-ailog-suppress` 来禁用。
+
+| 参数/标志 | 默认值 | 描述 |
+|---|---|---|
+| `CHARTER-ID` | — | 与 `charter status` 相同的解析规则。 |
+| `--range` | `HEAD~1..HEAD` | 要检查的 git 修订范围。 |
+| `--no-ailog-suppress` *(cli-3.8.1+ 始终输出确认 INFO 行)* | false | 禁用 AILOG 感知抑制（显示每条已声明但被遗漏的路径）。传入此标志时，CLI 始终打印 `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` 行 — 即使 N=0 — 以便诊断模式即使在干净运行时也在输出中可见。 |
+| `--path` | `.` | 目标项目目录。 |
+
+**退出码：** `0` 没有漂移（或仅 AILOG 抑制）；`1` 存在未计入的漂移；`2` 用法错误（章程未找到、bash 缺失等）。
+
+**示例：**
+
+```bash
+$ devtrail charter drift CHARTER-01 --range origin/main..HEAD
+=== Charter drift check ===
+  Charter: docs/charters/01-test.md
+  Range:   origin/main..HEAD
+  Declared: 5 files
+  Modified: 3 files
+
+WARNING: Declared in Charter but NOT modified (1 files):
+  - src/services/policy/repository.go
+
+AILOG-suppressed: 1 path(s)
+  - src/services/policy/repository.go [documented in AILOG-2026-05-02-001]
+
+OK all declared-omitted paths are documented in AILOGs — drift accepted.
+```
+
+> **平台说明。** 漂移检查委托给 `bash`。在 Linux/macOS/WSL/Git Bash 上开箱即用。Windows 原生且无 WSL 时需安装 Git Bash；纯 Rust fallback 在路线图上但不在 fw-4.6.x 中。
+
+#### 已声明路径的通配符支持 *(fw-4.7.1+)*
+
+漂移检查在 `## Files to modify` 中解析两种通配符形式：
+
+| 形式 | 示例 | 用例 |
+|---|---|---|
+| 省略号 | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | 任何带该前缀的修改路径满足通配符。历史上用于执行期间会创建未知数量 AILOG 的情况。 |
+| Glob | `` `AILOG-*.md` `` 或 `` `src/services/foo-*.rs` `` | 任何匹配该 glob（`*` → `.*`）的修改路径满足通配符。用于参数化集合被触动的批量章程声明。在 fw-4.7.1 中加入，源于 Sentinel CHARTER-04 暴露的摩擦（[issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)）。 |
+
+两种形式都双向处理：声明的通配符既抑制"已声明但未修改"警告（当至少一个匹配文件被修改时），也抑制"已修改但未声明"警告（当一个修改路径匹配某个已声明通配符时）。
+
+#### 设计：治理路径始终在 scope 内
+
+`docs/charters/*` 和 `.devtrail/07-ai-audit/*` 下的路径**永远不会**被报告为"已修改但未声明"。这是有意的设计 — 当章程本身或执行的 AILOG 被触动时，这些路径总是合法的。在 Sentinel CHARTER-04 中实证验证：一次意外的 `git add -A` 暂存了无关的用户未跟踪文件（`.claude/skills/`、`cmd/sentinel/sentinel`）；该规则正确抑制了治理噪声而没有掩盖真正的项目文件扩展（[issue #81 W2](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)）。
+
+如果你运行的章程显式 scope 是治理 churn（例如仅触动 `.devtrail/07-ai-audit/` 的批量批准章程），漂移检查将报告 0 个修改文件，你需要通过阅读 AILOG 来验证 scope。一个 `--strict-scope` 标志（禁用"始终在 scope"规则）在桌面上，用于未来 minor 版本，前提是真实的 adopter 报告这种不对称为摩擦。
+
+#### `devtrail charter audit <CHARTER-ID> [--range <REV..REV>] [--calibrate | --finalize] [--path <dir>]`
+
+*自 **cli-3.8.0** + **fw-4.7.0** 起可用（Phase 3 v0）。*
+
+编排章程执行的多模型外部审计。**仅编排** — CLI 准备 prompts、根据 schema 验证 outputs，并打印可粘贴到章程遥测中的 findings。**它不调用 LLM API。** 操作员在自己选择的审计器（Copilot、Gemini、Claude 等）中运行 prompts，并将响应保存到规范路径。
+
+三步，每步可独立调用：
+
+| 步骤 | 标志 | 发生什么 |
+|---|---|---|
+| 1. PREPARE | （默认） | 根据章程 + git diff + 来源 AILOGs 解析 `auditor-primary` 和 `auditor-secondary` prompts。写入到 `audit/charters/<CHARTER-ID>/prompts/` 之下。 |
+| 2. CALIBRATE | `--calibrate` | 读取 `auditor-primary.md` 和 `auditor-secondary.md`（操作员必须在步骤 1 和 2 之间保存它们）。根据 `audit-output.schema.v0.json` 验证。解析 calibrator prompt 并嵌入两个响应。 |
+| 3. FINALIZE | `--finalize` | 读取 calibrator 响应。验证全部 3 个 outputs。打印一个 YAML 格式的 `external_audit` 数组块，可粘贴到章程遥测中。 |
+
+| 参数/标志 | 默认值 | 描述 |
+|---|---|---|
+| `<CHARTER-ID>` | — | 与 `charter status` 相同的解析规则。 |
+| `--range` | `HEAD~1..HEAD` | 审计员将审查的 git 修订范围。 |
+| `--calibrate` | off | 运行步骤 2。与 `--finalize` 互斥。 |
+| `--finalize` | off | 运行步骤 3。与 `--calibrate` 互斥。 |
+| `--path` | `.` | 项目目录。 |
+
+##### 异质性建议（在 v0 中不强制）
+
+按照设计理由（`devtrail-cli-roadmap.md` §5.2），auditor pair 应该是**不同模型族**：一个 Anthropic + 一个 Google + 一个 OpenAI，任意组合，永远不要两个同族。跨族异质性是使 findings 上的趋同成为高信号的原因 — 同族审计员共享盲点。
+
+Calibrator-reconciler 可以是任何家族（包括实现者的家族），因为它的任务是定义性的（在已产生的判定上应用 schema），而非发现性。异质性对 auditor pair 重要，对 calibrator 不重要。
+
+v0 文档化此建议但不自动检测或强制。一个 `--implementer-family X` 标志（拒绝单色配置）是 v1 候选项，等到 adopter 报告真实情况。
+
+##### 产生的布局
+
+```
+audit/charters/CHARTER-NN/
+├── prompts/
+│   ├── auditor-primary.prompt.md      # 由步骤 1 解析，被发送的内容
+│   ├── auditor-secondary.prompt.md    # 由步骤 1 解析
+│   └── calibrator-reconciler.prompt.md  # 由步骤 2 解析
+├── auditor-primary.md                 # 操作员粘贴 auditor 1 的响应
+├── auditor-secondary.md               # 操作员粘贴 auditor 2 的响应
+└── calibrator-reconciler.md           # 操作员粘贴 calibrator 的响应
+```
+
+`prompts/` 子目录持久化 API 调用*之前*发送给每个 auditor 的内容（关闭关于审计可见性的 [RFC #82](https://github.com/StrangeDaysTech/devtrail/issues/82)）。Adopters 可以 `git add` 整个 `audit/` 目录得到完全版本化的审计轨迹，或 `.gitignore` 它（如果偏好周期是临时的）。
+
+**示例：**
+
+```bash
+$ devtrail charter audit CHARTER-05
+  Step 1/3: PREPARE (CHARTER-05)
+  ✔ Wrote audit/charters/CHARTER-05/prompts/auditor-primary.prompt.md
+  ✔ Wrote audit/charters/CHARTER-05/prompts/auditor-secondary.prompt.md
+
+  Next:
+    1. Paste each prompt into your auditor of choice (use a model
+       of a different family per auditor — see CLI-REFERENCE).
+    2. Save the auditor responses to:
+         audit/charters/CHARTER-05/auditor-primary.md
+         audit/charters/CHARTER-05/auditor-secondary.md
+    3. Run: devtrail charter audit CHARTER-05 --calibrate
+
+# (操作员在 Copilot 中运行 auditor 1，保存响应。在 Gemini 中运行 auditor 2，保存响应。)
+
+$ devtrail charter audit CHARTER-05 --calibrate
+  Step 2/3: CALIBRATE (CHARTER-05)
+  ✔ Validated audit/charters/CHARTER-05/auditor-primary.md
+  ✔ Validated audit/charters/CHARTER-05/auditor-secondary.md
+  ✔ Wrote audit/charters/CHARTER-05/prompts/calibrator-reconciler.prompt.md
+
+  Next:
+    1. Run the calibrator prompt in a model of your choice (calibrator
+       may be of any family).
+    2. Save the response to: audit/charters/CHARTER-05/calibrator-reconciler.md
+    3. Run: devtrail charter audit CHARTER-05 --finalize
+
+# (操作员在 Claude 中运行 calibrator，保存响应。)
+
+$ devtrail charter audit CHARTER-05 --finalize
+  Step 3/3: FINALIZE (CHARTER-05)
+  ✔ Validated audit/charters/CHARTER-05/auditor-primary.md (5 findings)
+  ✔ Validated audit/charters/CHARTER-05/auditor-secondary.md (4 findings)
+  ✔ Validated audit/charters/CHARTER-05/calibrator-reconciler.md
+
+  Charter audit complete.
+
+  external_audit YAML — paste into telemetry:
+    - auditor: "copilot-v1.0.37"
+      findings_total: 5
+      findings_by_category:
+        hallucination: 0
+        implementation_gap: 2
+        real_debt: 2
+        false_positive: 1
+      audit_quality: "high"
+      audit_notes: "see audit/charters/<charter-id>/auditor-primary.md"
+    - auditor: "gemini-cli-v1.5"
+      findings_total: 4
+      findings_by_category: ...
+
+  Calibrator summary (copy to outcome.scope_change_notes if relevant):
+    audit/charters/CHARTER-05/calibrator-reconciler.md
+```
+
+> **为什么仅编排？** 实现 3 个 HTTP 客户端（OpenAI / Google / Anthropic）需要 1-2 周 + 当 API 变化时的永久维护。Phase 3 v0 是实验性的 — CLI 的价值是 canon（prompt 形状 + output schema + 与遥测的集成），而非 API 调用本身。当 adopter 报告真实需求时，v1 可能加入 HTTP 客户端；在此之前，人在环模式与激发 Phase 3 的 Sentinel 实证 `/plan-audit` 模式相符。
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the documentation freshness audit performed against the post-Phase-3 shipped state (`fw-4.7.1` / `cli-3.8.1`). EN canonical was current; ES and zh-CN translations were 2 release cycles behind — Phase 2 (`cli-3.7.0`) and Phase 3 (`cli-3.8.0`) had never landed in translation. A literal future-tense claim ("La Fase 2 del CLI roadmap añadirá… / 第 2 阶段将增加…") survived from the v0.2 era and was misleading.

### What changed

- **EN canonical CLI-REFERENCE** — `--no-ailog-suppress` row now documents the `cli-3.8.1` O3 behavior (always emits an INFO line, including when N=0).
- **ES + zh-CN CLI-REFERENCE** (parallel changes ~170 lines each): added `init --hooks`, `validate --check-pending-reviews`/`--max-pending-days`, full `devtrail approve` section (RFC #67 closure), full `charter close` / `charter drift` / `charter audit` sections including the orchestration-only declaration (decision A1) and the wildcard subsection (`fw-4.7.1+`). Removed the future-tense "Phase 2/3 will add" sentences.
- **README (3 langs)** — `devtrail explore` description now mentions the Charter view.
- **`dist/docs/examples/README.md`** (NEW) — index of the 3 anonymized examples, explains the AILOG↔Charter pairing pattern, states that `devtrail init` does **not** install these (browse-only).

### No version bump

Pure docs sync. None of the touched paths are in `dist/dist-manifest.yml:files` (the manifest only ships `.devtrail/`, `DEVTRAIL.md`, agent skills, and the CI workflow). Adopters get the updated translations and example index by reading the upstream repo, not via `devtrail update-framework`.

## Test plan

- [x] Cross-language structural parity: all 3 CLI-REFERENCE files now have 1 `### devtrail approve` heading + 6 `#### devtrail charter <subcmd>` headings.
- [x] No future-tense Phase 2/3 claims remain in ES or zh-CN.
- [x] EN `--no-ailog-suppress` row mentions the INFO-line behavior + N=0 case.
- [x] `dist/docs/examples/README.md` exists and references all 3 example files.
- [x] No version-bump file edits (`cli/Cargo.toml`, `cli/Cargo.lock`, `dist/dist-manifest.yml` untouched).
- [ ] Manual rendering check on GitHub (translated tables and code blocks render correctly) — to verify after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)