### PR TITLE
feat(framework): Phase 1 PR 3 — audit checkpoint guidance in AGENT-RULES (3 langs)

### DIFF
--- a/cli/tests/checkpoint_guidance_test.rs
+++ b/cli/tests/checkpoint_guidance_test.rs
@@ -1,0 +1,111 @@
+//! Sanity tests for the §12 Audit Checkpoint guidance added to
+//! AGENT-RULES.md across the 3 languages. These verify the section is
+//! present, has the load-bearing structural elements, and stays in
+//! parity across translations.
+
+use std::path::PathBuf;
+
+fn agent_rules_path(lang: &str) -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let base = PathBuf::from(manifest_dir)
+        .join("..")
+        .join("dist")
+        .join(".devtrail")
+        .join("00-governance");
+    match lang {
+        "en" => base.join("AGENT-RULES.md"),
+        other => base.join("i18n").join(other).join("AGENT-RULES.md"),
+    }
+}
+
+fn read(lang: &str) -> String {
+    let path = agent_rules_path(lang);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("expected file to exist: {}", path.display()))
+}
+
+#[test]
+fn agent_rules_en_has_audit_checkpoint_section() {
+    let body = read("en");
+    assert!(
+        body.contains("\n## 12. Audit Checkpoint"),
+        "EN AGENT-RULES.md must declare §12 Audit Checkpoint"
+    );
+    // Load-bearing structural elements
+    assert!(
+        body.contains("When to emit the checkpoint"),
+        "must describe trigger conditions"
+    );
+    assert!(
+        body.contains("/devtrail-audit-prompt"),
+        "must reference the audit-prompt skill"
+    );
+    assert!(
+        body.contains("/devtrail-audit-review"),
+        "must reference the audit-review skill"
+    );
+    assert!(
+        body.contains("permanent v0+v1 design decision"),
+        "must surface the permanent no-enforcement commitment"
+    );
+    assert!(
+        body.contains("2× the configured threshold"),
+        "must include the arborist heuristic"
+    );
+    assert!(
+        body.contains("graceful-degradation") || body.contains("Graceful-degradation"),
+        "must mention graceful degradation when analyze feature is absent"
+    );
+}
+
+#[test]
+fn agent_rules_es_has_audit_checkpoint_section() {
+    let body = read("es");
+    assert!(
+        body.contains("\n## 12. Checkpoint de Auditoría"),
+        "ES AGENT-RULES.md must declare §12 Checkpoint de Auditoría"
+    );
+    assert!(body.contains("/devtrail-audit-prompt"));
+    assert!(body.contains("/devtrail-audit-review"));
+    assert!(
+        body.contains("decisión de diseño v0+v1 permanente"),
+        "must surface the permanent no-enforcement commitment in ES"
+    );
+}
+
+#[test]
+fn agent_rules_zh_has_audit_checkpoint_section() {
+    let body = read("zh-CN");
+    assert!(
+        body.contains("\n## 12. 审计检查点"),
+        "zh-CN AGENT-RULES.md must declare §12 Audit Checkpoint"
+    );
+    assert!(body.contains("/devtrail-audit-prompt"));
+    assert!(body.contains("/devtrail-audit-review"));
+    assert!(
+        body.contains("v0+v1 永久设计决策"),
+        "must surface the permanent no-enforcement commitment in zh-CN"
+    );
+}
+
+#[test]
+fn audit_checkpoint_section_three_langs_share_load_bearing_anchors() {
+    // Anchors that must appear identically across translations because
+    // they reference language-agnostic identifiers (skill names, file
+    // paths, propuesta sections).
+    let anchors = [
+        "/devtrail-audit-prompt",
+        "/devtrail-audit-review",
+        "complexity.threshold",
+        "Propuesta/devtrail-audit-skills.md",
+    ];
+    for lang in ["en", "es", "zh-CN"] {
+        let body = read(lang);
+        for anchor in anchors {
+            assert!(
+                body.contains(anchor),
+                "anchor {anchor:?} missing in {lang} AGENT-RULES.md"
+            );
+        }
+    }
+}

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -270,4 +270,79 @@ When a change modifies API endpoints:
 
 ---
 
+## 12. Audit Checkpoint (Charter workflow)
+
+When co-implementing a Charter, the agent **proactively offers** an external multi-model audit at a specific moment in the workflow. The checkpoint is **soft** — it never blocks `charter close` and is never escalated to enforcement. External audit is opt-in by design (cost, trust in the operator's primary discipline).
+
+### When to emit the checkpoint
+
+Emit the checkpoint **once per Charter** when **all four** triggers are simultaneously true:
+
+1. The Charter is in status `in-progress` or `declared` (not `closed`).
+2. All tasks in the Charter's `## Tasks` section are marked `[x]` complete (or the agent just completed the last one).
+3. `devtrail charter drift <CHARTER-ID>` exits 0 (no unaccounted drift).
+4. The developer has **not** invoked `devtrail charter close <CHARTER-ID>` yet, nor mentioned intent to close.
+
+If the developer declined audit on a previous turn for the same Charter, **do not re-emit** in subsequent turns of the same conversation.
+
+### Form of the checkpoint message
+
+Render the message like this (substitute `<CHARTER-ID>` and the recommendation reasoning):
+
+```
+Reached the checkpoint for <CHARTER-ID>. Implementation is done, drift
+check is clean, only `devtrail charter close` is pending.
+
+At this point you can run an external audit (typically 2 LLMs of
+different families + a calibrator) that produces cross-model findings
+on the implementation.
+
+My recommendation: [YES / NO], because:
+  - <one specific reason grounded in the Charter, AILOGs, or diff>
+
+If you decide to audit:
+  Run /devtrail-audit-prompt <CHARTER-ID> and I will surface the two
+  prompts inline. Once you have the responses from the external
+  auditors saved to canonical paths, run /devtrail-audit-review
+  <CHARTER-ID> and I will calibrate them locally and merge the
+  findings into the Charter telemetry.
+
+If you decide not to audit:
+  Continue with `devtrail charter close <CHARTER-ID>` when you're
+  ready. External audit is fully optional — DevTrail's declarative
+  Charter + drift check + AILOG discipline gives the cycle enough
+  rigor for confident close without it.
+```
+
+### Heuristics for the YES/NO recommendation
+
+These are heuristics, not rigid rules — you are close to the context, refine them with the adopter.
+
+**Recommend YES when** (any one suffices):
+
+- The Charter touched security-critical surface (auth, RLS, secret handling, IAM).
+- The Charter introduced a new component (not a refactor) that the developer has not co-implemented before.
+- An associated AILOG documents an `R<N>` with `confidence: low | medium` and `risk_level: medium` or higher.
+- The developer marked the Charter as `effort_estimate: L` and this is the adopter's first Charter.
+- The developer **explicitly** asked for cross-model validation in the Charter trigger.
+- **Structural complexity signal** *(only when the CLI was compiled with the `analyze` feature, true for official binaries)*: the diff in `range` introduces or modifies at least one function whose cognitive complexity exceeds **2× the configured threshold** in `.devtrail/config.yml` (`complexity.threshold`, default `8` → ≥ `17`). A dense new function is exactly the case where two cross-family auditors capture implementation gaps that a single model misses. **Graceful-degradation:** if the binary lacks the `analyze` feature, silently skip this signal — do not warn, do not mention.
+
+**Recommend NO when** (all of these together):
+
+- The Charter is a refactor or documentation change (no new behavior).
+- `effort_estimate` is `XS` or `S`.
+- Associated AILOGs all have `confidence: high` and no emergent `R<N+1>` risks.
+- The Charter's `risk_level` is `low` (or unset).
+
+**Default case (no clear signal either way):** recommend **NO** with neutral framing ("I don't see a specific signal that justifies the cost of two additional models; close when you're ready"). The cost of external audit is real — do not inflate adoption by recommending YES on inertia.
+
+### Rules of engagement
+
+- The checkpoint is **never** repeated within the same Charter once the developer responds.
+- The checkpoint **does not** block any subsequent action. If the developer ignores it and runs `charter close`, close proceeds normally — there is no enforcement and there will not be (this is a permanent v0+v1 design decision; see `Propuesta/devtrail-audit-skills.md` §2.2).
+- The checkpoint is **not** counted in any quality metric. There is no "% Charters audited" KPI in `devtrail metrics` — by design, to avoid creating an incentive to inflate the audit count.
+- If the developer accepts the audit, the next two skills (`/devtrail-audit-prompt` then `/devtrail-audit-review`) carry the workflow forward.
+
+---
+
 *DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -270,4 +270,79 @@ Cuando un cambio modifica endpoints de API:
 
 ---
 
+## 12. Checkpoint de Auditoría (workflow de Charter)
+
+Cuando estés co-implementando un Charter, el agente **proactivamente ofrece** una auditoría externa multi-modelo en un momento específico del workflow. El checkpoint es **soft** — nunca bloquea `charter close` y nunca escala a enforcement. La auditoría externa es opt-in por diseño (costo, confianza en la disciplina primaria del operador).
+
+### Cuándo emitir el checkpoint
+
+Emite el checkpoint **una sola vez por Charter** cuando los **cuatro** triggers se cumplen simultáneamente:
+
+1. El Charter está en status `in-progress` o `declared` (no `closed`).
+2. Todas las tasks de la sección `## Tasks` del Charter están marcadas `[x]` completadas (o el agente acaba de completar la última).
+3. `devtrail charter drift <CHARTER-ID>` retorna exit 0 (sin drift no contabilizado).
+4. El developer **no** ha invocado `devtrail charter close <CHARTER-ID>` aún, ni ha mencionado intención de cerrar.
+
+Si el developer rechazó la auditoría en un turno previo para el mismo Charter, **no re-emitir** en turnos subsiguientes de la misma conversación.
+
+### Forma del mensaje del checkpoint
+
+Renderiza el mensaje así (sustituye `<CHARTER-ID>` y la justificación de la recomendación):
+
+```
+Llegamos al checkpoint del Charter <CHARTER-ID>. Está implementado,
+drift check OK, pendiente solo `devtrail charter close`.
+
+En este punto puedes correr una auditoría externa (típicamente 2 LLMs
+de familias distintas + un calibrador) que arroje findings cross-modelo
+sobre la implementación.
+
+Mi recomendación: [SÍ / NO], porque:
+  - <razón concreta basada en el Charter, AILOGs o diff>
+
+Si decides auditar:
+  Ejecuta /devtrail-audit-prompt <CHARTER-ID> y te imprimo aquí mismo
+  los dos prompts. Cuando tengas las respuestas de los auditores externos
+  guardadas en los paths canónicos, ejecuta /devtrail-audit-review
+  <CHARTER-ID> y yo calibro localmente y mergeo los findings en la
+  telemetría del Charter.
+
+Si decides no auditar:
+  Continúa con `devtrail charter close <CHARTER-ID>` cuando estés listo.
+  La auditoría externa es completamente opcional — la disciplina del
+  Charter declarativo + drift check + AILOG da suficiente rigor para
+  un cierre confiable sin auditoría.
+```
+
+### Heurísticas para la recomendación SÍ/NO
+
+Son heurísticas, no reglas rígidas — estás cerca del contexto, afínalas con el adoptante.
+
+**Recomienda SÍ cuando** (cualquiera basta):
+
+- El Charter tocó superficie crítica de seguridad (auth, RLS, manejo de secrets, IAM).
+- El Charter introdujo un componente nuevo (no refactor) que el developer no había co-implementado antes.
+- Algún AILOG asociado documenta un `R<N>` con `confidence: low | medium` y `risk_level: medium` o mayor.
+- El developer marcó el Charter como `effort_estimate: L` y este es el primer Charter del adoptante.
+- El developer **explícitamente** pidió validación cross-modelo en el trigger del Charter.
+- **Señal estructural de complejidad** *(disponible solo cuando el CLI fue compilado con el feature `analyze` activo, true en los binarios oficiales)*: el diff del `range` introduce o modifica al menos una función cuya complejidad cognitiva supera **2× el threshold configurado** en `.devtrail/config.yml` (`complexity.threshold`, default `8` → ≥ `17`). Una función densa nueva es exactamente el caso donde dos auditores cross-familia capturan implementation gaps que un solo modelo deja pasar. **Graceful-degradation:** si el binario no tiene el feature `analyze`, omite silenciosamente esta señal — no avises, no menciones la ausencia.
+
+**Recomienda NO cuando** (todas juntas):
+
+- El Charter es refactor o cambio de documentación (sin comportamiento nuevo).
+- `effort_estimate` es `XS` o `S`.
+- Los AILOGs asociados tienen todos `confidence: high` y sin riesgos `R<N+1>` emergentes.
+- `risk_level` del Charter es `low` (o no está marcado).
+
+**Caso default (ninguna señal clara):** recomienda **NO** con framing neutro ("no veo señal específica que justifique el costo de dos modelos adicionales; cierra cuando estés listo"). El costo de la auditoría externa es real — no infles adopción recomendando SÍ por inercia.
+
+### Reglas de engagement
+
+- El checkpoint **nunca** se repite dentro del mismo Charter una vez que el developer responde.
+- El checkpoint **no** bloquea ninguna acción posterior. Si el developer lo ignora y corre `charter close`, close procede normalmente — no hay enforcement y no lo habrá (decisión de diseño v0+v1 permanente; ver `Propuesta/devtrail-audit-skills.md` §2.2).
+- El checkpoint **no** se cuenta en ninguna métrica de calidad. No hay KPI "% Charters auditados" en `devtrail metrics` — por diseño, para evitar incentivos a inflar el conteo.
+- Si el developer acepta la auditoría, las siguientes dos skills (`/devtrail-audit-prompt` luego `/devtrail-audit-review`) llevan el workflow adelante.
+
+---
+
 *DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -270,4 +270,76 @@ confidence: high | medium | low
 
 ---
 
+## 12. 审计检查点（Charter 工作流）
+
+在与人共同实现 Charter 时，Agent **主动**在工作流的特定时刻提议外部多模型审计。该检查点是**软性**的——它从不阻塞 `charter close`，也不会升级到强制执行。外部审计在设计上是 opt-in 的（成本，对操作员主要纪律的信任）。
+
+### 何时发出检查点
+
+当**四个**触发条件同时为真时，**每个 Charter 仅发出一次**检查点：
+
+1. Charter 处于 `in-progress` 或 `declared` 状态（非 `closed`）。
+2. Charter 的 `## Tasks` 节中所有任务被标记为 `[x]` 已完成（或 Agent 刚完成最后一个）。
+3. `devtrail charter drift <CHARTER-ID>` 退出码为 0（无未计入的漂移）。
+4. Developer **尚未**调用 `devtrail charter close <CHARTER-ID>`，也未提及关闭意图。
+
+如果 developer 在同一 Charter 的之前轮次中拒绝了审计，**不要在同一对话的后续轮次中重新发出**。
+
+### 检查点消息的形式
+
+按以下格式渲染消息（替换 `<CHARTER-ID>` 和推荐理由）：
+
+```
+到达 <CHARTER-ID> 的检查点。实现已完成，drift check OK，
+仅待执行 `devtrail charter close`。
+
+此时你可以运行外部审计（典型为 2 个不同族的 LLM + 1 个校准器），
+该审计会对实现产出跨模型 findings。
+
+我的建议：[是 / 否]，因为：
+  - <基于 Charter、AILOGs 或 diff 的具体原因>
+
+如果决定审计：
+  运行 /devtrail-audit-prompt <CHARTER-ID>，我会在此处直接展示
+  两个 prompts。当你保存了外部审计员的回复到规范路径后，运行
+  /devtrail-audit-review <CHARTER-ID>，我会在本地校准并将
+  findings 合并到 Charter 遥测中。
+
+如果决定不审计：
+  准备好后继续 `devtrail charter close <CHARTER-ID>`。外部审计
+  完全可选——DevTrail 的声明性 Charter + drift check + AILOG
+  纪律已为周期提供了足够严格的关闭信心。
+```
+
+### 是/否推荐的启发式
+
+这些是启发式，不是硬性规则——你接近上下文，可与 adopter 一起细化。
+
+**当满足以下任一条件时推荐"是"**：
+
+- Charter 触及安全关键面（auth、RLS、secret 处理、IAM）。
+- Charter 引入了 developer 之前未共同实现过的新组件（非重构）。
+- 某关联的 AILOG 记录了 `R<N>`，其 `confidence: low | medium` 且 `risk_level: medium` 或更高。
+- Developer 将 Charter 标记为 `effort_estimate: L` 且这是 adopter 的第一个 Charter。
+- Developer 在 Charter trigger 中**明确**要求跨模型验证。
+- **结构性复杂度信号** *(仅当 CLI 编译启用了 `analyze` feature 时可用，对官方二进制为真)*：`range` 中的 diff 引入或修改了至少一个函数，其认知复杂度超过 `.devtrail/config.yml` 中配置的 `complexity.threshold`（默认 `8`）的 **2 倍**（即 ≥ `17`）。一个新的密集函数恰好是两个跨族审计员能捕获 implementation gap、单一模型会遗漏的场景。**优雅降级**：如果二进制缺少 `analyze` feature，静默跳过此信号——不警告，不提及缺失。
+
+**当以下条件**全部**满足时推荐"否"**：
+
+- Charter 是重构或文档变更（无新行为）。
+- `effort_estimate` 为 `XS` 或 `S`。
+- 所有关联 AILOGs 的 `confidence` 均为 `high`，无涌现的 `R<N+1>` 风险。
+- Charter 的 `risk_level` 为 `low`（或未设置）。
+
+**默认情况（无明显信号）**：推荐**"否"**，使用中性措辞（"我没有看到具体信号能正当化两个额外模型的成本；准备好就关闭吧"）。外部审计的成本是真实的——不要靠惯性推荐"是"来虚胖采用。
+
+### 行为规则
+
+- 检查点在同一 Charter 内一旦 developer 回复就**永不**重复。
+- 检查点**不**阻塞任何后续操作。如果 developer 忽略它并运行 `charter close`，close 正常进行——没有强制执行，将来也不会有（这是 v0+v1 永久设计决策；见 `Propuesta/devtrail-audit-skills.md` §2.2）。
+- 检查点**不**计入任何质量度量。`devtrail metrics` 中没有"已审计 Charter 百分比"KPI——按设计，避免产生虚胖审计计数的激励。
+- 如果 developer 接受审计，接下来的两个 skills（`/devtrail-audit-prompt` 然后 `/devtrail-audit-review`）会推进工作流。
+
+---
+
 *DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*


### PR DESCRIPTION
## Summary

Third of 5 PRs implementing **Phase 1** of `Propuesta/devtrail-audit-skills.md`. Adds §12 "Audit Checkpoint" to `AGENT-RULES.md` across the 3 supported languages, codifying the workflow checkpoint from the propuesta §4 — the moment where the agent proactively offers an external audit at the right point in the Charter cycle.

## What the section codifies

- **4 boolean triggers** that must all be simultaneously true: status `in-progress`/`declared` + all tasks `[x]` + `drift` exits 0 + `charter close` not yet invoked.
- **Literal YES/NO message text** the agent should render to the developer (with placeholders for charter id and reasoning).
- **YES/NO heuristics**:
  - YES on security surface, new component, low/medium-confidence AILOG risks, large effort + first Charter, explicit cross-model request, **or** arborist 2× threshold signal (graceful-degradation when the `analyze` feature is absent).
  - NO when refactor + small effort + high-confidence AILOGs + low risk_level.
  - **Default NO** when no signal is clear (neutral framing to avoid inflating cost via inertia).
- **Rules of engagement**: emit once per Charter; do not re-emit after developer response; never block any action; not counted as a quality metric. **Permanent v0+v1 design decision** (no enforcement ever) is stated explicitly with reference to the propuesta §2.2.

## Files

- `dist/.devtrail/00-governance/AGENT-RULES.md` (EN canonical) — new §12.
- `dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md` — new §12 in Spanish.
- `dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md` — new §12 in zh-CN.
- `cli/tests/checkpoint_guidance_test.rs` — 4 fixture tests covering per-language section presence + cross-language parity of load-bearing anchors (skill names, file paths, propuesta references).

## Test plan

- [x] `cargo test --test checkpoint_guidance_test` → 4/4 green
- [x] `cargo test` (full suite) → all green, no regressions
- [x] No version bump (Phase 1 PR 5)
- [x] No CHANGELOG (release-time)

## Phase 1 progress

| PR | Title | Status |
|---|---|---|
| 1 | Skill `devtrail-audit-prompt` + tests | merged (#96) |
| 2 | Skill `devtrail-audit-review` + CLI `--merge-into` flag | merged (#97) |
| 3 | Checkpoint guidance in `AGENT-RULES.md` (3 langs) + fixture tests | **this PR** |
| 4 | Adopter docs (WORKFLOWS / CLI-REFERENCE / ADOPTION-GUIDE / QUICK-REFERENCE in 3 langs) | pending |
| 5 | Bump `fw-X.Y.0` + `cli-X.Y.0` + CHANGELOG + tag release | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)