### PR TITLE
feat(framework): Phase 1 PR 1 — skill devtrail-audit-prompt (3 platforms)

### DIFF
--- a/cli/tests/audit_skill_test.rs
+++ b/cli/tests/audit_skill_test.rs
@@ -1,0 +1,129 @@
+//! Sanity tests for the audit-related skills shipped under `dist/`.
+//!
+//! These tests verify that the skill files exist and have the expected
+//! frontmatter shape (Claude has `allowed-tools`, Gemini has `name` but no
+//! `allowed-tools`, agent workflow has only `description`). They run
+//! against the source tree, not against an `init`-ed project, because the
+//! manifest already includes the parent directories recursively — if the
+//! files exist in `dist/`, `init` will copy them.
+
+use std::path::PathBuf;
+
+fn dist_root() -> PathBuf {
+    // tests/ is at cli/tests/, dist/ is at the repo root.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir).join("..").join("dist")
+}
+
+fn read(path: PathBuf) -> String {
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("expected file to exist: {}", path.display()))
+}
+
+#[test]
+fn devtrail_audit_prompt_claude_skill_exists_and_has_allowed_tools() {
+    let body = read(
+        dist_root()
+            .join(".claude")
+            .join("skills")
+            .join("devtrail-audit-prompt")
+            .join("SKILL.md"),
+    );
+    assert!(body.starts_with("---\n"), "missing YAML frontmatter");
+    assert!(
+        body.contains("name: devtrail-audit-prompt"),
+        "missing name field"
+    );
+    assert!(
+        body.contains("allowed-tools:"),
+        "Claude skill must declare allowed-tools"
+    );
+    assert!(
+        body.contains("devtrail charter audit"),
+        "skill body must reference the CLI command it wraps"
+    );
+}
+
+#[test]
+fn devtrail_audit_prompt_gemini_skill_exists_without_allowed_tools() {
+    let body = read(
+        dist_root()
+            .join(".gemini")
+            .join("skills")
+            .join("devtrail-audit-prompt")
+            .join("SKILL.md"),
+    );
+    assert!(body.starts_with("---\n"), "missing YAML frontmatter");
+    assert!(
+        body.contains("name: devtrail-audit-prompt"),
+        "missing name field"
+    );
+    assert!(
+        !body.contains("allowed-tools:"),
+        "Gemini skill must not declare allowed-tools (no such field in Gemini skill schema)"
+    );
+}
+
+#[test]
+fn devtrail_audit_prompt_agent_workflow_exists_with_description_only() {
+    let body = read(
+        dist_root()
+            .join(".agent")
+            .join("workflows")
+            .join("devtrail-audit-prompt.md"),
+    );
+    assert!(body.starts_with("---\n"), "missing YAML frontmatter");
+    assert!(
+        !body.contains("name:"),
+        "agent workflow must not declare a name field (description-only frontmatter)"
+    );
+    assert!(
+        !body.contains("allowed-tools:"),
+        "agent workflow must not declare allowed-tools"
+    );
+    assert!(
+        body.contains("description:"),
+        "agent workflow must declare description"
+    );
+}
+
+#[test]
+fn devtrail_audit_prompt_three_platforms_share_core_guidance() {
+    let claude = read(
+        dist_root()
+            .join(".claude")
+            .join("skills")
+            .join("devtrail-audit-prompt")
+            .join("SKILL.md"),
+    );
+    let gemini = read(
+        dist_root()
+            .join(".gemini")
+            .join("skills")
+            .join("devtrail-audit-prompt")
+            .join("SKILL.md"),
+    );
+    let agent = read(
+        dist_root()
+            .join(".agent")
+            .join("workflows")
+            .join("devtrail-audit-prompt.md"),
+    );
+
+    // The next-steps guidance text is load-bearing for the workflow —
+    // the operator gets the same instructions regardless of platform.
+    for body in [&claude, &gemini, &agent] {
+        assert!(
+            body.contains("Run AUDITOR PRIMARY PROMPT"),
+            "next-steps guidance missing"
+        );
+        assert!(
+            body.contains("DO NOT use the same family for both"),
+            "heterogeneity recommendation missing"
+        );
+        assert!(
+            body.contains("/devtrail-audit-review"),
+            "skill must point operator at the follow-up review skill"
+        );
+    }
+}

--- a/dist/.agent/workflows/devtrail-audit-prompt.md
+++ b/dist/.agent/workflows/devtrail-audit-prompt.md
@@ -1,0 +1,90 @@
+---
+description: Prepare external multi-model audit for a Charter. Generates auditor prompts inline so the operator can paste them into 2 LLM auditors of different families.
+---
+
+# DevTrail Audit Prompt Workflow
+
+Generate prompts for external multi-model audit of a Charter, surfaced inline in the conversation so the operator can paste them into auditors of two different model families without leaving the chat.
+
+## When to invoke
+
+Use this workflow when the developer agreed to run an external audit at the Charter checkpoint (see `.devtrail/00-governance/AGENT-RULES.md` § Audit checkpoint, available from `fw-4.8.0`).
+
+The Charter should be in `in-progress` or `declared` status — auditing closed Charters is allowed but atypical (warn the operator and proceed only on confirmation).
+
+## Instructions
+
+### 1. Resolve the Charter
+
+Argument: a Charter identifier (`CHARTER-04`, `04`, or the full id with slug).
+
+```bash
+devtrail charter status <CHARTER-ID>
+```
+
+Verify the Charter exists and capture its `status`. If `status: closed`, surface a one-line warning to the operator and ask whether to proceed.
+
+### 2. Generate the auditor prompts (PREPARE step)
+
+```bash
+devtrail charter audit <CHARTER-ID>
+```
+
+The CLI writes the resolved prompts to disk:
+
+- `audit/charters/<CHARTER-ID>/prompts/auditor-primary.prompt.md`
+- `audit/charters/<CHARTER-ID>/prompts/auditor-secondary.prompt.md`
+
+This is `devtrail charter audit` step 1 (PREPARE). The CLI does NOT invoke any LLM — it only resolves placeholders against the Charter content, the git diff, and the originating AILOGs.
+
+### 3. Surface the prompts inline
+
+Read both files and print their contents in the conversation, with clear separators:
+
+```
+═══════════════════ AUDITOR PRIMARY PROMPT ═══════════════════
+[full contents of auditor-primary.prompt.md]
+══════════════════════════════════════════════════════════════
+
+═══════════════════ AUDITOR SECONDARY PROMPT ═════════════════
+[full contents of auditor-secondary.prompt.md]
+══════════════════════════════════════════════════════════════
+```
+
+Do not summarise or truncate. The operator needs the full prompts to paste into the external auditors as-is.
+
+### 4. Provide next-steps guidance
+
+After surfacing the prompts, print this guidance verbatim (substituting `<CHARTER-ID>`):
+
+```
+Next steps:
+
+  1. Run AUDITOR PRIMARY PROMPT in a model of family A
+     (e.g., Anthropic — claude-sonnet-4-6 or claude-opus-4-7).
+
+  2. Run AUDITOR SECONDARY PROMPT in a model of family B
+     (e.g., Google — gemini-2.5-pro, or OpenAI — gpt-4o / Copilot).
+     DO NOT use the same family for both. Heterogeneity inter-family
+     is what makes convergent findings high-signal — same-family
+     auditors share blind spots.
+
+  3. Save the auditor responses to canonical paths:
+       audit/charters/<CHARTER-ID>/auditor-primary.md
+       audit/charters/<CHARTER-ID>/auditor-secondary.md
+
+  4. Return with: /devtrail-audit-review <CHARTER-ID>
+     I will calibrate the responses, generate the calibrator analysis
+     locally, and merge the findings into the Charter telemetry.
+```
+
+## Output schema for auditor responses
+
+The `auditor-primary.md` and `auditor-secondary.md` files the operator saves must follow `audit-output.schema.v0.json` (validated by `devtrail charter audit --calibrate`). The required frontmatter is documented inside each prompt — the operator should preserve it when pasting the LLM response.
+
+## Notes
+
+- This workflow is **orchestration-only**. It does NOT invoke LLM APIs, decide which models the operator uses, or wait for responses. It surfaces prompts and exits.
+- Re-running on the same Charter regenerates the prompts (idempotent at the prompt level). It does NOT overwrite operator-saved responses in `auditor-primary.md` / `auditor-secondary.md`.
+- Heterogeneity inter-family is recommended but not enforced in v0. The operator decides the model pairing; the workflow surfaces the recommendation in the next-steps guidance.
+- For the rationale on why dual auditors of different families produce calibration that mono-auditor cannot, see `dist/.devtrail/audit-prompts/auditor-primary.md` § heterogeneity (or `Propuesta/devtrail-cli-roadmap.md` §5.2 in the upstream repo).

--- a/dist/.claude/skills/devtrail-audit-prompt/SKILL.md
+++ b/dist/.claude/skills/devtrail-audit-prompt/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: devtrail-audit-prompt
+description: Prepare external multi-model audit for a Charter. Generates auditor prompts inline so the operator can paste them into 2 LLM auditors of different families.
+allowed-tools: Read, Bash(devtrail charter audit *, devtrail charter status *, ls *)
+---
+
+# DevTrail Audit Prompt Skill
+
+Generate prompts for external multi-model audit of a Charter, surfaced inline in the conversation so the operator can paste them into auditors of two different model families without leaving the chat.
+
+## When to invoke
+
+Use this skill when the developer agreed to run an external audit at the Charter checkpoint (see `.devtrail/00-governance/AGENT-RULES.md` § Audit checkpoint, available from `fw-4.8.0`).
+
+The Charter should be in `in-progress` or `declared` status — auditing closed Charters is allowed but atypical (warn the operator and proceed only on confirmation).
+
+## Instructions
+
+### 1. Resolve the Charter
+
+Argument: a Charter identifier (`CHARTER-04`, `04`, or the full id with slug).
+
+```bash
+devtrail charter status <CHARTER-ID>
+```
+
+Verify the Charter exists and capture its `status`. If `status: closed`, surface a one-line warning to the operator and ask whether to proceed.
+
+### 2. Generate the auditor prompts (PREPARE step)
+
+```bash
+devtrail charter audit <CHARTER-ID>
+```
+
+The CLI writes the resolved prompts to disk:
+
+- `audit/charters/<CHARTER-ID>/prompts/auditor-primary.prompt.md`
+- `audit/charters/<CHARTER-ID>/prompts/auditor-secondary.prompt.md`
+
+This is `devtrail charter audit` step 1 (PREPARE). The CLI does NOT invoke any LLM — it only resolves placeholders against the Charter content, the git diff, and the originating AILOGs.
+
+### 3. Surface the prompts inline
+
+Read both files and print their contents in the conversation, with clear separators:
+
+```
+═══════════════════ AUDITOR PRIMARY PROMPT ═══════════════════
+[full contents of auditor-primary.prompt.md]
+══════════════════════════════════════════════════════════════
+
+═══════════════════ AUDITOR SECONDARY PROMPT ═════════════════
+[full contents of auditor-secondary.prompt.md]
+══════════════════════════════════════════════════════════════
+```
+
+Do not summarise or truncate. The operator needs the full prompts to paste into the external auditors as-is.
+
+### 4. Provide next-steps guidance
+
+After surfacing the prompts, print this guidance verbatim (substituting `<CHARTER-ID>`):
+
+```
+Next steps:
+
+  1. Run AUDITOR PRIMARY PROMPT in a model of family A
+     (e.g., Anthropic — claude-sonnet-4-6 or claude-opus-4-7).
+
+  2. Run AUDITOR SECONDARY PROMPT in a model of family B
+     (e.g., Google — gemini-2.5-pro, or OpenAI — gpt-4o / Copilot).
+     DO NOT use the same family for both. Heterogeneity inter-family
+     is what makes convergent findings high-signal — same-family
+     auditors share blind spots.
+
+  3. Save the auditor responses to canonical paths:
+       audit/charters/<CHARTER-ID>/auditor-primary.md
+       audit/charters/<CHARTER-ID>/auditor-secondary.md
+
+  4. Return with: /devtrail-audit-review <CHARTER-ID>
+     I will calibrate the responses, generate the calibrator analysis
+     locally, and merge the findings into the Charter telemetry.
+```
+
+## Output schema for auditor responses
+
+The `auditor-primary.md` and `auditor-secondary.md` files the operator saves must follow `audit-output.schema.v0.json` (validated by `devtrail charter audit --calibrate`). The required frontmatter is documented inside each prompt — the operator should preserve it when pasting the LLM response.
+
+## Notes
+
+- This skill is **orchestration-only**. It does NOT invoke LLM APIs, decide which models the operator uses, or wait for responses. It surfaces prompts and exits.
+- Re-running the skill on the same Charter regenerates the prompts (idempotent at the prompt level). It does NOT overwrite operator-saved responses in `auditor-primary.md` / `auditor-secondary.md`.
+- Heterogeneity inter-family is recommended but not enforced in v0. The operator decides the model pairing; the skill surfaces the recommendation in the next-steps guidance.
+- For the rationale on why dual auditors of different families produce calibration that mono-auditor cannot, see `dist/.devtrail/audit-prompts/auditor-primary.md` § heterogeneity (or `Propuesta/devtrail-cli-roadmap.md` §5.2 in the upstream repo).

--- a/dist/.gemini/skills/devtrail-audit-prompt/SKILL.md
+++ b/dist/.gemini/skills/devtrail-audit-prompt/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: devtrail-audit-prompt
+description: Prepare external multi-model audit for a Charter. Generates auditor prompts inline so the operator can paste them into 2 LLM auditors of different families.
+---
+
+# DevTrail Audit Prompt Skill
+
+Generate prompts for external multi-model audit of a Charter, surfaced inline in the conversation so the operator can paste them into auditors of two different model families without leaving the chat.
+
+## When to invoke
+
+Use this skill when the developer agreed to run an external audit at the Charter checkpoint (see `.devtrail/00-governance/AGENT-RULES.md` § Audit checkpoint, available from `fw-4.8.0`).
+
+The Charter should be in `in-progress` or `declared` status — auditing closed Charters is allowed but atypical (warn the operator and proceed only on confirmation).
+
+## Instructions
+
+### 1. Resolve the Charter
+
+Argument: a Charter identifier (`CHARTER-04`, `04`, or the full id with slug).
+
+```bash
+devtrail charter status <CHARTER-ID>
+```
+
+Verify the Charter exists and capture its `status`. If `status: closed`, surface a one-line warning to the operator and ask whether to proceed.
+
+### 2. Generate the auditor prompts (PREPARE step)
+
+```bash
+devtrail charter audit <CHARTER-ID>
+```
+
+The CLI writes the resolved prompts to disk:
+
+- `audit/charters/<CHARTER-ID>/prompts/auditor-primary.prompt.md`
+- `audit/charters/<CHARTER-ID>/prompts/auditor-secondary.prompt.md`
+
+This is `devtrail charter audit` step 1 (PREPARE). The CLI does NOT invoke any LLM — it only resolves placeholders against the Charter content, the git diff, and the originating AILOGs.
+
+### 3. Surface the prompts inline
+
+Read both files and print their contents in the conversation, with clear separators:
+
+```
+═══════════════════ AUDITOR PRIMARY PROMPT ═══════════════════
+[full contents of auditor-primary.prompt.md]
+══════════════════════════════════════════════════════════════
+
+═══════════════════ AUDITOR SECONDARY PROMPT ═════════════════
+[full contents of auditor-secondary.prompt.md]
+══════════════════════════════════════════════════════════════
+```
+
+Do not summarise or truncate. The operator needs the full prompts to paste into the external auditors as-is.
+
+### 4. Provide next-steps guidance
+
+After surfacing the prompts, print this guidance verbatim (substituting `<CHARTER-ID>`):
+
+```
+Next steps:
+
+  1. Run AUDITOR PRIMARY PROMPT in a model of family A
+     (e.g., Anthropic — claude-sonnet-4-6 or claude-opus-4-7).
+
+  2. Run AUDITOR SECONDARY PROMPT in a model of family B
+     (e.g., Google — gemini-2.5-pro, or OpenAI — gpt-4o / Copilot).
+     DO NOT use the same family for both. Heterogeneity inter-family
+     is what makes convergent findings high-signal — same-family
+     auditors share blind spots.
+
+  3. Save the auditor responses to canonical paths:
+       audit/charters/<CHARTER-ID>/auditor-primary.md
+       audit/charters/<CHARTER-ID>/auditor-secondary.md
+
+  4. Return with: /devtrail-audit-review <CHARTER-ID>
+     I will calibrate the responses, generate the calibrator analysis
+     locally, and merge the findings into the Charter telemetry.
+```
+
+## Output schema for auditor responses
+
+The `auditor-primary.md` and `auditor-secondary.md` files the operator saves must follow `audit-output.schema.v0.json` (validated by `devtrail charter audit --calibrate`). The required frontmatter is documented inside each prompt — the operator should preserve it when pasting the LLM response.
+
+## Notes
+
+- This skill is **orchestration-only**. It does NOT invoke LLM APIs, decide which models the operator uses, or wait for responses. It surfaces prompts and exits.
+- Re-running the skill on the same Charter regenerates the prompts (idempotent at the prompt level). It does NOT overwrite operator-saved responses in `auditor-primary.md` / `auditor-secondary.md`.
+- Heterogeneity inter-family is recommended but not enforced in v0. The operator decides the model pairing; the skill surfaces the recommendation in the next-steps guidance.
+- For the rationale on why dual auditors of different families produce calibration that mono-auditor cannot, see `dist/.devtrail/audit-prompts/auditor-primary.md` § heterogeneity (or `Propuesta/devtrail-cli-roadmap.md` §5.2 in the upstream repo).


### PR DESCRIPTION
## Summary

First of 5 PRs implementing **Phase 1** of `Propuesta/devtrail-audit-skills.md` (audit skills + checkpoint guidance). This PR adds the `devtrail-audit-prompt` skill on the 3 supported platforms (Claude / Gemini / generic agent), wrapping the existing `devtrail charter audit` PREPARE step so the operator gets the resolved auditor prompts inline in the conversation rather than having to open files manually.

Per the propuesta §3.1, the skill is **orchestration-only**:

- It delegates prompt resolution to `devtrail charter audit <CHARTER-ID>` (the CLI is the single source of truth for the templates in `dist/.devtrail/audit-prompts/`).
- It reads the resolved files and surfaces them inline with clear separators.
- It prints next-steps guidance: which model families to use (heterogeneity inter-family recommended, not enforced in v0), where to save responses, and how to return via `/devtrail-audit-review` (PR 2).

## Files

- `dist/.claude/skills/devtrail-audit-prompt/SKILL.md` — frontmatter has `allowed-tools` (Claude convention).
- `dist/.gemini/skills/devtrail-audit-prompt/SKILL.md` — frontmatter without `allowed-tools` (Gemini schema).
- `dist/.agent/workflows/devtrail-audit-prompt.md` — description-only frontmatter (generic agent).
- `cli/tests/audit_skill_test.rs` — 4 sanity tests covering file existence, per-platform frontmatter shape, and cross-platform parity of the load-bearing next-steps guidance.

## What this PR does NOT do

- No `dist-manifest.yml` change — the parent directories are already recursively included.
- No version bump — that lands in Phase 1 PR 5.
- No CHANGELOG entry — sections are written at release time.

## Test plan

- [x] `cargo test --test audit_skill_test` → 4/4 green
- [x] `cargo test` (full suite) → 26 existing + 4 new = 30/30 green
- [x] No regressions in existing skill files (only new files added)

## Phase 1 progress

| PR | Title | Status |
|---|---|---|
| 1 | Skill `devtrail-audit-prompt` + tests | **this PR** |
| 2 | Skill `devtrail-audit-review` + CLI `--merge-into` flag | pending |
| 3 | Checkpoint guidance in `AGENT-RULES.md` (3 langs) + fixture tests | pending |
| 4 | Adopter docs (WORKFLOWS / CLI-REFERENCE / ADOPTION-GUIDE / QUICK-REFERENCE in 3 langs) | pending |
| 5 | Bump `fw-X.Y.0` + CHANGELOG + tag release | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)