### PR TITLE
chore: bump fw-4.8.0 / cli-3.9.0 — Phase 1 audit skills release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.8.0 / CLI 3.9.0 — External audit skills + workflow checkpoint
+
+Phase 1 of `Propuesta/devtrail-audit-skills.md`: closes the back-half of the external multi-model audit cycle by surfacing it inside the AI assistant in the loop, and codifies a soft (never-enforced) workflow checkpoint where the agent proactively offers the audit at the right moment. External audit remains **fully optional** — the Charter's declarative scope + drift check + AILOG discipline already provide rigorous closure without it. The skills only add UX-inline; the underlying CLI orchestration is unchanged in shape, only extended with a new `--merge-into` flag to close the manual copy-paste loop.
+
+This release also fixes a pre-existing bug in `devtrail charter audit --finalize` where the rendered `audit_notes:` field contained the literal placeholder `<charter-id>` instead of the canonical Charter id.
+
+### Added (Framework)
+
+- **Skill `/devtrail-audit-prompt CHARTER-ID`** (3 platforms): `dist/.claude/skills/devtrail-audit-prompt/SKILL.md`, `dist/.gemini/skills/devtrail-audit-prompt/SKILL.md`, `dist/.agent/workflows/devtrail-audit-prompt.md`. Wraps `devtrail charter audit` PREPARE — surfaces both auditor prompts inline in the conversation so the operator can paste them into 2 LLMs of different families without leaving the IDE.
+- **Skill `/devtrail-audit-review CHARTER-ID`** (3 platforms): same install shape. Validates the operator-saved auditor responses, runs the calibrator inline (the agent driving the conversation IS a valid calibrator since heterogeneity is required only for the auditor pair), and triggers `devtrail charter audit --finalize --merge-into` so the `external_audit:` array lands directly in the Charter telemetry. Branch B (telemetry not yet present) writes `audit/charters/<id>/external-audit-pending.yaml` for later manual merge.
+- **AGENT-RULES.md §12 "Audit Checkpoint"** (3 langs: EN / ES / zh-CN): codifies the 4 boolean triggers, the literal YES/NO message text, the YES/NO heuristics (security surface, new component, AILOG risks, large + first Charter, explicit cross-model request, **arborist 2× threshold complexity signal with graceful-degradation when the `analyze` feature is absent**), and the rules of engagement (emit once per Charter, never block, not counted as a metric). Permanent v0+v1 design decision — the checkpoint will never be escalated to enforcement.
+- **Adopter docs surfaced** the new skills + checkpoint in `WORKFLOWS.md`, `CLI-REFERENCE.md` (new `## Skills` section listing all 9 shipped skills), `ADOPTION-GUIDE.md` (new `## External Audit (Optional)` section), and `QUICK-REFERENCE.md` (skills table expanded from 1 row to all 9), across all 3 languages.
+
+### Added (CLI)
+
+- **`devtrail charter audit --finalize --merge-into <PATH>`** *(`cli-3.9.0+`)* — appends the rendered `external_audit:` array directly into the telemetry YAML at `<PATH>` instead of printing it to stdout. String-level append at indent 2 under `charter_telemetry:` (preserves the hand-written shape from `charter close`; no full re-serialization → no comment loss). v0 deliberately rejects re-audit (file already has `external_audit:`) with a clear error — operator reconciles manually rather than risk silent duplication. Missing telemetry path errors with explicit guidance to run `devtrail charter close` first or omit the flag.
+
+### Fixed (CLI)
+
+- **`render_external_audit_yaml` now emits the canonical Charter id** in `audit_notes:` instead of the literal placeholder `<charter-id>`. The function takes the canonical id as a parameter; both the stdout path and the new `--merge-into` path produce correct output.
+
+### Tests
+
+- 4 new integration tests in `cli/tests/charter_audit_test.rs` covering the `--merge-into` flag (happy path, missing telemetry, re-audit guard, clap rejection without `--finalize`).
+- 8 new fixture tests in `cli/tests/audit_skill_test.rs` covering both audit skills across 3 platforms (per-platform frontmatter shape + cross-platform parity of load-bearing guidance).
+- 4 new fixture tests in `cli/tests/checkpoint_guidance_test.rs` covering the §12 Audit Checkpoint section across 3 languages (presence + cross-language parity of language-agnostic anchors).
+
+### Documentation only
+
+- Versioning tables, governance footers, and CLI output examples updated from `fw-4.7.1` / `cli-3.8.1` to `fw-4.8.0` / `cli-3.9.0` across 22 files (3 languages).
+
+---
+
 ## Framework 4.7.1 / CLI 3.8.1 — O3 resolved (`--no-ailog-suppress` always emits INFO line)
 
 Closes the last `pending design discussion` carried forward from issue #81:

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ DevTrail uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.7.1` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.8.1` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.8.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.9.0` | The `devtrail` binary |
 
 Check installed versions with `devtrail status` or `devtrail about`.
 
@@ -292,7 +292,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/a
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/devtrail/releases
-# and download the latest fw-* release (e.g., fw-4.7.1)
+# and download the latest fw-* release (e.g., fw-4.8.0)
 
 # Extract and copy to your project
 unzip devtrail-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "devtrail-cli"
-version = "3.8.1"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtrail-cli"
-version = "3.8.1"
+version = "3.9.0"
 edition = "2021"
 description = "CLI for DevTrail — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/dist/.devtrail/00-governance/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/AGENT-RULES.md
@@ -345,4 +345,4 @@ These are heuristics, not rigid rules — you are close to the context, refine t
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md
@@ -307,4 +307,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/QUICK-REFERENCE.md
@@ -218,4 +218,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/es/AGENT-RULES.md
@@ -345,4 +345,4 @@ Son heurísticas, no reglas rígidas — estás cerca del contexto, afínalas co
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -300,4 +300,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -193,4 +193,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -342,4 +342,4 @@ confidence: high | medium | low
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -299,4 +299,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.devtrail/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -193,4 +193,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*DevTrail v4.7.1 | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.devtrail/QUICK-REFERENCE.md
+++ b/dist/.devtrail/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*DevTrail v4.7.1 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*
+*DevTrail v4.8.0 | [GitHub](https://github.com/StrangeDaysTech/devtrail) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.7.1"
+version: "4.8.0"
 description: "DevTrail distribution manifest"
 repository: "https://github.com/StrangeDaysTech/devtrail"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.7.1`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.8.0`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.7.1` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.8.1` | The `devtrail` binary |
+| Framework | `fw-` | `fw-4.8.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.9.0` | The `devtrail` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize DevTrail in a project directory.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.7.1
+✔ Downloaded DevTrail fw-4.8.0
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.devtrail/` does not exist in the current directory, the framework update is
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.7.1
+✔ Framework updated to fw-4.8.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.7.1
+✔ Framework updated to fw-4.8.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.7.1                 │
+  │ Framework │ fw-4.8.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.7.1
+  Using version: fw-4.8.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -423,7 +423,7 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 - `devtrail charter status` — show Charter detail, or the most recent 5 Charters
 - `devtrail charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.0+)*
 - `devtrail charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.0+)*
-- `devtrail charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.7.1+)*
+- `devtrail charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.8.0+)*
 
 #### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
@@ -556,7 +556,7 @@ Detect file-vs-commit drift at Charter close. Wraps the framework's `.devtrail/s
 |---|---|---|
 | `CHARTER-ID` | — | Same resolution rules as `charter status` |
 | `--range` | `HEAD~1..HEAD` | Git revision range to check |
-| `--no-ailog-suppress` *(cli-3.8.1+ always emits a confirming INFO line)* | false | Disable AILOG-aware suppression (show every declared-omitted path). When passed, the CLI always prints an `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` line — including when N=0 — so that the diagnostic mode is visible in output even on a clean run. |
+| `--no-ailog-suppress` *(cli-3.9.0+ always emits a confirming INFO line)* | false | Disable AILOG-aware suppression (show every declared-omitted path). When passed, the CLI always prints an `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` line — including when N=0 — so that the diagnostic mode is visible in output even on a clean run. |
 | `--path` | `.` | Target project directory |
 
 **Exit codes:** `0` if no drift (or only AILOG-suppressed); `1` if there's unaccounted drift; `2` for usage errors (Charter not found, bash missing, etc.).
@@ -582,14 +582,14 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 > **Platform note.** The drift check delegates to `bash`. On Linux/macOS/WSL/Git Bash this works out of the box. On Windows native without WSL, install Git Bash; a pure-Rust fallback is on the roadmap but not in fw-4.6.x.
 
-#### Wildcard support in declared paths *(fw-4.7.1+)*
+#### Wildcard support in declared paths *(fw-4.8.0+)*
 
 The drift check resolves two forms of wildcard in `## Files to modify`:
 
 | Form | Example | Use case |
 |---|---|---|
 | Ellipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Any modified path with that prefix satisfies the wildcard. Used historically when an unknown number of AILOGs would be created during execution. |
-| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.7.1 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.8.0 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
 
 Both forms are handled in both directions: a declared wildcard suppresses both "declared but not modified" warnings (when at least one matching file was modified) and "modified but not declared" warnings (when a modified path matches a declared wildcard).
 
@@ -1050,7 +1050,7 @@ Show version, authorship, and license information.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.7.1
+  Framework version: fw-4.8.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -222,8 +222,8 @@ DevTrail usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.7.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.8.1` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.8.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.9.0` | El binario `devtrail` |
 
 Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
 
@@ -255,7 +255,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/devtrail/releases
-# y descarga el último release fw-* (ej. fw-4.7.1)
+# y descarga el último release fw-* (ej. fw-4.8.0)
 
 # Extraer y copiar a tu proyecto
 unzip devtrail-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.7.1`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.8.0`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.7.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.8.1` | El binario `devtrail` |
+| Framework | `fw-` | `fw-4.8.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.9.0` | El binario `devtrail` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -88,7 +88,7 @@ Inicializa DevTrail en un directorio de proyecto.
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.7.1
+✔ Downloaded DevTrail fw-4.8.0
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.devtrail/` no existe en el directorio actual, la actualización del framewo
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.7.1
+✔ Framework updated to fw-4.8.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.7.1
+✔ Framework updated to fw-4.8.0
 ```
 
 ---
@@ -205,7 +205,7 @@ $ devtrail status
 DevTrail Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.7.1
+Framework version: fw-4.8.0
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -269,7 +269,7 @@ Valida documentos DevTrail verificando cumplimiento y corrección.
 | `path` | `.` (directorio actual) | Directorio del proyecto |
 | `--fix` | — | Corregir automáticamente problemas simples |
 | `--staged` | — | Validar solo archivos staged en Git (ideal para hooks pre-commit) |
-| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.8.1. |
+| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.9.0. |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | Lista documentos con `review_required: true` y sin `review_outcome` cuya antigüedad supere `--max-pending-days`. **Solo warn** — nunca falla el exit code de validate; útil para dashboards de CI sobre el backlog de aprobaciones. |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | Umbral en días para `--check-pending-reviews`. |
 
@@ -490,7 +490,7 @@ Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del fr
 |---|---|---|
 | `CHARTER-ID` | — | Mismas reglas de resolución que `charter status`. |
 | `--range` | `HEAD~1..HEAD` | Rango de revisiones git a chequear. |
-| `--no-ailog-suppress` *(cli-3.8.1+ siempre emite una línea INFO de confirmación)* | false | Deshabilita la supresión AILOG-aware (muestra todo path declarado-omitido). Cuando se pasa el flag, el CLI siempre imprime una línea `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` — incluso cuando N=0 — para que el modo diagnóstico sea visible en la salida aun en una corrida limpia. |
+| `--no-ailog-suppress` *(cli-3.9.0+ siempre emite una línea INFO de confirmación)* | false | Deshabilita la supresión AILOG-aware (muestra todo path declarado-omitido). Cuando se pasa el flag, el CLI siempre imprime una línea `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` — incluso cuando N=0 — para que el modo diagnóstico sea visible en la salida aun en una corrida limpia. |
 | `--path` | `.` | Directorio del proyecto. |
 
 **Códigos de salida:** `0` si no hay drift (o solo AILOG-suprimido); `1` si hay drift no contabilizado; `2` para errores de uso (Charter no encontrado, bash ausente, etc.).
@@ -516,14 +516,14 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 > **Nota de plataforma.** El chequeo de drift delega en `bash`. En Linux/macOS/WSL/Git Bash funciona out-of-the-box. En Windows nativo sin WSL, instalar Git Bash; un fallback puro Rust está en el roadmap pero no en fw-4.6.x.
 
-#### Soporte de wildcards en paths declarados *(fw-4.7.1+)*
+#### Soporte de wildcards en paths declarados *(fw-4.8.0+)*
 
 El chequeo de drift resuelve dos formas de wildcard en `## Files to modify`:
 
 | Forma | Ejemplo | Caso de uso |
 |---|---|---|
 | Elipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Cualquier path modificado con ese prefijo satisface el wildcard. Usado históricamente cuando un número desconocido de AILOGs serían creados durante la ejecución. |
-| Glob | `` `AILOG-*.md` `` o `` `src/services/foo-*.rs` `` | Cualquier path modificado que matchee el glob (`*` → `.*`) satisface el wildcard. Usado para declaraciones bulk de Charter donde un set parametrizado es tocado. Añadido en fw-4.7.1 tras la fricción surgida en Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+| Glob | `` `AILOG-*.md` `` o `` `src/services/foo-*.rs` `` | Cualquier path modificado que matchee el glob (`*` → `.*`) satisface el wildcard. Usado para declaraciones bulk de Charter donde un set parametrizado es tocado. Añadido en fw-4.8.0 tras la fricción surgida en Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
 
 Ambas formas se manejan en ambas direcciones: un wildcard declarado suprime tanto warnings de "declarado pero no modificado" (cuando al menos un archivo matching fue modificado) como warnings de "modificado pero no declarado" (cuando un path modificado matchea un wildcard declarado).
 
@@ -886,7 +886,7 @@ Muestra información de versión, autoría y licencia.
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.7.1
+  Framework version: fw-4.8.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -240,8 +240,8 @@ DevTrail 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.7.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.8.1` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.8.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.9.0` | `devtrail` 二进制文件 |
 
 使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
 
@@ -273,7 +273,7 @@ DevTrail 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/devtrail/releases
-# 下载最新的 fw-* 发布（例如 fw-4.7.1）
+# 下载最新的 fw-* 发布（例如 fw-4.8.0）
 
 # 解压并复制到你的项目
 unzip devtrail-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.7.1`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.8.0`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ DevTrail 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.7.1` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.8.1` | `devtrail` 二进制文件 |
+| Framework | `fw-` | `fw-4.8.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.9.0` | `devtrail` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -88,7 +88,7 @@ devtrail status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ devtrail init .
-✔ Downloaded DevTrail fw-4.7.1
+✔ Downloaded DevTrail fw-4.8.0
 ✔ Created .devtrail/ directory structure
 ✔ Created DEVTRAIL.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
 ```bash
 $ devtrail update
 Updating framework...
-✔ Framework updated to fw-4.7.1
+✔ Framework updated to fw-4.8.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ devtrail update-framework
-✔ Framework updated to fw-4.7.1
+✔ Framework updated to fw-4.8.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ devtrail status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.7.1                 │
+  │ Framework │ fw-4.8.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing DevTrail in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .devtrail/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.7.1
+  Using version: fw-4.8.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -288,7 +288,7 @@ Repairing DevTrail in /home/user/my-project
 | `path` | `.`（当前目录） | 目标项目目录 |
 | `--fix` | — | 自动修复简单问题（例如为高风险文档添加缺失的 `review_required: true`） |
 | `--staged` | — | 仅验证已暂存（git add）的文件。适合 pre-commit 钩子。 |
-| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.8.1 中加入。 |
+| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.9.0 中加入。 |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | 列出所有 `review_required: true` 且没有 `review_outcome`、年龄超过 `--max-pending-days` 的文档。**仅警告** — 永不影响 validate 的退出码；适合用于 CI 仪表板上的审批积压视图。 |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | `--check-pending-reviews` 的天数阈值。 |
 
@@ -507,7 +507,7 @@ $ devtrail charter close CHARTER-01
 |---|---|---|
 | `CHARTER-ID` | — | 与 `charter status` 相同的解析规则。 |
 | `--range` | `HEAD~1..HEAD` | 要检查的 git 修订范围。 |
-| `--no-ailog-suppress` *(cli-3.8.1+ 始终输出确认 INFO 行)* | false | 禁用 AILOG 感知抑制（显示每条已声明但被遗漏的路径）。传入此标志时，CLI 始终打印 `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` 行 — 即使 N=0 — 以便诊断模式即使在干净运行时也在输出中可见。 |
+| `--no-ailog-suppress` *(cli-3.9.0+ 始终输出确认 INFO 行)* | false | 禁用 AILOG 感知抑制（显示每条已声明但被遗漏的路径）。传入此标志时，CLI 始终打印 `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` 行 — 即使 N=0 — 以便诊断模式即使在干净运行时也在输出中可见。 |
 | `--path` | `.` | 目标项目目录。 |
 
 **退出码：** `0` 没有漂移（或仅 AILOG 抑制）；`1` 存在未计入的漂移；`2` 用法错误（章程未找到、bash 缺失等）。
@@ -533,14 +533,14 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 > **平台说明。** 漂移检查委托给 `bash`。在 Linux/macOS/WSL/Git Bash 上开箱即用。Windows 原生且无 WSL 时需安装 Git Bash；纯 Rust fallback 在路线图上但不在 fw-4.6.x 中。
 
-#### 已声明路径的通配符支持 *(fw-4.7.1+)*
+#### 已声明路径的通配符支持 *(fw-4.8.0+)*
 
 漂移检查在 `## Files to modify` 中解析两种通配符形式：
 
 | 形式 | 示例 | 用例 |
 |---|---|---|
 | 省略号 | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | 任何带该前缀的修改路径满足通配符。历史上用于执行期间会创建未知数量 AILOG 的情况。 |
-| Glob | `` `AILOG-*.md` `` 或 `` `src/services/foo-*.rs` `` | 任何匹配该 glob（`*` → `.*`）的修改路径满足通配符。用于参数化集合被触动的批量章程声明。在 fw-4.7.1 中加入，源于 Sentinel CHARTER-04 暴露的摩擦（[issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)）。 |
+| Glob | `` `AILOG-*.md` `` 或 `` `src/services/foo-*.rs` `` | 任何匹配该 glob（`*` → `.*`）的修改路径满足通配符。用于参数化集合被触动的批量章程声明。在 fw-4.8.0 中加入，源于 Sentinel CHARTER-04 暴露的摩擦（[issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)）。 |
 
 两种形式都双向处理：声明的通配符既抑制"已声明但未修改"警告（当至少一个匹配文件被修改时），也抑制"已修改但未声明"警告（当一个修改路径匹配某个已声明通配符时）。
 
@@ -993,7 +993,7 @@ $ devtrail explore --lang es             # 会话内切换到西班牙语
 $ devtrail about
 DevTrail CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.7.1
+  Framework version: fw-4.8.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/devtrail


### PR DESCRIPTION
## Summary

**Phase 1 release** of `Propuesta/devtrail-audit-skills.md`. Tags the previously-merged PRs (#96, #97, #98, #99) into a coherent shipped release.

### Bumps

- `cli/Cargo.toml`: **3.8.1 → 3.9.0** (minor — new `--merge-into` flag on `devtrail charter audit --finalize`, plus a fix for the `audit_notes:` placeholder bug; no breaking changes).
- `dist/dist-manifest.yml`: **4.7.1 → 4.8.0** (minor — 2 new skills + new `AGENT-RULES.md §12` section; no breaking changes).

### What's in the release

- **Skill `/devtrail-audit-prompt CHARTER-ID`** — wraps `devtrail charter audit` PREPARE; surfaces both auditor prompts inline so the operator can paste into 2 LLMs of different families without leaving the IDE.
- **Skill `/devtrail-audit-review CHARTER-ID`** — counterpart back-half: validates auditor responses, runs the calibrator inline, triggers `--merge-into` so `external_audit:` lands directly in Charter telemetry.
- **CLI `--merge-into <PATH>`** flag on `--finalize` — string-level append at indent 2 under `charter_telemetry:`, preserves the hand-written shape from `charter close`. v0 rejects re-audit (file already has `external_audit:`).
- **AGENT-RULES.md §12 Audit Checkpoint** — codifies the soft (never-enforced) workflow checkpoint where the agent proactively offers the audit at the right moment. Includes the arborist 2× threshold heuristic with graceful-degradation when the `analyze` feature is absent.
- **Adopter docs** updated across `WORKFLOWS.md`, `CLI-REFERENCE.md` (new `## Skills` section listing all 9 skills), `ADOPTION-GUIDE.md` (new `## External Audit (Optional)`), and `QUICK-REFERENCE.md` (skills table now complete) — all 3 langs.
- **Bug fix**: `render_external_audit_yaml` now emits the canonical Charter id in `audit_notes:` instead of the literal placeholder `<charter-id>`.

### Tests

- 4 new integration tests on `--merge-into` behaviour (happy / missing telemetry / re-audit guard / clap rejection).
- 8 new fixture tests on the two skills × 3 platforms.
- 4 new fixture tests on `AGENT-RULES.md §12` × 3 langs.
- Full suite: 271 unit tests + all integration tests green.

### After merge

Tags `fw-4.8.0` and `cli-3.9.0` will be pushed, triggering the release workflows (framework ZIP + 4 platform CLI binaries). Adopters get the new release via `devtrail update-framework` / `devtrail update-cli`.

## Phase 1 progress

| PR | Title | Status |
|---|---|---|
| 1 | Skill `devtrail-audit-prompt` + tests | merged (#96) |
| 2 | Skill `devtrail-audit-review` + CLI `--merge-into` flag | merged (#97) |
| 3 | Checkpoint guidance in `AGENT-RULES.md` (3 langs) + fixture tests | merged (#98) |
| 4 | Adopter docs (3 langs) | merged (#99) |
| 5 | Bump `fw-4.8.0` + `cli-3.9.0` + CHANGELOG + tag release | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)