### PR TITLE
docs: Phase 1 PR 4 — adopter docs for audit skills + checkpoint (3 langs)

### DIFF
--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -210,6 +210,11 @@ Mark `review_required: true` when:
 | Command | Purpose |
 |---------|---------|
 | `/devtrail-status` | Check documentation status and compliance |
+| `/devtrail-new` | Create any document type (interactive) |
+| `/devtrail-ailog` / `/devtrail-aidec` / `/devtrail-adr` | Quick shortcuts for AILOG / AIDEC / ADR |
+| `/devtrail-mcard` / `/devtrail-sec` | Interactive flows for Model Card / SEC assessment |
+| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+)* | External multi-model audit — generate prompts inline |
+| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+)* | Calibrate audit responses + merge into Charter telemetry |
 
 ---
 

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -185,6 +185,11 @@ Marcar `review_required: true` cuando:
 | Comando | Propósito |
 |---------|-----------|
 | `/devtrail-status` | Verificar estado y cumplimiento de documentación |
+| `/devtrail-new` | Crear cualquier tipo de documento (interactivo) |
+| `/devtrail-ailog` / `/devtrail-aidec` / `/devtrail-adr` | Atajos rápidos para AILOG / AIDEC / ADR |
+| `/devtrail-mcard` / `/devtrail-sec` | Flujos interactivos para Model Card / SEC assessment |
+| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+)* | Auditoría externa multi-modelo — genera prompts inline |
+| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+)* | Calibra respuestas de auditoría + mergea en telemetría del Charter |
 
 ---
 

--- a/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -185,6 +185,11 @@ risk_level: low | medium | high | critical
 | 命令 | 用途 |
 |------|------|
 | `/devtrail-status` | 检查文档状态和合规性 |
+| `/devtrail-new` | 创建任意类型文档（交互式） |
+| `/devtrail-ailog` / `/devtrail-aidec` / `/devtrail-adr` | AILOG / AIDEC / ADR 的快速快捷方式 |
+| `/devtrail-mcard` / `/devtrail-sec` | Model Card / SEC 评估的交互流程 |
+| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+)* | 外部多模型审计 — 内联生成 prompts |
+| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+)* | 校准审计响应 + 合并入 Charter 遥测 |
 
 ---
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -498,6 +498,21 @@ devtrail validate
 
 ---
 
+## External Audit (Optional)
+
+From `fw-4.8.0`, when you co-implement Charters with an AI assistant in the loop (Claude Code, Gemini Code, Cursor), you can optionally run an external multi-model audit at Charter close. Two skills wrap the underlying CLI orchestration:
+
+- **`/devtrail-audit-prompt CHARTER-XX`** — generates the auditor prompts inline in the conversation, ready to paste into 2 LLM auditors of different families.
+- **`/devtrail-audit-review CHARTER-XX`** — back-half: validates the operator-saved auditor responses, runs the calibrator inline, and merges findings into the Charter telemetry directly (`external_audit:` array).
+
+The agent will **proactively offer** the audit at one specific moment in the workflow — when implementation is done, drift check is clean, and `charter close` has not been invoked. Recommendation is YES/NO based on the Charter's risk surface and complexity (heuristics in `.devtrail/00-governance/AGENT-RULES.md` §12).
+
+**External audit is fully optional** and **never enforced**. The Charter's declarative scope + drift check + AILOG discipline already provides rigorous closure. Audit adds cross-model signal where the Charter touched security surface, introduced new components, or has high-complexity functions in the diff. Decline freely if the cost (2-3 LLM auditors) does not match the value for your case.
+
+For the underlying CLI commands (PREPARE / CALIBRATE / FINALIZE / `--merge-into`), see [`CLI-REFERENCE.md` § devtrail charter audit](./CLI-REFERENCE.md#devtrail-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir).
+
+---
+
 ## FAQ
 
 ### General Questions

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -705,6 +705,8 @@ $ devtrail charter audit CHARTER-05 --finalize
 
 > **Why orchestration-only?** Implementing 3 HTTP clients (OpenAI / Google / Anthropic) is 1-2 weeks + perpetual maintenance when APIs change. Phase 3 v0 is experimental — the CLI's value is the canon (prompt shape + output schema + telemetry integration), not the API call. v1 may add HTTP clients when an adopter reports a real need; until then the human-in-the-loop shape matches Sentinel's empirical `/plan-audit` pattern that motivated Phase 3 in the first place.
 
+> **Skill alternative *(fw-4.8.0+)*.** When working with an AI assistant in the loop (Claude Code, Gemini Code, Cursor, etc.), the skills `/devtrail-audit-prompt CHARTER-ID` and `/devtrail-audit-review CHARTER-ID` wrap this command and surface the prompts inline in the conversation. The skills also handle the calibrator step (the agent driving the conversation runs the calibrator) and trigger `--finalize --merge-into` so the `external_audit:` array is appended to telemetry without manual copy-paste. See the [Skills](#skills) section below. The CLI remains the single source of truth — the skills only add UX-inline.
+
 ---
 
 ### `devtrail compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
@@ -1054,6 +1056,36 @@ DevTrail CLI
   Repository:        https://github.com/StrangeDaysTech/devtrail
   Website:           https://strangedays.tech
 ```
+
+---
+
+## Skills
+
+DevTrail ships a set of skills (slash commands) for use inside an AI assistant (Claude Code, Gemini Code, Cursor, generic agent runtimes). Each skill is installed in 3 parallel forms during `devtrail init`:
+
+- `dist/.claude/skills/<skill>/SKILL.md` (Claude — frontmatter with `allowed-tools`)
+- `dist/.gemini/skills/<skill>/SKILL.md` (Gemini — frontmatter without `allowed-tools`)
+- `dist/.agent/workflows/<skill>.md` (generic agent — `description`-only frontmatter)
+
+| Skill | Purpose | Files produced |
+|---|---|---|
+| `/devtrail-status` | Check documentation compliance for recent changes. | none (read-only) |
+| `/devtrail-new` | Create any document type interactively. Suggests best fit from context. | `.devtrail/<type-dir>/<TYPE>-YYYY-MM-DD-NNN-*.md` |
+| `/devtrail-ailog` | Quick AILOG creation shortcut. | `.devtrail/07-ai-audit/agent-logs/AILOG-*.md` |
+| `/devtrail-aidec` | Quick AIDEC creation shortcut. | `.devtrail/07-ai-audit/decisions/AIDEC-*.md` |
+| `/devtrail-adr` | Quick ADR creation shortcut. | `.devtrail/04-architecture/decisions/ADR-*.md` |
+| `/devtrail-mcard` | Interactive Model Card creation flow. | `.devtrail/09-ai-models/MCARD-*.md` |
+| `/devtrail-sec` | Interactive SEC (security assessment) flow. | `.devtrail/08-security/SEC-*.md` |
+| `/devtrail-audit-prompt CHARTER-ID` *(fw-4.8.0+)* | Generate external multi-model audit prompts inline. Wraps `devtrail charter audit` PREPARE — runs the CLI to resolve `auditor-primary.prompt.md` and `auditor-secondary.prompt.md`, then surfaces both prompts in the conversation so the operator can paste them into 2 LLMs of different families without leaving the chat. | `audit/charters/<CHARTER-ID>/prompts/auditor-{primary,secondary}.prompt.md` (via the CLI it wraps) |
+| `/devtrail-audit-review CHARTER-ID` *(fw-4.8.0+)* | Counterpart to `/devtrail-audit-prompt`. Validates the operator's saved auditor responses, runs the calibrator inline (the agent driving the conversation IS a valid calibrator since heterogeneity is required only for the auditor pair), and runs `devtrail charter audit --finalize --merge-into` to append `external_audit:` directly into `.devtrail/charters/<CHARTER-ID>.telemetry.yaml`. If the telemetry does not yet exist (Charter not yet closed), writes `audit/charters/<CHARTER-ID>/external-audit-pending.yaml` for later manual merge. | `audit/charters/<CHARTER-ID>/calibrator-reconciler.md`, `external_audit:` array merged into telemetry |
+
+### Skill vs CLI
+
+The two audit skills are **wrappers** around the CLI commands. The `audit/` directory layout, the prompts, the schema validation, and the `external_audit` shape all live in the CLI — the skills only handle the UX-inline part (surfacing prompts in the conversation, running the calibrator inline, triggering the merge). Adopters using DevTrail without an AI assistant in the loop can drive the same workflow directly via `devtrail charter audit` (PREPARE / `--calibrate` / `--finalize [--merge-into <path>]`).
+
+### Audit checkpoint *(fw-4.8.0+)*
+
+`.devtrail/00-governance/AGENT-RULES.md` §12 codifies a workflow checkpoint where the agent proactively offers the audit at one specific moment — when the Charter implementation is done, drift is clean, and `charter close` has not yet been invoked. The recommendation is YES/NO based on heuristics (security surface, new components, AILOG risks, complexity). External audit is **fully optional**; the checkpoint is **soft** — never blocks `charter close`, never enforced (permanent v0+v1 design decision).
 
 ---
 

--- a/docs/adopters/WORKFLOWS.md
+++ b/docs/adopters/WORKFLOWS.md
@@ -122,8 +122,16 @@ DevTrail has two documentation systems:
 | `/devtrail-ailog` | Quick AILOG creation |
 | `/devtrail-aidec` | Quick AIDEC creation |
 | `/devtrail-adr` | Quick ADR creation |
+| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+)* | Generate external multi-model audit prompts inline. Wraps `devtrail charter audit` PREPARE; surfaces both auditor prompts in the conversation so the operator can paste them into 2 LLMs of different families. |
+| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+)* | Counterpart to `audit-prompt`. Validates auditor responses, runs the calibrator inline, and merges findings into the Charter telemetry via `--merge-into`. |
 
 For full skill details, see the [README](../../README.md#skills).
+
+### Charter audit checkpoint *(fw-4.8.0+)*
+
+When co-implementing a Charter, the agent will proactively offer an external audit at one specific moment: when implementation is done, drift is clean, and `charter close` has not yet been invoked. The recommendation is YES/NO based on the Charter's risk surface and complexity (full heuristics in `.devtrail/00-governance/AGENT-RULES.md` §12).
+
+External audit is **fully optional** and **never enforced**. The Charter's declarative scope + drift check + AILOG discipline already provide rigorous closure without it. Audit adds cross-model signal where the Charter touched security surface, introduced new components, or has high-complexity functions in the diff. Decline freely if the cost (2-3 LLM auditors) does not match the value for your case.
 
 ---
 

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -492,6 +492,21 @@ devtrail validate
 
 ---
 
+## Auditoría Externa (Opcional)
+
+A partir de `fw-4.8.0`, cuando co-implementas Charters con un asistente IA en el loop (Claude Code, Gemini Code, Cursor), puedes opcionalmente correr una auditoría externa multi-modelo al cierre del Charter. Dos skills envuelven la orquestación subyacente del CLI:
+
+- **`/devtrail-audit-prompt CHARTER-XX`** — genera los prompts de auditores inline en la conversación, listos para pegar en 2 LLMs auditores de familias distintas.
+- **`/devtrail-audit-review CHARTER-XX`** — back-half: valida las respuestas guardadas por el operador, corre el calibrador inline, y mergea los findings en la telemetría del Charter directamente (array `external_audit:`).
+
+El agente **proactivamente ofrecerá** la auditoría en un momento específico del workflow — cuando la implementación está lista, el drift check está limpio, y `charter close` no se ha invocado. La recomendación es SÍ/NO basada en la superficie de riesgo y complejidad del Charter (heurísticas en `.devtrail/00-governance/AGENT-RULES.md` §12).
+
+**La auditoría externa es completamente opcional** y **nunca enforced**. El scope declarativo del Charter + drift check + disciplina AILOG ya proporcionan cierre riguroso. La auditoría agrega señal cross-modelo cuando el Charter tocó superficie de seguridad, introdujo componentes nuevos, o tiene funciones de alta complejidad en el diff. Declina libremente si el costo (2-3 auditores LLM) no se ajusta al valor de tu caso.
+
+Para los comandos CLI subyacentes (PREPARE / CALIBRATE / FINALIZE / `--merge-into`), ver [`CLI-REFERENCE.md` § devtrail charter audit](./CLI-REFERENCE.md#devtrail-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir).
+
+---
+
 ## Preguntas Frecuentes
 
 ### Preguntas Generales

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -639,6 +639,8 @@ $ devtrail charter audit CHARTER-05 --finalize
 
 > **¿Por qué orchestration-only?** Implementar 3 HTTP clients (OpenAI / Google / Anthropic) son 1-2 semanas + mantenimiento perpetuo cuando las APIs cambian. La Fase 3 v0 es experimental — el valor del CLI es el canon (forma del prompt + schema de output + integración con telemetría), no la API call. v1 puede agregar HTTP clients cuando un adopter reporte una necesidad real; hasta entonces el patrón humano-en-el-loop coincide con el `/plan-audit` empírico de Sentinel que motivó la Fase 3.
 
+> **Alternativa con skill *(fw-4.8.0+)*.** Cuando trabajas con un asistente IA en el loop (Claude Code, Gemini Code, Cursor, etc.), las skills `/devtrail-audit-prompt CHARTER-ID` y `/devtrail-audit-review CHARTER-ID` envuelven este comando y muestran los prompts inline en la conversación. Las skills también manejan el paso del calibrador (el agente que conduce la conversación corre el calibrador) y disparan `--finalize --merge-into` para que el array `external_audit:` se anexe a la telemetría sin copy-paste manual. Ver la sección [Skills](#skills) más abajo. El CLI sigue siendo la fuente única de verdad — las skills solo agregan UX-inline.
+
 ---
 
 ### `devtrail compliance [path] [--standard <nombre>] [--region <nombre>] [--all] [--output <formato>]`
@@ -890,6 +892,36 @@ DevTrail CLI
   Repository:        https://github.com/StrangeDaysTech/devtrail
   Website:           https://strangedays.tech
 ```
+
+---
+
+## Skills
+
+DevTrail incluye un conjunto de skills (slash commands) para usar dentro de un asistente IA (Claude Code, Gemini Code, Cursor, runtimes de agente genérico). Cada skill se instala en 3 formas paralelas durante `devtrail init`:
+
+- `dist/.claude/skills/<skill>/SKILL.md` (Claude — frontmatter con `allowed-tools`)
+- `dist/.gemini/skills/<skill>/SKILL.md` (Gemini — frontmatter sin `allowed-tools`)
+- `dist/.agent/workflows/<skill>.md` (agente genérico — frontmatter solo `description`)
+
+| Skill | Propósito | Archivos producidos |
+|---|---|---|
+| `/devtrail-status` | Verificar cumplimiento de documentación para cambios recientes. | ninguno (read-only) |
+| `/devtrail-new` | Crear cualquier tipo de documento interactivamente. Sugiere el más adecuado al contexto. | `.devtrail/<dir-tipo>/<TIPO>-YYYY-MM-DD-NNN-*.md` |
+| `/devtrail-ailog` | Atajo de creación rápida de AILOG. | `.devtrail/07-ai-audit/agent-logs/AILOG-*.md` |
+| `/devtrail-aidec` | Atajo de creación rápida de AIDEC. | `.devtrail/07-ai-audit/decisions/AIDEC-*.md` |
+| `/devtrail-adr` | Atajo de creación rápida de ADR. | `.devtrail/04-architecture/decisions/ADR-*.md` |
+| `/devtrail-mcard` | Flujo interactivo de creación de Model Card. | `.devtrail/09-ai-models/MCARD-*.md` |
+| `/devtrail-sec` | Flujo interactivo SEC (security assessment). | `.devtrail/08-security/SEC-*.md` |
+| `/devtrail-audit-prompt CHARTER-ID` *(fw-4.8.0+)* | Genera prompts de auditoría externa multi-modelo inline. Envuelve `devtrail charter audit` PREPARE — corre el CLI para resolver `auditor-primary.prompt.md` y `auditor-secondary.prompt.md`, y muestra ambos prompts en la conversación para que el operador los pegue en 2 LLMs de familias distintas sin salir del chat. | `audit/charters/<CHARTER-ID>/prompts/auditor-{primary,secondary}.prompt.md` (vía el CLI que envuelve) |
+| `/devtrail-audit-review CHARTER-ID` *(fw-4.8.0+)* | Contraparte de `/devtrail-audit-prompt`. Valida las respuestas de auditores guardadas por el operador, corre el calibrador inline (el agente que conduce la conversación ES un calibrador válido porque la heterogeneidad solo es requisito para el par auditor), y ejecuta `devtrail charter audit --finalize --merge-into` para anexar `external_audit:` directamente en `.devtrail/charters/<CHARTER-ID>.telemetry.yaml`. Si la telemetría no existe (Charter no cerrado aún), escribe `audit/charters/<CHARTER-ID>/external-audit-pending.yaml` para merge manual posterior. | `audit/charters/<CHARTER-ID>/calibrator-reconciler.md`, array `external_audit:` mergeado en telemetría |
+
+### Skill vs CLI
+
+Las dos skills de auditoría son **wrappers** sobre los comandos del CLI. El layout del directorio `audit/`, los prompts, la validación de schema, y el shape de `external_audit` viven en el CLI — las skills solo manejan la parte UX-inline (mostrar prompts en la conversación, correr el calibrador inline, disparar el merge). Adoptantes que usen DevTrail sin asistente IA en el loop pueden manejar el mismo workflow directamente vía `devtrail charter audit` (PREPARE / `--calibrate` / `--finalize [--merge-into <path>]`).
+
+### Audit checkpoint *(fw-4.8.0+)*
+
+`.devtrail/00-governance/AGENT-RULES.md` §12 codifica un checkpoint del workflow donde el agente proactivamente ofrece la auditoría en un momento específico — cuando la implementación del Charter está lista, drift está limpio, y `charter close` no se ha invocado aún. La recomendación es SÍ/NO basada en heurísticas (superficie de seguridad, componentes nuevos, riesgos AILOG, complejidad). La auditoría externa es **completamente opcional**; el checkpoint es **soft** — nunca bloquea `charter close`, nunca enforced (decisión de diseño v0+v1 permanente).
 
 ---
 

--- a/docs/i18n/es/adopters/WORKFLOWS.md
+++ b/docs/i18n/es/adopters/WORKFLOWS.md
@@ -122,8 +122,16 @@ DevTrail tiene dos sistemas de documentación:
 | `/devtrail-ailog` | Creación rápida de AILOG |
 | `/devtrail-aidec` | Creación rápida de AIDEC |
 | `/devtrail-adr` | Creación rápida de ADR |
+| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+)* | Genera los prompts de auditoría externa multi-modelo inline. Envuelve `devtrail charter audit` PREPARE; muestra ambos prompts en la conversación para que el operador los pegue en 2 LLMs de familias distintas. |
+| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+)* | Contraparte de `audit-prompt`. Valida las respuestas de los auditores, corre el calibrador inline, y mergea los findings en la telemetría del Charter vía `--merge-into`. |
 
 Para detalles completos de skills, consulta el [README](../README.md#skills).
+
+### Charter audit checkpoint *(fw-4.8.0+)*
+
+Cuando estés co-implementando un Charter, el agente proactivamente ofrecerá una auditoría externa en un momento específico: cuando la implementación esté lista, el drift esté limpio, y `charter close` aún no se haya invocado. La recomendación es SÍ/NO basada en la superficie de riesgo y complejidad del Charter (heurísticas completas en `.devtrail/00-governance/AGENT-RULES.md` §12).
+
+La auditoría externa es **completamente opcional** y **nunca enforced**. El scope declarativo del Charter + drift check + disciplina AILOG ya proporcionan cierre riguroso sin ella. La auditoría agrega señal cross-modelo cuando el Charter tocó superficie de seguridad, introdujo componentes nuevos, o tiene funciones de alta complejidad en el diff. Declina libremente si el costo (2-3 auditores LLM) no se ajusta al valor de tu caso.
 
 ---
 

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -499,6 +499,21 @@ devtrail validate
 
 ---
 
+## 外部审计（可选）
+
+自 `fw-4.8.0` 起，当你与 AI 助手在循环中协作实现 Charter 时（Claude Code、Gemini Code、Cursor），你可以在 Charter 关闭时可选地运行外部多模型审计。两个 skills 封装底层 CLI 编排：
+
+- **`/devtrail-audit-prompt CHARTER-XX`** — 在对话中内联生成审计员 prompts，可粘贴到 2 个不同族的 LLM 审计员。
+- **`/devtrail-audit-review CHARTER-XX`** — 后半部分：验证操作员保存的审计员响应，内联运行校准器，并直接将 findings 合并到 Charter 遥测中（`external_audit:` 数组）。
+
+Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成、drift check 干净，且 `charter close` 尚未调用时。推荐基于 Charter 的风险面和复杂度给出 是/否（启发式见 `.devtrail/00-governance/AGENT-RULES.md` §12）。
+
+**外部审计完全可选**且**永不强制**。Charter 的声明性范围 + drift check + AILOG 纪律已为关闭提供严格支撑。审计在 Charter 触及安全面、引入新组件或 diff 中存在高复杂度函数时增加跨模型信号。如果你的情况下成本（2-3 个 LLM 审计员）与价值不匹配，可以自由拒绝。
+
+底层 CLI 命令（PREPARE / CALIBRATE / FINALIZE / `--merge-into`）见 [`CLI-REFERENCE.md` § devtrail charter audit](./CLI-REFERENCE.md#devtrail-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir)。
+
+---
+
 ## 常见问题
 
 ### 通用问题

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -655,6 +655,8 @@ $ devtrail charter audit CHARTER-05 --finalize
 
 > **为什么仅编排？** 实现 3 个 HTTP 客户端（OpenAI / Google / Anthropic）需要 1-2 周 + 当 API 变化时的永久维护。Phase 3 v0 是实验性的 — CLI 的价值是 canon（prompt 形状 + output schema + 与遥测的集成），而非 API 调用本身。当 adopter 报告真实需求时，v1 可能加入 HTTP 客户端；在此之前，人在环模式与激发 Phase 3 的 Sentinel 实证 `/plan-audit` 模式相符。
 
+> **Skill 替代方案 *(fw-4.8.0+)*。** 当与 AI 助手在循环中协作时（Claude Code、Gemini Code、Cursor 等），skills `/devtrail-audit-prompt CHARTER-ID` 和 `/devtrail-audit-review CHARTER-ID` 封装此命令并在对话中内联展示 prompts。Skills 还处理校准器步骤（驱动对话的 Agent 运行校准器）并触发 `--finalize --merge-into`，使得 `external_audit:` 数组直接追加到遥测中无需手动复制粘贴。详见下方的 [Skills](#skills) 章节。CLI 仍是唯一真相来源 — skills 仅添加 UX-inline。
+
 ---
 
 ### `devtrail compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
@@ -997,6 +999,36 @@ DevTrail CLI
   Repository:        https://github.com/StrangeDaysTech/devtrail
   Website:           https://strangedays.tech
 ```
+
+---
+
+## Skills
+
+DevTrail 提供一组 skills（slash 命令）供 AI 助手内使用（Claude Code、Gemini Code、Cursor、通用 Agent 运行时）。每个 skill 在 `devtrail init` 时以 3 种平行形式安装：
+
+- `dist/.claude/skills/<skill>/SKILL.md`（Claude — frontmatter 含 `allowed-tools`）
+- `dist/.gemini/skills/<skill>/SKILL.md`（Gemini — frontmatter 不含 `allowed-tools`）
+- `dist/.agent/workflows/<skill>.md`（通用 Agent — 仅 `description` frontmatter）
+
+| Skill | 用途 | 产生的文件 |
+|---|---|---|
+| `/devtrail-status` | 检查近期变更的文档合规状态。 | 无（read-only） |
+| `/devtrail-new` | 交互式创建任意类型的文档。从上下文建议最佳匹配。 | `.devtrail/<type-dir>/<TYPE>-YYYY-MM-DD-NNN-*.md` |
+| `/devtrail-ailog` | 快速 AILOG 创建快捷方式。 | `.devtrail/07-ai-audit/agent-logs/AILOG-*.md` |
+| `/devtrail-aidec` | 快速 AIDEC 创建快捷方式。 | `.devtrail/07-ai-audit/decisions/AIDEC-*.md` |
+| `/devtrail-adr` | 快速 ADR 创建快捷方式。 | `.devtrail/04-architecture/decisions/ADR-*.md` |
+| `/devtrail-mcard` | 交互式 Model Card 创建流程。 | `.devtrail/09-ai-models/MCARD-*.md` |
+| `/devtrail-sec` | 交互式 SEC（安全评估）流程。 | `.devtrail/08-security/SEC-*.md` |
+| `/devtrail-audit-prompt CHARTER-ID` *(fw-4.8.0+)* | 内联生成外部多模型审计 prompts。封装 `devtrail charter audit` PREPARE — 运行 CLI 解析 `auditor-primary.prompt.md` 与 `auditor-secondary.prompt.md`，并在对话中展示两个 prompts，操作员可粘贴到 2 个不同族的 LLM。 | `audit/charters/<CHARTER-ID>/prompts/auditor-{primary,secondary}.prompt.md`（通过其封装的 CLI） |
+| `/devtrail-audit-review CHARTER-ID` *(fw-4.8.0+)* | `/devtrail-audit-prompt` 的对应。验证操作员保存的审计员响应，内联运行校准器（驱动对话的 Agent 是有效的校准器，因为异质性仅对审计员对必需），并运行 `devtrail charter audit --finalize --merge-into` 直接将 `external_audit:` 追加到 `.devtrail/charters/<CHARTER-ID>.telemetry.yaml`。如果遥测尚不存在（Charter 未关闭），写入 `audit/charters/<CHARTER-ID>/external-audit-pending.yaml` 供后续手动合并。 | `audit/charters/<CHARTER-ID>/calibrator-reconciler.md`，`external_audit:` 数组合并入遥测 |
+
+### Skill vs CLI
+
+两个审计 skill 是 CLI 命令的**封装**。`audit/` 目录布局、prompts、schema 验证、`external_audit` 形状全部在 CLI 中 — skills 仅处理 UX-inline 部分（在对话中展示 prompts，内联运行校准器，触发合并）。不在循环中使用 AI 助手的 adopter 可直接通过 `devtrail charter audit`（PREPARE / `--calibrate` / `--finalize [--merge-into <path>]`）驱动相同工作流。
+
+### 审计检查点 *(fw-4.8.0+)*
+
+`.devtrail/00-governance/AGENT-RULES.md` §12 编码了一个工作流检查点，其中 Agent 在某个特定时刻主动提议审计 — 当 Charter 实现完成、drift 干净，且 `charter close` 尚未调用时。推荐基于启发式给出 是/否（安全面、新组件、AILOG 风险、复杂度）。外部审计**完全可选**；检查点是**软性**的 — 永不阻塞 `charter close`，永不强制（v0+v1 永久设计决策）。
 
 ---
 

--- a/docs/i18n/zh-CN/adopters/WORKFLOWS.md
+++ b/docs/i18n/zh-CN/adopters/WORKFLOWS.md
@@ -122,8 +122,16 @@ DevTrail 有两个文档系统：
 | `/devtrail-ailog` | 快速创建 AILOG |
 | `/devtrail-aidec` | 快速创建 AIDEC |
 | `/devtrail-adr` | 快速创建 ADR |
+| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+)* | 内联生成外部多模型审计 prompts。封装 `devtrail charter audit` PREPARE；在对话中展示两个审计员 prompts，操作员可粘贴到 2 个不同族的 LLM。 |
+| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+)* | `audit-prompt` 的对应。验证审计员响应，内联运行校准器，并通过 `--merge-into` 将 findings 合并到 Charter 遥测。 |
 
 完整 Skill 详情参见 [README](../README.md#skills)。
+
+### Charter 审计检查点 *(fw-4.8.0+)*
+
+在与人共同实现 Charter 时，Agent 会在一个特定时刻主动提议外部审计：当实现完成、drift 干净，且 `charter close` 尚未调用时。推荐基于 Charter 的风险面和复杂度给出 是/否（完整启发式见 `.devtrail/00-governance/AGENT-RULES.md` §12）。
+
+外部审计**完全可选**且**永不强制**。Charter 的声明性范围 + drift check + AILOG 纪律已为关闭提供了足够严格的支撑。审计在 Charter 触及安全面、引入新组件或 diff 中存在高复杂度函数时增加跨模型信号。如果你的情况下成本（2-3 个 LLM 审计员）与价值不匹配，可以自由拒绝。
 
 ---
 


### PR DESCRIPTION
## Summary

Fourth of 5 PRs implementing **Phase 1** of `Propuesta/devtrail-audit-skills.md`. Surfaces the two new skills (`/devtrail-audit-prompt`, `/devtrail-audit-review`) and the audit checkpoint to adopter-facing documentation, across the 3 supported languages.

## What changed (12 files: 4 docs × 3 langs)

### `WORKFLOWS.md`
- Skills table gains 2 rows for the audit skills, both marked `(fw-4.8.0+)`.
- New "Charter audit checkpoint" subsection summarising the trigger moment and the explicit "fully optional, never enforced" framing from `AGENT-RULES.md §12`.

### `CLI-REFERENCE.md`
- New `## Skills` section listing all 9 shipped skills (7 existing + 2 audit) with purpose + files produced. Documents the 3-platform install shape (Claude / Gemini / generic agent).
- New `### Skill vs CLI` subsection clarifying that the two audit skills are wrappers — CLI remains the single source of truth.
- New `### Audit checkpoint` subsection cross-referencing `AGENT-RULES §12`.
- `### devtrail charter audit` gains a "Skill alternative" callout pointing at the wrapper skills for IDE-driven workflows.

### `ADOPTION-GUIDE.md`
- New `## External Audit (Optional)` section between the verification checklist and the FAQ, summarising what the skills do and the explicit optionality / no-enforcement commitment.

### `QUICK-REFERENCE.md` (in `dist/.devtrail/00-governance/`)
- Skills table expanded from 1 row to a complete cheat-sheet of all 9 skills (previously only listed `/devtrail-status`).

## Test plan

- [x] No CLI / test changes; tests from PR 3 (`checkpoint_guidance_test.rs`, `audit_skill_test.rs`) continue to pass — none of the files they assert against were touched here.
- [x] All 3 language versions of each doc are kept in structural parity (same new sections, same anchor text where it references skill names or fw versions).
- [x] No version bump (Phase 1 PR 5).

## Phase 1 progress

| PR | Title | Status |
|---|---|---|
| 1 | Skill `devtrail-audit-prompt` + tests | merged (#96) |
| 2 | Skill `devtrail-audit-review` + CLI `--merge-into` flag | merged (#97) |
| 3 | Checkpoint guidance in `AGENT-RULES.md` (3 langs) + fixture tests | merged (#98) |
| 4 | Adopter docs (WORKFLOWS / CLI-REFERENCE / ADOPTION-GUIDE / QUICK-REFERENCE in 3 langs) | **this PR** |
| 5 | Bump `fw-X.Y.0` + `cli-X.Y.0` + CHANGELOG + tag release | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)