### PR TITLE
feat: Phase 1 PR 2 — devtrail-audit-review skill + CLI --merge-into flag

### DIFF
--- a/cli/src/commands/charter/audit.rs
+++ b/cli/src/commands/charter/audit.rs
@@ -41,9 +41,13 @@ pub fn run(
     range: Option<&str>,
     calibrate: bool,
     finalize: bool,
+    merge_into: Option<&str>,
 ) -> Result<()> {
     if calibrate && finalize {
         bail!("--calibrate and --finalize are mutually exclusive — run one at a time");
+    }
+    if merge_into.is_some() && !finalize {
+        bail!("--merge-into is only valid with --finalize");
     }
 
     let resolved = utils::resolve_project_root(path)
@@ -69,7 +73,14 @@ pub fn run(
     let range = range.unwrap_or(DEFAULT_RANGE).to_string();
 
     if finalize {
-        return run_finalize(project_root, &devtrail_dir, &audit_dir, &charter);
+        return run_finalize(
+            project_root,
+            &devtrail_dir,
+            &audit_dir,
+            &charter,
+            &canonical_id,
+            merge_into.map(Path::new),
+        );
     }
     if calibrate {
         return run_calibrate(
@@ -276,6 +287,8 @@ fn run_finalize(
     devtrail_dir: &Path,
     audit_dir: &Path,
     charter: &Charter,
+    canonical_id: &str,
+    merge_into: Option<&Path>,
 ) -> Result<()> {
     println!(
         "{} {} ({})",
@@ -346,16 +359,102 @@ fn run_finalize(
     println!();
     println!("  {}", "Charter audit complete.".green().bold());
     println!();
-    println!("  {}", "external_audit YAML — paste into telemetry:".bold());
-    println!("  {}", "(charter_telemetry.external_audit array)".dimmed());
-    println!();
-    println!("{}", render_external_audit_yaml(&auditor_summaries));
-    println!();
-    println!("  {}", "Calibrator summary (copy to outcome.scope_change_notes if relevant):".dimmed());
+
+    if let Some(target) = merge_into {
+        merge_external_audit_into(target, &auditor_summaries, canonical_id)?;
+        println!(
+            "  {} Merged external_audit array into {}",
+            "✔".green().bold(),
+            relative_path(project_root, target).display()
+        );
+        println!();
+        println!(
+            "  {}",
+            "Run `git diff` on the telemetry file to review the merge before commit.".dimmed()
+        );
+    } else {
+        println!("  {}", "external_audit YAML — paste into telemetry:".bold());
+        println!("  {}", "(charter_telemetry.external_audit array)".dimmed());
+        println!();
+        println!("{}", render_external_audit_yaml(&auditor_summaries, canonical_id));
+        println!();
+    }
+    println!(
+        "  {}",
+        "Calibrator summary (copy to outcome.scope_change_notes if relevant):".dimmed()
+    );
     println!(
         "  {}",
         relative_path(project_root, &calibrator_path).display().to_string().dimmed()
     );
+    Ok(())
+}
+
+/// Append a freshly-rendered `external_audit:` block to an existing Charter
+/// telemetry YAML. v0 deliberately rejects re-audit (file already has the
+/// key) so the operator can reconcile manually rather than silently
+/// duplicating findings.
+fn merge_external_audit_into(
+    telemetry_path: &Path,
+    auditor_summaries: &[AuditorSummary],
+    canonical_charter_id: &str,
+) -> Result<()> {
+    if !telemetry_path.exists() {
+        bail!(
+            "Telemetry file not found: {}\n  \
+             Run `devtrail charter close <CHARTER-ID>` first to create the telemetry,\n  \
+             then re-run with --merge-into. Or omit --merge-into to print the YAML\n  \
+             for manual paste.",
+            telemetry_path.display()
+        );
+    }
+
+    let mut content = std::fs::read_to_string(telemetry_path)
+        .with_context(|| format!("Failed to read {}", telemetry_path.display()))?;
+
+    // Sanity: must parse as YAML.
+    let _: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("{} is not valid YAML", telemetry_path.display()))?;
+
+    if !content.contains("charter_telemetry:") {
+        bail!(
+            "{} does not have a top-level `charter_telemetry:` key — \
+             expected the standard charter close output shape.",
+            telemetry_path.display()
+        );
+    }
+
+    // v0: re-audit (appending to existing array) is not supported. Detect
+    // the key at indent 0 or 2 and bail with guidance.
+    if content.contains("\n  external_audit:")
+        || content.contains("\nexternal_audit:")
+        || content.starts_with("  external_audit:")
+        || content.starts_with("external_audit:")
+    {
+        bail!(
+            "{} already has an `external_audit:` block. Re-audit (appending\n  \
+             to an existing array) is not supported in v0. Re-run\n  \
+             `devtrail charter audit <id> --finalize` (without --merge-into) to\n  \
+             print the new YAML, then merge manually if you want to append.",
+            telemetry_path.display()
+        );
+    }
+
+    while content.ends_with("\n\n") {
+        content.pop();
+    }
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    content.push_str("\n  external_audit:\n");
+    content.push_str(&render_external_audit_yaml(
+        auditor_summaries,
+        canonical_charter_id,
+    ));
+
+    std::fs::write(telemetry_path, &content)
+        .with_context(|| format!("Failed to write {}", telemetry_path.display()))?;
     Ok(())
 }
 
@@ -557,9 +656,9 @@ impl AuditorSummary {
     }
 }
 
-fn render_external_audit_yaml(summaries: &[AuditorSummary]) -> String {
+fn render_external_audit_yaml(summaries: &[AuditorSummary], canonical_charter_id: &str) -> String {
     let mut out = String::new();
-    for s in summaries {
+    for (idx, s) in summaries.iter().enumerate() {
         out.push_str(&format!("    - auditor: \"{}\"\n", s.auditor));
         out.push_str(&format!("      findings_total: {}\n", s.findings_total));
         out.push_str("      findings_by_category:\n");
@@ -575,14 +674,16 @@ fn render_external_audit_yaml(summaries: &[AuditorSummary]) -> String {
         if let Some(quality) = &s.audit_quality {
             out.push_str(&format!("      audit_quality: \"{}\"\n", quality));
         }
+        // First summary maps to auditor-primary.md, second to
+        // auditor-secondary.md — that's the order finalize reads them in.
+        let role_file = if idx == 0 {
+            "auditor-primary"
+        } else {
+            "auditor-secondary"
+        };
         out.push_str(&format!(
             "      audit_notes: \"see audit/charters/{}/{}.md\"\n",
-            "<charter-id>",
-            if s.auditor.contains("primary") || s.findings_total > 0 {
-                "auditor-primary"
-            } else {
-                "auditor-secondary"
-            }
+            canonical_charter_id, role_file
         ));
     }
     out

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -330,6 +330,12 @@ enum CharterCommands {
         /// telemetry.
         #[arg(long, conflicts_with = "calibrate")]
         finalize: bool,
+        /// On --finalize only: append the external_audit array directly into
+        /// the Charter's telemetry YAML at the given path instead of printing
+        /// it to stdout. Re-audit (file already has external_audit) is
+        /// rejected with a clear error in v0.
+        #[arg(long, requires = "finalize")]
+        merge_into: Option<String>,
         /// Project directory (default: current directory)
         #[arg(long = "path", default_value = ".")]
         path: String,
@@ -481,6 +487,7 @@ fn main() {
                 range,
                 calibrate,
                 finalize,
+                merge_into,
                 path,
             } => commands::charter::audit::run(
                 &path,
@@ -488,6 +495,7 @@ fn main() {
                 range.as_deref(),
                 calibrate,
                 finalize,
+                merge_into.as_deref(),
             ),
         },
     };

--- a/cli/tests/audit_skill_test.rs
+++ b/cli/tests/audit_skill_test.rs
@@ -127,3 +127,115 @@ fn devtrail_audit_prompt_three_platforms_share_core_guidance() {
         );
     }
 }
+
+// ── devtrail-audit-review (PR 2) ───────────────────────────────────────────
+
+#[test]
+fn devtrail_audit_review_claude_skill_exists_and_has_allowed_tools() {
+    let body = read(
+        dist_root()
+            .join(".claude")
+            .join("skills")
+            .join("devtrail-audit-review")
+            .join("SKILL.md"),
+    );
+    assert!(body.starts_with("---\n"), "missing YAML frontmatter");
+    assert!(
+        body.contains("name: devtrail-audit-review"),
+        "missing name field"
+    );
+    assert!(
+        body.contains("allowed-tools:"),
+        "Claude skill must declare allowed-tools"
+    );
+    assert!(
+        body.contains("--merge-into"),
+        "skill body must reference the CLI flag it wraps"
+    );
+}
+
+#[test]
+fn devtrail_audit_review_gemini_skill_exists_without_allowed_tools() {
+    let body = read(
+        dist_root()
+            .join(".gemini")
+            .join("skills")
+            .join("devtrail-audit-review")
+            .join("SKILL.md"),
+    );
+    assert!(body.starts_with("---\n"), "missing YAML frontmatter");
+    assert!(
+        body.contains("name: devtrail-audit-review"),
+        "missing name field"
+    );
+    assert!(
+        !body.contains("allowed-tools:"),
+        "Gemini skill must not declare allowed-tools"
+    );
+}
+
+#[test]
+fn devtrail_audit_review_agent_workflow_exists_with_description_only() {
+    let body = read(
+        dist_root()
+            .join(".agent")
+            .join("workflows")
+            .join("devtrail-audit-review.md"),
+    );
+    assert!(body.starts_with("---\n"), "missing YAML frontmatter");
+    assert!(
+        !body.contains("name:"),
+        "agent workflow must not declare a name field"
+    );
+    assert!(
+        !body.contains("allowed-tools:"),
+        "agent workflow must not declare allowed-tools"
+    );
+    assert!(
+        body.contains("description:"),
+        "agent workflow must declare description"
+    );
+}
+
+#[test]
+fn devtrail_audit_review_three_platforms_share_core_guidance() {
+    let claude = read(
+        dist_root()
+            .join(".claude")
+            .join("skills")
+            .join("devtrail-audit-review")
+            .join("SKILL.md"),
+    );
+    let gemini = read(
+        dist_root()
+            .join(".gemini")
+            .join("skills")
+            .join("devtrail-audit-review")
+            .join("SKILL.md"),
+    );
+    let agent = read(
+        dist_root()
+            .join(".agent")
+            .join("workflows")
+            .join("devtrail-audit-review.md"),
+    );
+
+    for body in [&claude, &gemini, &agent] {
+        assert!(
+            body.contains("--calibrate"),
+            "skill must reference the CALIBRATE step"
+        );
+        assert!(
+            body.contains("--finalize"),
+            "skill must reference the FINALIZE step"
+        );
+        assert!(
+            body.contains("external-audit-pending.yaml"),
+            "skill must handle the Branch B (telemetry not yet present) case"
+        );
+        assert!(
+            body.contains("re-audit") || body.contains("re-merge"),
+            "skill must surface the v0 re-audit limitation"
+        );
+    }
+}

--- a/cli/tests/charter_audit_test.rs
+++ b/cli/tests/charter_audit_test.rs
@@ -413,3 +413,242 @@ fn audit_calibrate_and_finalize_are_mutually_exclusive() {
         .assert()
         .failure();
 }
+
+// ── --merge-into: PR 2 of audit-skills rollout ─────────────────────────────
+
+/// Set up a Charter that has been fully audited (3 outputs present), so we
+/// can drive --finalize repeatedly with different --merge-into targets.
+fn setup_finalized_audit(dir: &Path) {
+    setup_devtrail(dir);
+    write_charter(dir);
+    init_repo_with_diff(dir);
+
+    // PREPARE
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args(["charter", "audit", "CHARTER-01", "--path"])
+        .arg(dir.to_str().unwrap())
+        .assert()
+        .success();
+
+    let audit_dir = dir.join("audit/charters/CHARTER-01");
+    std::fs::write(
+        audit_dir.join("auditor-primary.md"),
+        r#"---
+audit_role: auditor-primary
+auditor: copilot-v1.0.37
+charter_id: CHARTER-01
+git_range: "HEAD~1..HEAD"
+prompt_used: prompts/auditor-primary.prompt.md
+audited_at: "2026-05-03"
+findings_total: 2
+findings_by_category:
+  hallucination: 0
+  implementation_gap: 1
+  real_debt: 1
+  false_positive: 0
+audit_quality: high
+---
+# Body
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        audit_dir.join("auditor-secondary.md"),
+        r#"---
+audit_role: auditor-secondary
+auditor: gemini-cli-v1.5
+charter_id: CHARTER-01
+git_range: "HEAD~1..HEAD"
+prompt_used: prompts/auditor-secondary.prompt.md
+audited_at: "2026-05-03"
+findings_total: 1
+findings_by_category:
+  hallucination: 0
+  implementation_gap: 1
+  real_debt: 0
+  false_positive: 0
+audit_quality: medium
+---
+# Body
+"#,
+    )
+    .unwrap();
+
+    // CALIBRATE (the CLI writes calibrator-reconciler.prompt.md but here we
+    // just simulate the operator pasting the calibrator response directly).
+    std::fs::write(
+        audit_dir.join("calibrator-reconciler.md"),
+        r#"---
+audit_role: calibrator-reconciler
+calibrator: claude-opus-4
+charter_id: CHARTER-01
+git_range: "HEAD~1..HEAD"
+prompt_used: prompts/calibrator-reconciler.prompt.md
+calibrated_at: "2026-05-03"
+auditors_reconciled:
+  - auditor-primary.md
+  - auditor-secondary.md
+findings_consolidated: 2
+findings_by_status:
+  agreed: 1
+  disputed: 0
+  unique_primary: 1
+  unique_secondary: 0
+  rejected: 0
+---
+# Body
+"#,
+    )
+    .unwrap();
+}
+
+/// Build a minimal Charter telemetry file (the shape charter close emits).
+fn write_minimal_telemetry(dir: &Path) -> std::path::PathBuf {
+    let path = dir
+        .join(".devtrail/charters/CHARTER-01.telemetry.yaml");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"charter_telemetry:
+  charter_id: "CHARTER-01"
+  charter_title: "Audit test"
+  closed_at: "2026-05-03"
+
+  trigger:
+    declared_kind: "manual"
+    declared_description: "test"
+    fired_at: "2026-05-03"
+    fire_clarity: "clear"
+    fire_clarity_notes: ""
+"#,
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn audit_merge_into_appends_external_audit_to_telemetry() {
+    if !bash_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_finalized_audit(dir.path());
+    let telemetry_path = write_minimal_telemetry(dir.path());
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "audit",
+            "CHARTER-01",
+            "--finalize",
+            "--merge-into",
+            telemetry_path.to_str().unwrap(),
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Merged external_audit"));
+
+    let merged = std::fs::read_to_string(&telemetry_path).unwrap();
+    assert!(
+        merged.contains("\n  external_audit:\n"),
+        "external_audit block must be appended at indent 2:\n{merged}"
+    );
+    assert!(
+        merged.contains("    - auditor: \"copilot-v1.0.37\""),
+        "primary auditor present in merged output"
+    );
+    assert!(
+        merged.contains("    - auditor: \"gemini-cli-v1.5\""),
+        "secondary auditor present in merged output"
+    );
+    assert!(
+        merged.contains("audit/charters/CHARTER-01/auditor-primary.md"),
+        "audit_notes must reference real charter id (not <charter-id> placeholder)"
+    );
+    // Pre-existing keys preserved.
+    assert!(merged.contains("charter_id: \"CHARTER-01\""));
+    assert!(merged.contains("trigger:"));
+}
+
+#[test]
+fn audit_merge_into_missing_telemetry_fails_with_helpful_message() {
+    if !bash_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_finalized_audit(dir.path());
+    let missing = dir.path().join(".devtrail/charters/CHARTER-01.telemetry.yaml");
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "audit",
+            "CHARTER-01",
+            "--finalize",
+            "--merge-into",
+            missing.to_str().unwrap(),
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Telemetry file not found"))
+        .stderr(predicate::str::contains("devtrail charter close"));
+}
+
+#[test]
+fn audit_merge_into_rejects_existing_external_audit() {
+    if !bash_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_finalized_audit(dir.path());
+    let telemetry_path = write_minimal_telemetry(dir.path());
+
+    // Pre-populate external_audit so re-audit guard fires.
+    let mut existing = std::fs::read_to_string(&telemetry_path).unwrap();
+    existing.push_str("\n  external_audit:\n    - auditor: \"old-auditor\"\n      findings_total: 0\n");
+    std::fs::write(&telemetry_path, &existing).unwrap();
+
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "audit",
+            "CHARTER-01",
+            "--finalize",
+            "--merge-into",
+            telemetry_path.to_str().unwrap(),
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already has an `external_audit:`"));
+}
+
+#[test]
+fn audit_merge_into_requires_finalize() {
+    let dir = TempDir::new().unwrap();
+    setup_devtrail(dir.path());
+
+    // Without --finalize, clap should reject --merge-into.
+    Command::cargo_bin("devtrail")
+        .unwrap()
+        .args([
+            "charter",
+            "audit",
+            "CHARTER-01",
+            "--merge-into",
+            "/tmp/whatever.yaml",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure();
+}

--- a/dist/.agent/workflows/devtrail-audit-review.md
+++ b/dist/.agent/workflows/devtrail-audit-review.md
@@ -1,0 +1,107 @@
+---
+description: Calibrate the responses of two external auditors and merge findings into the Charter telemetry. Counterpart to /devtrail-audit-prompt — invoke after the operator has saved the auditor responses.
+---
+
+# DevTrail Audit Review Skill
+
+Reconcile the responses of two external auditors and produce the calibrator analysis. When the Charter has telemetry, append the consolidated `external_audit:` array directly into the YAML so the operator does not have to copy/paste.
+
+## When to invoke
+
+After running `/devtrail-audit-prompt <CHARTER-ID>`, having pasted both prompts into LLMs of different families, and saved the responses to:
+
+- `audit/charters/<CHARTER-ID>/auditor-primary.md`
+- `audit/charters/<CHARTER-ID>/auditor-secondary.md`
+
+This skill produces the calibrator response and merges findings into telemetry.
+
+## Instructions
+
+### 1. Verify auditor responses exist
+
+```bash
+ls audit/charters/<CHARTER-ID>/auditor-primary.md \
+   audit/charters/<CHARTER-ID>/auditor-secondary.md
+```
+
+If either file is missing, instruct the operator to run `/devtrail-audit-prompt <CHARTER-ID>` first and exit.
+
+### 2. Resolve the calibrator prompt (CALIBRATE step)
+
+```bash
+devtrail charter audit <CHARTER-ID> --calibrate
+```
+
+The CLI:
+- Validates `auditor-primary.md` and `auditor-secondary.md` against `audit-output.schema.v0.json`. If validation fails, surface the error to the operator and exit — the auditor response frontmatter must follow the schema documented inside each prompt.
+- Writes `audit/charters/<CHARTER-ID>/prompts/calibrator-reconciler.prompt.md`.
+
+### 3. Run the calibrator inline (this conversation IS the calibrator)
+
+The calibrator-reconciler prompt is designed to run in any model family — the agent currently in this conversation can produce the calibrator response directly. Heterogeneity inter-family is required for the auditor pair, NOT for the calibrator (the calibrator's task is definitional, not discovery — see `Propuesta/devtrail-cli-roadmap.md` §5.2 for the rationale).
+
+Read the resolved prompt:
+
+```bash
+cat audit/charters/<CHARTER-ID>/prompts/calibrator-reconciler.prompt.md
+```
+
+Produce the response **following the prompt's output schema exactly** — the frontmatter is required (`audit_role: calibrator-reconciler`, `calibrator: <model-id>`, `auditors_reconciled`, `findings_consolidated`, `findings_by_status`). Save to:
+
+- `audit/charters/<CHARTER-ID>/calibrator-reconciler.md`
+
+### 4. Finalize and merge into telemetry
+
+Determine the telemetry path: `.devtrail/charters/<CHARTER-ID>.telemetry.yaml` (canonical form, `<CHARTER-ID>` without slug).
+
+```bash
+test -f .devtrail/charters/<CHARTER-ID>.telemetry.yaml
+```
+
+**Branch A — telemetry exists** (operator has already run `devtrail charter close`):
+
+```bash
+devtrail charter audit <CHARTER-ID> --finalize \
+  --merge-into .devtrail/charters/<CHARTER-ID>.telemetry.yaml
+```
+
+The CLI validates all 3 outputs and appends `external_audit:` to the telemetry YAML directly. **Do NOT** edit the YAML by hand afterwards — `git diff` will show what changed; the operator reviews before commit.
+
+If the CLI rejects the merge because `external_audit:` already exists (re-audit guard, v0 does not support re-merge), surface the message to the operator. Manual append of new findings is the v0 fallback for that case.
+
+**Branch B — telemetry does NOT exist** (Charter not yet closed):
+
+```bash
+devtrail charter audit <CHARTER-ID> --finalize > /tmp/external-audit-block.yaml
+mkdir -p audit/charters/<CHARTER-ID>
+mv /tmp/external-audit-block.yaml audit/charters/<CHARTER-ID>/external-audit-pending.yaml
+```
+
+Tell the operator: "The Charter is not yet closed. The findings are saved in `audit/charters/<CHARTER-ID>/external-audit-pending.yaml`. When you run `devtrail charter close <CHARTER-ID>`, paste the `external_audit:` block from that file into the telemetry when prompted, or merge it manually after close completes."
+
+### 5. Print summary
+
+After step 4, print to the operator:
+
+```
+Audit review complete for <CHARTER-ID>.
+
+  Auditors reconciled:
+    - auditor-primary.md   (<N> findings, <model-id>)
+    - auditor-secondary.md (<M> findings, <model-id>)
+  Calibrator:               <calibrator-model-id> (<K> findings consolidated)
+
+  external_audit YAML:
+    [merged into .devtrail/charters/<CHARTER-ID>.telemetry.yaml]
+    or
+    [pending in audit/charters/<CHARTER-ID>/external-audit-pending.yaml]
+
+  Run `git diff .devtrail/charters/<CHARTER-ID>.telemetry.yaml` to review.
+```
+
+## Notes
+
+- This skill **does** invoke an LLM (the calibrator runs in the current conversation), unlike `/devtrail-audit-prompt` which is purely orchestration. The distinction is intentional: the calibrator is family-agnostic, so the agent driving the conversation is a valid calibrator.
+- The skill is **idempotent for steps 1-3** (re-running regenerates the calibrator response if you delete `calibrator-reconciler.md`). It is **NOT idempotent for step 4 in Branch A** — once telemetry has `external_audit:`, the CLI rejects re-merge to prevent silent duplication.
+- The auto-merge re-emits the YAML using the existing `charter_telemetry:` shape; cosmetic formatting of the merged file matches the close.rs output. Comments in the original telemetry YAML, if any, are preserved (the CLI uses string-level append, not full re-serialization).
+- The `audit_notes:` field in the merged block points at the canonical paths `audit/charters/<CHARTER-ID>/auditor-{primary,secondary}.md`. If you renamed those files, fix the field manually after merge.

--- a/dist/.claude/skills/devtrail-audit-review/SKILL.md
+++ b/dist/.claude/skills/devtrail-audit-review/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: devtrail-audit-review
+description: Calibrate the responses of two external auditors and merge findings into the Charter telemetry. Counterpart to /devtrail-audit-prompt — invoke after the operator has saved the auditor responses.
+allowed-tools: Read, Write, Bash(devtrail charter audit *, devtrail charter status *, ls *, git diff *)
+---
+
+# DevTrail Audit Review Skill
+
+Reconcile the responses of two external auditors and produce the calibrator analysis. When the Charter has telemetry, append the consolidated `external_audit:` array directly into the YAML so the operator does not have to copy/paste.
+
+## When to invoke
+
+After running `/devtrail-audit-prompt <CHARTER-ID>`, having pasted both prompts into LLMs of different families, and saved the responses to:
+
+- `audit/charters/<CHARTER-ID>/auditor-primary.md`
+- `audit/charters/<CHARTER-ID>/auditor-secondary.md`
+
+This skill produces the calibrator response and merges findings into telemetry.
+
+## Instructions
+
+### 1. Verify auditor responses exist
+
+```bash
+ls audit/charters/<CHARTER-ID>/auditor-primary.md \
+   audit/charters/<CHARTER-ID>/auditor-secondary.md
+```
+
+If either file is missing, instruct the operator to run `/devtrail-audit-prompt <CHARTER-ID>` first and exit.
+
+### 2. Resolve the calibrator prompt (CALIBRATE step)
+
+```bash
+devtrail charter audit <CHARTER-ID> --calibrate
+```
+
+The CLI:
+- Validates `auditor-primary.md` and `auditor-secondary.md` against `audit-output.schema.v0.json`. If validation fails, surface the error to the operator and exit — the auditor response frontmatter must follow the schema documented inside each prompt.
+- Writes `audit/charters/<CHARTER-ID>/prompts/calibrator-reconciler.prompt.md`.
+
+### 3. Run the calibrator inline (this conversation IS the calibrator)
+
+The calibrator-reconciler prompt is designed to run in any model family — the agent currently in this conversation can produce the calibrator response directly. Heterogeneity inter-family is required for the auditor pair, NOT for the calibrator (the calibrator's task is definitional, not discovery — see `Propuesta/devtrail-cli-roadmap.md` §5.2 for the rationale).
+
+Read the resolved prompt:
+
+```bash
+cat audit/charters/<CHARTER-ID>/prompts/calibrator-reconciler.prompt.md
+```
+
+Produce the response **following the prompt's output schema exactly** — the frontmatter is required (`audit_role: calibrator-reconciler`, `calibrator: <model-id>`, `auditors_reconciled`, `findings_consolidated`, `findings_by_status`). Save to:
+
+- `audit/charters/<CHARTER-ID>/calibrator-reconciler.md`
+
+### 4. Finalize and merge into telemetry
+
+Determine the telemetry path: `.devtrail/charters/<CHARTER-ID>.telemetry.yaml` (canonical form, `<CHARTER-ID>` without slug).
+
+```bash
+test -f .devtrail/charters/<CHARTER-ID>.telemetry.yaml
+```
+
+**Branch A — telemetry exists** (operator has already run `devtrail charter close`):
+
+```bash
+devtrail charter audit <CHARTER-ID> --finalize \
+  --merge-into .devtrail/charters/<CHARTER-ID>.telemetry.yaml
+```
+
+The CLI validates all 3 outputs and appends `external_audit:` to the telemetry YAML directly. **Do NOT** edit the YAML by hand afterwards — `git diff` will show what changed; the operator reviews before commit.
+
+If the CLI rejects the merge because `external_audit:` already exists (re-audit guard, v0 does not support re-merge), surface the message to the operator. Manual append of new findings is the v0 fallback for that case.
+
+**Branch B — telemetry does NOT exist** (Charter not yet closed):
+
+```bash
+devtrail charter audit <CHARTER-ID> --finalize > /tmp/external-audit-block.yaml
+mkdir -p audit/charters/<CHARTER-ID>
+mv /tmp/external-audit-block.yaml audit/charters/<CHARTER-ID>/external-audit-pending.yaml
+```
+
+Tell the operator: "The Charter is not yet closed. The findings are saved in `audit/charters/<CHARTER-ID>/external-audit-pending.yaml`. When you run `devtrail charter close <CHARTER-ID>`, paste the `external_audit:` block from that file into the telemetry when prompted, or merge it manually after close completes."
+
+### 5. Print summary
+
+After step 4, print to the operator:
+
+```
+Audit review complete for <CHARTER-ID>.
+
+  Auditors reconciled:
+    - auditor-primary.md   (<N> findings, <model-id>)
+    - auditor-secondary.md (<M> findings, <model-id>)
+  Calibrator:               <calibrator-model-id> (<K> findings consolidated)
+
+  external_audit YAML:
+    [merged into .devtrail/charters/<CHARTER-ID>.telemetry.yaml]
+    or
+    [pending in audit/charters/<CHARTER-ID>/external-audit-pending.yaml]
+
+  Run `git diff .devtrail/charters/<CHARTER-ID>.telemetry.yaml` to review.
+```
+
+## Notes
+
+- This skill **does** invoke an LLM (the calibrator runs in the current conversation), unlike `/devtrail-audit-prompt` which is purely orchestration. The distinction is intentional: the calibrator is family-agnostic, so the agent driving the conversation is a valid calibrator.
+- The skill is **idempotent for steps 1-3** (re-running regenerates the calibrator response if you delete `calibrator-reconciler.md`). It is **NOT idempotent for step 4 in Branch A** — once telemetry has `external_audit:`, the CLI rejects re-merge to prevent silent duplication.
+- The auto-merge re-emits the YAML using the existing `charter_telemetry:` shape; cosmetic formatting of the merged file matches the close.rs output. Comments in the original telemetry YAML, if any, are preserved (the CLI uses string-level append, not full re-serialization).
+- The `audit_notes:` field in the merged block points at the canonical paths `audit/charters/<CHARTER-ID>/auditor-{primary,secondary}.md`. If you renamed those files, fix the field manually after merge.

--- a/dist/.gemini/skills/devtrail-audit-review/SKILL.md
+++ b/dist/.gemini/skills/devtrail-audit-review/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: devtrail-audit-review
+description: Calibrate the responses of two external auditors and merge findings into the Charter telemetry. Counterpart to /devtrail-audit-prompt — invoke after the operator has saved the auditor responses.
+---
+
+# DevTrail Audit Review Skill
+
+Reconcile the responses of two external auditors and produce the calibrator analysis. When the Charter has telemetry, append the consolidated `external_audit:` array directly into the YAML so the operator does not have to copy/paste.
+
+## When to invoke
+
+After running `/devtrail-audit-prompt <CHARTER-ID>`, having pasted both prompts into LLMs of different families, and saved the responses to:
+
+- `audit/charters/<CHARTER-ID>/auditor-primary.md`
+- `audit/charters/<CHARTER-ID>/auditor-secondary.md`
+
+This skill produces the calibrator response and merges findings into telemetry.
+
+## Instructions
+
+### 1. Verify auditor responses exist
+
+```bash
+ls audit/charters/<CHARTER-ID>/auditor-primary.md \
+   audit/charters/<CHARTER-ID>/auditor-secondary.md
+```
+
+If either file is missing, instruct the operator to run `/devtrail-audit-prompt <CHARTER-ID>` first and exit.
+
+### 2. Resolve the calibrator prompt (CALIBRATE step)
+
+```bash
+devtrail charter audit <CHARTER-ID> --calibrate
+```
+
+The CLI:
+- Validates `auditor-primary.md` and `auditor-secondary.md` against `audit-output.schema.v0.json`. If validation fails, surface the error to the operator and exit — the auditor response frontmatter must follow the schema documented inside each prompt.
+- Writes `audit/charters/<CHARTER-ID>/prompts/calibrator-reconciler.prompt.md`.
+
+### 3. Run the calibrator inline (this conversation IS the calibrator)
+
+The calibrator-reconciler prompt is designed to run in any model family — the agent currently in this conversation can produce the calibrator response directly. Heterogeneity inter-family is required for the auditor pair, NOT for the calibrator (the calibrator's task is definitional, not discovery — see `Propuesta/devtrail-cli-roadmap.md` §5.2 for the rationale).
+
+Read the resolved prompt:
+
+```bash
+cat audit/charters/<CHARTER-ID>/prompts/calibrator-reconciler.prompt.md
+```
+
+Produce the response **following the prompt's output schema exactly** — the frontmatter is required (`audit_role: calibrator-reconciler`, `calibrator: <model-id>`, `auditors_reconciled`, `findings_consolidated`, `findings_by_status`). Save to:
+
+- `audit/charters/<CHARTER-ID>/calibrator-reconciler.md`
+
+### 4. Finalize and merge into telemetry
+
+Determine the telemetry path: `.devtrail/charters/<CHARTER-ID>.telemetry.yaml` (canonical form, `<CHARTER-ID>` without slug).
+
+```bash
+test -f .devtrail/charters/<CHARTER-ID>.telemetry.yaml
+```
+
+**Branch A — telemetry exists** (operator has already run `devtrail charter close`):
+
+```bash
+devtrail charter audit <CHARTER-ID> --finalize \
+  --merge-into .devtrail/charters/<CHARTER-ID>.telemetry.yaml
+```
+
+The CLI validates all 3 outputs and appends `external_audit:` to the telemetry YAML directly. **Do NOT** edit the YAML by hand afterwards — `git diff` will show what changed; the operator reviews before commit.
+
+If the CLI rejects the merge because `external_audit:` already exists (re-audit guard, v0 does not support re-merge), surface the message to the operator. Manual append of new findings is the v0 fallback for that case.
+
+**Branch B — telemetry does NOT exist** (Charter not yet closed):
+
+```bash
+devtrail charter audit <CHARTER-ID> --finalize > /tmp/external-audit-block.yaml
+mkdir -p audit/charters/<CHARTER-ID>
+mv /tmp/external-audit-block.yaml audit/charters/<CHARTER-ID>/external-audit-pending.yaml
+```
+
+Tell the operator: "The Charter is not yet closed. The findings are saved in `audit/charters/<CHARTER-ID>/external-audit-pending.yaml`. When you run `devtrail charter close <CHARTER-ID>`, paste the `external_audit:` block from that file into the telemetry when prompted, or merge it manually after close completes."
+
+### 5. Print summary
+
+After step 4, print to the operator:
+
+```
+Audit review complete for <CHARTER-ID>.
+
+  Auditors reconciled:
+    - auditor-primary.md   (<N> findings, <model-id>)
+    - auditor-secondary.md (<M> findings, <model-id>)
+  Calibrator:               <calibrator-model-id> (<K> findings consolidated)
+
+  external_audit YAML:
+    [merged into .devtrail/charters/<CHARTER-ID>.telemetry.yaml]
+    or
+    [pending in audit/charters/<CHARTER-ID>/external-audit-pending.yaml]
+
+  Run `git diff .devtrail/charters/<CHARTER-ID>.telemetry.yaml` to review.
+```
+
+## Notes
+
+- This skill **does** invoke an LLM (the calibrator runs in the current conversation), unlike `/devtrail-audit-prompt` which is purely orchestration. The distinction is intentional: the calibrator is family-agnostic, so the agent driving the conversation is a valid calibrator.
+- The skill is **idempotent for steps 1-3** (re-running regenerates the calibrator response if you delete `calibrator-reconciler.md`). It is **NOT idempotent for step 4 in Branch A** — once telemetry has `external_audit:`, the CLI rejects re-merge to prevent silent duplication.
+- The auto-merge re-emits the YAML using the existing `charter_telemetry:` shape; cosmetic formatting of the merged file matches the close.rs output. Comments in the original telemetry YAML, if any, are preserved (the CLI uses string-level append, not full re-serialization).
+- The `audit_notes:` field in the merged block points at the canonical paths `audit/charters/<CHARTER-ID>/auditor-{primary,secondary}.md`. If you renamed those files, fix the field manually after merge.


### PR DESCRIPTION
## Summary

Second of 5 PRs implementing **Phase 1** of `Propuesta/devtrail-audit-skills.md`. Closes the back-half of the external audit cycle by adding (a) a CLI flag that auto-appends the `external_audit:` array into the Charter telemetry, and (b) a skill that orchestrates the full review flow — validate auditor responses, run the calibrator inline, finalize, and merge into telemetry.

### CLI changes

- New `--merge-into <PATH>` flag on `devtrail charter audit --finalize` (clap-enforced via `requires = "finalize"`).
- String-level append at indent 2 under `charter_telemetry:`, preserving the hand-written YAML shape that `charter close` produces (no full re-serialization → no comment loss).
- v0 deliberately **rejects re-audit** (file already has `external_audit:`) with a clear error message — operator reconciles manually rather than risk silent duplication.
- Missing telemetry path errors with explicit guidance ("run `devtrail charter close` first").
- `render_external_audit_yaml` now takes the canonical charter id; **bonus fix** for a pre-existing bug where the rendered `audit_notes:` contained the literal placeholder `<charter-id>` instead of the real id.

### Skill files

- `dist/.claude/skills/devtrail-audit-review/SKILL.md` (frontmatter with `allowed-tools`).
- `dist/.gemini/skills/devtrail-audit-review/SKILL.md` (frontmatter without `allowed-tools`).
- `dist/.agent/workflows/devtrail-audit-review.md` (description-only frontmatter).

The skill orchestrates: verify auditor responses exist → `--calibrate` → produce calibrator response inline (the agent driving the conversation IS the calibrator, since heterogeneity is required only for the auditor pair) → `--finalize --merge-into <telemetry-path>`. **Branch B** handles the case where `charter close` has not yet run: the skill writes `external-audit-pending.yaml` for later manual merge at close time.

## Tests

- **4 new integration tests** in `cli/tests/charter_audit_test.rs`:
  - `audit_merge_into_appends_external_audit_to_telemetry` — happy path, asserts indent 2, both auditors present, real charter id (no placeholder), pre-existing keys preserved.
  - `audit_merge_into_missing_telemetry_fails_with_helpful_message`.
  - `audit_merge_into_rejects_existing_external_audit` — re-audit guard.
  - `audit_merge_into_requires_finalize` — clap rejection.
- **4 new sanity tests** in `cli/tests/audit_skill_test.rs` mirroring PR 1's pattern for `devtrail-audit-review`: per-platform frontmatter shape + cross-platform parity of load-bearing guidance (`--calibrate`, `--finalize`, `external-audit-pending.yaml`, re-audit limitation note).

## Test plan

- [x] `cargo test --test charter_audit_test` → 11/11 (7 existing + 4 new) green
- [x] `cargo test --test audit_skill_test` → 8/8 (4 prompt + 4 review) green
- [x] `cargo test` (full suite) → all suites green, no regressions
- [x] No version bump (Phase 1 PR 5)
- [x] No CHANGELOG entry (written at release time)

## Phase 1 progress

| PR | Title | Status |
|---|---|---|
| 1 | Skill `devtrail-audit-prompt` + tests | merged (#96) |
| 2 | Skill `devtrail-audit-review` + CLI `--merge-into` flag | **this PR** |
| 3 | Checkpoint guidance in `AGENT-RULES.md` (3 langs) + fixture tests | pending |
| 4 | Adopter docs (WORKFLOWS / CLI-REFERENCE / ADOPTION-GUIDE / QUICK-REFERENCE in 3 langs) | pending |
| 5 | Bump `fw-X.Y.0` + `cli-X.Y.0` + CHANGELOG + tag release | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)