### PR TITLE
docs: mention audit skills wrapper in README CLI Tooling bullet (3 langs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Built-in safeguards ensure humans stay in control:
 
 Built-in commands that turn the discipline into actionable feedback:
 
-- **`devtrail charter <new|list|status|close|drift|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression; `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls).
+- **`devtrail charter <new|list|status|close|drift|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression; `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/devtrail-audit-prompt` and `/devtrail-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
 - **`devtrail approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
 - **`devtrail validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `docs/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
 - **`devtrail metrics`** — Governance KPIs, review rates, risk distribution, trends

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -125,7 +125,7 @@ Salvaguardas incorporadas que aseguran que los humanos mantengan el control:
 
 Comandos integrados que convierten la disciplina en feedback accionable:
 
-- **`devtrail charter <new|list|status|close|drift|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware; `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM).
+- **`devtrail charter <new|list|status|close|drift|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware; `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/devtrail-audit-prompt` y `/devtrail-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
 - **`devtrail approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
 - **`devtrail validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `docs/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
 - **`devtrail metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -125,7 +125,7 @@ DevTrail 的产品决策基于十二条明确的原则。它们按层级排序�
 
 将纪律转化为可执行反馈的内置命令：
 
-- **`devtrail charter <new|list|status|close|drift|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。
+- **`devtrail charter <new|list|status|close|drift|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/devtrail-audit-prompt` 和 `/devtrail-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
 - **`devtrail approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
 - **`devtrail validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `docs/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
 - **`devtrail metrics`** — 治理 KPI、审查率、风险分布、趋势


### PR DESCRIPTION
## Summary

Single-sentence callout on the existing \`devtrail charter audit\` bullet of the CLI Tooling section, pointing at the inline skill counterparts shipped in \`fw-4.8.0\` (\`/devtrail-audit-prompt\`, \`/devtrail-audit-review\`). Applied symmetrically to EN canonical + ES + zh-CN.

## Rationale for the minimal scope

- The README does **not** list any of the 9 shipped skills today; surfacing only the 2 audit ones in a dedicated section would be asymmetric. The \`charter audit\` bullet is the natural attachment point because the skills wrap that exact CLI command.
- Phrasing is **atemporal** (no \`fw-4.8.0\` mentioned) so the README does not need re-touching at each release.
- The checkpoint guidance (\`AGENT-RULES.md §12\`) is agent behavior, not CLI feature — it stays in \`WORKFLOWS.md\` and \`AGENT-RULES.md\`, not the README CLI Tooling section.

## Test plan

- [x] Each README contains exactly one line referencing both skill names (verified via grep).
- [x] No CLI changes, no test changes, no version bump.
- [x] 3 langs in structural parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)