### PR TITLE
PR 3/6 (rebrand) — public repo docs (README, CLAUDE.md, adopter docs in 3 langs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to DevTrail will be documented in this file.
+All notable changes to StrayMark (formerly DevTrail; rebranded 2026-05-08, see [`ADR-2026-05-08-001`](docs/decisions/ADR-2026-05-08-rebranding-straymark.md)) will be documented in this file. Historical entries below preserve the "DevTrail" name where present — that was the project's name at the time of those releases.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [independent versioning](README.md#versioning) for Framework (`fw-`) and CLI (`cli-`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,21 @@
-# DevTrail — Development Instructions
+# StrayMark — Development Instructions
 
-This is the DevTrail project repository. It contains two main components:
+This is the StrayMark project repository. It contains two main components:
 
 - **Framework** (`dist/`): documentation templates, governance policies, and agent directives
-- **CLI** (`cli/`): the `devtrail` Rust binary that manages the framework in user projects
+- **CLI** (`cli/`): the `straymark` Rust binary that manages the framework in user projects
 
 ## Project Structure
 
 ```
-devtrail/
+straymark/
 ├── cli/                    # Rust CLI source code
 │   ├── src/
 │   │   ├── main.rs         # Entry point, command routing
 │   │   ├── commands/       # Subcommands: init, update, remove, status, repair, validate, new, compliance, metrics, analyze, audit, explore, about
 │   │   ├── tui/            # Terminal UI for `explore` (ratatui + crossterm)
 │   │   ├── analysis_engine.rs # Code complexity analysis (arborist-metrics)
-│   │   ├── config.rs       # DevTrailConfig, Checksums, ComplexityConfig
+│   │   ├── config.rs       # StrayMarkConfig, Checksums, ComplexityConfig
 │   │   ├── download.rs     # GitHub API, ZIP downloads
 │   │   ├── inject.rs       # Directive injection system
 │   │   ├── manifest.rs     # dist-manifest.yml parser
@@ -26,8 +26,8 @@ devtrail/
 │   ├── Cargo.toml
 │   └── Cargo.lock
 ├── dist/                   # Framework distribution files
-│   ├── .devtrail/          # Templates, governance, config
-│   ├── DEVTRAIL.md         # Unified governance rules
+│   ├── .straymark/          # Templates, governance, config
+│   ├── STRAYMARK.md         # Unified governance rules
 │   └── dist-manifest.yml   # What gets installed
 ├── docs/                   # Project documentation (EN + ES)
 ├── .github/workflows/      # CI/CD
@@ -38,7 +38,7 @@ devtrail/
 
 ## Versioning
 
-DevTrail uses **independent versions** for framework and CLI:
+StrayMark uses **independent versions** for framework and CLI:
 
 | Component | Tag format | Current | Example |
 |-----------|-----------|---------|---------|
@@ -114,7 +114,7 @@ gh release view cli-X.Y.Z --json assets --jq '.assets[].name'
 # Should show 4 binaries
 ```
 
-Users can now run `devtrail update-cli` to get the new version.
+Users can now run `straymark update-cli` to get the new version.
 
 ## Release Workflow — Framework
 
@@ -132,10 +132,10 @@ Update version references in docs:
 - `docs/i18n/es/adopters/CLI-REFERENCE.md` (ES — versioning table)
 - `docs/i18n/zh-CN/adopters/CLI-REFERENCE.md` (zh-CN — versioning table)
 - `README.md`, `docs/i18n/es/README.md`, and `docs/i18n/zh-CN/README.md` (versioning tables)
-- `dist/.devtrail/00-governance/QUICK-REFERENCE.md` (EN + ES + zh-CN footer)
-- `dist/.devtrail/00-governance/AGENT-RULES.md` (EN + ES + zh-CN footer)
-- `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` (EN + ES + zh-CN footer)
-- `dist/.devtrail/00-governance/C4-DIAGRAM-GUIDE.md` (EN + ES + zh-CN footer)
+- `dist/.straymark/00-governance/QUICK-REFERENCE.md` (EN + ES + zh-CN footer)
+- `dist/.straymark/00-governance/AGENT-RULES.md` (EN + ES + zh-CN footer)
+- `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md` (EN + ES + zh-CN footer)
+- `dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md` (EN + ES + zh-CN footer)
 
 Update `CHANGELOG.md` (root) following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
 - Add a new `## Framework X.Y.Z` section at the top (below the header)
@@ -160,7 +160,7 @@ git push origin fw-X.Y.Z
 
 The `release-framework.yml` workflow triggers automatically:
 1. Verifies `dist-manifest.yml` version matches the tag
-2. Packages `dist/` contents into `devtrail-fw-X.Y.Z.zip`
+2. Packages `dist/` contents into `straymark-fw-X.Y.Z.zip`
 3. Creates the GitHub release with the ZIP as asset
 
 **If CI needs re-running**, trigger manually:
@@ -173,30 +173,30 @@ gh workflow run release-framework.yml -f tag=fw-X.Y.Z
 
 ```bash
 gh release view fw-X.Y.Z --json assets --jq '.assets[].name'
-# Should show: devtrail-fw-X.Y.Z.zip
+# Should show: straymark-fw-X.Y.Z.zip
 ```
 
-Users can now run `devtrail update-framework` to get the new version.
+Users can now run `straymark update-framework` to get the new version.
 
 ## CLI Commands Reference
 
 | Command | Description |
 |---------|-------------|
-| `devtrail init [path]` | Initialize DevTrail in a project |
-| `devtrail update` | Update both framework and CLI |
-| `devtrail update-framework` | Update only the framework |
-| `devtrail update-cli` | Update the CLI binary |
-| `devtrail remove [--full]` | Remove DevTrail from project |
-| `devtrail status [path]` | Show installation health and doc stats |
-| `devtrail repair [path]` | Restore missing directories and framework files |
-| `devtrail validate [path] [--staged]` | Validate documents for compliance and correctness |
-| `devtrail new [path] [-t type] [--title]` | Create a new DevTrail document from a template |
-| `devtrail compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
-| `devtrail metrics [path]` | Show governance metrics and documentation statistics |
-| `devtrail analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
-| `devtrail audit [path]` | Generate audit trail reports with timeline and traceability |
-| `devtrail explore [path]` | Interactive TUI documentation browser |
-| `devtrail about` | Show version and license info |
+| `straymark init [path]` | Initialize StrayMark in a project |
+| `straymark update` | Update both framework and CLI |
+| `straymark update-framework` | Update only the framework |
+| `straymark update-cli` | Update the CLI binary |
+| `straymark remove [--full]` | Remove StrayMark from project |
+| `straymark status [path]` | Show installation health and doc stats |
+| `straymark repair [path]` | Restore missing directories and framework files |
+| `straymark validate [path] [--staged]` | Validate documents for compliance and correctness |
+| `straymark new [path] [-t type] [--title]` | Create a new StrayMark document from a template |
+| `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
+| `straymark metrics [path]` | Show governance metrics and documentation statistics |
+| `straymark analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
+| `straymark audit [path]` | Generate audit trail reports with timeline and traceability |
+| `straymark explore [path]` | Interactive TUI documentation browser |
+| `straymark about` | Show version and license info |
 
 ## Development
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in the DevTrail community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in the StrayMark community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
@@ -53,7 +53,7 @@ This Code of Conduct also applies when an individual is officially representing 
 
 If you experience or witness unacceptable behavior, or have any other concerns, please report it by contacting the project team at:
 
-**GitHub Issues**: [Report here](https://github.com/StrangeDaysTech/devtrail/issues)
+**GitHub Issues**: [Report here](https://github.com/StrangeDaysTech/straymark/issues)
 
 All reports will be reviewed and investigated promptly and fairly.
 
@@ -101,7 +101,7 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 ## Appeals
 
-If you believe you have been falsely or unfairly accused of violating this Code of Conduct, you may appeal by opening a detailed issue at [GitHub Issues](https://github.com/StrangeDaysTech/devtrail/issues). Appeals will be reviewed by a different community leader than the one who made the original decision.
+If you believe you have been falsely or unfairly accused of violating this Code of Conduct, you may appeal by opening a detailed issue at [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues). Appeals will be reviewed by a different community leader than the one who made the original decision.
 
 ## Attribution
 
@@ -127,7 +127,7 @@ For answers to common questions about this code of conduct, see the FAQ at [http
 ---
 
 <p align="center">
-  <strong>DevTrail</strong><br>
+  <strong>StrayMark</strong><br>
   Building an inclusive community together<br>
   <a href="https://strangedays.tech">Strange Days Tech, S.A.S.</a>
 </p>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to DevTrail
+# Contributing to StrayMark
 
-Thank you for your interest in contributing to DevTrail! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to StrayMark! This document provides guidelines and information for contributors.
 
 **Languages**: English | [Español](docs/i18n/es/CONTRIBUTING.md) | [简体中文](docs/i18n/zh-CN/CONTRIBUTING.md)
 
@@ -35,7 +35,7 @@ This project requires all contributors to sign a **Contributor License Agreement
 3. The CLA only needs to be signed once — it covers all future contributions to this project.
 4. Once signed, CLA Assistant will update the PR check status and your contribution can proceed to review.
 
-If you have questions about the CLA, please open a [Discussion](https://github.com/StrangeDaysTech/devtrail/discussions).
+If you have questions about the CLA, please open a [Discussion](https://github.com/StrangeDaysTech/straymark/discussions).
 
 ---
 
@@ -96,17 +96,17 @@ Code contributions should:
 
 1. **Fork the repository**
 
-   Click "Fork" on the [GitHub repository page](https://github.com/StrangeDaysTech/devtrail).
+   Click "Fork" on the [GitHub repository page](https://github.com/StrangeDaysTech/straymark).
 
 2. **Clone your fork**
    ```bash
-   git clone https://github.com/your-username/devtrail.git
-   cd devtrail
+   git clone https://github.com/your-username/straymark.git
+   cd straymark
    ```
 
 3. **Install the pre-commit hook**
    ```bash
-   echo 'devtrail validate --staged' > .git/hooks/pre-commit
+   echo 'straymark validate --staged' > .git/hooks/pre-commit
    chmod +x .git/hooks/pre-commit
    ```
 
@@ -125,7 +125,7 @@ Code contributions should:
 
 6. **Make your changes and validate**
    ```bash
-   devtrail validate
+   straymark validate
    ```
 
 ---
@@ -134,7 +134,7 @@ Code contributions should:
 
 ### Before Submitting
 
-- [ ] Run `devtrail validate` successfully
+- [ ] Run `straymark validate` successfully
 - [ ] Update documentation if needed
 - [ ] Add yourself to CONTRIBUTORS.md (if applicable)
 - [ ] Write a clear PR description
@@ -178,7 +178,7 @@ Why is this change needed?
 How were these changes tested?
 
 ## Checklist
-- [ ] `devtrail validate` passes
+- [ ] `straymark validate` passes
 - [ ] Documentation updated
 - [ ] No sensitive information included
 ```
@@ -215,7 +215,7 @@ created: YYYY-MM-DD
 
 ### File Naming
 
-DevTrail documents:
+StrayMark documents:
 ```
 [TYPE]-[YYYY-MM-DD]-[NNN]-[description].md
 ```
@@ -239,13 +239,13 @@ DevTrail documents:
 If you're proposing a new document type:
 
 1. **Create the template**
-   - Add `TEMPLATE-NEWTYPE.md` to `dist/.devtrail/templates/`
+   - Add `TEMPLATE-NEWTYPE.md` to `dist/.straymark/templates/`
    - Follow existing template patterns
 
 2. **Update governance docs**
-   - `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md`
-   - `dist/.devtrail/00-governance/AGENT-RULES.md`
-   - `dist/.devtrail/QUICK-REFERENCE.md`
+   - `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md`
+   - `dist/.straymark/00-governance/AGENT-RULES.md`
+   - `dist/.straymark/QUICK-REFERENCE.md`
 
 3. **Update agent configs**
    - `dist/dist-templates/directives/` (distribution templates)
@@ -278,7 +278,7 @@ Templates should include:
 
 ## CLI Development
 
-The DevTrail CLI is written in Rust and located in the `cli/` directory.
+The StrayMark CLI is written in Rust and located in the `cli/` directory.
 
 ### Building
 
@@ -310,13 +310,13 @@ cli/src/
 ├── main.rs              # Entry point + clap CLI definition
 ├── commands/
 │   ├── mod.rs           # Subcommand routing
-│   ├── init.rs          # devtrail init [path]
-│   ├── update.rs        # devtrail update (combined)
-│   ├── update_framework.rs # devtrail update-framework
-│   ├── update_cli.rs    # devtrail update-cli
-│   ├── remove.rs        # devtrail remove [--full]
-│   ├── status.rs        # devtrail status [path]
-│   └── about.rs         # devtrail about
+│   ├── init.rs          # straymark init [path]
+│   ├── update.rs        # straymark update (combined)
+│   ├── update_framework.rs # straymark update-framework
+│   ├── update_cli.rs    # straymark update-cli
+│   ├── remove.rs        # straymark remove [--full]
+│   ├── status.rs        # straymark status [path]
+│   └── about.rs         # straymark about
 ├── config.rs            # Config and checksums management
 ├── download.rs          # GitHub Releases API (prefix-filtered)
 ├── inject.rs            # Directive file injection (markers)
@@ -334,8 +334,8 @@ cli/src/
 
 If you have questions about contributing:
 
-1. Check existing [Issues](https://github.com/StrangeDaysTech/devtrail/issues)
-2. Check [Discussions](https://github.com/StrangeDaysTech/devtrail/discussions)
+1. Check existing [Issues](https://github.com/StrangeDaysTech/straymark/issues)
+2. Check [Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 3. Open a new Discussion for general questions
 4. Open an Issue for specific bugs or features
 
@@ -349,10 +349,10 @@ Contributors are recognized in:
 - Release notes for significant contributions
 - CONTRIBUTORS.md (for recurring contributors)
 
-Thank you for helping make DevTrail better!
+Thank you for helping make StrayMark better!
 
 ---
 
-*DevTrail — Because every change tells a story.*
+*StrayMark — Because every change tells a story.*
 
 [Strange Days Tech](https://strangedays.tech)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 <div align="center">
 
-# DevTrail
+# StrayMark
 
 **The cognitive discipline your AI-assisted projects need**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/StrangeDaysTech/devtrail/blob/main/LICENSE)
-[![Crates.io](https://img.shields.io/crates/v/devtrail-cli.svg)](https://crates.io/crates/devtrail-cli)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/StrangeDaysTech/devtrail/blob/main/CONTRIBUTING.md)
-[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](https://github.com/StrangeDaysTech/devtrail/blob/main/dist/.devtrail/QUICK-REFERENCE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/LICENSE)
+[![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md)
+[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/QUICK-REFERENCE.md)
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
 [Getting Started](#getting-started) •
-[Who is it for](#who-is-devtrail-for) •
+[Who is it for](#who-is-straymark-for) •
 [Design Principles](#design-principles) •
 [Features](#features) •
 [Compliance](#compliance) •
 [Documentation](#documentation)
 
-**Languages**: English | [Español](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/i18n/es/README.md) | [简体中文](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/i18n/zh-CN/README.md)
+**Languages**: English | [Español](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md) | [简体中文](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md)
 
 </div>
 
@@ -31,7 +31,7 @@ The senior engineers orchestrating these agents don't need *more* agent autonomy
 
 ## The Solution
 
-DevTrail is a **framework + CLI** that externalizes the cognitive discipline of senior software engineering work — explicit scope, declared decisions, named risks, recorded alternatives, audited trails — into versioned files that live alongside the code.
+StrayMark is a **framework + CLI** that externalizes the cognitive discipline of senior software engineering work — explicit scope, declared decisions, named risks, recorded alternatives, audited trails — into versioned files that live alongside the code.
 
 > **"No significant change without a documented trace — and a constrained decision space for the agent."**
 
@@ -39,32 +39,32 @@ The discipline produces, as a side effect, evidence compatible with **ISO/IEC 42
 
 ---
 
-## Who is DevTrail for
+## Who is StrayMark for
 
-DevTrail's primary user is the **senior engineer orchestrating AI agents on a non-trivial system** — someone with strong technical judgment who uses agents to take on work they couldn't realistically do alone, and who needs externalized cognitive discipline so the agent doesn't introduce systemic chaos.
+StrayMark's primary user is the **senior engineer orchestrating AI agents on a non-trivial system** — someone with strong technical judgment who uses agents to take on work they couldn't realistically do alone, and who needs externalized cognitive discipline so the agent doesn't introduce systemic chaos.
 
-If that describes you, DevTrail's flows, defaults, and language are tuned for you.
+If that describes you, StrayMark's flows, defaults, and language are tuned for you.
 
-DevTrail also serves three secondary audiences, on top of that base — never at its expense:
+StrayMark also serves three secondary audiences, on top of that base — never at its expense:
 
 - **Tech leads and architects** standardizing how their team works with AI assistants.
 - **Compliance officers and auditors** who need evidence of governed AI development (ISO 42001, EU AI Act, NIST AI RMF, PIPL, TC260, …).
 - **Adopters in regulated environments** (finance, health, public sector, China) who need traceability built into the workflow rather than reconstructed after the fact.
 
-DevTrail is **not** trying to be: an LLM gateway, a model evaluator, a "10× your code" productivity skin, or a substitute for engineering judgment. See [Honest Limits](#honest-limits) below.
+StrayMark is **not** trying to be: an LLM gateway, a model evaluator, a "10× your code" productivity skin, or a substitute for engineering judgment. See [Honest Limits](#honest-limits) below.
 
 ---
 
 ## Design Principles
 
-DevTrail's product decisions are anchored in twelve explicit principles. They are ordered by hierarchy: when two conflict, the earlier one wins.
+StrayMark's product decisions are anchored in twelve explicit principles. They are ordered by hierarchy: when two conflict, the earlier one wins.
 
 1. **The tool serves the craft, not the product.** The metric is whether the engineer produces work they're proud of — not adoption, retention, or revenue.
 2. **The primary user is the senior engineer orchestrating agents.** Not the VP, not the CISO, not the compliance officer.
 3. **Strict open source, no asterisks in the core.** Framework, CLI and TUI are MIT, with no capped features pushing toward a paid tier.
 4. **Regulatory compliance is a side effect, not the product.** ISO 42001, EU AI Act, NIST AI RMF are useful frames; they are not the goal.
 5. **Schema-driven before feature-driven.** Central entities (Stage Closure Bundle, Charter, Document) are versioned schemas first, features second.
-6. **Cognitive discipline over raw productivity.** DevTrail competes against the chaos that fast AI code generates in serious projects — not against the speed itself.
+6. **Cognitive discipline over raw productivity.** StrayMark competes against the chaos that fast AI code generates in serious projects — not against the speed itself.
 7. **Local-first, Cloud as amplifier.** The CLI works fully offline. Cloud may add value (cross-repo aggregation, signed evidence) but never gates the core.
 8. **Project memory lives in the repo, not in an external database.** AILOGs, ADRs, AIDECs, Charters and bundles are versioned files alongside the code, in markdown + JSON Schema.
 9. **Simplicity over capability.** When two designs meet the goal, the simpler one wins. Patterns crystallize after they're validated in real projects, not before.
@@ -72,7 +72,7 @@ DevTrail's product decisions are anchored in twelve explicit principles. They ar
 11. **The community takes care of the tool, not the other way around.** Contributions and feedback are taken seriously without becoming a democracy.
 12. **The product's velocity is the velocity of learning.** No premature crystallization; schemas marked `v0` until validated against a second domain.
 
-The full document, with empirical annotations from validation cycles, lives in [`Propuesta/devtrail-design-principles.md`](https://github.com/StrangeDaysTech/devtrail/blob/main/Propuesta/devtrail-design-principles.md).
+The full document, with empirical annotations from validation cycles, lives in [`Propuesta/straymark-design-principles.md`](https://github.com/StrangeDaysTech/straymark/blob/main/Propuesta/straymark-design-principles.md).
 
 ---
 
@@ -101,7 +101,7 @@ Sixteen document types covering the full development lifecycle (twelve core + fo
 | **TC260RA** ⚪ | TC260 Risk Assessment (China) | Five-level risk grading per AI Safety Framework v2.0 |
 | **AILABEL** ⚪ | GB 45438 Content Labeling Plan (China) | Explicit + implicit labeling for generative AI |
 
-⚪ Available only when `regional_scope: china` is enabled in `.devtrail/config.yml` — see [Compliance](#compliance) below.
+⚪ Available only when `regional_scope: china` is enabled in `.straymark/config.yml` — see [Compliance](#compliance) below.
 
 ### 🤖 AI Agent Support
 
@@ -131,21 +131,21 @@ Built-in safeguards ensure humans stay in control:
 
 Built-in commands that turn the discipline into actionable feedback:
 
-- **`devtrail charter <new|list|status|close|drift|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression; `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/devtrail-audit-prompt` and `/devtrail-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
-- **`devtrail approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
-- **`devtrail validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `docs/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
-- **`devtrail metrics`** — Governance KPIs, review rates, risk distribution, trends
-- **`devtrail analyze`** — Code complexity analysis (cognitive + cyclomatic) powered by [arborist-metrics](https://github.com/StrangeDaysTech/arborist), our open-source Rust library for multi-language code metrics
-- **`devtrail audit`** — Audit trail reports with timeline, traceability maps, and HTML export
-- **`devtrail compliance`** — Regulatory compliance scoring as a side effect of the documented work (EU AI Act, ISO 42001, NIST AI RMF; six Chinese frameworks opt-in via `--region china`)
-- **`devtrail explore`** — Interactive TUI for navigating the project's documentation graph, including a Charter view (lifecycle status, origin AILOG/spec, file location)
+- **`straymark charter <new|list|status|close|drift|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression; `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
+- **`straymark approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
+- **`straymark validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `docs/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
+- **`straymark metrics`** — Governance KPIs, review rates, risk distribution, trends
+- **`straymark analyze`** — Code complexity analysis (cognitive + cyclomatic) powered by [arborist-metrics](https://github.com/StrangeDaysTech/arborist), our open-source Rust library for multi-language code metrics
+- **`straymark audit`** — Audit trail reports with timeline, traceability maps, and HTML export
+- **`straymark compliance`** — Regulatory compliance scoring as a side effect of the documented work (EU AI Act, ISO 42001, NIST AI RMF; six Chinese frameworks opt-in via `--region china`)
+- **`straymark explore`** — Interactive TUI for navigating the project's documentation graph, including a Charter view (lifecycle status, origin AILOG/spec, file location)
 - **Pre-commit hooks** + **GitHub Actions** for CI/CD validation
 
 ---
 
 ## Honest Limits
 
-DevTrail does **not**:
+StrayMark does **not**:
 
 - evaluate, benchmark, or rank LLMs;
 - act as an LLM gateway or routing layer;
@@ -153,17 +153,17 @@ DevTrail does **not**:
 - automatically certify regulatory compliance — it produces evidence, not certifications;
 - replace the judgment of a senior engineer.
 
-If your problem is one of those, DevTrail is not the tool.
+If your problem is one of those, StrayMark is not the tool.
 
 ---
 
 ## Compliance
 
-The discipline DevTrail externalizes — explicit scope, declared decisions, named risks, recorded alternatives — produces, as a side effect, evidence that maps cleanly onto the major AI governance frameworks. Compliance is therefore positioned as a *consequence of doing the engineering work well*, not as the product itself (Principle #4).
+The discipline StrayMark externalizes — explicit scope, declared decisions, named risks, recorded alternatives — produces, as a side effect, evidence that maps cleanly onto the major AI governance frameworks. Compliance is therefore positioned as a *consequence of doing the engineering work well*, not as the product itself (Principle #4).
 
 ### Standards Alignment
 
-| Standard | DevTrail Integration |
+| Standard | StrayMark Integration |
 |----------|---------------------|
 | **ISO/IEC 42001:2023** | Vertebral standard — AI Management System governance |
 | **EU AI Act** | Risk classification, incident reporting, transparency |
@@ -176,7 +176,7 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 
 ### China Regulatory Coverage — opt-in via `regional_scope: china`
 
-| Standard | DevTrail Integration |
+| Standard | StrayMark Integration |
 |----------|---------------------|
 | **TC260 AI Safety Governance Framework v2.0** | Five-level risk grading (TC260RA) |
 | **PIPL — Personal Information Protection Law** | Personal Information Protection Impact Assessment (PIPIA), retention ≥ 3 years |
@@ -185,15 +185,15 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 | **GB/T 45652-2025** | Pre-training & fine-tuning data security (SBOM/MCARD) |
 | **CSL 2026** | Cybersecurity incident reporting (1h / 4h+72h+30d windows) on INC |
 
-DevTrail covers six Chinese AI / data regulations as an **opt-in** regional scope. Activate by adding `regional_scope: china` to `.devtrail/config.yml`; projects without it are unaffected. When enabled, four China-specific document types (PIPIA, CACFILE, TC260RA, AILABEL) become available, twelve validation rules begin to enforce the new cross-references, and `devtrail compliance --region china` produces a per-framework score. Detailed guides live under `.devtrail/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, `TC260-IMPLEMENTATION-GUIDE.md`, `PIPL-PIPIA-GUIDE.md`, `CAC-FILING-GUIDE.md`, `GB-45438-LABELING-GUIDE.md`).
+StrayMark covers six Chinese AI / data regulations as an **opt-in** regional scope. Activate by adding `regional_scope: china` to `.straymark/config.yml`; projects without it are unaffected. When enabled, four China-specific document types (PIPIA, CACFILE, TC260RA, AILABEL) become available, twelve validation rules begin to enforce the new cross-references, and `straymark compliance --region china` produces a per-framework score. Detailed guides live under `.straymark/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, `TC260-IMPLEMENTATION-GUIDE.md`, `PIPL-PIPIA-GUIDE.md`, `CAC-FILING-GUIDE.md`, `GB-45438-LABELING-GUIDE.md`).
 
 ### 中国法规支持
 
-DevTrail 现在以 **opt-in**(自愿启用)的方式覆盖六项中国 AI / 数据法规:**TC260《人工智能安全治理框架 v2.0》**(五级风险分级)、**《个人信息保护法》(PIPL)** 及其配套的 **PIPIA**(个人信息保护影响评估,留存 ≥ 3 年)、**强制性国家标准 GB 45438-2025**《网络安全技术 人工智能生成合成内容标识方法》(显式 + 隐式标识)、**CAC 算法备案**(包括省级 + 国家级双重备案)、**GB/T 45652-2025** 预训练与微调数据安全,以及自 2026-01-01 生效的 **《网络安全法》修订** 与《国家网络安全事件报告管理办法》(1 小时 / 4 小时 + 72 小时评估 + 30 天事后审查的报告窗口)。
+StrayMark 现在以 **opt-in**(自愿启用)的方式覆盖六项中国 AI / 数据法规:**TC260《人工智能安全治理框架 v2.0》**(五级风险分级)、**《个人信息保护法》(PIPL)** 及其配套的 **PIPIA**(个人信息保护影响评估,留存 ≥ 3 年)、**强制性国家标准 GB 45438-2025**《网络安全技术 人工智能生成合成内容标识方法》(显式 + 隐式标识)、**CAC 算法备案**(包括省级 + 国家级双重备案)、**GB/T 45652-2025** 预训练与微调数据安全,以及自 2026-01-01 生效的 **《网络安全法》修订** 与《国家网络安全事件报告管理办法》(1 小时 / 4 小时 + 72 小时评估 + 30 天事后审查的报告窗口)。
 
 #### 启用方式
 
-在 `.devtrail/config.yml` 中添加:
+在 `.straymark/config.yml` 中添加:
 
 ```yaml
 regional_scope:
@@ -204,10 +204,10 @@ regional_scope:
 
 #### 启用后获得
 
-- **4 个中国专属文档类型**:`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`(均经 `devtrail new` 生成,模板已翻译为中文,位于 `.devtrail/templates/i18n/zh-CN/`)。
-- **6 个合规检查器**:通过 `devtrail compliance --region china` 一次性运行,或单独运行 `--standard china-tc260 | china-pipl | china-gb45438 | china-cac | china-gb45652 | china-csl`。
+- **4 个中国专属文档类型**:`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`(均经 `straymark new` 生成,模板已翻译为中文,位于 `.straymark/templates/i18n/zh-CN/`)。
+- **6 个合规检查器**:通过 `straymark compliance --region china` 一次性运行,或单独运行 `--standard china-tc260 | china-pipl | china-gb45438 | china-cac | china-gb45652 | china-csl`。
 - **12 条新的验证规则**(`CROSS-004…011`、`TYPE-003…006`):自动校验跨文档引用一致性,例如:`cac_filing_required: true` 必须关联 CACFILE;`csl_severity_level: particularly_serious` 必须配合 `csl_report_deadline_hours: 1`;PIPIA 的 `pipl_retention_until` 必须至少为 `created` + 3 年。
-- **5 份中文治理指南**,位于 `.devtrail/00-governance/i18n/zh-CN/`:`CHINA-REGULATORY-FRAMEWORK.md`、`TC260-IMPLEMENTATION-GUIDE.md`、`PIPL-PIPIA-GUIDE.md`、`CAC-FILING-GUIDE.md`、`GB-45438-LABELING-GUIDE.md`。
+- **5 份中文治理指南**,位于 `.straymark/00-governance/i18n/zh-CN/`:`CHINA-REGULATORY-FRAMEWORK.md`、`TC260-IMPLEMENTATION-GUIDE.md`、`PIPL-PIPIA-GUIDE.md`、`CAC-FILING-GUIDE.md`、`GB-45438-LABELING-GUIDE.md`。
 
 #### 适用人群
 
@@ -228,114 +228,114 @@ regional_scope:
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 Or install from source with Cargo:
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
-> **Note:** `devtrail update-cli` automatically detects how you installed the CLI. Prebuilt binary installs update from GitHub Releases; cargo installs update via `cargo install`. You can override with `--method=github` or `--method=cargo`.
+> **Note:** `straymark update-cli` automatically detects how you installed the CLI. Prebuilt binary installs update from GitHub Releases; cargo installs update via `cargo install`. You can override with `--method=github` or `--method=cargo`.
 
 Then initialize in your project:
 
 ```bash
 cd your-project
-devtrail init .
+straymark init .
 ```
 
-The CLI downloads the latest DevTrail release, sets up the framework, and configures your AI agent directive files automatically.
+The CLI downloads the latest StrayMark release, sets up the framework, and configures your AI agent directive files automatically.
 
 ### Versioning
 
-DevTrail uses independent version tags for each component:
+StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.10.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.10.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.10.0` | The `straymark` binary |
 
-Check installed versions with `devtrail status` or `devtrail about`.
+Check installed versions with `straymark status` or `straymark about`.
 
 ### CLI Commands
 
 | Command | Description |
 |---------|-------------|
-| `devtrail init [path]` | Initialize DevTrail in a project |
-| `devtrail update` | Update both framework and CLI |
-| `devtrail update-framework` | Update only the framework |
-| `devtrail update-cli` | Update the CLI binary |
-| `devtrail remove [--full]` | Remove DevTrail from project |
-| `devtrail status [path]` | Show installation health and doc stats |
-| `devtrail repair [path]` | Restore missing directories and framework files |
-| `devtrail validate [path]` | Validate documents for compliance and correctness (use `--include-charters` for Charters, `--check-pending-reviews` for approval backlog) |
-| `devtrail charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness), `audit` (multi-model external review, orchestration-only) |
-| `devtrail approve <doc-id>` | Record a formal human approval on a `review_required: true` document (frontmatter + canonical body section) |
-| `devtrail compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
-| `devtrail metrics [path]` | Show governance metrics and documentation statistics |
-| `devtrail analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
-| `devtrail audit [path]` | Generate audit trail reports with timeline and traceability |
-| `devtrail explore [path]` | Browse documentation interactively in a TUI |
-| `devtrail about` | Show version and license info |
+| `straymark init [path]` | Initialize StrayMark in a project |
+| `straymark update` | Update both framework and CLI |
+| `straymark update-framework` | Update only the framework |
+| `straymark update-cli` | Update the CLI binary |
+| `straymark remove [--full]` | Remove StrayMark from project |
+| `straymark status [path]` | Show installation health and doc stats |
+| `straymark repair [path]` | Restore missing directories and framework files |
+| `straymark validate [path]` | Validate documents for compliance and correctness (use `--include-charters` for Charters, `--check-pending-reviews` for approval backlog) |
+| `straymark charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness), `audit` (multi-model external review, orchestration-only) |
+| `straymark approve <doc-id>` | Record a formal human approval on a `review_required: true` document (frontmatter + canonical body section) |
+| `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
+| `straymark metrics [path]` | Show governance metrics and documentation statistics |
+| `straymark analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
+| `straymark audit [path]` | Generate audit trail reports with timeline and traceability |
+| `straymark explore [path]` | Browse documentation interactively in a TUI |
+| `straymark about` | Show version and license info |
 
-See [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/CLI-REFERENCE.md) for detailed usage.
+See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/CLI-REFERENCE.md) for detailed usage.
 
 ### Option 2: Manual Setup
 
 ```bash
 # Download the latest framework release ZIP from GitHub
-# Go to https://github.com/StrangeDaysTech/devtrail/releases
+# Go to https://github.com/StrangeDaysTech/straymark/releases
 # and download the latest fw-* release (e.g., fw-4.10.0)
 
 # Extract and copy to your project
-unzip devtrail-fw-*.zip -d your-project/
+unzip straymark-fw-*.zip -d your-project/
 cd your-project
 
 # Commit
-git add .devtrail/ DEVTRAIL.md
-git commit -m "chore: adopt DevTrail"
+git add .straymark/ STRAYMARK.md
+git commit -m "chore: adopt StrayMark"
 ```
 
-📖 **See [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/ADOPTION-GUIDE.md) for detailed instructions, migration strategies, and team rollout plans.**
+📖 **See [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md) for detailed instructions, migration strategies, and team rollout plans.**
 
 ---
 
 ## Documentation
 
-DevTrail documentation is organized by audience:
+StrayMark documentation is organized by audience:
 
 | Track | For | Start here |
 |-------|-----|------------|
-| [**Adopters**](https://github.com/StrangeDaysTech/devtrail/tree/main/docs/adopters) | Teams adopting DevTrail in their projects | [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/ADOPTION-GUIDE.md) |
-| [**Contributors**](https://github.com/StrangeDaysTech/devtrail/tree/main/docs/contributors) | Developers contributing to DevTrail | [TRANSLATION-GUIDE.md](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/contributors/TRANSLATION-GUIDE.md) |
+| [**Adopters**](https://github.com/StrangeDaysTech/straymark/tree/main/docs/adopters) | Teams adopting StrayMark in their projects | [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md) |
+| [**Contributors**](https://github.com/StrangeDaysTech/straymark/tree/main/docs/contributors) | Developers contributing to StrayMark | [TRANSLATION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/contributors/TRANSLATION-GUIDE.md) |
 
-**Adopters**: Follow the [Adoption Guide](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/ADOPTION-GUIDE.md) for step-by-step instructions, the [CLI Reference](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/CLI-REFERENCE.md) for command details, and the [Workflows Guide](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/WORKFLOWS.md) for daily usage patterns.
+**Adopters**: Follow the [Adoption Guide](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md) for step-by-step instructions, the [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/CLI-REFERENCE.md) for command details, and the [Workflows Guide](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/WORKFLOWS.md) for daily usage patterns.
 
-**Contributors**: See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/devtrail/blob/main/CONTRIBUTING.md) for development guidelines, and the [Translation Guide](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/contributors/TRANSLATION-GUIDE.md) for adding new languages.
+**Contributors**: See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md) for development guidelines, and the [Translation Guide](https://github.com/StrangeDaysTech/straymark/blob/main/docs/contributors/TRANSLATION-GUIDE.md) for adding new languages.
 
 ### Key References
 
 | Document | Description |
 |----------|-------------|
-| [**Quick Reference**](https://github.com/StrangeDaysTech/devtrail/blob/main/dist/.devtrail/QUICK-REFERENCE.md) | One-page overview of document types and naming |
-| [DEVTRAIL.md](https://github.com/StrangeDaysTech/devtrail/blob/main/dist/DEVTRAIL.md) | Unified governance rules (source of truth) |
-| [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/ADOPTION-GUIDE.md) | Adoption guide for new/existing projects |
-| [CLI-REFERENCE.md](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/CLI-REFERENCE.md) | Complete CLI command reference |
-| [WORKFLOWS.md](https://github.com/StrangeDaysTech/devtrail/blob/main/docs/adopters/WORKFLOWS.md) | Recommended daily workflows and team patterns |
+| [**Quick Reference**](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/QUICK-REFERENCE.md) | One-page overview of document types and naming |
+| [STRAYMARK.md](https://github.com/StrangeDaysTech/straymark/blob/main/dist/STRAYMARK.md) | Unified governance rules (source of truth) |
+| [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md) | Adoption guide for new/existing projects |
+| [CLI-REFERENCE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/CLI-REFERENCE.md) | Complete CLI command reference |
+| [WORKFLOWS.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/WORKFLOWS.md) | Recommended daily workflows and team patterns |
 
 ### Internal Structure
 
-Once adopted, DevTrail creates a `.devtrail/` directory in your project for development governance:
+Once adopted, StrayMark creates a `.straymark/` directory in your project for development governance:
 
 ```
-.devtrail/
+.straymark/
 ├── 00-governance/           # Policies and rules (China guides ⚪)
 ├── 01-requirements/         # REQ documents
 ├── 02-design/decisions/     # ADR documents
@@ -354,7 +354,7 @@ Once adopted, DevTrail creates a `.devtrail/` directory in your project for deve
 │   └── labeling/            # AILABEL ⚪
 └── templates/               # Document templates
 
-⚪ Created only when regional_scope: china is enabled in .devtrail/config.yml
+⚪ Created only when regional_scope: china is enabled in .straymark/config.yml
 ```
 
 ### Naming Convention
@@ -374,7 +374,7 @@ Example: `ADR-2025-01-27-001-use-postgresql-for-persistence.md`
 An AI assistant working on your code automatically:
 
 ```yaml
-# Creates: .devtrail/07-ai-audit/agent-logs/AILOG-2025-01-27-001-implement-auth.md
+# Creates: .straymark/07-ai-audit/agent-logs/AILOG-2025-01-27-001-implement-auth.md
 ---
 id: AILOG-2025-01-27-001
 title: Implement JWT authentication
@@ -402,7 +402,7 @@ High-risk or low-confidence changes are flagged:
 When choosing between alternatives, decisions are documented:
 
 ```yaml
-# Creates: .devtrail/07-ai-audit/decisions/AIDEC-2025-01-27-001-auth-strategy.md
+# Creates: .straymark/07-ai-audit/decisions/AIDEC-2025-01-27-001-auth-strategy.md
 ---
 id: AIDEC-2025-01-27-001
 title: Choose JWT over session-based auth
@@ -419,7 +419,7 @@ justification: "Stateless architecture requirement..."
 When AI encounters ethical considerations:
 
 ```yaml
-# Creates: .devtrail/07-ai-audit/ethical-reviews/ETH-2025-01-27-001-user-data.md
+# Creates: .straymark/07-ai-audit/ethical-reviews/ETH-2025-01-27-001-user-data.md
 ---
 id: ETH-2025-01-27-001
 title: User data collection scope
@@ -439,15 +439,15 @@ concerns:
 
 ```bash
 # Install the pre-commit hook
-echo 'devtrail validate --staged' > .git/hooks/pre-commit
+echo 'straymark validate --staged' > .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
 ### Manual Validation
 
 ```bash
-# Cross-platform (any OS with devtrail installed)
-devtrail validate
+# Cross-platform (any OS with straymark installed)
+straymark validate
 ```
 
 ### GitHub Actions
@@ -463,38 +463,38 @@ The included workflow (`.github/workflows/docs-validation.yml`) automatically va
 
 ## Skills
 
-DevTrail includes skills for AI agents that enable **active documentation creation**.
+StrayMark includes skills for AI agents that enable **active documentation creation**.
 
-> **Binary System**: DevTrail uses a passive system (agents auto-document via context instructions) and an active system (users invoke skills to create documentation manually or when the agent missed something).
+> **Binary System**: StrayMark uses a passive system (agents auto-document via context instructions) and an active system (users invoke skills to create documentation manually or when the agent missed something).
 
 ### Available Skills
 
 | Skill | Purpose | Claude | Gemini |
 |-------|---------|--------|--------|
-| `/devtrail-status` | Check documentation compliance | ✅ | ✅ |
-| `/devtrail-new` | Create any document type (unified) | ✅ | ✅ |
-| `/devtrail-ailog` | Quick AILOG creation | ✅ | ✅ |
-| `/devtrail-aidec` | Quick AIDEC creation | ✅ | ✅ |
-| `/devtrail-adr` | Quick ADR creation | ✅ | ✅ |
-| `/devtrail-sec` | Security Assessment creation | ✅ | ✅ |
-| `/devtrail-mcard` | Model/System Card creation | ✅ | ✅ |
+| `/straymark-status` | Check documentation compliance | ✅ | ✅ |
+| `/straymark-new` | Create any document type (unified) | ✅ | ✅ |
+| `/straymark-ailog` | Quick AILOG creation | ✅ | ✅ |
+| `/straymark-aidec` | Quick AIDEC creation | ✅ | ✅ |
+| `/straymark-adr` | Quick ADR creation | ✅ | ✅ |
+| `/straymark-sec` | Security Assessment creation | ✅ | ✅ |
+| `/straymark-mcard` | Model/System Card creation | ✅ | ✅ |
 
 ### Usage Examples
 
 ```bash
 # Check documentation status
-/devtrail-status
+/straymark-status
 
 # Create documentation (agent suggests type)
-/devtrail-new
+/straymark-new
 
 # Force specific document type
-/devtrail-new ailog
+/straymark-new ailog
 
 # Direct shortcuts
-/devtrail-ailog
-/devtrail-aidec
-/devtrail-adr
+/straymark-ailog
+/straymark-aidec
+/straymark-adr
 ```
 
 ### CLI Commands (Manual Use)
@@ -503,13 +503,13 @@ For users who prefer the command line or use agents without skill support:
 
 ```bash
 # Interactive document creation
-devtrail new
+straymark new
 
 # Create specific type directly
-devtrail new --doc-type ailog
+straymark new --doc-type ailog
 
 # Check documentation status
-devtrail status
+straymark status
 ```
 
 ### Agent Reporting
@@ -518,25 +518,25 @@ AI agents report documentation status at the end of each task:
 
 | Status | Meaning |
 |--------|---------|
-| `DevTrail: Created AILOG-...` | Documentation was created |
-| `DevTrail: No documentation required` | Change was minor |
-| `DevTrail: Documentation pending` | May need manual review |
+| `StrayMark: Created AILOG-...` | Documentation was created |
+| `StrayMark: No documentation required` | Change was minor |
+| `StrayMark: Documentation pending` | May need manual review |
 
 ### Multi-Agent Architecture
 
-DevTrail provides native skill support for multiple AI agents through a layered architecture:
+StrayMark provides native skill support for multiple AI agents through a layered architecture:
 
 ```
 your-project/
 ├── .agent/workflows/       # 🌐 Agnostic (Antigravity, future agents)
-│   ├── devtrail-new.md
-│   ├── devtrail-status.md
+│   ├── straymark-new.md
+│   ├── straymark-status.md
 │   └── ...
 ├── .gemini/skills/         # 🔵 Gemini CLI (Google)
-│   ├── devtrail-new/SKILL.md
+│   ├── straymark-new/SKILL.md
 │   └── ...
 └── .claude/skills/         # 🟣 Claude Code (Anthropic)
-    ├── devtrail-new/SKILL.md
+    ├── straymark-new/SKILL.md
     └── ...
 ```
 
@@ -567,9 +567,9 @@ All skill implementations are **functionally identical**—only the format diffe
 
 | OS | Validation |
 |----|------------|
-| Linux | `devtrail validate` |
-| macOS | `devtrail validate` |
-| Windows | `devtrail validate` |
+| Linux | `straymark validate` |
+| macOS | `straymark validate` |
+| Windows | `straymark validate` |
 
 ### CI/CD Platforms
 
@@ -585,7 +585,7 @@ All skill implementations are **functionally identical**—only the format diffe
 
 ## Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/devtrail/blob/main/CONTRIBUTING.md) for guidelines.
+We welcome contributions! See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md) for guidelines.
 
 ### Ways to Contribute
 
@@ -599,7 +599,7 @@ We welcome contributions! See [CONTRIBUTING.md](https://github.com/StrangeDaysTe
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/StrangeDaysTech/devtrail/blob/main/LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/StrangeDaysTech/straymark/blob/main/LICENSE) file for details.
 
 ---
 
@@ -613,7 +613,7 @@ Our open-source ecosystem:
 
 | Project | Description |
 |---------|-------------|
-| **[DevTrail](https://github.com/StrangeDaysTech/devtrail)** | The cognitive discipline your AI-assisted projects need |
+| **[StrayMark](https://github.com/StrangeDaysTech/straymark)** | The cognitive discipline your AI-assisted projects need |
 | **[arborist-metrics](https://github.com/StrangeDaysTech/arborist)** | Multi-language code complexity analysis library for Rust — [crates.io](https://crates.io/crates/arborist-metrics) |
 
 [Website](https://strangedays.tech) • [GitHub](https://github.com/StrangeDaysTech)
@@ -624,8 +624,8 @@ Our open-source ecosystem:
 
 <div align="center">
 
-**DevTrail** — Engineering discipline, externalized. Compliance, as a side effect.
+**StrayMark** — Engineering discipline, externalized. Compliance, as a side effect.
 
-[⬆ Back to top](#devtrail)
+[⬆ Back to top](#straymark)
 
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,16 @@
 # Documentation
 
-This directory contains DevTrail's user-facing documentation, organized by audience.
+This directory contains StrayMark's user-facing documentation, organized by audience.
 
 ## Structure
 
 ```
 docs/
-├── adopters/           # For teams adopting DevTrail
+├── adopters/           # For teams adopting StrayMark
 │   ├── ADOPTION-GUIDE.md
 │   ├── CLI-REFERENCE.md
 │   └── WORKFLOWS.md
-├── contributors/       # For developers contributing to DevTrail
+├── contributors/       # For developers contributing to StrayMark
 │   └── TRANSLATION-GUIDE.md
 └── i18n/               # Translations
     └── es/             # Spanish
@@ -23,13 +23,13 @@ docs/
 
 ## Versioning
 
-DevTrail uses independent version tags: `fw-*` for framework releases and `cli-*` for CLI releases. See the [CLI Reference](adopters/CLI-REFERENCE.md#versioning) for details.
+StrayMark uses independent version tags: `fw-*` for framework releases and `cli-*` for CLI releases. See the [CLI Reference](adopters/CLI-REFERENCE.md#versioning) for details.
 
 ## For Adopters
 
 | Document | Description |
 |----------|-------------|
-| [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) | Step-by-step guide for adopting DevTrail in new or existing projects |
+| [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) | Step-by-step guide for adopting StrayMark in new or existing projects |
 | [CLI-REFERENCE.md](adopters/CLI-REFERENCE.md) | Complete CLI command reference with flags, arguments, and examples |
 | [WORKFLOWS.md](adopters/WORKFLOWS.md) | Recommended daily workflows, update cadences, and team patterns |
 
@@ -38,14 +38,14 @@ DevTrail uses independent version tags: `fw-*` for framework releases and `cli-*
 | Document | Description |
 |----------|-------------|
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Development setup, PR process, style guidelines |
-| [TRANSLATION-GUIDE.md](contributors/TRANSLATION-GUIDE.md) | Rules and guidelines for translating DevTrail documentation |
+| [TRANSLATION-GUIDE.md](contributors/TRANSLATION-GUIDE.md) | Rules and guidelines for translating StrayMark documentation |
 
 ## Key References
 
 | Document | Description |
 |----------|-------------|
-| [QUICK-REFERENCE.md](../dist/.devtrail/QUICK-REFERENCE.md) | One-page cheat sheet: document types, naming, metadata |
-| [DEVTRAIL.md](../dist/DEVTRAIL.md) | Unified governance rules (source of truth) |
+| [QUICK-REFERENCE.md](../dist/.straymark/QUICK-REFERENCE.md) | One-page cheat sheet: document types, naming, metadata |
+| [STRAYMARK.md](../dist/STRAYMARK.md) | Unified governance rules (source of truth) |
 
 ## Translations
 
@@ -55,4 +55,4 @@ DevTrail uses independent version tags: `fw-*` for framework releases and `cli-*
 
 ---
 
-> **Note**: Development governance documentation (policies, templates, agent rules) lives in [`dist/.devtrail/`](../dist/.devtrail/) — not in this directory. See [QUICK-REFERENCE.md](../dist/.devtrail/QUICK-REFERENCE.md) for an overview.
+> **Note**: Development governance documentation (policies, templates, agent rules) lives in [`dist/.straymark/`](../dist/.straymark/) — not in this directory. See [QUICK-REFERENCE.md](../dist/.straymark/QUICK-REFERENCE.md) for an overview.

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -1,6 +1,6 @@
-# DevTrail - Adoption Guide
+# StrayMark - Adoption Guide
 
-**A comprehensive guide for adopting DevTrail in new or existing projects.**
+**A comprehensive guide for adopting StrayMark in new or existing projects.**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -10,7 +10,7 @@
 
 ## Table of Contents
 
-1. [What is DevTrail?](#what-is-devtrail-framework)
+1. [What is StrayMark?](#what-is-straymark-framework)
 2. [Who is it for?](#who-is-it-for)
 3. [Benefits](#benefits)
 4. [Standards Compliance](#standards-compliance)
@@ -22,9 +22,9 @@
 
 ---
 
-## What is DevTrail?
+## What is StrayMark?
 
-DevTrail is a **framework + CLI** that externalizes the cognitive discipline of senior software engineering work — explicit scope, declared decisions, named risks, recorded alternatives, audited trails — into versioned files that live alongside the code. The intent is to constrain the agent's decision space so AI-assisted work stays coherent across many turns instead of drifting into hidden technical debt.
+StrayMark is a **framework + CLI** that externalizes the cognitive discipline of senior software engineering work — explicit scope, declared decisions, named risks, recorded alternatives, audited trails — into versioned files that live alongside the code. The intent is to constrain the agent's decision space so AI-assisted work stays coherent across many turns instead of drifting into hidden technical debt.
 
 It provides:
 
@@ -39,15 +39,15 @@ It provides:
 
 > **"No significant change without a documented trace — and a constrained decision space for the agent."**
 
-DevTrail ensures that every meaningful change — whether by human or AI — is documented, attributed, and auditable. The discipline produces evidence compatible with **ISO/IEC 42001**, **EU AI Act**, and **NIST AI RMF** — but the goal is engineering quality first; compliance is what falls out when the discipline is real (see Principle #4 in [`Propuesta/devtrail-design-principles.md`](https://github.com/StrangeDaysTech/devtrail/blob/main/Propuesta/devtrail-design-principles.md)).
+StrayMark ensures that every meaningful change — whether by human or AI — is documented, attributed, and auditable. The discipline produces evidence compatible with **ISO/IEC 42001**, **EU AI Act**, and **NIST AI RMF** — but the goal is engineering quality first; compliance is what falls out when the discipline is real (see Principle #4 in [`Propuesta/straymark-design-principles.md`](https://github.com/StrangeDaysTech/straymark/blob/main/Propuesta/straymark-design-principles.md)).
 
 ### Why Now?
 
 AI agents make code fast. They don't make code coherent. After enough turns, an agent loses the thread: it re-introduces patterns the team rejected, accumulates hidden technical debt, and produces work that compiles but doesn't fit the system's grain. The faster the agent, the harder this debt is to see — until a regression, an incident, or a refactor surfaces it.
 
-In parallel, the regulatory floor is rising — the **EU AI Act becomes mandatory in August 2026**, and **ISO/IEC 42001** is now the international standard for AI Management Systems. Adopting DevTrail addresses the engineering problem first; the regulatory evidence is produced as a by-product of the discipline, ready when an auditor asks.
+In parallel, the regulatory floor is rising — the **EU AI Act becomes mandatory in August 2026**, and **ISO/IEC 42001** is now the international standard for AI Management Systems. Adopting StrayMark addresses the engineering problem first; the regulatory evidence is produced as a by-product of the discipline, ready when an auditor asks.
 
-### What DevTrail is NOT
+### What StrayMark is NOT
 
 - It is not a documentation generator — it provides structure, templates, and governance rules
 - It is not a replacement for code comments or API docs
@@ -62,7 +62,7 @@ In parallel, the regulatory floor is rising — the **EU AI Act becomes mandator
 
 ### Primary user
 
-DevTrail's primary user is the **senior engineer orchestrating AI agents on a non-trivial system** — someone with strong technical judgment who uses agents to take on work they couldn't realistically do alone, and who needs externalized cognitive discipline so the agent doesn't introduce systemic chaos. The framework's flows, defaults and language are tuned for that person; secondary audiences are served on top of that base, never at its expense.
+StrayMark's primary user is the **senior engineer orchestrating AI agents on a non-trivial system** — someone with strong technical judgment who uses agents to take on work they couldn't realistically do alone, and who needs externalized cognitive discipline so the agent doesn't introduce systemic chaos. The framework's flows, defaults and language are tuned for that person; secondary audiences are served on top of that base, never at its expense.
 
 ### Target Users
 
@@ -77,7 +77,7 @@ DevTrail's primary user is the **senior engineer orchestrating AI agents on a no
 
 ### Compatible Development Environments
 
-DevTrail provides configuration files for:
+StrayMark provides configuration files for:
 
 | Platform | Configuration File | Status |
 |----------|-------------------|--------|
@@ -89,9 +89,9 @@ DevTrail provides configuration files for:
 
 ### Compatible Methodologies
 
-DevTrail works with any development methodology:
+StrayMark works with any development methodology:
 
-| Methodology | How DevTrail Fits |
+| Methodology | How StrayMark Fits |
 |-------------|-------------------|
 | **Agile/Scrum** | REQ documents map to user stories; ADRs capture sprint decisions |
 | **Waterfall** | Full traceability from requirements through implementation |
@@ -121,7 +121,7 @@ DevTrail works with any development methodology:
 | **AI transparency** | Every AI action is logged with confidence levels |
 | **Human oversight** | Critical decisions require human approval |
 | **Ethical safeguards** | ETH and DPIA documents flag concerns for human decision |
-| **Governance metrics** | `devtrail metrics` tracks review rates, risk distribution, and trends |
+| **Governance metrics** | `straymark metrics` tracks review rates, risk distribution, and trends |
 
 ### For Regulatory Compliance (as a side effect)
 
@@ -130,18 +130,18 @@ DevTrail works with any development methodology:
 | **EU AI Act ready** | Risk classification, incident reporting, and transparency templates built in |
 | **ISO 42001 compatible** | Documentation structure aligns with certification audit requirements |
 | **NIST AI RMF mapped** | 12 GenAI risk categories and governance functions explicitly covered |
-| **Audit trail complete** | `devtrail audit` generates exportable timeline and traceability reports |
-| **Compliance scoring** | `devtrail compliance` provides percentage-based regulatory gap analysis |
+| **Audit trail complete** | `straymark audit` generates exportable timeline and traceability reports |
+| **Compliance scoring** | `straymark compliance` provides percentage-based regulatory gap analysis |
 
 ---
 
 ## Standards Compliance
 
-The discipline DevTrail externalizes — explicit scope, declared decisions, named risks, recorded alternatives — produces, as a side effect, evidence that maps cleanly onto the major engineering and AI governance frameworks. The tables below describe *how* DevTrail's artifacts align with each standard; the goal is the engineering work, the alignment is what falls out:
+The discipline StrayMark externalizes — explicit scope, declared decisions, named risks, recorded alternatives — produces, as a side effect, evidence that maps cleanly onto the major engineering and AI governance frameworks. The tables below describe *how* StrayMark's artifacts align with each standard; the goal is the engineering work, the alignment is what falls out:
 
 ### Software Engineering Standards
 
-| Standard | How DevTrail Helps |
+| Standard | How StrayMark Helps |
 |----------|-------------------|
 | **ISO/IEC/IEEE 29148:2018** | REQ documents follow structured requirements format with external interfaces and traceability |
 | **ISO/IEC 25010:2023** | 9 quality characteristics evaluated in ADRs and REQ non-functional requirements |
@@ -150,9 +150,9 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 
 ### AI Management & Governance
 
-| Standard | How DevTrail Helps |
+| Standard | How StrayMark Helps |
 |----------|-------------------|
-| **ISO/IEC 42001:2023** | Vertebral standard — AI-GOVERNANCE-POLICY.md maps all Annex A controls to DevTrail documents |
+| **ISO/IEC 42001:2023** | Vertebral standard — AI-GOVERNANCE-POLICY.md maps all Annex A controls to StrayMark documents |
 | **EU AI Act** | Risk classification in ETH, incident reporting timelines in INC, regulatory fields in AILOG |
 | **NIST AI RMF 1.0 / 600-1** | 12 GenAI risk categories in ETH/AILOG, MAP/MEASURE/MANAGE/GOVERN coverage |
 | **ISO/IEC 23894:2023** | AI risk management aligned with ETH and AI-RISK-CATALOG (Fase 3) |
@@ -160,7 +160,7 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 
 ### China Regulatory Coverage *(opt-in via `regional_scope: china`)*
 
-| Standard | How DevTrail Helps |
+| Standard | How StrayMark Helps |
 |----------|-------------------|
 | **TC260 AI Safety Governance Framework v2.0** | Five-level risk grading (TC260RA), `tc260_*` fields on ETH/MCARD/AILOG/SEC |
 | **PIPL — Personal Information Protection Law** | PIPIA template with PIPL Art. 55-56 sections, `pipl_*` fields, retention ≥ 3 years (`TYPE-003`) |
@@ -169,11 +169,11 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 | **GB/T 45652-2025** | Training-data security section in SBOM and MCARD; `gb45652_training_data_compliance` field |
 | **CSL 2026** | INC extension with `csl_severity_level`, deadline-coherence rules (1h / 4h+72h+30d windows) |
 
-> Activate by adding `china` to `regional_scope` in `.devtrail/config.yml`. See the *Configuration* section below and the installed `CHINA-REGULATORY-FRAMEWORK.md` guide for details.
+> Activate by adding `china` to `regional_scope` in `.straymark/config.yml`. See the *Configuration* section below and the installed `CHINA-REGULATORY-FRAMEWORK.md` guide for details.
 
 ### Architecture Documentation
 
-| Standard | How DevTrail Helps |
+| Standard | How StrayMark Helps |
 |----------|-------------------|
 | **ADR (Architecture Decision Records)** | Native ADR support with extended metadata and immutability rules |
 | **arc42** | ADRs complement arc42 decision documentation |
@@ -181,7 +181,7 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 
 ### Compliance & Governance
 
-| Regulation | How DevTrail Helps |
+| Regulation | How StrayMark Helps |
 |------------|-------------------|
 | **GDPR** | ETH documents for privacy, DPIA for data protection impact |
 | **SOC 2** | Change documentation and access logging via AILOG |
@@ -190,7 +190,7 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 
 ### Observability (Optional)
 
-| Standard | How DevTrail Helps |
+| Standard | How StrayMark Helps |
 |----------|-------------------|
 | **OpenTelemetry** | Optional observability sections in REQ, TES, INC; tag `observabilidad` for instrumentation changes |
 
@@ -204,34 +204,34 @@ The discipline DevTrail externalizes — explicit scope, declared decisions, nam
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 Or install from source with Cargo:
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
 Then initialize and commit:
 
 ```bash
 cd your-project
-devtrail init .
+straymark init .
 
-git add .devtrail/ DEVTRAIL.md
-git commit -m "chore: adopt DevTrail"
+git add .straymark/ STRAYMARK.md
+git commit -m "chore: adopt StrayMark"
 ```
 
 The CLI automatically:
-- Downloads the latest DevTrail release from GitHub
-- Sets up the `.devtrail/` directory structure
-- Creates `DEVTRAIL.md` with governance rules
+- Downloads the latest StrayMark release from GitHub
+- Sets up the `.straymark/` directory structure
+- Creates `STRAYMARK.md` with governance rules
 - Configures AI agent directives (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 - Copies CI/CD workflows
 
@@ -239,17 +239,17 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.10.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.10.0`).
 
 2. **Extract to your project**
    ```bash
-   unzip devtrail-fw-*.zip -d your-project/
+   unzip straymark-fw-*.zip -d your-project/
    ```
 
 3. **Commit the structure**
    ```bash
-   git add .devtrail/ DEVTRAIL.md
-   git commit -m "chore: adopt DevTrail for documentation governance"
+   git add .straymark/ STRAYMARK.md
+   git commit -m "chore: adopt StrayMark for documentation governance"
    ```
 
 ---
@@ -270,32 +270,32 @@ The CLI automatically:
 
    | Current State | Recommended Action |
    |---------------|-------------------|
-   | No documentation | Start fresh with DevTrail |
-   | Docs in `docs/` folder | Keep `docs/` for user-facing docs, add `.devtrail/` for development docs |
-   | Existing ADRs | Migrate to `.devtrail/02-design/decisions/` with new naming |
+   | No documentation | Start fresh with StrayMark |
+   | Docs in `docs/` folder | Keep `docs/` for user-facing docs, add `.straymark/` for development docs |
+   | Existing ADRs | Migrate to `.straymark/02-design/decisions/` with new naming |
    | Mixed documentation | Categorize and migrate gradually |
 
 ### Phase 2: Installation (Day 1-2)
 
-1. **Add DevTrail structure**
+1. **Add StrayMark structure**
    ```bash
    # Using CLI (recommended)
-   devtrail init .
+   straymark init .
 
    # Or manually: download the latest fw-* release from GitHub Releases
-   # https://github.com/StrangeDaysTech/devtrail/releases
+   # https://github.com/StrangeDaysTech/straymark/releases
    ```
 
 2. **Resolve conflicts with existing `docs/`**
 
-   DevTrail uses `.devtrail/` specifically to avoid conflicts:
+   StrayMark uses `.straymark/` specifically to avoid conflicts:
 
    ```
    your-project/
    ├── docs/                    ← Keep for API docs, user guides, etc.
    │   ├── api/
    │   └── user-guide/
-   ├── .devtrail/              ← Add for development documentation
+   ├── .straymark/              ← Add for development documentation
    │   ├── 00-governance/
    │   ├── 01-requirements/
    │   └── ...
@@ -309,10 +309,10 @@ The CLI automatically:
    For each existing ADR:
    ```bash
    # Old: docs/adr/001-use-postgresql.md
-   # New: .devtrail/02-design/decisions/ADR-2024-01-15-001-use-postgresql.md
+   # New: .straymark/02-design/decisions/ADR-2024-01-15-001-use-postgresql.md
    ```
 
-   Add DevTrail metadata to the front-matter:
+   Add StrayMark metadata to the front-matter:
    ```yaml
    ---
    id: ADR-2024-01-15-001
@@ -333,7 +333,7 @@ The CLI automatically:
 
    Create an AILOG documenting the migration:
    ```
-   .devtrail/07-ai-audit/agent-logs/AILOG-2025-01-27-001-devtrail-adoption.md
+   .straymark/07-ai-audit/agent-logs/AILOG-2025-01-27-001-straymark-adoption.md
    ```
 
 ### Phase 4: Team Adoption (Week 2-4)
@@ -344,23 +344,23 @@ The CLI automatically:
    ```markdown
    ## Documentation
 
-   This project uses [DevTrail](https://github.com/StrangeDaysTech/devtrail) for documentation governance.
+   This project uses [StrayMark](https://github.com/StrangeDaysTech/straymark) for documentation governance.
 
-   - All significant changes must be documented in `.devtrail/`
+   - All significant changes must be documented in `.straymark/`
    - AI-assisted changes require AILOG entries
    - Architectural decisions require ADR documents
 
-   See `.devtrail/QUICK-REFERENCE.md` for document types and naming.
+   See `.straymark/QUICK-REFERENCE.md` for document types and naming.
    ```
 
 2. **Enable pre-commit hooks (optional)**
    ```bash
    # Install the pre-commit hook
-   echo 'devtrail validate --staged' > .git/hooks/pre-commit
+   echo 'straymark validate --staged' > .git/hooks/pre-commit
    chmod +x .git/hooks/pre-commit
 
    # Or with Husky
-   npx husky add .husky/pre-commit "devtrail validate --staged"
+   npx husky add .husky/pre-commit "straymark validate --staged"
    ```
 
 3. **Enable GitHub Actions (optional)**
@@ -371,7 +371,7 @@ The CLI automatically:
 
 | Week | Focus |
 |------|-------|
-| Week 1 | Core team adopts DevTrail for new decisions |
+| Week 1 | Core team adopts StrayMark for new decisions |
 | Week 2 | Migrate critical existing ADRs |
 | Week 3 | Enable validation in CI/CD |
 | Week 4 | Full team adoption; document existing technical debt |
@@ -382,7 +382,7 @@ The CLI automatically:
 
 ### Regional Regulatory Scope
 
-`.devtrail/config.yml` controls which compliance frameworks are evaluated by `devtrail compliance` and which document types are exposed by `devtrail new`:
+`.straymark/config.yml` controls which compliance frameworks are evaluated by `straymark compliance` and which document types are exposed by `straymark new`:
 
 ```yaml
 regional_scope:
@@ -391,14 +391,14 @@ regional_scope:
   - china    # TC260 v2.0, PIPL/PIPIA, GB 45438, CAC, GB/T 45652, CSL 2026
 ```
 
-**Default if omitted**: `[global, eu]` — preserves the behavior of every DevTrail version prior to `fw-4.3.0`.
+**Default if omitted**: `[global, eu]` — preserves the behavior of every StrayMark version prior to `fw-4.3.0`.
 
 When you add `china` to the list:
 
-- Four China-specific document types become available via `devtrail new`: `PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`.
-- Six new compliance checkers run with `devtrail compliance` (or via `--region china` / `--standard china-*`).
+- Four China-specific document types become available via `straymark new`: `PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`.
+- Six new compliance checkers run with `straymark compliance` (or via `--region china` / `--standard china-*`).
 - Twelve scope-aware validation rules activate (`CROSS-004` to `CROSS-011`, `TYPE-003` to `TYPE-006`).
-- Five new governance guides are referenced from `.devtrail/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, plus per-framework guides for TC260, PIPL/PIPIA, CAC filing, and GB 45438 labeling) — all available in EN, ES, and zh-CN.
+- Five new governance guides are referenced from `.straymark/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, plus per-framework guides for TC260, PIPL/PIPIA, CAC filing, and GB 45438 labeling) — all available in EN, ES, and zh-CN.
 
 A project without `china` in `regional_scope` is unaffected: no new files, no new prompts, no new rules. Adding `china` later is fully reversible.
 
@@ -428,15 +428,15 @@ To add a new document type:
 
 1. **Create the template**
    ```
-   .devtrail/templates/TEMPLATE-NEWTYPE.md
+   .straymark/templates/TEMPLATE-NEWTYPE.md
    ```
 
 2. **Update governance docs**
 
    Add the new type to:
-   - `.devtrail/00-governance/DOCUMENTATION-POLICY.md`
-   - `.devtrail/00-governance/AGENT-RULES.md`
-   - `.devtrail/QUICK-REFERENCE.md`
+   - `.straymark/00-governance/DOCUMENTATION-POLICY.md`
+   - `.straymark/00-governance/AGENT-RULES.md`
+   - `.straymark/QUICK-REFERENCE.md`
 
 3. **Update agent configs**
 
@@ -467,11 +467,11 @@ You can rename folders, but update all references in:
 If using Claude Code, verify documentation compliance with the built-in skill:
 
 ```bash
-/devtrail-status
+/straymark-status
 ```
 
 This skill shows:
-- What DevTrail documents were created recently
+- What StrayMark documents were created recently
 - Which modified files may need documentation
 - Overall documentation compliance status
 
@@ -481,18 +481,18 @@ After adoption, verify your setup:
 
 ```bash
 # Run validation (cross-platform)
-devtrail validate
+straymark validate
 ```
 
 ### Checklist
 
-- [ ] `.devtrail/` folder structure exists
+- [ ] `.straymark/` folder structure exists
 - [ ] At least one agent config file exists (`CLAUDE.md`, `GEMINI.md`, etc.)
-- [ ] Governance documents are present in `.devtrail/00-governance/`
-- [ ] Templates are present in `.devtrail/templates/`
-- [ ] Git branching strategy documented in `.devtrail/03-implementation/`
+- [ ] Governance documents are present in `.straymark/00-governance/`
+- [ ] Templates are present in `.straymark/templates/`
+- [ ] Git branching strategy documented in `.straymark/03-implementation/`
 - [ ] `QUICK-REFERENCE.md` is accessible
-- [ ] `devtrail validate` runs without errors
+- [ ] `straymark validate` runs without errors
 - [ ] (Optional) Pre-commit hook is installed
 - [ ] (Optional) GitHub Actions workflow is enabled
 
@@ -502,15 +502,15 @@ devtrail validate
 
 From `fw-4.9.0`, when you co-implement Charters with an AI assistant in the loop (Claude Code, Gemini Code, Cursor), you can optionally run an external multi-model audit at Charter close. Two skills wrap the underlying CLI orchestration:
 
-- **`/devtrail-audit-prompt CHARTER-XX`** — writes the unified audit prompt at the canonical path `.devtrail/audits/<id>/audit-prompt.md`. Operator opens N auditor-side CLIs and runs `/devtrail-audit-execute` in each. No copy/paste.
-- **`/devtrail-audit-execute [CHARTER-XX]`** *(fw-4.9.0+)* — runs inside an auditor-side CLI (gemini-cli, claude-cli, copilot-cli, codex-cli). Reads the prompt, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id.
-- **`/devtrail-audit-review CHARTER-XX`** — consolidates N reports into a six-section `review.md` (Executive summary / Scope / Per-auditor evaluation / Remediation plan P0-P4 / Discarded / Auditor ratings) and merges the `external_audit:` YAML into Charter telemetry.
+- **`/straymark-audit-prompt CHARTER-XX`** — writes the unified audit prompt at the canonical path `.straymark/audits/<id>/audit-prompt.md`. Operator opens N auditor-side CLIs and runs `/straymark-audit-execute` in each. No copy/paste.
+- **`/straymark-audit-execute [CHARTER-XX]`** *(fw-4.9.0+)* — runs inside an auditor-side CLI (gemini-cli, claude-cli, copilot-cli, codex-cli). Reads the prompt, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id.
+- **`/straymark-audit-review CHARTER-XX`** — consolidates N reports into a six-section `review.md` (Executive summary / Scope / Per-auditor evaluation / Remediation plan P0-P4 / Discarded / Auditor ratings) and merges the `external_audit:` YAML into Charter telemetry.
 
-The agent will **proactively offer** the audit at one specific moment in the workflow — when implementation is done, drift check is clean, and `charter close` has not been invoked. Recommendation is YES/NO based on the Charter's risk surface and complexity (heuristics in `.devtrail/00-governance/AGENT-RULES.md` §12).
+The agent will **proactively offer** the audit at one specific moment in the workflow — when implementation is done, drift check is clean, and `charter close` has not been invoked. Recommendation is YES/NO based on the Charter's risk surface and complexity (heuristics in `.straymark/00-governance/AGENT-RULES.md` §12).
 
 **External audit is fully optional** and **never enforced**. The Charter's declarative scope + drift check + AILOG discipline already provides rigorous closure. Audit adds cross-model signal where the Charter touched security surface, introduced new components, or has high-complexity functions in the diff. Decline freely if the cost (2-3 LLM auditors) does not match the value for your case.
 
-For the underlying CLI commands (PREPARE / CALIBRATE / FINALIZE / `--merge-into`), see [`CLI-REFERENCE.md` § devtrail charter audit](./CLI-REFERENCE.md#devtrail-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir).
+For the underlying CLI commands (PREPARE / CALIBRATE / FINALIZE / `--merge-into`), see [`CLI-REFERENCE.md` § straymark charter audit](./CLI-REFERENCE.md#straymark-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir).
 
 ---
 
@@ -518,34 +518,34 @@ For the underlying CLI commands (PREPARE / CALIBRATE / FINALIZE / `--merge-into`
 
 ### General Questions
 
-**Q: Does DevTrail replace my existing documentation?**
+**Q: Does StrayMark replace my existing documentation?**
 
-A: No. DevTrail is for *development process documentation* (decisions, changes, reviews). Keep your existing `docs/` folder for user-facing documentation, API references, and guides.
+A: No. StrayMark is for *development process documentation* (decisions, changes, reviews). Keep your existing `docs/` folder for user-facing documentation, API references, and guides.
 
-**Q: Do I need to use AI coding assistants to benefit from DevTrail?**
+**Q: Do I need to use AI coding assistants to benefit from StrayMark?**
 
-A: No. DevTrail works for human-only teams too. The AI audit features (AILOG, AIDEC, ETH) become especially valuable when using AI assistants, but ADR, REQ, TDE, and other document types are useful for any team.
+A: No. StrayMark works for human-only teams too. The AI audit features (AILOG, AIDEC, ETH) become especially valuable when using AI assistants, but ADR, REQ, TDE, and other document types are useful for any team.
 
-**Q: How much overhead does DevTrail add?**
+**Q: How much overhead does StrayMark add?**
 
-A: DevTrail follows a "minimum viable documentation" principle. Only significant changes require documentation. Trivial changes (typos, formatting) are explicitly excluded.
+A: StrayMark follows a "minimum viable documentation" principle. Only significant changes require documentation. Trivial changes (typos, formatting) are explicitly excluded.
 
 ### Technical Questions
 
-**Q: Why use `.devtrail/` instead of `docs/`?**
+**Q: Why use `.straymark/` instead of `docs/`?**
 
-A: The `docs/` folder is commonly used for user-facing documentation, GitHub Pages, or generated API docs. Using `.devtrail/` avoids conflicts and clearly separates development documentation from user documentation.
+A: The `docs/` folder is commonly used for user-facing documentation, GitHub Pages, or generated API docs. Using `.straymark/` avoids conflicts and clearly separates development documentation from user documentation.
 
-**Q: Can I use DevTrail with monorepos?**
+**Q: Can I use StrayMark with monorepos?**
 
 A: Yes. You can either:
-- Have one `.devtrail/` at the root for the entire monorepo
-- Have separate `.devtrail/` folders in each package/service
+- Have one `.straymark/` at the root for the entire monorepo
+- Have separate `.straymark/` folders in each package/service
 - Use a hybrid approach with shared governance at root
 
 **Q: How do I handle sensitive information?**
 
-A: DevTrail explicitly prohibits documenting credentials, tokens, or secrets. The validation scripts check for common sensitive patterns and warn you. For genuinely sensitive decisions, document the *existence* of the decision without the sensitive details.
+A: StrayMark explicitly prohibits documenting credentials, tokens, or secrets. The validation scripts check for common sensitive patterns and warn you. For genuinely sensitive decisions, document the *existence* of the decision without the sensitive details.
 
 ### Adoption Questions
 
@@ -557,17 +557,17 @@ A: Start small:
 3. Demonstrate time saved when revisiting old decisions
 4. Gradually expand to other document types
 
-**Q: How do I handle documents created before adopting DevTrail?**
+**Q: How do I handle documents created before adopting StrayMark?**
 
 A: You have three options:
-1. **Migrate**: Convert old documents to DevTrail format (recommended for important docs)
-2. **Reference**: Keep old docs in place, reference them from DevTrail docs
-3. **Archive**: Move old docs to an archive folder, start fresh with DevTrail
+1. **Migrate**: Convert old documents to StrayMark format (recommended for important docs)
+2. **Reference**: Keep old docs in place, reference them from StrayMark docs
+3. **Archive**: Move old docs to an archive folder, start fresh with StrayMark
 
 **Q: What if my AI assistant doesn't follow the rules?**
 
-A: DevTrail rules are instructions, not enforcement. If an AI assistant creates non-compliant documentation:
-1. The pre-commit hook (`devtrail validate --staged`) will catch validation errors
+A: StrayMark rules are instructions, not enforcement. If an AI assistant creates non-compliant documentation:
+1. The pre-commit hook (`straymark validate --staged`) will catch validation errors
 2. CI/CD will flag issues in PRs
 3. You can manually fix and educate the AI in the next prompt
 
@@ -577,8 +577,8 @@ A: DevTrail rules are instructions, not enforcement. If an AI assistant creates 
 
 - **CLI Reference**: [CLI-REFERENCE.md](CLI-REFERENCE.md) — detailed command reference
 - **Workflows**: [WORKFLOWS.md](WORKFLOWS.md) — recommended daily usage patterns
-- **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/devtrail/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/StrangeDaysTech/devtrail/discussions)
+- **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 - **Contributing**: See [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 ---
@@ -587,7 +587,7 @@ A: DevTrail rules are instructions, not enforcement. If an AI assistant creates 
 
 <div align="center">
 
-**DevTrail** — Because every change tells a story.
+**StrayMark** — Because every change tells a story.
 
 [Back to README](../../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -1,6 +1,6 @@
-# DevTrail CLI Reference
+# StrayMark CLI Reference
 
-**Complete reference for the `devtrail` command-line tool.**
+**Complete reference for the `straymark` command-line tool.**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -20,66 +20,66 @@
 
 ## Installation
 
-Install the DevTrail CLI using one of the methods below. For full setup instructions, see the [README](../../README.md#getting-started).
+Install the StrayMark CLI using one of the methods below. For full setup instructions, see the [README](../../README.md#getting-started).
 
 **Quick install (prebuilt binary):**
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 **From source:**
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
 ---
 
 ## Versioning
 
-DevTrail uses **independent version tags** for each component:
+StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.10.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.10.0` | The `devtrail` binary |
+| CLI | `cli-` | `cli-3.10.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
 **Check installed versions:**
 
 ```bash
-devtrail about    # Shows CLI version + framework version (if installed)
-devtrail status   # Shows full installation health including versions
+straymark about    # Shows CLI version + framework version (if installed)
+straymark status   # Shows full installation health including versions
 ```
 
 ---
 
 ## Commands
 
-### `devtrail init [path] [--hooks]`
+### `straymark init [path] [--hooks]`
 
-Initialize DevTrail in a project directory.
+Initialize StrayMark in a project directory.
 
 **Arguments and flags:**
 
 | Argument/Flag | Default | Description |
 |---|---|---|
 | `path` | `.` (current directory) | Target project directory |
-| `--hooks` *(cli-3.7.0+)* | off | After init, install the framework's pre-PR hook (`.devtrail/hooks/pre-pr.sh`) as `.git/hooks/pre-push`. Runs `devtrail charter drift` automatically before each push. Opt-in per principle #6 (cognitive discipline > raw productivity). Refuses to overwrite an existing `pre-push` hook; skips silently if not a git repo. |
+| `--hooks` *(cli-3.7.0+)* | off | After init, install the framework's pre-PR hook (`.straymark/hooks/pre-pr.sh`) as `.git/hooks/pre-push`. Runs `straymark charter drift` automatically before each push. Opt-in per principle #6 (cognitive discipline > raw productivity). Refuses to overwrite an existing `pre-push` hook; skips silently if not a git repo. |
 
 **What it does:**
 
 1. Downloads the latest framework release (`fw-*`) from GitHub
-2. Creates the `.devtrail/` directory structure
-3. Creates `DEVTRAIL.md` with governance rules
+2. Creates the `.straymark/` directory structure
+3. Creates `STRAYMARK.md` with governance rules
 4. Configures AI agent directive files (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 5. Copies CI/CD workflows
 6. *(`--hooks`)* installs the pre-PR hook
@@ -87,28 +87,28 @@ Initialize DevTrail in a project directory.
 **Example:**
 
 ```bash
-$ devtrail init .
-✔ Downloaded DevTrail fw-4.10.0
-✔ Created .devtrail/ directory structure
-✔ Created DEVTRAIL.md
+$ straymark init .
+✔ Downloaded StrayMark fw-4.10.0
+✔ Created .straymark/ directory structure
+✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
 
-DevTrail initialized successfully!
-Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
+StrayMark initialized successfully!
+Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```
 
 ---
 
-### `devtrail update`
+### `straymark update`
 
 Update **both** framework and CLI to their latest versions. Equivalent to running `update-framework` followed by `update-cli`.
 
-If `.devtrail/` does not exist in the current directory, the framework update is skipped with a warning.
+If `.straymark/` does not exist in the current directory, the framework update is skipped with a warning.
 
 **Example:**
 
 ```bash
-$ devtrail update
+$ straymark update
 Updating framework...
 ✔ Framework updated to fw-4.10.0
 Updating CLI...
@@ -117,7 +117,7 @@ Updating CLI...
 
 ---
 
-### `devtrail update-framework`
+### `straymark update-framework`
 
 Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
@@ -126,61 +126,61 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 **Example:**
 
 ```bash
-$ devtrail update-framework
+$ straymark update-framework
 ✔ Framework updated to fw-4.10.0
 ```
 
 ---
 
-### `devtrail update-cli`
+### `straymark update-cli`
 
-Auto-update the `devtrail` binary itself. Automatically detects the installation method and uses the appropriate update mechanism:
+Auto-update the `straymark` binary itself. Automatically detects the installation method and uses the appropriate update mechanism:
 
 - **Prebuilt binary** (installed via `install.sh` / `install.ps1`): Downloads the latest binary from GitHub Releases
-- **Cargo** (installed via `cargo install`): Runs `cargo install --force devtrail-cli`
+- **Cargo** (installed via `cargo install`): Runs `cargo install --force straymark-cli`
 
 Use `--method` to override auto-detection: `--method=github` or `--method=cargo`.
 
 **Example:**
 
 ```bash
-$ devtrail update-cli
+$ straymark update-cli
 ✔ CLI updated to cli-3.5.2
 
-$ devtrail update-cli --method=cargo
+$ straymark update-cli --method=cargo
 Compiling from source, this may take a few minutes...
 ✔ CLI updated to cli-3.5.2
 ```
 
 ---
 
-### `devtrail remove [--full]`
+### `straymark remove [--full]`
 
-Remove DevTrail from the current project.
+Remove StrayMark from the current project.
 
 **Flags:**
 
 | Flag | Description |
 |------|-------------|
-| `--full` | Remove everything, including user-created documents in `.devtrail/`. Asks for confirmation. |
+| `--full` | Remove everything, including user-created documents in `.straymark/`. Asks for confirmation. |
 
-**Default behavior** (without `--full`): removes the framework structure but preserves documents you created inside `.devtrail/`.
+**Default behavior** (without `--full`): removes the framework structure but preserves documents you created inside `.straymark/`.
 
 **Example:**
 
 ```bash
-$ devtrail remove
-✔ DevTrail framework removed. User documents preserved in .devtrail/.
+$ straymark remove
+✔ StrayMark framework removed. User documents preserved in .straymark/.
 
-$ devtrail remove --full
-⚠ This will delete all DevTrail files including your documents.
+$ straymark remove --full
+⚠ This will delete all StrayMark files including your documents.
 Continue? [y/N]: y
-✔ DevTrail completely removed.
+✔ StrayMark completely removed.
 ```
 
 ---
 
-### `devtrail status [path]`
+### `straymark status [path]`
 
 Show installation health and documentation statistics.
 
@@ -202,10 +202,10 @@ Show installation health and documentation statistics.
 **Example:**
 
 ```
-$ devtrail status
+$ straymark status
 
   ╔════════════════════════════════════════════════╗
-  ║ DevTrail Status                                ║
+  ║ StrayMark Status                                ║
   ╚════════════════════════════════════════════════╝
 
   Project
@@ -236,14 +236,14 @@ $ devtrail status
   │ Total                        │    30 │
   └──────────────────────────────┴───────┘
 
-  → Run devtrail explore to browse documentation interactively
+  → Run straymark explore to browse documentation interactively
 ```
 
 ---
 
-### `devtrail repair [path]`
+### `straymark repair [path]`
 
-Repair a broken DevTrail installation by restoring missing directories and framework files.
+Repair a broken StrayMark installation by restoring missing directories and framework files.
 
 **Arguments:**
 
@@ -255,31 +255,31 @@ Repair a broken DevTrail installation by restoring missing directories and frame
 
 1. Checks for missing directories and restores them with `.gitkeep`
 2. Downloads the framework release **once** if files need restoration (templates, governance docs, config)
-3. Re-injects directives if `DEVTRAIL.md` is missing
+3. Re-injects directives if `STRAYMARK.md` is missing
 4. Recalculates checksums after repair
 5. Never modifies or deletes user-generated documents
 
 **Example:**
 
 ```bash
-$ devtrail repair
-Repairing DevTrail in /home/user/my-project
+$ straymark repair
+Repairing StrayMark in /home/user/my-project
   → Found 1 issue(s) to repair
 → Restoring 1 missing directory...
-✓ Restored .devtrail/templates/
+✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
   Using version: fw-4.10.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
-✓ DevTrail repaired successfully!
+✓ StrayMark repaired successfully!
 ```
 
 ---
 
-### `devtrail validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
+### `straymark validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
 
-Validate DevTrail documents for compliance and correctness.
+Validate StrayMark documents for compliance and correctness.
 
 **Arguments and flags:**
 
@@ -306,20 +306,20 @@ When `regional_scope` includes `china`, twelve additional rules activate (`CROSS
 **Example:**
 
 ```bash
-$ devtrail validate
-  DevTrail Validate
+$ straymark validate
+  StrayMark Validate
   All 15 document(s) passed validation
   0 error(s), 0 warning(s) in 15 document(s)
 
-$ devtrail validate --fix
-  DevTrail Validate
+$ straymark validate --fix
+  StrayMark Validate
   Auto-fixing 2 issue(s)...
   ✓ Fixed 2 issue(s)
 ```
 
 ---
 
-### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
+### `straymark approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
 
 *Available since **cli-3.7.0** + **fw-4.6.0**. `--quiet` and high-risk warning added in cli-3.8.0.*
 
@@ -345,7 +345,7 @@ Record a formal human approval on a `review_required: true` document. Writes the
 
 ```bash
 # Flag-driven (CI / scripts)
-$ devtrail approve AIDEC-2026-05-02-001 \
+$ straymark approve AIDEC-2026-05-02-001 \
     --outcome approved \
     --reviewer pepe@example.com \
     --notes "Reviewed against ADR-007. LGTM."
@@ -353,25 +353,25 @@ $ devtrail approve AIDEC-2026-05-02-001 \
   ✔ AIDEC-2026-05-02-001 marked as approved.
     Reviewer: pepe@example.com
     Date:     2026-05-02
-    File:     .devtrail/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
+    File:     .straymark/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
 
 # Iterative review cycle: revisions_requested → re-approve
-$ devtrail approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
+$ straymark approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
 # (author iterates)
-$ devtrail approve AIDEC-... --outcome approved --reviewer reviewer@x.io
+$ straymark approve AIDEC-... --outcome approved --reviewer reviewer@x.io
 # Frontmatter shows the latest (approved); body shows BOTH blocks chronologically.
 
 # Backlog visibility
-$ devtrail validate --check-pending-reviews --max-pending-days 14
+$ straymark validate --check-pending-reviews --max-pending-days 14
 ```
 
-> See `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval" for the canonical workflow definition (closure semantics, body format, multi-reviewer convention).
+> See `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval" for the canonical workflow definition (closure semantics, body format, multi-reviewer convention).
 
 ---
 
-### `devtrail new [path] [-t <type>] [--title <title>]`
+### `straymark new [path] [-t <type>] [--title <title>]`
 
-Create a new DevTrail document from a template.
+Create a new StrayMark document from a template.
 
 **Arguments and flags:**
 
@@ -387,45 +387,45 @@ If `--doc-type` or `--title` are omitted, the command prompts interactively. Chi
 
 ```bash
 # Interactive — prompts for type and title
-$ devtrail new
+$ straymark new
 
 # Create an AILOG with a title (non-interactive)
-$ devtrail new -t ailog --title "Implement JWT authentication"
+$ straymark new -t ailog --title "Implement JWT authentication"
 
 # Create an ADR
-$ devtrail new --doc-type adr --title "Use PostgreSQL for persistence"
+$ straymark new --doc-type adr --title "Use PostgreSQL for persistence"
 ```
 
 **Example output:**
 
 ```
-$ devtrail new -t ailog --title "Implement JWT authentication"
+$ straymark new -t ailog --title "Implement JWT authentication"
 
-  ✔ Created: .devtrail/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
+  ✔ Created: .straymark/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
 
   Next steps:
     1. Edit the document to fill in details
-    2. Commit: git add .devtrail/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
+    2. Commit: git add .straymark/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
 ```
 
 ---
 
-### `devtrail charter <subcommand>`
+### `straymark charter <subcommand>`
 
-Manage **Charters**: bounded, auditable units of work declared ex-ante and validated ex-post. A Charter pairs declarative scope (files to touch, risks, executable verification) with ex-post audit anchoring (drift detection, multi-model audit). Charters live at `docs/charters/NN-slug.md` (project-root level, **not** under `.devtrail/`).
+Manage **Charters**: bounded, auditable units of work declared ex-ante and validated ex-post. A Charter pairs declarative scope (files to touch, risks, executable verification) with ex-post audit anchoring (drift detection, multi-model audit). Charters live at `docs/charters/NN-slug.md` (project-root level, **not** under `.straymark/`).
 
-> **Naming history.** In the Sentinel `/plan-audit` experiment that crystallized this pattern (2026-04, 6 cycles), Charters were called *Plans*. The DevTrail CLI uses **Charter** going forward to disambiguate from GitHub SpecKit's `plan.md`. Sentinel's historical files preserve "Plan" deliberately. The full conceptual scope and the rename rationale live in `Propuesta/que-es-un-charter.md`.
+> **Naming history.** In the Sentinel `/plan-audit` experiment that crystallized this pattern (2026-04, 6 cycles), Charters were called *Plans*. The StrayMark CLI uses **Charter** going forward to disambiguate from GitHub SpecKit's `plan.md`. Sentinel's historical files preserve "Plan" deliberately. The full conceptual scope and the rename rationale live in `Propuesta/que-es-un-charter.md`.
 
 **Subcommands:**
 
-- `devtrail charter new` — scaffold a new Charter from the framework template
-- `devtrail charter list` — enumerate Charters with optional filters
-- `devtrail charter status` — show Charter detail, or the most recent 5 Charters
-- `devtrail charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.0+)*
-- `devtrail charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.0+)*
-- `devtrail charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.9.0+)*
+- `straymark charter new` — scaffold a new Charter from the framework template
+- `straymark charter list` — enumerate Charters with optional filters
+- `straymark charter status` — show Charter detail, or the most recent 5 Charters
+- `straymark charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.0+)*
+- `straymark charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.0+)*
+- `straymark charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.9.0+)*
 
-#### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
+#### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
 Scaffold a Charter from the framework template into `docs/charters/NN-slug.md`. Prompts for the title interactively if not passed. The two origin flags are mutually exclusive at the clap level.
 
@@ -443,19 +443,19 @@ When neither origin flag is given, both `originating_ailogs` and `originating_sp
 
 ```bash
 # Standalone (no origin) — interactive title prompt
-$ devtrail charter new --type M
+$ straymark charter new --type M
 
 # Maintenance / post-MVP mode — Charter rooted in an existing AILOG
-$ devtrail charter new -t S --from-ailog AILOG-2026-04-28-021 --title "per-service thresholds"
+$ straymark charter new -t S --from-ailog AILOG-2026-04-28-021 --title "per-service thresholds"
 
 # Greenfield mode — Charter implementing a SpecKit spec
-$ devtrail charter new -t L --from-spec specs/001-payments/spec.md --title "wire payment provider"
+$ straymark charter new -t L --from-spec specs/001-payments/spec.md --title "wire payment provider"
 ```
 
 **Example output:**
 
 ```
-$ devtrail charter new -t M --title "test charter"
+$ straymark charter new -t M --title "test charter"
 
   ✔ Created: docs/charters/01-test-charter.md
 
@@ -466,7 +466,7 @@ $ devtrail charter new -t M --title "test charter"
     4. When you start executing: change frontmatter status from `declared` to `in-progress`.
 ```
 
-#### `devtrail charter list [--status declared|in-progress|closed|all] [--origin ailog|spec|any] [path]`
+#### `straymark charter list [--status declared|in-progress|closed|all] [--origin ailog|spec|any] [path]`
 
 Enumerate Charters as a table.
 
@@ -481,14 +481,14 @@ Files that fail to parse are reported as warnings to stderr without failing the 
 **Example:**
 
 ```bash
-$ devtrail charter list
+$ straymark charter list
   NN  STATUS       EFFORT  ORIGIN                 TITLE
   01  declared     M       AILOG-2026-04-28-021   Per-service anomaly thresholds
   02  in-progress  XS      —                      Baseline recompute
   03  closed       L       specs/001/spec.md      Wire payment provider
 ```
 
-#### `devtrail charter status [CHARTER-ID] [--path <dir>]`
+#### `straymark charter status [CHARTER-ID] [--path <dir>]`
 
 With an ID: print the full Charter detail (frontmatter, file location, body section list, Phase 2 placeholders). Without an ID: print the 5 most recent Charters by NN descending.
 
@@ -501,17 +501,17 @@ With an ID: print the full Charter detail (frontmatter, file location, body sect
 
 ```bash
 # Most recent 5
-$ devtrail charter status
+$ straymark charter status
 
 # Detail for a specific Charter (any of these resolves to CHARTER-02-baseline-recompute)
-$ devtrail charter status CHARTER-02-baseline-recompute
-$ devtrail charter status CHARTER-02
-$ devtrail charter status 2
+$ straymark charter status CHARTER-02-baseline-recompute
+$ straymark charter status CHARTER-02
+$ straymark charter status 2
 ```
 
-#### `devtrail charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
+#### `straymark charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
 
-Record the post-execution telemetry and bump the Charter's status to `closed`. Telemetry is written to `.devtrail/charters/CHARTER-NN.telemetry.yaml` (lateral file, **not** embedded in Charter frontmatter — frontmatter is declarative ex-ante; telemetry is voluminous ex-post). The shape is validated against `.devtrail/schemas/charter-telemetry.schema.v0.json`.
+Record the post-execution telemetry and bump the Charter's status to `closed`. Telemetry is written to `.straymark/charters/CHARTER-NN.telemetry.yaml` (lateral file, **not** embedded in Charter frontmatter — frontmatter is declarative ex-ante; telemetry is voluminous ex-post). The shape is validated against `.straymark/schemas/charter-telemetry.schema.v0.json`.
 
 Two modes:
 
@@ -531,7 +531,7 @@ Two modes:
 **Example:**
 
 ```bash
-$ devtrail charter close CHARTER-01
+$ straymark charter close CHARTER-01
 
   Closing CHARTER-01-test-charter
     Title: Test charter
@@ -544,13 +544,13 @@ $ devtrail charter close CHARTER-01
   ...
 
   ✔ Charter CHARTER-01 closed.
-    Telemetry: .devtrail/charters/CHARTER-01.telemetry.yaml
+    Telemetry: .straymark/charters/CHARTER-01.telemetry.yaml
     Status updated: in-progress/declared → closed
 ```
 
-#### `devtrail charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
 
-Detect file-vs-commit drift at Charter close. Wraps the framework's `.devtrail/scripts/check-charter-drift.sh` (zero false positives validated empirically across PLAN-05 retrospective + PLAN-06 prospective in Sentinel). The CLI value-add over the raw script is **AILOG-awareness**: paths reported as "declared but not modified" are silenced when they appear in the `## Risk` / `## Riesgos` / `## 风险` section of any AILOG referenced by the Charter's `originating_ailogs`. Use `--no-ailog-suppress` to disable.
+Detect file-vs-commit drift at Charter close. Wraps the framework's `.straymark/scripts/check-charter-drift.sh` (zero false positives validated empirically across PLAN-05 retrospective + PLAN-06 prospective in Sentinel). The CLI value-add over the raw script is **AILOG-awareness**: paths reported as "declared but not modified" are silenced when they appear in the `## Risk` / `## Riesgos` / `## 风险` section of any AILOG referenced by the Charter's `originating_ailogs`. Use `--no-ailog-suppress` to disable.
 
 | Argument/Flag | Default | Description |
 |---|---|---|
@@ -564,7 +564,7 @@ Detect file-vs-commit drift at Charter close. Wraps the framework's `.devtrail/s
 **Example:**
 
 ```bash
-$ devtrail charter drift CHARTER-01 --range origin/main..HEAD
+$ straymark charter drift CHARTER-01 --range origin/main..HEAD
 === Charter drift check ===
   Charter: docs/charters/01-test.md
   Range:   origin/main..HEAD
@@ -588,29 +588,29 @@ The drift check resolves two forms of wildcard in `## Files to modify`:
 
 | Form | Example | Use case |
 |---|---|---|
-| Ellipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Any modified path with that prefix satisfies the wildcard. Used historically when an unknown number of AILOGs would be created during execution. |
-| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.9.0 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+| Ellipsis | `` `.straymark/07-ai-audit/agent-logs/AILOG-...md` `` | Any modified path with that prefix satisfies the wildcard. Used historically when an unknown number of AILOGs would be created during execution. |
+| Glob | `` `AILOG-*.md` `` or `` `src/services/foo-*.rs` `` | Any modified path matching the glob (`*` → `.*`) satisfies the wildcard. Used for bulk Charter declarations where a parameterized set is touched. Added in fw-4.9.0 after the friction surfaced in Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/straymark/issues/81)). |
 
 Both forms are handled in both directions: a declared wildcard suppresses both "declared but not modified" warnings (when at least one matching file was modified) and "modified but not declared" warnings (when a modified path matches a declared wildcard).
 
 #### Designed: governance paths are always in scope
 
-Paths under `docs/charters/*` and `.devtrail/07-ai-audit/*` are **never** reported as "modified but not declared". This is opinionated by design — those paths are always legitimate when the Charter itself or the AILOG of execution is touched. Empirically validated in Sentinel CHARTER-04: a stray `git add -A` staged unrelated user-untracked files (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly suppressed the governance noise without hiding the genuine project-file expansion ([issue #81 W2](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)).
+Paths under `docs/charters/*` and `.straymark/07-ai-audit/*` are **never** reported as "modified but not declared". This is opinionated by design — those paths are always legitimate when the Charter itself or the AILOG of execution is touched. Empirically validated in Sentinel CHARTER-04: a stray `git add -A` staged unrelated user-untracked files (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly suppressed the governance noise without hiding the genuine project-file expansion ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
 
-If you're running a Charter whose explicit scope is governance churn (e.g., a bulk approval Charter touching only `.devtrail/07-ai-audit/`), the drift check will report 0 modified files and you'll need to verify scope by reading the AILOG. A `--strict-scope` flag that disables the always-in-scope rule is on the table for a future minor if a real adopter reports the asymmetry as a friction.
+If you're running a Charter whose explicit scope is governance churn (e.g., a bulk approval Charter touching only `.straymark/07-ai-audit/`), the drift check will report 0 modified files and you'll need to verify scope by reading the AILOG. A `--strict-scope` flag that disables the always-in-scope rule is on the table for a future minor if a real adopter reports the asymmetry as a friction.
 
-#### `devtrail charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
+#### `straymark charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
 
-*Available since **cli-3.8.0** + **fw-4.7.0**. v1 unified flow shipped in **cli-3.10.0** + **fw-4.9.0** — replaces the v0 three-step (PREPARE/CALIBRATE/FINALIZE) with a two-step (PREPARE/MERGE-REPORTS), unifies the auditor template, and moves canonical paths to `.devtrail/audits/`.*
+*Available since **cli-3.8.0** + **fw-4.7.0**. v1 unified flow shipped in **cli-3.10.0** + **fw-4.9.0** — replaces the v0 three-step (PREPARE/CALIBRATE/FINALIZE) with a two-step (PREPARE/MERGE-REPORTS), unifies the auditor template, and moves canonical paths to `.straymark/audits/`.*
 
-Orchestrate a multi-model external review of a Charter's execution. **Orchestration-only** — the CLI prepares the unified audit prompt, validates auditor reports against the schema, and emits/merges the `external_audit` YAML block. **It does NOT invoke LLM APIs.** The operator runs N auditor-side CLIs (gemini-cli, claude-cli, copilot-cli, codex-cli — whatever they have) configured with read-only filesystem access; each invokes the `/devtrail-audit-execute` skill to read the prompt, audit with tool use citing `path:line`, and write the report.
+Orchestrate a multi-model external review of a Charter's execution. **Orchestration-only** — the CLI prepares the unified audit prompt, validates auditor reports against the schema, and emits/merges the `external_audit` YAML block. **It does NOT invoke LLM APIs.** The operator runs N auditor-side CLIs (gemini-cli, claude-cli, copilot-cli, codex-cli — whatever they have) configured with read-only filesystem access; each invokes the `/straymark-audit-execute` skill to read the prompt, audit with tool use citing `path:line`, and write the report.
 
 Two steps, each invokable independently:
 
 | Step | Flag | What happens |
 |---|---|---|
-| 1. PREPARE | `--prepare` (default) | Resolves the unified audit prompt against the Charter + git diff + originating AILOGs. Writes it to `.devtrail/audits/<CHARTER-ID>/audit-prompt.md`. |
-| 2. MERGE-REPORTS | `--merge-reports` | Reads all `report-*.md` files in `.devtrail/audits/<CHARTER-ID>/` (one per auditor that completed). Validates each against `audit-output.schema.v0.json`. Emits the YAML-formatted `external_audit` array — combine with `--merge-into <PATH>` to append it directly into the Charter's telemetry YAML. |
+| 1. PREPARE | `--prepare` (default) | Resolves the unified audit prompt against the Charter + git diff + originating AILOGs. Writes it to `.straymark/audits/<CHARTER-ID>/audit-prompt.md`. |
+| 2. MERGE-REPORTS | `--merge-reports` | Reads all `report-*.md` files in `.straymark/audits/<CHARTER-ID>/` (one per auditor that completed). Validates each against `audit-output.schema.v0.json`. Emits the YAML-formatted `external_audit` array — combine with `--merge-into <PATH>` to append it directly into the Charter's telemetry YAML. |
 
 | Argument/Flag | Default | Description |
 |---|---|---|
@@ -623,98 +623,98 @@ Two steps, each invokable independently:
 
 **Deprecated v0 flags (hidden in `--help`):**
 
-- `--calibrate` — emits a warning and exits with error. The v0 calibrate step is replaced by the `/devtrail-audit-review` skill, which reconciles N reports inline with filesystem access (no separate paste-based prompt).
+- `--calibrate` — emits a warning and exits with error. The v0 calibrate step is replaced by the `/straymark-audit-review` skill, which reconciles N reports inline with filesystem access (no separate paste-based prompt).
 - `--finalize` — deprecated alias for `--merge-reports` with backwards-compat behavior. Emits a warning and routes through the new path.
 
 ### Heterogeneity recommendation (not enforced in v0)
 
-Per the design rationale (`devtrail-cli-roadmap.md` §5.2), the auditor pair should be of **different model families**: one Anthropic + one Google + one OpenAI, in any combination, never two of the same family. Cross-family heterogeneity is what makes convergence on findings high-signal — same-family auditors share blind spots.
+Per the design rationale (`straymark-cli-roadmap.md` §5.2), the auditor pair should be of **different model families**: one Anthropic + one Google + one OpenAI, in any combination, never two of the same family. Cross-family heterogeneity is what makes convergence on findings high-signal — same-family auditors share blind spots.
 
-v1 supports **N≥2 auditors** (no longer fixed to 2). Operators may opt in to 3 or 4 auditors for high-risk Charters, including specialized models (security-focused, code-review-tuned, etc.). The skill `/devtrail-audit-review` iterates over all `report-*.md` files in the audit dir.
+v1 supports **N≥2 auditors** (no longer fixed to 2). Operators may opt in to 3 or 4 auditors for high-risk Charters, including specialized models (security-focused, code-review-tuned, etc.). The skill `/straymark-audit-review` iterates over all `report-*.md` files in the audit dir.
 
-The calibrator role moves from a paste-based template (v0) to the in-conversation main agent via the `/devtrail-audit-review` skill — its task is definitional (reconcile already-produced verdicts), so heterogeneity from the implementer is NOT required.
+The calibrator role moves from a paste-based template (v0) to the in-conversation main agent via the `/straymark-audit-review` skill — its task is definitional (reconcile already-produced verdicts), so heterogeneity from the implementer is NOT required.
 
 ### Canonical layout produced (v1)
 
 ```
-.devtrail/audits/CHARTER-NN/
+.straymark/audits/CHARTER-NN/
 ├── audit-prompt.md                          # resolved by --prepare (single unified prompt)
-├── report-claude-sonnet-4-6.md              # written by /devtrail-audit-execute in claude-cli
-├── report-gemini-2-5-pro.md                 # written by /devtrail-audit-execute in gemini-cli
+├── report-claude-sonnet-4-6.md              # written by /straymark-audit-execute in claude-cli
+├── report-gemini-2-5-pro.md                 # written by /straymark-audit-execute in gemini-cli
 ├── report-gpt-5-3-codex.md                  # optional 3rd auditor
-├── review.md                                # written by /devtrail-audit-review (consolidated 6-section analysis)
-└── external-audit-pending.yaml              # written by /devtrail-audit-review when telemetry doesn't yet exist (Branch B)
+├── review.md                                # written by /straymark-audit-review (consolidated 6-section analysis)
+└── external-audit-pending.yaml              # written by /straymark-audit-review when telemetry doesn't yet exist (Branch B)
 ```
 
-The directory is namespaced under `.devtrail/` to avoid collisions with adopter-defined `audit/` folders. The `<UNIT-TYPE>-<UNIT-ID>` shape leaves room for future audit-unit categories beyond Charter (e.g. `MODULE-payments/`, `RELEASE-v2.0/`) without restructuring.
+The directory is namespaced under `.straymark/` to avoid collisions with adopter-defined `audit/` folders. The `<UNIT-TYPE>-<UNIT-ID>` shape leaves room for future audit-unit categories beyond Charter (e.g. `MODULE-payments/`, `RELEASE-v2.0/`) without restructuring.
 
-Adopters can `git add` the entire `.devtrail/audits/` directory for a fully version-controlled audit trail, or `.gitignore` it if they prefer the cycle to be ephemeral.
+Adopters can `git add` the entire `.straymark/audits/` directory for a fully version-controlled audit trail, or `.gitignore` it if they prefer the cycle to be ephemeral.
 
 **Example (v1, with the audit-skills wrappers — recommended for IDE-driven workflows):**
 
 ```bash
 # In the main IDE (Claude Code, Gemini Code, Cursor, ...):
-> /devtrail-audit-prompt CHARTER-05
-  → runs `devtrail charter audit CHARTER-05 --prepare`
-  → writes .devtrail/audits/CHARTER-05/audit-prompt.md
+> /straymark-audit-prompt CHARTER-05
+  → runs `straymark charter audit CHARTER-05 --prepare`
+  → writes .straymark/audits/CHARTER-05/audit-prompt.md
   → instructs operator to open auditor CLIs
 
 # In claude-cli (with read access to repo):
-> /devtrail-audit-execute CHARTER-05
-  → reads .devtrail/audits/CHARTER-05/audit-prompt.md
+> /straymark-audit-execute CHARTER-05
+  → reads .straymark/audits/CHARTER-05/audit-prompt.md
   → audits with tool use, citing path:line
-  → writes .devtrail/audits/CHARTER-05/report-claude-sonnet-4-6.md
+  → writes .straymark/audits/CHARTER-05/report-claude-sonnet-4-6.md
   → reminds operator to wait for ALL audits before review
 
 # In gemini-cli:
-> /devtrail-audit-execute CHARTER-05
-  → writes .devtrail/audits/CHARTER-05/report-gemini-2-5-pro.md
+> /straymark-audit-execute CHARTER-05
+  → writes .straymark/audits/CHARTER-05/report-gemini-2-5-pro.md
 
 # Back in the main IDE, after ALL audits complete:
-> /devtrail-audit-review CHARTER-05
+> /straymark-audit-review CHARTER-05
   → reads N reports, verifies each finding against code
-  → writes .devtrail/audits/CHARTER-05/review.md (6-section consolidated)
-  → runs `devtrail charter audit CHARTER-05 --merge-reports --merge-into <telemetry>`
+  → writes .straymark/audits/CHARTER-05/review.md (6-section consolidated)
+  → runs `straymark charter audit CHARTER-05 --merge-reports --merge-into <telemetry>`
   → external_audit YAML merged into Charter telemetry
 ```
 
 **Example (CLI direct, without skills — for CI / batch / non-IDE use):**
 
 ```bash
-$ devtrail charter audit CHARTER-05 --prepare
+$ straymark charter audit CHARTER-05 --prepare
   PREPARE audit prompt (CHARTER-05)
-  ✔ Wrote .devtrail/audits/CHARTER-05/audit-prompt.md
+  ✔ Wrote .straymark/audits/CHARTER-05/audit-prompt.md
 
   Next:
-    1. Open one or more auditor CLIs ... and invoke /devtrail-audit-execute CHARTER-05.
+    1. Open one or more auditor CLIs ... and invoke /straymark-audit-execute CHARTER-05.
     2. Each auditor reads the prompt above and writes report-<model-slug>.md.
-    3. When ALL audits complete, run: /devtrail-audit-review CHARTER-05
+    3. When ALL audits complete, run: /straymark-audit-review CHARTER-05
 
 # (operator runs auditors in their CLIs of choice; reports land at canonical paths)
 
-$ devtrail charter audit CHARTER-05 --merge-reports \
-    --merge-into .devtrail/charters/CHARTER-05.telemetry.yaml
+$ straymark charter audit CHARTER-05 --merge-reports \
+    --merge-into .straymark/charters/CHARTER-05.telemetry.yaml
   MERGE-REPORTS audit cycle (CHARTER-05)
-  ✔ Validated .devtrail/audits/CHARTER-05/report-claude-sonnet-4-6.md (5 findings)
-  ✔ Validated .devtrail/audits/CHARTER-05/report-gemini-2-5-pro.md (4 findings)
-  ✔ Validated .devtrail/audits/CHARTER-05/report-gpt-5-3-codex.md (3 findings)
+  ✔ Validated .straymark/audits/CHARTER-05/report-claude-sonnet-4-6.md (5 findings)
+  ✔ Validated .straymark/audits/CHARTER-05/report-gemini-2-5-pro.md (4 findings)
+  ✔ Validated .straymark/audits/CHARTER-05/report-gpt-5-3-codex.md (3 findings)
 
   Audit cycle merge complete.
 
-  ✔ Merged external_audit array into .devtrail/charters/CHARTER-05.telemetry.yaml
+  ✔ Merged external_audit array into .straymark/charters/CHARTER-05.telemetry.yaml
 
   Run `git diff` on the telemetry file to review the merge before commit.
 ```
 
-> **Why orchestration-only?** Implementing 3 HTTP clients (OpenAI / Google / Anthropic) is 1-2 weeks + perpetual maintenance when APIs change. v1 audit-skills extend the orchestration-only stance to a second mode (CLI auditor-side with tool use enforcement) where the operator runs their own auditor CLIs and DevTrail's prompts enforce the discipline (`cite path:line of files actually opened`). DevTrail still doesn't manage API keys, doesn't invoke APIs, doesn't maintain HTTP clients.
+> **Why orchestration-only?** Implementing 3 HTTP clients (OpenAI / Google / Anthropic) is 1-2 weeks + perpetual maintenance when APIs change. v1 audit-skills extend the orchestration-only stance to a second mode (CLI auditor-side with tool use enforcement) where the operator runs their own auditor CLIs and StrayMark's prompts enforce the discipline (`cite path:line of files actually opened`). StrayMark still doesn't manage API keys, doesn't invoke APIs, doesn't maintain HTTP clients.
 
-> **Skill alternative *(fw-4.9.0+, expanded in fw-4.9.0)*.** Three skills wrap the CLI for IDE-driven workflows: `/devtrail-audit-prompt CHARTER-ID` (calls `--prepare`), `/devtrail-audit-execute CHARTER-ID` (runs in auditor CLIs to read the prompt and write a report), and `/devtrail-audit-review CHARTER-ID` (consolidates N reports into `review.md` and merges YAML). With these skills the operator never copies/pastes prompts or reports — file exchange happens via the canonical filesystem paths under `.devtrail/audits/`. See the [Skills](#skills) section below. The CLI remains the single source of truth — the skills only add UX-inline.
+> **Skill alternative *(fw-4.9.0+, expanded in fw-4.9.0)*.** Three skills wrap the CLI for IDE-driven workflows: `/straymark-audit-prompt CHARTER-ID` (calls `--prepare`), `/straymark-audit-execute CHARTER-ID` (runs in auditor CLIs to read the prompt and write a report), and `/straymark-audit-review CHARTER-ID` (consolidates N reports into `review.md` and merges YAML). With these skills the operator never copies/pastes prompts or reports — file exchange happens via the canonical filesystem paths under `.straymark/audits/`. See the [Skills](#skills) section below. The CLI remains the single source of truth — the skills only add UX-inline.
 
 ---
 
-### `devtrail compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
+### `straymark compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
 
-Check regulatory compliance. By default, evaluates the standards whose region is in `regional_scope` from `.devtrail/config.yml` (default `[global, eu]`). Six Chinese frameworks are available opt-in when `china` is added to `regional_scope`.
+Check regulatory compliance. By default, evaluates the standards whose region is in `regional_scope` from `.straymark/config.yml` (default `[global, eu]`). Six Chinese frameworks are available opt-in when `china` is added to `regional_scope`.
 
 **Arguments and flags:**
 
@@ -749,8 +749,8 @@ China (opt-in via `regional_scope: china`):
 
 ```bash
 # Default: runs only standards whose region is in regional_scope
-$ devtrail compliance
-  DevTrail Compliance
+$ straymark compliance
+  StrayMark Compliance
   /home/user/my-project
   12 document(s) analyzed
 
@@ -772,7 +772,7 @@ $ devtrail compliance
   Overall compliance: 78%
 
 # Run only the six Chinese frameworks (requires regional_scope: china)
-$ devtrail compliance --region china
+$ straymark compliance --region china
   ■ China TC260 v2.0 67%
     ✓ [TC260-001] At least one TC260 Risk Assessment (TC260RA) is present
     ~ [TC260-002] High / very-high / extremely-severe TC260 levels mandate review
@@ -790,14 +790,14 @@ $ devtrail compliance --region china
   ■ China CSL 2026 ...
 
 # A single Chinese framework
-$ devtrail compliance --standard china-pipl --output json
+$ straymark compliance --standard china-pipl --output json
 [{"standard":"ChinaPipl","standard_label":"China PIPL","checks":[...],"score":100.0}]
 
 # Force every standard, ignoring regional_scope
-$ devtrail compliance --all
+$ straymark compliance --all
 ```
 
-> **Activation note**: Chinese frameworks evaluate only when you opt in. Add to `.devtrail/config.yml`:
+> **Activation note**: Chinese frameworks evaluate only when you opt in. Add to `.straymark/config.yml`:
 >
 > ```yaml
 > regional_scope:
@@ -806,11 +806,11 @@ $ devtrail compliance --all
 >   - china
 > ```
 >
-> Use `--standard china-*` or `--region china` to run them ad-hoc even when not in scope. See the `CHINA-REGULATORY-FRAMEWORK.md` guide installed under `.devtrail/00-governance/`.
+> Use `--standard china-*` or `--region china` to run them ad-hoc even when not in scope. See the `CHINA-REGULATORY-FRAMEWORK.md` guide installed under `.straymark/00-governance/`.
 
 ---
 
-### `devtrail metrics [path] [--period <period>] [--output <format>]`
+### `straymark metrics [path] [--period <period>] [--output <format>]`
 
 Show governance metrics and documentation statistics.
 
@@ -833,8 +833,8 @@ Show governance metrics and documentation statistics.
 **Example:**
 
 ```bash
-$ devtrail metrics --period last-30-days
-  DevTrail Metrics
+$ straymark metrics --period last-30-days
+  StrayMark Metrics
   /home/user/my-project
   Period: Last 30 days — 2026-02-25 to 2026-03-27
 
@@ -865,7 +865,7 @@ $ devtrail metrics --period last-30-days
 
 ---
 
-### `devtrail analyze [path] [--threshold <N>] [--output <format>] [--top <N>]`
+### `straymark analyze [path] [--threshold <N>] [--output <format>] [--top <N>]`
 
 Analyze code complexity using cognitive and cyclomatic metrics powered by [arborist-metrics](https://crates.io/crates/arborist-metrics).
 
@@ -880,9 +880,9 @@ Analyze code complexity using cognitive and cyclomatic metrics powered by [arbor
 
 **Supported languages:** Rust, Python, JavaScript, TypeScript, Java, Go, C, C++, C#, PHP, Kotlin, Swift
 
-**Threshold resolution:** CLI flag → `.devtrail/config.yml` → default (8)
+**Threshold resolution:** CLI flag → `.straymark/config.yml` → default (8)
 
-**Configuration** (optional, in `.devtrail/config.yml`):
+**Configuration** (optional, in `.straymark/config.yml`):
 
 ```yaml
 complexity:
@@ -893,22 +893,22 @@ complexity:
 
 ```bash
 # Analyze current directory
-$ devtrail analyze
+$ straymark analyze
 
 # Custom threshold and top 10
-$ devtrail analyze --threshold 5 --top 10
+$ straymark analyze --threshold 5 --top 10
 
 # JSON output for CI integration
-$ devtrail analyze --output json
+$ straymark analyze --output json
 
 # Analyze a specific project
-$ devtrail analyze /path/to/project
+$ straymark analyze /path/to/project
 ```
 
 **Example output:**
 
 ```
-  DevTrail Analyze
+  StrayMark Analyze
   /home/user/project
   Threshold: cognitive complexity > 8
 
@@ -927,13 +927,13 @@ $ devtrail analyze /path/to/project
     → Average cognitive complexity: 3.8
 ```
 
-> **Note:** This command works without `devtrail init`. It operates on source files, not DevTrail documents. The `analyze` feature can be disabled at compile time with `--no-default-features`.
+> **Note:** This command works without `straymark init`. It operates on source files, not StrayMark documents. The `analyze` feature can be disabled at compile time with `--no-default-features`.
 
-> **Documentation trigger:** AI agents use `devtrail analyze --output json` as the primary method to determine when to create AILOG documents. If `summary.above_threshold > 0` in the JSON output, the agent should create an AILOG. When the CLI is not available, agents fall back to the >20 lines of business logic heuristic.
+> **Documentation trigger:** AI agents use `straymark analyze --output json` as the primary method to determine when to create AILOG documents. If `summary.above_threshold > 0` in the JSON output, the agent should create an AILOG. When the CLI is not available, agents fall back to the >20 lines of business logic heuristic.
 
 ---
 
-### `devtrail audit [path] [--from <date>] [--to <date>] [--system <name>] [--output <format>]`
+### `straymark audit [path] [--from <date>] [--to <date>] [--system <name>] [--output <format>]`
 
 Generate audit trail reports with timeline, traceability map, and compliance summary.
 
@@ -967,26 +967,26 @@ Generate audit trail reports with timeline, traceability map, and compliance sum
 
 ```bash
 # Full audit report
-$ devtrail audit
+$ straymark audit
 
 # Audit for Q1 2026
-$ devtrail audit --from 2026-01-01 --to 2026-03-31
+$ straymark audit --from 2026-01-01 --to 2026-03-31
 
 # Audit filtered by system
-$ devtrail audit --system auth-service
+$ straymark audit --system auth-service
 
 # Generate HTML report
-$ devtrail audit --from 2026-01-01 --to 2026-03-31 --output html > audit-q1.html
+$ straymark audit --from 2026-01-01 --to 2026-03-31 --output html > audit-q1.html
 
 # Generate Markdown for a PR
-$ devtrail audit --output markdown
+$ straymark audit --output markdown
 ```
 
 ---
 
-### `devtrail explore [path]`
+### `straymark explore [path]`
 
-Browse and read DevTrail documentation interactively in a terminal UI.
+Browse and read StrayMark documentation interactively in a terminal UI.
 
 **Arguments:**
 
@@ -1003,7 +1003,7 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 **Language resolution order** (since cli-3.5.2):
 
 1. `--lang <code>` flag, when provided
-2. `language` field in `.devtrail/config.yml`, when the file exists (an explicit value — even `language: en` — is treated as a deliberate user choice)
+2. `language` field in `.straymark/config.yml`, when the file exists (an explicit value — even `language: en` — is treated as a deliberate user choice)
 3. `$LC_ALL` / `$LANG` env vars, mapped to a supported locale (e.g., `zh_CN.UTF-8` → `zh-CN`, `es_MX.UTF-8` → `es`). Traditional Chinese (`zh_TW` / `zh_HK`) and other unsupported locales fall through.
 4. `en`
 
@@ -1015,7 +1015,7 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 - Navigate between related documents via hyperlinks
 - Search by filename, title, tags, or date
 - Fullscreen document mode, with `j` / `k` as alternate keys for `↓` / `↑`
-- Localization-aware: framework docs (`QUICK-REFERENCE`, `AGENT-RULES`, China regulatory guides, etc.) are served in the language set by `language` in `.devtrail/config.yml` or by `--lang`
+- Localization-aware: framework docs (`QUICK-REFERENCE`, `AGENT-RULES`, China regulatory guides, etc.) are served in the language set by `language` in `.straymark/config.yml` or by `--lang`
 
 **Key bindings:**
 
@@ -1034,29 +1034,29 @@ Browse and read DevTrail documentation interactively in a terminal UI.
 **Examples:**
 
 ```bash
-$ devtrail explore                       # uses config.language (defaults to en)
-$ devtrail explore --lang zh-CN          # browse framework docs in Simplified Chinese
-$ devtrail explore --lang es             # session override to Spanish
+$ straymark explore                       # uses config.language (defaults to en)
+$ straymark explore --lang zh-CN          # browse framework docs in Simplified Chinese
+$ straymark explore --lang es             # session override to Spanish
 ```
 
 > **Note:** The `explore` command requires the `tui` feature (enabled by default). To compile without it: `cargo build --no-default-features`.
 
 ---
 
-### `devtrail about`
+### `straymark about`
 
 Show version, authorship, and license information.
 
 **Example:**
 
 ```bash
-$ devtrail about
-DevTrail CLI
+$ straymark about
+StrayMark CLI
   CLI version:       cli-3.5.2
   Framework version: fw-4.10.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
-  Repository:        https://github.com/StrangeDaysTech/devtrail
+  Repository:        https://github.com/StrangeDaysTech/straymark
   Website:           https://strangedays.tech
 ```
 
@@ -1064,7 +1064,7 @@ DevTrail CLI
 
 ## Skills
 
-DevTrail ships a set of skills (slash commands) for use inside an AI assistant (Claude Code, Gemini Code, Cursor, generic agent runtimes). Each skill is installed in 3 parallel forms during `devtrail init`:
+StrayMark ships a set of skills (slash commands) for use inside an AI assistant (Claude Code, Gemini Code, Cursor, generic agent runtimes). Each skill is installed in 3 parallel forms during `straymark init`:
 
 - `dist/.claude/skills/<skill>/SKILL.md` (Claude — frontmatter with `allowed-tools`)
 - `dist/.gemini/skills/<skill>/SKILL.md` (Gemini — frontmatter without `allowed-tools`)
@@ -1072,26 +1072,26 @@ DevTrail ships a set of skills (slash commands) for use inside an AI assistant (
 
 | Skill | Purpose | Files produced |
 |---|---|---|
-| `/devtrail-status` | Check documentation compliance for recent changes. | none (read-only) |
-| `/devtrail-new` | Create any document type interactively. Suggests best fit from context. | `.devtrail/<type-dir>/<TYPE>-YYYY-MM-DD-NNN-*.md` |
-| `/devtrail-ailog` | Quick AILOG creation shortcut. | `.devtrail/07-ai-audit/agent-logs/AILOG-*.md` |
-| `/devtrail-aidec` | Quick AIDEC creation shortcut. | `.devtrail/07-ai-audit/decisions/AIDEC-*.md` |
-| `/devtrail-adr` | Quick ADR creation shortcut. | `.devtrail/04-architecture/decisions/ADR-*.md` |
-| `/devtrail-mcard` | Interactive Model Card creation flow. | `.devtrail/09-ai-models/MCARD-*.md` |
-| `/devtrail-sec` | Interactive SEC (security assessment) flow. | `.devtrail/08-security/SEC-*.md` |
-| `/devtrail-audit-prompt CHARTER-ID` *(fw-4.9.0+, refactored in fw-4.9.0)* | Generate the unified audit prompt for a Charter at the canonical path. Wraps `devtrail charter audit --prepare`. The operator then opens N auditor CLIs in the same repo and invokes `/devtrail-audit-execute` in each — no copy/paste. | `.devtrail/audits/<CHARTER-ID>/audit-prompt.md` |
-| `/devtrail-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **Run inside an auditor-side CLI** (gemini-cli, claude-cli, copilot-cli, codex-cli, ...). Reads the prepared prompt from disk, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id. CHARTER-ID argument is optional — auto-discovers prompts that don't yet have a report from this model. | `.devtrail/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
-| `/devtrail-audit-review CHARTER-ID` *(fw-4.9.0+, expanded in fw-4.9.0)* | Counterpart to `/devtrail-audit-prompt`. Reads N reports under `.devtrail/audits/<CHARTER-ID>/`, verifies each finding against actual code (Explore agents in parallel), produces a six-section consolidated `review.md` (Executive summary, Scope, Per-auditor evaluation, Remediation plan P0-P4, Discarded findings, Auditor ratings), and runs `devtrail charter audit --merge-reports --merge-into` to append `external_audit:` into the Charter telemetry. If the telemetry doesn't yet exist (Charter not yet closed), writes `external-audit-pending.yaml` for later merge at close time. | `.devtrail/audits/<CHARTER-ID>/review.md`, `external_audit:` array merged into telemetry (or pending YAML) |
+| `/straymark-status` | Check documentation compliance for recent changes. | none (read-only) |
+| `/straymark-new` | Create any document type interactively. Suggests best fit from context. | `.straymark/<type-dir>/<TYPE>-YYYY-MM-DD-NNN-*.md` |
+| `/straymark-ailog` | Quick AILOG creation shortcut. | `.straymark/07-ai-audit/agent-logs/AILOG-*.md` |
+| `/straymark-aidec` | Quick AIDEC creation shortcut. | `.straymark/07-ai-audit/decisions/AIDEC-*.md` |
+| `/straymark-adr` | Quick ADR creation shortcut. | `.straymark/04-architecture/decisions/ADR-*.md` |
+| `/straymark-mcard` | Interactive Model Card creation flow. | `.straymark/09-ai-models/MCARD-*.md` |
+| `/straymark-sec` | Interactive SEC (security assessment) flow. | `.straymark/08-security/SEC-*.md` |
+| `/straymark-audit-prompt CHARTER-ID` *(fw-4.9.0+, refactored in fw-4.9.0)* | Generate the unified audit prompt for a Charter at the canonical path. Wraps `straymark charter audit --prepare`. The operator then opens N auditor CLIs in the same repo and invokes `/straymark-audit-execute` in each — no copy/paste. | `.straymark/audits/<CHARTER-ID>/audit-prompt.md` |
+| `/straymark-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **Run inside an auditor-side CLI** (gemini-cli, claude-cli, copilot-cli, codex-cli, ...). Reads the prepared prompt from disk, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id. CHARTER-ID argument is optional — auto-discovers prompts that don't yet have a report from this model. | `.straymark/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
+| `/straymark-audit-review CHARTER-ID` *(fw-4.9.0+, expanded in fw-4.9.0)* | Counterpart to `/straymark-audit-prompt`. Reads N reports under `.straymark/audits/<CHARTER-ID>/`, verifies each finding against actual code (Explore agents in parallel), produces a six-section consolidated `review.md` (Executive summary, Scope, Per-auditor evaluation, Remediation plan P0-P4, Discarded findings, Auditor ratings), and runs `straymark charter audit --merge-reports --merge-into` to append `external_audit:` into the Charter telemetry. If the telemetry doesn't yet exist (Charter not yet closed), writes `external-audit-pending.yaml` for later merge at close time. | `.straymark/audits/<CHARTER-ID>/review.md`, `external_audit:` array merged into telemetry (or pending YAML) |
 
 ### Skill vs CLI
 
-The three audit skills are **wrappers** around the CLI commands and discipline. The canonical paths under `.devtrail/audits/`, the unified prompt template, the schema validation, and the `external_audit` shape all live in the CLI + framework — the skills handle the UX-inline part: dispatching the operator across the audit cycle without manual file management. **Operators never copy/paste prompts or reports** — the skills exchange artifacts via the canonical filesystem paths.
+The three audit skills are **wrappers** around the CLI commands and discipline. The canonical paths under `.straymark/audits/`, the unified prompt template, the schema validation, and the `external_audit` shape all live in the CLI + framework — the skills handle the UX-inline part: dispatching the operator across the audit cycle without manual file management. **Operators never copy/paste prompts or reports** — the skills exchange artifacts via the canonical filesystem paths.
 
-Adopters using DevTrail without an AI assistant in the loop can drive the same workflow directly via `devtrail charter audit` (`--prepare` / `--merge-reports [--merge-into <path>]`). The audit prompt at `.devtrail/audits/<id>/audit-prompt.md` works equally well pasted into a chat-based LLM if no auditor-side CLI is available — the skill just automates the file exchange.
+Adopters using StrayMark without an AI assistant in the loop can drive the same workflow directly via `straymark charter audit` (`--prepare` / `--merge-reports [--merge-into <path>]`). The audit prompt at `.straymark/audits/<id>/audit-prompt.md` works equally well pasted into a chat-based LLM if no auditor-side CLI is available — the skill just automates the file exchange.
 
 ### Audit checkpoint *(fw-4.9.0+)*
 
-`.devtrail/00-governance/AGENT-RULES.md` §12 codifies a workflow checkpoint where the agent proactively offers the audit at one specific moment — when the Charter implementation is done, drift is clean, and `charter close` has not yet been invoked. The recommendation is YES/NO based on heuristics (security surface, new components, AILOG risks, complexity). External audit is **fully optional**; the checkpoint is **soft** — never blocks `charter close`, never enforced (permanent v0+v1 design decision).
+`.straymark/00-governance/AGENT-RULES.md` §12 codifies a workflow checkpoint where the agent proactively offers the audit at one specific moment — when the Charter implementation is done, drift is clean, and `charter close` has not yet been invoked. The recommendation is YES/NO based on heuristics (security surface, new components, AILOG risks, complexity). External audit is **fully optional**; the checkpoint is **soft** — never blocks `charter close`, never enforced (permanent v0+v1 design decision).
 
 ---
 
@@ -1114,7 +1114,7 @@ Adopters using DevTrail without an AI assistant in the loop can drive the same w
 
 <div align="center">
 
-**DevTrail** — Because every change tells a story.
+**StrayMark** — Because every change tells a story.
 
 [Back to docs](../README.md) • [README](../../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/adopters/WORKFLOWS.md
+++ b/docs/adopters/WORKFLOWS.md
@@ -1,6 +1,6 @@
-# DevTrail - Recommended Workflows
+# StrayMark - Recommended Workflows
 
-**Patterns and cadences for using DevTrail day to day.**
+**Patterns and cadences for using StrayMark day to day.**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -12,7 +12,7 @@
 
 1. [After Initial Setup](#after-initial-setup)
 2. [Daily Development](#daily-development)
-3. [Keeping DevTrail Updated](#keeping-devtrail-updated)
+3. [Keeping StrayMark Updated](#keeping-straymark-updated)
 4. [Checking Project Health](#checking-project-health)
 5. [Using Skills (Active Documentation)](#using-skills-active-documentation)
 6. [Team Patterns](#team-patterns)
@@ -22,12 +22,12 @@
 
 ## After Initial Setup
 
-You ran `devtrail init .` and committed the result. Now what?
+You ran `straymark init .` and committed the result. Now what?
 
 1. **Open your project** with your AI coding assistant (Claude Code, Cursor, Gemini CLI, etc.)
-2. The assistant will **automatically read** the DevTrail directives (`CLAUDE.md`, `GEMINI.md`, etc.)
-3. From this point on, the assistant **creates documentation** in `.devtrail/` as part of its normal workflow
-4. **No extra configuration needed** — DevTrail works passively through the directive files
+2. The assistant will **automatically read** the StrayMark directives (`CLAUDE.md`, `GEMINI.md`, etc.)
+3. From this point on, the assistant **creates documentation** in `.straymark/` as part of its normal workflow
+4. **No extra configuration needed** — StrayMark works passively through the directive files
 
 ---
 
@@ -36,7 +36,7 @@ You ran `devtrail init .` and committed the result. Now what?
 ### The Passive Loop
 
 1. Work normally with your AI assistant — write features, fix bugs, refactor
-2. The AI creates documents in `.devtrail/` according to the governance rules:
+2. The AI creates documents in `.straymark/` according to the governance rules:
    - **AILOG** for significant implementations (>10 lines changed)
    - **AIDEC** when choosing between alternatives
    - **ADR** for architectural decisions
@@ -55,27 +55,27 @@ Use the active system (skills) when:
 
 ---
 
-## Keeping DevTrail Updated
+## Keeping StrayMark Updated
 
 ### Recommended Cadence
 
 - **Monthly** or when you see a new release on GitHub
-- Check the [releases page](https://github.com/StrangeDaysTech/devtrail/releases) for changelogs
+- Check the [releases page](https://github.com/StrangeDaysTech/straymark/releases) for changelogs
 
 ### Update Commands
 
 | Goal | Command |
 |------|---------|
-| Update both framework and CLI | `devtrail update` |
-| Update only templates and governance files | `devtrail update-framework` |
-| Update only the CLI binary | `devtrail update-cli` |
+| Update both framework and CLI | `straymark update` |
+| Update only templates and governance files | `straymark update-framework` |
+| Update only the CLI binary | `straymark update-cli` |
 
 Framework and CLI have **independent versions** — you can update one without the other. See [Understanding Versions](#understanding-versions).
 
 ### After Updating
 
 1. Review changes to directive files and governance docs
-2. Commit the updated files: `git add .devtrail/ && git commit -m "chore: update DevTrail framework"`
+2. Commit the updated files: `git add .straymark/ && git commit -m "chore: update StrayMark framework"`
 3. If you customized any framework files, check for conflicts
 
 ---
@@ -85,7 +85,7 @@ Framework and CLI have **independent versions** — you can update one without t
 ### CLI Status
 
 ```bash
-devtrail status
+straymark status
 ```
 
 Shows: framework version, CLI version, directory structure integrity, and document statistics by type. Use it to verify that the installation is healthy.
@@ -93,10 +93,10 @@ Shows: framework version, CLI version, directory structure integrity, and docume
 ### Documentation Compliance (Skill)
 
 ```bash
-/devtrail-status
+/straymark-status
 ```
 
-The `/devtrail-status` skill (available in Claude Code and Gemini CLI) analyzes:
+The `/straymark-status` skill (available in Claude Code and Gemini CLI) analyzes:
 
 - Which recent code changes lack corresponding documentation
 - Document compliance against governance rules
@@ -106,7 +106,7 @@ The `/devtrail-status` skill (available in Claude Code and Gemini CLI) analyzes:
 
 ## Using Skills (Active Documentation)
 
-DevTrail has two documentation systems:
+StrayMark has two documentation systems:
 
 | System | How it works | When to use |
 |--------|-------------|-------------|
@@ -117,20 +117,20 @@ DevTrail has two documentation systems:
 
 | Skill | Purpose |
 |-------|---------|
-| `/devtrail-status` | Check documentation compliance |
-| `/devtrail-new` | Create any document type (suggests best fit) |
-| `/devtrail-ailog` | Quick AILOG creation |
-| `/devtrail-aidec` | Quick AIDEC creation |
-| `/devtrail-adr` | Quick ADR creation |
-| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+, refactored in fw-4.9.0)* | Generate the unified audit prompt at the canonical path `.devtrail/audits/<id>/audit-prompt.md`. Wraps `devtrail charter audit --prepare`. Operator then opens N auditor CLIs and runs `/devtrail-audit-execute` in each — no copy/paste. |
-| `/devtrail-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **Run inside an auditor-side CLI** (gemini-cli, claude-cli, copilot-cli, codex-cli). Reads the prompt from disk, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id. Argument optional — auto-discovers prompts pending from this model. |
-| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+, expanded in fw-4.9.0)* | Counterpart to `audit-prompt`. Reads N reports, verifies findings against actual code, produces `review.md` consolidated 6-section analysis (Executive summary / Scope / Per-auditor evaluation / Remediation plan P0-P4 / Discarded / Auditor ratings), and merges `external_audit:` YAML into telemetry. |
+| `/straymark-status` | Check documentation compliance |
+| `/straymark-new` | Create any document type (suggests best fit) |
+| `/straymark-ailog` | Quick AILOG creation |
+| `/straymark-aidec` | Quick AIDEC creation |
+| `/straymark-adr` | Quick ADR creation |
+| `/straymark-audit-prompt CHARTER-XX` *(fw-4.8.0+, refactored in fw-4.9.0)* | Generate the unified audit prompt at the canonical path `.straymark/audits/<id>/audit-prompt.md`. Wraps `straymark charter audit --prepare`. Operator then opens N auditor CLIs and runs `/straymark-audit-execute` in each — no copy/paste. |
+| `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **Run inside an auditor-side CLI** (gemini-cli, claude-cli, copilot-cli, codex-cli). Reads the prompt from disk, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id. Argument optional — auto-discovers prompts pending from this model. |
+| `/straymark-audit-review CHARTER-XX` *(fw-4.8.0+, expanded in fw-4.9.0)* | Counterpart to `audit-prompt`. Reads N reports, verifies findings against actual code, produces `review.md` consolidated 6-section analysis (Executive summary / Scope / Per-auditor evaluation / Remediation plan P0-P4 / Discarded / Auditor ratings), and merges `external_audit:` YAML into telemetry. |
 
 For full skill details, see the [README](../../README.md#skills).
 
 ### Charter audit checkpoint *(fw-4.8.0+)*
 
-When co-implementing a Charter, the agent will proactively offer an external audit at one specific moment: when implementation is done, drift is clean, and `charter close` has not yet been invoked. The recommendation is YES/NO based on the Charter's risk surface and complexity (full heuristics in `.devtrail/00-governance/AGENT-RULES.md` §12).
+When co-implementing a Charter, the agent will proactively offer an external audit at one specific moment: when implementation is done, drift is clean, and `charter close` has not yet been invoked. The recommendation is YES/NO based on the Charter's risk surface and complexity (full heuristics in `.straymark/00-governance/AGENT-RULES.md` §12).
 
 External audit is **fully optional** and **never enforced**. The Charter's declarative scope + drift check + AILOG discipline already provide rigorous closure without it. Audit adds cross-model signal where the Charter touched security surface, introduced new components, or has high-complexity functions in the diff. Decline freely if the cost (2-3 LLM auditors) does not match the value for your case.
 
@@ -140,13 +140,13 @@ External audit is **fully optional** and **never enforced**. The Charter's decla
 
 ### PR Reviews
 
-- Check that significant code changes include corresponding `.devtrail/` documents
+- Check that significant code changes include corresponding `.straymark/` documents
 - Review any documents with `review_required: true`
 - Verify that AILOGs accurately describe what the AI did
 
 ### Onboarding New Team Members
 
-1. Point them to `.devtrail/QUICK-REFERENCE.md` for a quick overview
+1. Point them to `.straymark/QUICK-REFERENCE.md` for a quick overview
 2. Have them read recent ADRs to understand architectural context
 3. Show them AILOGs from recent features to see how documentation works in practice
 
@@ -172,15 +172,15 @@ If your project operates in mainland China or processes personal information of 
 
 ### One-time Setup
 
-1. Edit `.devtrail/config.yml` and add `china` to `regional_scope`:
+1. Edit `.straymark/config.yml` and add `china` to `regional_scope`:
    ```yaml
    regional_scope:
      - global
      - eu      # if also EU-subject
      - china
    ```
-2. Run `devtrail compliance --region china` to see the baseline (all checks will fail until you create the supporting documents).
-3. Read the guides installed under `.devtrail/00-governance/`:
+2. Run `straymark compliance --region china` to see the baseline (all checks will fail until you create the supporting documents).
+3. Read the guides installed under `.straymark/00-governance/`:
    - `CHINA-REGULATORY-FRAMEWORK.md` — overview and coverage matrix
    - `TC260-IMPLEMENTATION-GUIDE.md` — five-level risk grading
    - `PIPL-PIPIA-GUIDE.md` — when a PIPIA is required and what it must contain
@@ -200,7 +200,7 @@ Bundle of documents to create together (cross-linked via `related:`):
 | `PIPIA` | Personal-info impact assessment (Art. 55-56) | When personal info is processed |
 | `SBOM` | Training-data inventory + GB/T 45652 compliance | Always |
 
-`devtrail compliance --region china` confirms the bundle is complete.
+`straymark compliance --region china` confirms the bundle is complete.
 
 ### When an Incident Occurs
 
@@ -211,7 +211,7 @@ csl_severity_level: relatively_major   # or particularly_serious | major | gener
 csl_report_deadline_hours: 4           # 1 for particularly_serious, 4 for relatively_major
 ```
 
-`devtrail validate` enforces severity-to-deadline coherence (`CROSS-008`, `CROSS-009`). Major+ incidents must be closed (status `accepted`) within 30 days for the `CSL-003` check to pass.
+`straymark validate` enforces severity-to-deadline coherence (`CROSS-008`, `CROSS-009`). Major+ incidents must be closed (status `accepted`) within 30 days for the `CSL-003` check to pass.
 
 ### Cross-Border Data Transfer
 
@@ -221,20 +221,20 @@ When a process involves transferring personal information out of mainland China,
 
 ```bash
 # Before merging a feature branch that touches AI services
-devtrail validate                    # cross-rules including CROSS-004..011
-devtrail compliance --region china   # per-framework score
+straymark validate                    # cross-rules including CROSS-004..011
+straymark compliance --region china   # per-framework score
 ```
 
 ---
 
 ## Understanding Versions
 
-DevTrail uses **independent versioning** for its two components:
+StrayMark uses **independent versioning** for its two components:
 
 | Component | Tag prefix | Contains | Updated via |
 |-----------|-----------|----------|-------------|
-| **Framework** | `fw-` | Templates, governance docs, directives, scripts | `devtrail update-framework` |
-| **CLI** | `cli-` | The `devtrail` binary | `devtrail update-cli` |
+| **Framework** | `fw-` | Templates, governance docs, directives, scripts | `straymark update-framework` |
+| **CLI** | `cli-` | The `straymark` binary | `straymark update-cli` |
 
 ### Why Independent Versions?
 
@@ -245,8 +245,8 @@ DevTrail uses **independent versioning** for its two components:
 ### Checking Your Versions
 
 ```bash
-devtrail about     # Quick version check
-devtrail status    # Full health report including versions
+straymark about     # Quick version check
+straymark status    # Full health report including versions
 ```
 
 For detailed CLI information, see the [CLI Reference](CLI-REFERENCE.md#versioning).
@@ -255,7 +255,7 @@ For detailed CLI information, see the [CLI Reference](CLI-REFERENCE.md#versionin
 
 <div align="center">
 
-**DevTrail** — Because every change tells a story.
+**StrayMark** — Because every change tells a story.
 
 [Back to docs](../README.md) • [README](../../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/contributors/TRANSLATION-GUIDE.md
+++ b/docs/contributors/TRANSLATION-GUIDE.md
@@ -1,6 +1,6 @@
-# Translation Guide - DevTrail
+# Translation Guide - StrayMark
 
-This guide provides rules and guidelines for translating DevTrail documentation to other languages.
+This guide provides rules and guidelines for translating StrayMark documentation to other languages.
 
 ---
 
@@ -18,9 +18,9 @@ This guide provides rules and guidelines for translating DevTrail documentation 
 
 ## Language Configuration
 
-DevTrail uses a configuration file to set the project's language:
+StrayMark uses a configuration file to set the project's language:
 
-**File**: `.devtrail/config.yml`
+**File**: `.straymark/config.yml`
 
 ```yaml
 # Language setting for templates and documentation
@@ -31,14 +31,14 @@ language: en
 
 ### How It Works
 
-1. AI agents read `.devtrail/config.yml` at the start of each session
+1. AI agents read `.straymark/config.yml` at the start of each session
 2. Based on the `language` value, they use templates from the appropriate path:
 
 | Language | Template Path |
 |----------|---------------|
-| `en` (default) | `.devtrail/templates/TEMPLATE-*.md` |
-| `es` | `.devtrail/templates/i18n/es/TEMPLATE-*.md` |
-| `zh-CN` | `.devtrail/templates/i18n/zh-CN/TEMPLATE-*.md` |
+| `en` (default) | `.straymark/templates/TEMPLATE-*.md` |
+| `es` | `.straymark/templates/i18n/es/TEMPLATE-*.md` |
+| `zh-CN` | `.straymark/templates/i18n/zh-CN/TEMPLATE-*.md` |
 
 3. If the config file doesn't exist or `language` is not set, English is used as default
 
@@ -62,8 +62,8 @@ The AI agent will then use Spanish templates when creating documentation.
 |----------|-------|----------|
 | **Main Documentation** | README.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md | `docs/i18n/{lang}/` |
 | **Adopter Documentation** | ADOPTION-GUIDE.md, CLI-REFERENCE.md, WORKFLOWS.md | `docs/i18n/{lang}/adopters/` |
-| **Templates** | TEMPLATE-*.md (8 files) | `.devtrail/templates/i18n/{lang}/` |
-| **Governance** | PRINCIPLES.md, DOCUMENTATION-POLICY.md, AGENT-RULES.md, GIT-BRANCHING-STRATEGY.md, QUICK-REFERENCE.md | `.devtrail/00-governance/i18n/{lang}/` |
+| **Templates** | TEMPLATE-*.md (8 files) | `.straymark/templates/i18n/{lang}/` |
+| **Governance** | PRINCIPLES.md, DOCUMENTATION-POLICY.md, AGENT-RULES.md, GIT-BRANCHING-STRATEGY.md, QUICK-REFERENCE.md | `.straymark/00-governance/i18n/{lang}/` |
 
 ### Files NOT to Translate
 
@@ -180,9 +180,9 @@ Keep these values in English:
 
 ```markdown
 <!-- Keep paths exactly as shown -->
-.devtrail/
-.devtrail/07-ai-audit/agent-logs/
-.devtrail/templates/TEMPLATE-AILOG.md
+.straymark/
+.straymark/07-ai-audit/agent-logs/
+.straymark/templates/TEMPLATE-AILOG.md
 ```
 
 ### 5. File Naming Convention Pattern
@@ -226,7 +226,7 @@ Basado en [REQ-2025-01-15-003].          # Keep reference format
 
 ```
 Strange Days Tech
-DevTrail
+StrayMark
 Claude Code
 Cursor
 GitHub Copilot
@@ -240,7 +240,7 @@ Gemini CLI
 ### Directory Layout
 
 ```
-devtrail/
+straymark/
 ├── docs/
 │   ├── adopters/
 │   │   └── ADOPTION-GUIDE.md        # English adopter docs
@@ -261,7 +261,7 @@ devtrail/
 │       │       └── ADOPTION-GUIDE.md
 │       └── [other-lang]/            # Future languages
 │
-└── .devtrail/
+└── .straymark/
     ├── templates/
     │   ├── TEMPLATE-*.md            # English (default)
     │   └── i18n/
@@ -287,7 +287,7 @@ Translated files keep the same filename as the original:
 |----------|-------------|
 | `README.md` | `docs/i18n/es/README.md` |
 | `docs/adopters/ADOPTION-GUIDE.md` | `docs/i18n/es/adopters/ADOPTION-GUIDE.md` |
-| `TEMPLATE-AILOG.md` | `.devtrail/templates/i18n/es/TEMPLATE-AILOG.md` |
+| `TEMPLATE-AILOG.md` | `.straymark/templates/i18n/es/TEMPLATE-AILOG.md` |
 
 ---
 
@@ -326,7 +326,7 @@ Before submitting a translation, verify:
 - [ ] Document type prefixes unchanged (AILOG, AIDEC, ADR, etc.)
 - [ ] YAML keys unchanged (id, title, status, agent, confidence, etc.)
 - [ ] Enum values unchanged (draft, accepted, high, medium, low, etc.)
-- [ ] File paths unchanged (.devtrail/, 07-ai-audit/, etc.)
+- [ ] File paths unchanged (.straymark/, 07-ai-audit/, etc.)
 - [ ] Agent identifiers unchanged (claude-code-v1.0, etc.)
 - [ ] Cross-reference format unchanged ([ADR-YYYY-MM-DD-NNN])
 
@@ -370,6 +370,6 @@ See [CONTRIBUTING.md](../../CONTRIBUTING.md) for general contribution guidelines
 
 ---
 
-*DevTrail — Because every change tells a story.*
+*StrayMark — Because every change tells a story.*
 
 [Strange Days Tech](https://strangedays.tech)

--- a/docs/i18n/es/CODE_OF_CONDUCT.md
+++ b/docs/i18n/es/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 ## Nuestro Compromiso
 
-Nosotros, como miembros, contribuidores y líderes, nos comprometemos a hacer de la participación en la comunidad de DevTrail una experiencia libre de acoso para todos, independientemente de la edad, tamaño corporal, discapacidad visible o invisible, etnia, características sexuales, identidad y expresión de género, nivel de experiencia, educación, estatus socioeconómico, nacionalidad, apariencia personal, raza, casta, color, religión o identidad y orientación sexual.
+Nosotros, como miembros, contribuidores y líderes, nos comprometemos a hacer de la participación en la comunidad de StrayMark una experiencia libre de acoso para todos, independientemente de la edad, tamaño corporal, discapacidad visible o invisible, etnia, características sexuales, identidad y expresión de género, nivel de experiencia, educación, estatus socioeconómico, nacionalidad, apariencia personal, raza, casta, color, religión o identidad y orientación sexual.
 
 Nos comprometemos a actuar e interactuar de maneras que contribuyan a una comunidad abierta, acogedora, diversa, inclusiva y saludable.
 
@@ -53,7 +53,7 @@ Este Código de Conducta también aplica cuando un individuo representa oficialm
 
 Si experimentas o presencias comportamiento inaceptable, o tienes cualquier otra preocupación, por favor repórtalo contactando al equipo del proyecto en:
 
-**GitHub Issues**: [Reportar aquí](https://github.com/StrangeDaysTech/devtrail/issues)
+**GitHub Issues**: [Reportar aquí](https://github.com/StrangeDaysTech/straymark/issues)
 
 Todos los reportes serán revisados e investigados de manera pronta y justa.
 
@@ -101,7 +101,7 @@ Los líderes de la comunidad seguirán estas Guías de Impacto Comunitario para 
 
 ## Apelaciones
 
-Si crees que has sido acusado falsa o injustamente de violar este Código de Conducta, puedes apelar abriendo un issue detallado en [GitHub Issues](https://github.com/StrangeDaysTech/devtrail/issues). Las apelaciones serán revisadas por un líder de la comunidad diferente al que tomó la decisión original.
+Si crees que has sido acusado falsa o injustamente de violar este Código de Conducta, puedes apelar abriendo un issue detallado en [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues). Las apelaciones serán revisadas por un líder de la comunidad diferente al que tomó la decisión original.
 
 ## Atribución
 
@@ -127,7 +127,7 @@ Para respuestas a preguntas comunes sobre este código de conducta, ver las FAQ 
 ---
 
 <p align="center">
-  <strong>DevTrail</strong><br>
+  <strong>StrayMark</strong><br>
   Construyendo una comunidad inclusiva juntos<br>
   <a href="https://strangedays.tech">Strange Days Tech, S.A.S.</a>
 </p>

--- a/docs/i18n/es/CONTRIBUTING.md
+++ b/docs/i18n/es/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contribuir a DevTrail
+# Contribuir a StrayMark
 
-¡Gracias por tu interés en contribuir a DevTrail! Este documento proporciona guías e información para contribuidores.
+¡Gracias por tu interés en contribuir a StrayMark! Este documento proporciona guías e información para contribuidores.
 
 **Idiomas**: [English](../../../CONTRIBUTING.md) | Español | [简体中文](../zh-CN/CONTRIBUTING.md)
 
@@ -35,7 +35,7 @@ Este proyecto requiere que todos los contribuidores firmen un **Acuerdo de Licen
 3. El CLA solo necesita firmarse una vez — cubre todas las contribuciones futuras a este proyecto.
 4. Una vez firmado, CLA Assistant actualizará el estado del check del PR y tu contribución podrá proceder a revisión.
 
-Si tienes preguntas sobre el CLA, por favor abre una [Discusión](https://github.com/StrangeDaysTech/devtrail/discussions).
+Si tienes preguntas sobre el CLA, por favor abre una [Discusión](https://github.com/StrangeDaysTech/straymark/discussions).
 
 ---
 
@@ -89,7 +89,7 @@ Las contribuciones de código deben:
 
 - **Git**
 - **Un editor de texto** (VS Code recomendado)
-- **DevTrail CLI** (para validación de documentos — multiplataforma)
+- **StrayMark CLI** (para validación de documentos — multiplataforma)
 - **Rust toolchain** (para desarrollo del CLI — instalar vía [rustup.rs](https://rustup.rs/))
 - **Node.js 20+** (opcional, para markdownlint)
 
@@ -97,18 +97,18 @@ Las contribuciones de código deben:
 
 1. **Fork del repositorio**
 
-   Haz clic en "Fork" en la [página del repositorio de GitHub](https://github.com/StrangeDaysTech/devtrail).
+   Haz clic en "Fork" en la [página del repositorio de GitHub](https://github.com/StrangeDaysTech/straymark).
 
 2. **Clonar tu fork**
    ```bash
-   git clone https://github.com/tu-usuario/devtrail.git
-   cd devtrail
+   git clone https://github.com/tu-usuario/straymark.git
+   cd straymark
    ```
 
 3. **Instalar el hook de pre-commit**
    ```bash
    echo '#!/bin/sh
-   devtrail validate --staged' > .git/hooks/pre-commit
+   straymark validate --staged' > .git/hooks/pre-commit
    chmod +x .git/hooks/pre-commit
    ```
 
@@ -127,7 +127,7 @@ Las contribuciones de código deben:
 
 6. **Hacer tus cambios y validar**
    ```bash
-   devtrail validate
+   straymark validate
    ```
 
 ---
@@ -136,7 +136,7 @@ Las contribuciones de código deben:
 
 ### Antes de Enviar
 
-- [ ] Ejecutar `devtrail validate` exitosamente
+- [ ] Ejecutar `straymark validate` exitosamente
 - [ ] Actualizar documentación si es necesario
 - [ ] Agregarte a CONTRIBUTORS.md (si aplica)
 - [ ] Escribir una descripción clara del PR
@@ -180,7 +180,7 @@ Breve descripción de los cambios
 ¿Cómo se probaron estos cambios?
 
 ## Lista de Verificación
-- [ ] `devtrail validate` pasa sin errores
+- [ ] `straymark validate` pasa sin errores
 - [ ] Documentación actualizada
 - [ ] Sin información sensible incluida
 ```
@@ -217,7 +217,7 @@ created: YYYY-MM-DD
 
 ### Nomenclatura de Archivos
 
-Documentos DevTrail:
+Documentos StrayMark:
 ```
 [TIPO]-[YYYY-MM-DD]-[NNN]-[descripcion].md
 ```
@@ -241,13 +241,13 @@ Documentos DevTrail:
 Si estás proponiendo un nuevo tipo de documento:
 
 1. **Crear la plantilla**
-   - Agregar `TEMPLATE-NUEVOTIPO.md` a `dist/.devtrail/templates/`
+   - Agregar `TEMPLATE-NUEVOTIPO.md` a `dist/.straymark/templates/`
    - Seguir patrones de plantillas existentes
 
 2. **Actualizar docs de gobernanza**
-   - `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md`
-   - `dist/.devtrail/00-governance/AGENT-RULES.md`
-   - `dist/.devtrail/QUICK-REFERENCE.md`
+   - `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md`
+   - `dist/.straymark/00-governance/AGENT-RULES.md`
+   - `dist/.straymark/QUICK-REFERENCE.md`
 
 3. **Actualizar configs de agente**
    - `dist/dist-templates/directives/` (plantillas de distribución)
@@ -280,7 +280,7 @@ Las plantillas deben incluir:
 
 ## Desarrollo del CLI
 
-El CLI de DevTrail está escrito en Rust y se encuentra en el directorio `cli/`.
+El CLI de StrayMark está escrito en Rust y se encuentra en el directorio `cli/`.
 
 ### Compilar
 
@@ -312,13 +312,13 @@ cli/src/
 ├── main.rs              # Punto de entrada + definición CLI con clap
 ├── commands/
 │   ├── mod.rs           # Enrutamiento de subcomandos
-│   ├── init.rs          # devtrail init [path]
-│   ├── update.rs        # devtrail update (combinado)
-│   ├── update_framework.rs # devtrail update-framework
-│   ├── update_cli.rs    # devtrail update-cli
-│   ├── remove.rs        # devtrail remove [--full]
-│   ├── status.rs        # devtrail status [path]
-│   └── about.rs         # devtrail about
+│   ├── init.rs          # straymark init [path]
+│   ├── update.rs        # straymark update (combinado)
+│   ├── update_framework.rs # straymark update-framework
+│   ├── update_cli.rs    # straymark update-cli
+│   ├── remove.rs        # straymark remove [--full]
+│   ├── status.rs        # straymark status [path]
+│   └── about.rs         # straymark about
 ├── config.rs            # Gestión de configuración y checksums
 ├── download.rs          # API de GitHub Releases (filtrado por prefijo)
 ├── inject.rs            # Inyección de archivos de directiva (markers)
@@ -336,8 +336,8 @@ cli/src/
 
 Si tienes preguntas sobre contribuir:
 
-1. Revisa [Issues](https://github.com/StrangeDaysTech/devtrail/issues) existentes
-2. Revisa [Discussions](https://github.com/StrangeDaysTech/devtrail/discussions)
+1. Revisa [Issues](https://github.com/StrangeDaysTech/straymark/issues) existentes
+2. Revisa [Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 3. Abre una nueva Discussion para preguntas generales
 4. Abre un Issue para bugs o características específicas
 
@@ -351,10 +351,10 @@ Los contribuidores son reconocidos en:
 - Notas de release para contribuciones significativas
 - CONTRIBUTORS.md (para contribuidores recurrentes)
 
-¡Gracias por ayudar a mejorar DevTrail!
+¡Gracias por ayudar a mejorar StrayMark!
 
 ---
 
-*DevTrail — Porque cada cambio cuenta una historia.*
+*StrayMark — Porque cada cambio cuenta una historia.*
 
 [Strange Days Tech](https://strangedays.tech)

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -1,17 +1,17 @@
 <div align="center">
 
-# DevTrail
+# StrayMark
 
 **La disciplina cognitiva que tus proyectos asistidos por IA necesitan**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../../LICENSE)
-[![Crates.io](https://img.shields.io/crates/v/devtrail-cli.svg)](https://crates.io/crates/devtrail-cli)
+[![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](../../../dist/.devtrail/QUICK-REFERENCE.md)
+[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](../../../dist/.straymark/QUICK-REFERENCE.md)
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
 [Inicio Rápido](#inicio-rápido) •
-[¿Para quién es?](#para-quién-es-devtrail) •
+[¿Para quién es?](#para-quién-es-straymark) •
 [Principios de Diseño](#principios-de-diseño) •
 [Características](#características) •
 [Compliance](#compliance) •
@@ -31,7 +31,7 @@ Los ingenieros senior que orquestan estos agentes no necesitan *más* autonomía
 
 ## La Solución
 
-DevTrail es un **framework + CLI** que externaliza la disciplina cognitiva del trabajo de ingeniería de software senior — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas, rastros auditables — en archivos versionados que viven junto al código.
+StrayMark es un **framework + CLI** que externaliza la disciplina cognitiva del trabajo de ingeniería de software senior — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas, rastros auditables — en archivos versionados que viven junto al código.
 
 > **"Ningún cambio significativo sin un rastro documentado — y un espacio de decisión acotado para el agente."**
 
@@ -39,32 +39,32 @@ Como efecto secundario, la disciplina produce evidencia compatible con **ISO/IEC
 
 ---
 
-## ¿Para quién es DevTrail?
+## ¿Para quién es StrayMark?
 
-El usuario primario de DevTrail es el **ingeniero senior orquestando agentes de IA sobre un sistema no trivial** — alguien con criterio técnico fuerte que usa agentes para abordar trabajo que no podría hacer solo de forma realista, y que necesita disciplina cognitiva externalizada para que el agente no introduzca caos sistémico.
+El usuario primario de StrayMark es el **ingeniero senior orquestando agentes de IA sobre un sistema no trivial** — alguien con criterio técnico fuerte que usa agentes para abordar trabajo que no podría hacer solo de forma realista, y que necesita disciplina cognitiva externalizada para que el agente no introduzca caos sistémico.
 
-Si esa persona eres tú, los flujos, defaults y lenguaje de DevTrail están afinados para ti.
+Si esa persona eres tú, los flujos, defaults y lenguaje de StrayMark están afinados para ti.
 
-DevTrail también sirve a tres audiencias secundarias, sobre esa base — nunca a su costa:
+StrayMark también sirve a tres audiencias secundarias, sobre esa base — nunca a su costa:
 
 - **Tech leads y arquitectos** estandarizando cómo trabaja su equipo con asistentes de IA.
 - **Compliance officers y auditores** que necesitan evidencia de desarrollo de IA gobernado (ISO 42001, EU AI Act, NIST AI RMF, PIPL, TC260, …).
 - **Adoptantes en entornos regulados** (finanzas, salud, sector público, China) que necesitan trazabilidad integrada en el flujo en lugar de reconstruida después del hecho.
 
-DevTrail **no** intenta ser: un gateway de LLM, un evaluador de modelos, una capa de productividad estilo *"código 10× más rápido"* ni un sustituto del juicio del ingeniero. Ver [Límites Honestos](#límites-honestos) abajo.
+StrayMark **no** intenta ser: un gateway de LLM, un evaluador de modelos, una capa de productividad estilo *"código 10× más rápido"* ni un sustituto del juicio del ingeniero. Ver [Límites Honestos](#límites-honestos) abajo.
 
 ---
 
 ## Principios de Diseño
 
-Las decisiones de producto de DevTrail se anclan en doce principios explícitos. Están ordenados por jerarquía: cuando dos entran en conflicto, gana el que viene antes.
+Las decisiones de producto de StrayMark se anclan en doce principios explícitos. Están ordenados por jerarquía: cuando dos entran en conflicto, gana el que viene antes.
 
 1. **La herramienta sirve al oficio, no al producto.** La métrica es si el ingeniero produce trabajo del que se siente orgulloso — no adopción, retención ni revenue.
 2. **El usuario primario es el ingeniero senior orquestando agentes.** No el VP, no el CISO, no el compliance officer.
 3. **Open source estricto, sin asteriscos en el núcleo.** Framework, CLI y TUI son MIT, sin features capadas que empujen al pago.
 4. **El cumplimiento regulatorio es un side effect, no el producto.** ISO 42001, EU AI Act, NIST AI RMF son frames útiles; no son la meta.
 5. **Schema-driven antes que feature-driven.** Las entidades centrales (Stage Closure Bundle, Charter, Document) se definen primero como schemas versionados, las features después.
-6. **Disciplina cognitiva sobre productividad bruta.** DevTrail compite contra el caos que el código rápido con IA genera en proyectos serios — no contra la velocidad misma.
+6. **Disciplina cognitiva sobre productividad bruta.** StrayMark compite contra el caos que el código rápido con IA genera en proyectos serios — no contra la velocidad misma.
 7. **Local-first, Cloud como amplificador.** El CLI funciona completo, sin red. Cloud puede agregar valor (agregación cross-repo, evidencia firmada) pero nunca capa el núcleo.
 8. **La memoria del proyecto vive en el repo, no en una base de datos externa.** AILOGs, ADRs, AIDECs, Charters y bundles son archivos versionados junto al código, en markdown + JSON Schema.
 9. **Simplicidad sobre capacidad.** Cuando dos diseños cumplen el objetivo, gana el más simple. Los patrones cristalizan después de validarse en proyectos reales, no antes.
@@ -72,7 +72,7 @@ Las decisiones de producto de DevTrail se anclan en doce principios explícitos.
 11. **La comunidad cuida la herramienta, no al revés.** Las contribuciones y el feedback se toman en serio sin volverse democracia.
 12. **La velocidad del producto es la velocidad del aprendizaje.** Sin cristalización prematura; los schemas marcados `v0` hasta validarse contra un segundo dominio.
 
-El documento completo, con anotaciones empíricas de los ciclos de validación, vive en [`Propuesta/devtrail-design-principles.md`](https://github.com/StrangeDaysTech/devtrail/blob/main/Propuesta/devtrail-design-principles.md).
+El documento completo, con anotaciones empíricas de los ciclos de validación, vive en [`Propuesta/straymark-design-principles.md`](https://github.com/StrangeDaysTech/straymark/blob/main/Propuesta/straymark-design-principles.md).
 
 ---
 
@@ -125,21 +125,21 @@ Salvaguardas incorporadas que aseguran que los humanos mantengan el control:
 
 Comandos integrados que convierten la disciplina en feedback accionable:
 
-- **`devtrail charter <new|list|status|close|drift|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware; `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/devtrail-audit-prompt` y `/devtrail-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
-- **`devtrail approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
-- **`devtrail validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `docs/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
-- **`devtrail metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
-- **`devtrail analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) impulsado por [arborist-metrics](https://github.com/StrangeDaysTech/arborist), nuestra librería open-source en Rust para métricas de código multi-lenguaje
-- **`devtrail audit`** — Reportes de auditoría con línea temporal, mapas de trazabilidad y exportación HTML
-- **`devtrail compliance`** — Puntuación de cumplimiento regulatorio como side effect del trabajo documentado (EU AI Act, ISO 42001, NIST AI RMF; seis frameworks chinos opt-in vía `--region china`)
-- **`devtrail explore`** — TUI interactivo para navegar el grafo de documentación del proyecto, incluyendo una vista de Charters (estado del ciclo de vida, AILOG/spec de origen, ubicación del archivo)
+- **`straymark charter <new|list|status|close|drift|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware; `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
+- **`straymark approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
+- **`straymark validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `docs/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
+- **`straymark metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
+- **`straymark analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) impulsado por [arborist-metrics](https://github.com/StrangeDaysTech/arborist), nuestra librería open-source en Rust para métricas de código multi-lenguaje
+- **`straymark audit`** — Reportes de auditoría con línea temporal, mapas de trazabilidad y exportación HTML
+- **`straymark compliance`** — Puntuación de cumplimiento regulatorio como side effect del trabajo documentado (EU AI Act, ISO 42001, NIST AI RMF; seis frameworks chinos opt-in vía `--region china`)
+- **`straymark explore`** — TUI interactivo para navegar el grafo de documentación del proyecto, incluyendo una vista de Charters (estado del ciclo de vida, AILOG/spec de origen, ubicación del archivo)
 - **Hooks pre-commit** + **GitHub Actions** para validación CI/CD
 
 ---
 
 ## Límites Honestos
 
-DevTrail **no** hace lo siguiente:
+StrayMark **no** hace lo siguiente:
 
 - evaluar, comparar o rankear LLMs;
 - actuar como gateway o capa de routing de LLMs;
@@ -147,17 +147,17 @@ DevTrail **no** hace lo siguiente:
 - certificar automáticamente cumplimiento regulatorio — produce evidencia, no certificaciones;
 - reemplazar el juicio de un ingeniero senior.
 
-Si tu problema es uno de esos, DevTrail no es la herramienta.
+Si tu problema es uno de esos, StrayMark no es la herramienta.
 
 ---
 
 ## Compliance
 
-La disciplina que DevTrail externaliza — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas — produce, como efecto secundario, evidencia que mapea limpiamente a los principales marcos de gobernanza de IA. Por eso el cumplimiento se posiciona como *consecuencia de hacer bien el trabajo de ingeniería*, no como el producto en sí (Principio #4).
+La disciplina que StrayMark externaliza — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas — produce, como efecto secundario, evidencia que mapea limpiamente a los principales marcos de gobernanza de IA. Por eso el cumplimiento se posiciona como *consecuencia de hacer bien el trabajo de ingeniería*, no como el producto en sí (Principio #4).
 
 ### Alineación con estándares
 
-| Estándar | Integración con DevTrail |
+| Estándar | Integración con StrayMark |
 |----------|--------------------------|
 | **ISO/IEC 42001:2023** | Estándar vertebral — gobernanza de Sistemas de Gestión de IA |
 | **EU AI Act** | Clasificación de riesgo, reporte de incidentes, transparencia |
@@ -170,7 +170,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 
 ### Cobertura regulatoria de China — opt-in vía `regional_scope: china`
 
-| Estándar | Integración con DevTrail |
+| Estándar | Integración con StrayMark |
 |----------|--------------------------|
 | **TC260 AI Safety Governance Framework v2.0** | Cinco niveles de riesgo (TC260RA) |
 | **PIPL — Personal Information Protection Law** | Personal Information Protection Impact Assessment (PIPIA), retención ≥ 3 años |
@@ -179,7 +179,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 | **GB/T 45652-2025** | Seguridad de datos de pre-entrenamiento y fine-tuning (SBOM/MCARD) |
 | **CSL 2026** | Reporte de incidentes de ciberseguridad (ventanas 1h / 4h+72h+30d) en INC |
 
-DevTrail cubre seis regulaciones chinas de IA / datos como **scope regional opt-in**. Activa añadiendo `regional_scope: china` en `.devtrail/config.yml`; los proyectos sin esa configuración no se ven afectados. Cuando se activa, cuatro tipos de documento específicos de China (PIPIA, CACFILE, TC260RA, AILABEL) quedan disponibles, doce reglas de validación comienzan a aplicar las nuevas referencias cruzadas, y `devtrail compliance --region china` produce un score por marco. Las guías detalladas viven bajo `.devtrail/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, `TC260-IMPLEMENTATION-GUIDE.md`, `PIPL-PIPIA-GUIDE.md`, `CAC-FILING-GUIDE.md`, `GB-45438-LABELING-GUIDE.md`). El [README en chino](../zh-CN/README.md#中国法规支持) tiene la versión completa para adoptantes que operan en China continental.
+StrayMark cubre seis regulaciones chinas de IA / datos como **scope regional opt-in**. Activa añadiendo `regional_scope: china` en `.straymark/config.yml`; los proyectos sin esa configuración no se ven afectados. Cuando se activa, cuatro tipos de documento específicos de China (PIPIA, CACFILE, TC260RA, AILABEL) quedan disponibles, doce reglas de validación comienzan a aplicar las nuevas referencias cruzadas, y `straymark compliance --region china` produce un score por marco. Las guías detalladas viven bajo `.straymark/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, `TC260-IMPLEMENTATION-GUIDE.md`, `PIPL-PIPIA-GUIDE.md`, `CAC-FILING-GUIDE.md`, `GB-45438-LABELING-GUIDE.md`). El [README en chino](../zh-CN/README.md#中国法规支持) tiene la versión completa para adoptantes que operan en China continental.
 
 ---
 
@@ -191,62 +191,62 @@ DevTrail cubre seis regulaciones chinas de IA / datos como **scope regional opt-
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 O instalar desde el código fuente con Cargo:
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
-> **Nota:** `devtrail update-cli` detecta automáticamente cómo instalaste el CLI. Las instalaciones con binario precompilado se actualizan desde GitHub Releases; las instalaciones con cargo se actualizan via `cargo install`. Puedes forzar el método con `--method=github` o `--method=cargo`.
+> **Nota:** `straymark update-cli` detecta automáticamente cómo instalaste el CLI. Las instalaciones con binario precompilado se actualizan desde GitHub Releases; las instalaciones con cargo se actualizan via `cargo install`. Puedes forzar el método con `--method=github` o `--method=cargo`.
 
 Luego inicializa en tu proyecto:
 
 ```bash
 cd tu-proyecto
-devtrail init .
+straymark init .
 ```
 
-El CLI descarga la última versión de DevTrail, configura el framework y los archivos de directivas de agentes IA automáticamente.
+El CLI descarga la última versión de StrayMark, configura el framework y los archivos de directivas de agentes IA automáticamente.
 
 ### Versionado
 
-DevTrail usa tags de versión independientes para cada componente:
+StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.10.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.10.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.10.0` | El binario `straymark` |
 
-Verifica las versiones instaladas con `devtrail status` o `devtrail about`.
+Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
 ### Comandos CLI
 
 | Comando | Descripción |
 |---------|-------------|
-| `devtrail init [path]` | Inicializar DevTrail en un proyecto |
-| `devtrail update` | Actualizar framework y CLI |
-| `devtrail update-framework` | Actualizar solo el framework |
-| `devtrail update-cli` | Actualizar el binario del CLI |
-| `devtrail remove [--full]` | Eliminar DevTrail del proyecto |
-| `devtrail status [path]` | Mostrar estado de la instalación y estadísticas |
-| `devtrail repair [path]` | Restaurar directorios y archivos del framework faltantes |
-| `devtrail validate [path]` | Validar documentos por cumplimiento y corrección (use `--include-charters` para Charters, `--check-pending-reviews` para el backlog de aprobaciones) |
-| `devtrail charter <subcomando>` | Gestionar Charters: `new`, `list`, `status`, `close` (registra telemetría), `drift` (drift archivos-vs-commit con AILOG-awareness) |
-| `devtrail approve <doc-id>` | Registra una aprobación humana formal en un documento `review_required: true` (frontmatter + sección body canónica) |
-| `devtrail compliance [path]` | Verificar cumplimiento regulatorio (EU AI Act, ISO 42001, NIST) |
-| `devtrail metrics [path]` | Mostrar métricas de gobernanza y estadísticas |
-| `devtrail analyze [path]` | Analizar complejidad de código (métricas cognitiva + ciclomática) |
-| `devtrail audit [path]` | Generar reportes de auditoría con línea temporal y trazabilidad |
-| `devtrail explore [path]` | Explorar documentación interactivamente en terminal (TUI) |
-| `devtrail about` | Mostrar información de versión y licencia |
+| `straymark init [path]` | Inicializar StrayMark en un proyecto |
+| `straymark update` | Actualizar framework y CLI |
+| `straymark update-framework` | Actualizar solo el framework |
+| `straymark update-cli` | Actualizar el binario del CLI |
+| `straymark remove [--full]` | Eliminar StrayMark del proyecto |
+| `straymark status [path]` | Mostrar estado de la instalación y estadísticas |
+| `straymark repair [path]` | Restaurar directorios y archivos del framework faltantes |
+| `straymark validate [path]` | Validar documentos por cumplimiento y corrección (use `--include-charters` para Charters, `--check-pending-reviews` para el backlog de aprobaciones) |
+| `straymark charter <subcomando>` | Gestionar Charters: `new`, `list`, `status`, `close` (registra telemetría), `drift` (drift archivos-vs-commit con AILOG-awareness) |
+| `straymark approve <doc-id>` | Registra una aprobación humana formal en un documento `review_required: true` (frontmatter + sección body canónica) |
+| `straymark compliance [path]` | Verificar cumplimiento regulatorio (EU AI Act, ISO 42001, NIST) |
+| `straymark metrics [path]` | Mostrar métricas de gobernanza y estadísticas |
+| `straymark analyze [path]` | Analizar complejidad de código (métricas cognitiva + ciclomática) |
+| `straymark audit [path]` | Generar reportes de auditoría con línea temporal y trazabilidad |
+| `straymark explore [path]` | Explorar documentación interactivamente en terminal (TUI) |
+| `straymark about` | Mostrar información de versión y licencia |
 
 Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 
@@ -254,16 +254,16 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
-# Ve a https://github.com/StrangeDaysTech/devtrail/releases
+# Ve a https://github.com/StrangeDaysTech/straymark/releases
 # y descarga el último release fw-* (ej. fw-4.10.0)
 
 # Extraer y copiar a tu proyecto
-unzip devtrail-fw-*.zip -d tu-proyecto/
+unzip straymark-fw-*.zip -d tu-proyecto/
 cd tu-proyecto
 
 # Commit
-git add .devtrail/ DEVTRAIL.md
-git commit -m "chore: adoptar DevTrail"
+git add .straymark/ STRAYMARK.md
+git commit -m "chore: adoptar StrayMark"
 ```
 
 **Ver [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) para instrucciones detalladas, estrategias de migración y planes de implementación en equipos.**
@@ -272,12 +272,12 @@ git commit -m "chore: adoptar DevTrail"
 
 ## Documentación
 
-La documentación de DevTrail está organizada por audiencia:
+La documentación de StrayMark está organizada por audiencia:
 
 | Track | Para | Empieza aquí |
 |-------|------|--------------|
-| [**Adoptantes**](adopters/) | Equipos que adoptan DevTrail en sus proyectos | [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) |
-| [**Contribuidores**](../../../docs/contributors/) | Desarrolladores que contribuyen a DevTrail | [TRANSLATION-GUIDE.md](../../../docs/contributors/TRANSLATION-GUIDE.md) |
+| [**Adoptantes**](adopters/) | Equipos que adoptan StrayMark en sus proyectos | [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) |
+| [**Contribuidores**](../../../docs/contributors/) | Desarrolladores que contribuyen a StrayMark | [TRANSLATION-GUIDE.md](../../../docs/contributors/TRANSLATION-GUIDE.md) |
 
 **Adoptantes**: Sigue la [Guía de Adopción](adopters/ADOPTION-GUIDE.md) para instrucciones paso a paso, la [Referencia CLI](adopters/CLI-REFERENCE.md) para detalles de comandos, y la [Guía de Flujos de Trabajo](adopters/WORKFLOWS.md) para patrones de uso diario.
 
@@ -287,18 +287,18 @@ La documentación de DevTrail está organizada por audiencia:
 
 | Documento | Descripción |
 |-----------|-------------|
-| [**Referencia Rápida**](../../../dist/.devtrail/QUICK-REFERENCE.md) | Resumen de tipos de documentos y nomenclatura |
-| [DEVTRAIL.md](../../../dist/DEVTRAIL.md) | Reglas de gobernanza unificadas (fuente de verdad) |
+| [**Referencia Rápida**](../../../dist/.straymark/QUICK-REFERENCE.md) | Resumen de tipos de documentos y nomenclatura |
+| [STRAYMARK.md](../../../dist/STRAYMARK.md) | Reglas de gobernanza unificadas (fuente de verdad) |
 | [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) | Guía de adopción para proyectos nuevos/existentes |
 | [CLI-REFERENCE.md](adopters/CLI-REFERENCE.md) | Referencia completa de comandos CLI |
 | [WORKFLOWS.md](adopters/WORKFLOWS.md) | Flujos de trabajo diarios y patrones de equipo |
 
 ### Estructura Interna
 
-Una vez adoptado, DevTrail crea un directorio `.devtrail/` en tu proyecto para gobernanza de desarrollo:
+Una vez adoptado, StrayMark crea un directorio `.straymark/` en tu proyecto para gobernanza de desarrollo:
 
 ```
-.devtrail/
+.straymark/
 ├── 00-governance/           # Políticas y reglas
 ├── 01-requirements/         # Documentos REQ
 ├── 02-design/decisions/     # Documentos ADR
@@ -330,7 +330,7 @@ Ejemplo: `ADR-2025-01-27-001-usar-postgresql-para-persistencia.md`
 Un asistente de IA trabajando en tu código automáticamente:
 
 ```yaml
-# Crea: .devtrail/07-ai-audit/agent-logs/AILOG-2025-01-27-001-implementar-auth.md
+# Crea: .straymark/07-ai-audit/agent-logs/AILOG-2025-01-27-001-implementar-auth.md
 ---
 id: AILOG-2025-01-27-001
 title: Implementar autenticación JWT
@@ -358,7 +358,7 @@ AILOG-2025-01-27-001-implementar-auth.md
 Al elegir entre alternativas, las decisiones se documentan:
 
 ```yaml
-# Crea: .devtrail/07-ai-audit/decisions/AIDEC-2025-01-27-001-estrategia-auth.md
+# Crea: .straymark/07-ai-audit/decisions/AIDEC-2025-01-27-001-estrategia-auth.md
 ---
 id: AIDEC-2025-01-27-001
 title: Elegir JWT sobre autenticación basada en sesiones
@@ -375,7 +375,7 @@ justification: "Requisito de arquitectura sin estado..."
 Cuando la IA encuentra consideraciones éticas:
 
 ```yaml
-# Crea: .devtrail/07-ai-audit/ethical-reviews/ETH-2025-01-27-001-datos-usuario.md
+# Crea: .straymark/07-ai-audit/ethical-reviews/ETH-2025-01-27-001-datos-usuario.md
 ---
 id: ETH-2025-01-27-001
 title: Alcance de recolección de datos de usuario
@@ -398,7 +398,7 @@ Configura un hook de Git que ejecute la validación automáticamente antes de ca
 ```bash
 # Crear el hook pre-commit
 echo '#!/bin/sh
-devtrail validate --staged' > .git/hooks/pre-commit
+straymark validate --staged' > .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
@@ -406,7 +406,7 @@ chmod +x .git/hooks/pre-commit
 
 ```bash
 # Multiplataforma (Linux, macOS, Windows)
-devtrail validate
+straymark validate
 ```
 
 ### GitHub Actions
@@ -422,36 +422,36 @@ El flujo de trabajo incluido (`.github/workflows/docs-validation.yml`) valida au
 
 ## Skills
 
-DevTrail incluye skills para agentes IA que habilitan la **creación activa de documentación**.
+StrayMark incluye skills para agentes IA que habilitan la **creación activa de documentación**.
 
-> **Sistema Binario**: DevTrail usa un sistema pasivo (agentes auto-documentan via instrucciones de contexto) y un sistema activo (usuarios invocan skills para crear documentación manualmente o cuando el agente omitió algo).
+> **Sistema Binario**: StrayMark usa un sistema pasivo (agentes auto-documentan via instrucciones de contexto) y un sistema activo (usuarios invocan skills para crear documentación manualmente o cuando el agente omitió algo).
 
 ### Skills Disponibles
 
 | Skill | Propósito | Claude | Gemini |
 |-------|-----------|--------|--------|
-| `/devtrail-status` | Verificar cumplimiento de documentación | ✅ | ✅ |
-| `/devtrail-new` | Crear cualquier tipo de documento (unificado) | ✅ | ✅ |
-| `/devtrail-ailog` | Creación rápida de AILOG | ✅ | ✅ |
-| `/devtrail-aidec` | Creación rápida de AIDEC | ✅ | ✅ |
-| `/devtrail-adr` | Creación rápida de ADR | ✅ | ✅ |
+| `/straymark-status` | Verificar cumplimiento de documentación | ✅ | ✅ |
+| `/straymark-new` | Crear cualquier tipo de documento (unificado) | ✅ | ✅ |
+| `/straymark-ailog` | Creación rápida de AILOG | ✅ | ✅ |
+| `/straymark-aidec` | Creación rápida de AIDEC | ✅ | ✅ |
+| `/straymark-adr` | Creación rápida de ADR | ✅ | ✅ |
 
 ### Ejemplos de Uso
 
 ```bash
 # Verificar estado de documentación
-/devtrail-status
+/straymark-status
 
 # Crear documentación (agente sugiere tipo)
-/devtrail-new
+/straymark-new
 
 # Forzar tipo específico
-/devtrail-new ailog
+/straymark-new ailog
 
 # Accesos directos
-/devtrail-ailog
-/devtrail-aidec
-/devtrail-adr
+/straymark-ailog
+/straymark-aidec
+/straymark-adr
 ```
 
 ### Comandos CLI (Uso Manual)
@@ -460,13 +460,13 @@ Para usuarios que prefieren línea de comandos o usan agentes sin soporte de ski
 
 ```bash
 # Creación interactiva de documentos
-devtrail new
+straymark new
 
 # Crear tipo específico directamente
-devtrail new --doc-type ailog
+straymark new --doc-type ailog
 
 # Verificar estado de documentación
-devtrail status
+straymark status
 ```
 
 ### Reporte de Agentes
@@ -475,25 +475,25 @@ Los agentes IA reportan su estado de documentación al final de cada tarea:
 
 | Estado | Significado |
 |--------|-------------|
-| `DevTrail: Created AILOG-...` | Documentación fue creada |
-| `DevTrail: No documentation required` | Cambio menor (<10 líneas) |
-| `DevTrail: Documentation pending` | Puede necesitar revisión manual |
+| `StrayMark: Created AILOG-...` | Documentación fue creada |
+| `StrayMark: No documentation required` | Cambio menor (<10 líneas) |
+| `StrayMark: Documentation pending` | Puede necesitar revisión manual |
 
 ### Arquitectura Multi-Agente
 
-DevTrail proporciona soporte nativo de skills para múltiples agentes IA a través de una arquitectura en capas:
+StrayMark proporciona soporte nativo de skills para múltiples agentes IA a través de una arquitectura en capas:
 
 ```
 tu-proyecto/
 ├── .agent/workflows/       # 🌐 Agnóstico (Antigravity, futuros agentes)
-│   ├── devtrail-new.md
-│   ├── devtrail-status.md
+│   ├── straymark-new.md
+│   ├── straymark-status.md
 │   └── ...
 ├── .gemini/skills/         # 🔵 Gemini CLI (Google)
-│   ├── devtrail-new/SKILL.md
+│   ├── straymark-new/SKILL.md
 │   └── ...
 └── .claude/skills/         # 🟣 Claude Code (Anthropic)
-    ├── devtrail-new/SKILL.md
+    ├── straymark-new/SKILL.md
     └── ...
 ```
 
@@ -524,9 +524,9 @@ Todas las implementaciones de skills son **funcionalmente idénticas**—solo di
 
 | SO | Validación |
 |----|------------|
-| Linux | `devtrail validate` |
-| macOS | `devtrail validate` |
-| Windows | `devtrail validate` |
+| Linux | `straymark validate` |
+| macOS | `straymark validate` |
+| Windows | `straymark validate` |
 
 ### Plataformas CI/CD
 
@@ -568,7 +568,7 @@ Nuestro ecosistema open-source:
 
 | Proyecto | Descripción |
 |----------|-------------|
-| **[DevTrail](https://github.com/StrangeDaysTech/devtrail)** | La disciplina cognitiva que tus proyectos asistidos por IA necesitan |
+| **[StrayMark](https://github.com/StrangeDaysTech/straymark)** | La disciplina cognitiva que tus proyectos asistidos por IA necesitan |
 | **[arborist-metrics](https://github.com/StrangeDaysTech/arborist)** | Librería de análisis de complejidad de código multi-lenguaje para Rust — [crates.io](https://crates.io/crates/arborist-metrics) |
 
 [Sitio Web](https://strangedays.tech) • [GitHub](https://github.com/StrangeDaysTech)
@@ -579,8 +579,8 @@ Nuestro ecosistema open-source:
 
 <div align="center">
 
-**DevTrail** — Disciplina de ingeniería, externalizada. Compliance, como side effect.
+**StrayMark** — Disciplina de ingeniería, externalizada. Compliance, como side effect.
 
-[Volver arriba](#devtrail)
+[Volver arriba](#straymark)
 
 </div>

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -1,6 +1,6 @@
-# DevTrail - Guía de Adopción
+# StrayMark - Guía de Adopción
 
-**Una guía completa para adoptar DevTrail en proyectos nuevos o existentes.**
+**Una guía completa para adoptar StrayMark en proyectos nuevos o existentes.**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -10,7 +10,7 @@
 
 ## Tabla de Contenidos
 
-1. [¿Qué es DevTrail?](#qué-es-devtrail-framework)
+1. [¿Qué es StrayMark?](#qué-es-straymark-framework)
 2. [¿Para quién es?](#para-quién-es)
 3. [Beneficios](#beneficios)
 4. [Cumplimiento de Estándares](#cumplimiento-de-estándares)
@@ -22,9 +22,9 @@
 
 ---
 
-## ¿Qué es DevTrail?
+## ¿Qué es StrayMark?
 
-DevTrail es un **framework + CLI** que externaliza la disciplina cognitiva del trabajo de ingeniería de software senior — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas, rastros auditables — en archivos versionados que viven junto al código. La intención es acotar el espacio de decisión del agente para que el trabajo asistido por IA se mantenga coherente a través de muchos turnos en lugar de derivar hacia deuda técnica oculta.
+StrayMark es un **framework + CLI** que externaliza la disciplina cognitiva del trabajo de ingeniería de software senior — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas, rastros auditables — en archivos versionados que viven junto al código. La intención es acotar el espacio de decisión del agente para que el trabajo asistido por IA se mantenga coherente a través de muchos turnos en lugar de derivar hacia deuda técnica oculta.
 
 Proporciona:
 
@@ -39,15 +39,15 @@ Proporciona:
 
 > **"Ningún cambio significativo sin un rastro documentado — y un espacio de decisión acotado para el agente."**
 
-DevTrail asegura que cada cambio significativo — ya sea hecho por humano o IA — esté documentado, atribuido y sea auditable. La disciplina produce evidencia compatible con **ISO/IEC 42001**, **EU AI Act** y **NIST AI RMF** — pero la meta es la calidad de ingeniería primero; el cumplimiento es lo que cae como subproducto cuando la disciplina es real (ver Principio #4 en [`Propuesta/devtrail-design-principles.md`](https://github.com/StrangeDaysTech/devtrail/blob/main/Propuesta/devtrail-design-principles.md)).
+StrayMark asegura que cada cambio significativo — ya sea hecho por humano o IA — esté documentado, atribuido y sea auditable. La disciplina produce evidencia compatible con **ISO/IEC 42001**, **EU AI Act** y **NIST AI RMF** — pero la meta es la calidad de ingeniería primero; el cumplimiento es lo que cae como subproducto cuando la disciplina es real (ver Principio #4 en [`Propuesta/straymark-design-principles.md`](https://github.com/StrangeDaysTech/straymark/blob/main/Propuesta/straymark-design-principles.md)).
 
 ### ¿Por Qué Ahora?
 
 Los agentes de IA generan código rápido. No generan código coherente. Después de suficientes turnos, un agente pierde el hilo: re-introduce patrones rechazados por el equipo, acumula deuda técnica oculta y produce trabajo que compila pero no encaja con el grano del sistema. Cuanto más rápido va el agente, más difícil es ver esa deuda — hasta que una regresión, un incidente o una refactorización la sacan a la superficie.
 
-En paralelo, el piso regulatorio sube — el **EU AI Act es obligatorio desde agosto 2026** e **ISO/IEC 42001** es ahora el estándar internacional para Sistemas de Gestión de IA. Adoptar DevTrail aborda primero el problema de ingeniería; la evidencia regulatoria se produce como subproducto de la disciplina, lista cuando un auditor la pida.
+En paralelo, el piso regulatorio sube — el **EU AI Act es obligatorio desde agosto 2026** e **ISO/IEC 42001** es ahora el estándar internacional para Sistemas de Gestión de IA. Adoptar StrayMark aborda primero el problema de ingeniería; la evidencia regulatoria se produce como subproducto de la disciplina, lista cuando un auditor la pida.
 
-### Lo que DevTrail NO Es
+### Lo que StrayMark NO Es
 
 - No es un generador de documentación — proporciona estructura, plantillas y reglas de gobernanza
 - No es un reemplazo para comentarios de código o documentación de API
@@ -62,7 +62,7 @@ En paralelo, el piso regulatorio sube — el **EU AI Act es obligatorio desde ag
 
 ### Usuario primario
 
-El usuario primario de DevTrail es el **ingeniero senior orquestando agentes de IA sobre un sistema no trivial** — alguien con criterio técnico fuerte que usa agentes para abordar trabajo que no podría hacer solo de forma realista, y que necesita disciplina cognitiva externalizada para que el agente no introduzca caos sistémico. Los flujos, defaults y lenguaje del framework están afinados para esa persona; las audiencias secundarias se sirven sobre esa base, nunca a su costa.
+El usuario primario de StrayMark es el **ingeniero senior orquestando agentes de IA sobre un sistema no trivial** — alguien con criterio técnico fuerte que usa agentes para abordar trabajo que no podría hacer solo de forma realista, y que necesita disciplina cognitiva externalizada para que el agente no introduzca caos sistémico. Los flujos, defaults y lenguaje del framework están afinados para esa persona; las audiencias secundarias se sirven sobre esa base, nunca a su costa.
 
 ### Usuarios Objetivo
 
@@ -77,7 +77,7 @@ El usuario primario de DevTrail es el **ingeniero senior orquestando agentes de 
 
 ### Entornos de Desarrollo Compatibles
 
-DevTrail proporciona archivos de configuración para:
+StrayMark proporciona archivos de configuración para:
 
 | Plataforma | Archivo de Configuración | Estado |
 |------------|--------------------------|--------|
@@ -89,9 +89,9 @@ DevTrail proporciona archivos de configuración para:
 
 ### Metodologías Compatibles
 
-DevTrail funciona con cualquier metodología de desarrollo:
+StrayMark funciona con cualquier metodología de desarrollo:
 
-| Metodología | Cómo se Integra DevTrail |
+| Metodología | Cómo se Integra StrayMark |
 |-------------|---------------------------|
 | **Agile/Scrum** | Documentos REQ se mapean a historias de usuario; ADRs capturan decisiones de sprint |
 | **Cascada** | Trazabilidad completa desde requisitos hasta implementación |
@@ -121,7 +121,7 @@ DevTrail funciona con cualquier metodología de desarrollo:
 | **Transparencia de IA** | Cada acción de IA se registra con niveles de confianza |
 | **Supervisión humana** | Decisiones críticas requieren aprobación humana |
 | **Salvaguardas éticas** | Documentos ETH y DPIA marcan preocupaciones para decisión humana |
-| **Métricas de gobernanza** | `devtrail metrics` rastrea tasas de revisión, distribución de riesgo y tendencias |
+| **Métricas de gobernanza** | `straymark metrics` rastrea tasas de revisión, distribución de riesgo y tendencias |
 
 ### Para Cumplimiento Regulatorio (como side effect)
 
@@ -130,18 +130,18 @@ DevTrail funciona con cualquier metodología de desarrollo:
 | **Listo para EU AI Act** | Plantillas de clasificación de riesgo, reporte de incidentes y transparencia integradas |
 | **Compatible con ISO 42001** | La estructura de documentación se alinea con requisitos de auditoría de certificación |
 | **Mapeado a NIST AI RMF** | 12 categorías de riesgo GenAI y funciones de gobernanza cubiertas explícitamente |
-| **Trazas de auditoría completas** | `devtrail audit` genera reportes exportables de línea temporal y trazabilidad |
-| **Scoring de cumplimiento** | `devtrail compliance` proporciona análisis de brechas regulatorias basado en porcentajes |
+| **Trazas de auditoría completas** | `straymark audit` genera reportes exportables de línea temporal y trazabilidad |
+| **Scoring de cumplimiento** | `straymark compliance` proporciona análisis de brechas regulatorias basado en porcentajes |
 
 ---
 
 ## Cumplimiento de Estándares
 
-La disciplina que DevTrail externaliza — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas — produce, como efecto secundario, evidencia que mapea limpiamente a los principales marcos de ingeniería y de gobernanza de IA. Las tablas a continuación describen *cómo* los artefactos de DevTrail se alinean con cada estándar; la meta es el trabajo de ingeniería, la alineación es lo que cae como subproducto:
+La disciplina que StrayMark externaliza — alcance explícito, decisiones declaradas, riesgos nombrados, alternativas registradas — produce, como efecto secundario, evidencia que mapea limpiamente a los principales marcos de ingeniería y de gobernanza de IA. Las tablas a continuación describen *cómo* los artefactos de StrayMark se alinean con cada estándar; la meta es el trabajo de ingeniería, la alineación es lo que cae como subproducto:
 
 ### Estándares de Ingeniería de Software
 
-| Estándar | Cómo Ayuda DevTrail |
+| Estándar | Cómo Ayuda StrayMark |
 |----------|---------------------|
 | **IEEE 830** (SRS) | Documentos REQ siguen formato estructurado de requisitos |
 | **ISO/IEC 25010** | Atributos de calidad documentados en ADRs |
@@ -149,7 +149,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 
 ### Documentación de Arquitectura
 
-| Estándar | Cómo Ayuda DevTrail |
+| Estándar | Cómo Ayuda StrayMark |
 |----------|---------------------|
 | **ADR (Architecture Decision Records)** | Soporte nativo de ADR con metadatos extendidos |
 | **arc42** | ADRs complementan documentación de decisiones de arc42 |
@@ -157,7 +157,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 
 ### Cumplimiento y Gobernanza
 
-| Regulación | Cómo Ayuda DevTrail |
+| Regulación | Cómo Ayuda StrayMark |
 |------------|---------------------|
 | **GDPR** | Documentos ETH para evaluaciones de impacto de privacidad |
 | **SOC 2** | Documentación de cambios y registro de accesos |
@@ -166,7 +166,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 
 ### Gobernanza de IA
 
-| Marco | Cómo Ayuda DevTrail |
+| Marco | Cómo Ayuda StrayMark |
 |-------|---------------------|
 | **EU AI Act** | Transparencia a través de AILOG/AIDEC; supervisión humana via ETH |
 | **NIST AI RMF** | Documentación de riesgos en registros de decisión |
@@ -174,7 +174,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 
 ### Cobertura Regulatoria China *(opt-in vía `regional_scope: china`)*
 
-| Estándar | Cómo Ayuda DevTrail |
+| Estándar | Cómo Ayuda StrayMark |
 |----------|---------------------|
 | **TC260 AI Safety Governance Framework v2.0** | Clasificación de riesgo en 5 niveles (TC260RA), campos `tc260_*` en ETH/MCARD/AILOG/SEC |
 | **PIPL — Personal Information Protection Law** | Plantilla PIPIA con secciones del Art. 55-56, campos `pipl_*`, retención ≥ 3 años (`TYPE-003`) |
@@ -183,7 +183,7 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 | **GB/T 45652-2025** | Sección de seguridad de datos de entrenamiento en SBOM y MCARD; campo `gb45652_training_data_compliance` |
 | **CSL 2026** | Extensión de INC con `csl_severity_level`, reglas de coherencia de plazos (ventanas 1h / 4h+72h+30d) |
 
-> Activar añadiendo `china` a `regional_scope` en `.devtrail/config.yml`. Ver la sección *Configuración* abajo y la guía instalada `CHINA-REGULATORY-FRAMEWORK.md` para detalles.
+> Activar añadiendo `china` a `regional_scope` en `.straymark/config.yml`. Ver la sección *Configuración* abajo y la guía instalada `CHINA-REGULATORY-FRAMEWORK.md` para detalles.
 
 ---
 
@@ -195,34 +195,34 @@ La disciplina que DevTrail externaliza — alcance explícito, decisiones declar
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 O instalar desde el código fuente con Cargo:
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
 Luego inicializa y haz commit:
 
 ```bash
 cd tu-proyecto
-devtrail init .
+straymark init .
 
-git add .devtrail/ DEVTRAIL.md
-git commit -m "chore: adoptar DevTrail"
+git add .straymark/ STRAYMARK.md
+git commit -m "chore: adoptar StrayMark"
 ```
 
 El CLI automáticamente:
-- Descarga la última versión de DevTrail desde GitHub
-- Configura la estructura de directorios `.devtrail/`
-- Crea `DEVTRAIL.md` con las reglas de gobernanza
+- Descarga la última versión de StrayMark desde GitHub
+- Configura la estructura de directorios `.straymark/`
+- Crea `STRAYMARK.md` con las reglas de gobernanza
 - Configura las directivas de agentes IA (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 - Copia workflows de CI/CD
 
@@ -230,17 +230,17 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases) y descarga el último release `fw-*` (ej. `fw-4.10.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.10.0`).
 
 2. **Extraer en tu proyecto**
    ```bash
-   unzip devtrail-fw-*.zip -d tu-proyecto/
+   unzip straymark-fw-*.zip -d tu-proyecto/
    ```
 
 3. **Commit de la estructura**
    ```bash
-   git add .devtrail/ DEVTRAIL.md
-   git commit -m "chore: adoptar DevTrail para gobernanza de documentación"
+   git add .straymark/ STRAYMARK.md
+   git commit -m "chore: adoptar StrayMark para gobernanza de documentación"
    ```
 
 ---
@@ -261,32 +261,32 @@ El CLI automáticamente:
 
    | Estado Actual | Acción Recomendada |
    |---------------|-------------------|
-   | Sin documentación | Comenzar desde cero con DevTrail |
-   | Docs en carpeta `docs/` | Mantener `docs/` para docs orientados al usuario, agregar `.devtrail/` para docs de desarrollo |
-   | ADRs existentes | Migrar a `.devtrail/02-design/decisions/` con nueva nomenclatura |
+   | Sin documentación | Comenzar desde cero con StrayMark |
+   | Docs en carpeta `docs/` | Mantener `docs/` para docs orientados al usuario, agregar `.straymark/` para docs de desarrollo |
+   | ADRs existentes | Migrar a `.straymark/02-design/decisions/` con nueva nomenclatura |
    | Documentación mixta | Categorizar y migrar gradualmente |
 
 ### Fase 2: Instalación (Día 1-2)
 
-1. **Agregar estructura DevTrail**
+1. **Agregar estructura StrayMark**
    ```bash
    # Usando CLI (recomendado)
-   devtrail init .
+   straymark init .
 
    # O manualmente: descargar el último release fw-* desde GitHub Releases
-   # https://github.com/StrangeDaysTech/devtrail/releases
+   # https://github.com/StrangeDaysTech/straymark/releases
    ```
 
 2. **Resolver conflictos con `docs/` existente**
 
-   DevTrail usa `.devtrail/` específicamente para evitar conflictos:
+   StrayMark usa `.straymark/` específicamente para evitar conflictos:
 
    ```
    tu-proyecto/
    ├── docs/                    ← Mantener para docs de API, guías de usuario, etc.
    │   ├── api/
    │   └── user-guide/
-   ├── .devtrail/              ← Agregar para documentación de desarrollo
+   ├── .straymark/              ← Agregar para documentación de desarrollo
    │   ├── 00-governance/
    │   ├── 01-requirements/
    │   └── ...
@@ -300,10 +300,10 @@ El CLI automáticamente:
    Para cada ADR existente:
    ```bash
    # Antiguo: docs/adr/001-usar-postgresql.md
-   # Nuevo: .devtrail/02-design/decisions/ADR-2024-01-15-001-usar-postgresql.md
+   # Nuevo: .straymark/02-design/decisions/ADR-2024-01-15-001-usar-postgresql.md
    ```
 
-   Agregar metadatos DevTrail al front-matter:
+   Agregar metadatos StrayMark al front-matter:
    ```yaml
    ---
    id: ADR-2024-01-15-001
@@ -324,7 +324,7 @@ El CLI automáticamente:
 
    Crear un AILOG documentando la migración:
    ```
-   .devtrail/07-ai-audit/agent-logs/AILOG-2025-01-27-001-adopcion-devtrail.md
+   .straymark/07-ai-audit/agent-logs/AILOG-2025-01-27-001-adopcion-straymark.md
    ```
 
 ### Fase 4: Adopción del Equipo (Semana 2-4)
@@ -335,24 +335,24 @@ El CLI automáticamente:
    ```markdown
    ## Documentación
 
-   Este proyecto usa [DevTrail](https://github.com/StrangeDaysTech/devtrail) para gobernanza de documentación.
+   Este proyecto usa [StrayMark](https://github.com/StrangeDaysTech/straymark) para gobernanza de documentación.
 
-   - Todos los cambios significativos deben documentarse en `.devtrail/`
+   - Todos los cambios significativos deben documentarse en `.straymark/`
    - Cambios asistidos por IA requieren entradas AILOG
    - Decisiones arquitectónicas requieren documentos ADR
 
-   Ver `.devtrail/QUICK-REFERENCE.md` para tipos de documentos y nomenclatura.
+   Ver `.straymark/QUICK-REFERENCE.md` para tipos de documentos y nomenclatura.
    ```
 
 2. **Habilitar hooks pre-commit (opcional)**
    ```bash
    # Crear el hook pre-commit
    echo '#!/bin/sh
-   devtrail validate --staged' > .git/hooks/pre-commit
+   straymark validate --staged' > .git/hooks/pre-commit
    chmod +x .git/hooks/pre-commit
 
    # O con Husky
-   npx husky add .husky/pre-commit "devtrail validate --staged"
+   npx husky add .husky/pre-commit "straymark validate --staged"
    ```
 
 3. **Habilitar GitHub Actions (opcional)**
@@ -363,7 +363,7 @@ El CLI automáticamente:
 
 | Semana | Enfoque |
 |--------|---------|
-| Semana 1 | Equipo principal adopta DevTrail para nuevas decisiones |
+| Semana 1 | Equipo principal adopta StrayMark para nuevas decisiones |
 | Semana 2 | Migrar ADRs existentes críticos |
 | Semana 3 | Habilitar validación en CI/CD |
 | Semana 4 | Adopción completa del equipo; documentar deuda técnica existente |
@@ -374,7 +374,7 @@ El CLI automáticamente:
 
 ### Alcance Regulatorio Regional
 
-`.devtrail/config.yml` controla qué frameworks de cumplimiento evalúa `devtrail compliance` y qué tipos de documento expone `devtrail new`:
+`.straymark/config.yml` controla qué frameworks de cumplimiento evalúa `straymark compliance` y qué tipos de documento expone `straymark new`:
 
 ```yaml
 regional_scope:
@@ -383,14 +383,14 @@ regional_scope:
   - china    # TC260 v2.0, PIPL/PIPIA, GB 45438, CAC, GB/T 45652, CSL 2026
 ```
 
-**Default si se omite**: `[global, eu]` — preserva el comportamiento de toda versión de DevTrail anterior a `fw-4.3.0`.
+**Default si se omite**: `[global, eu]` — preserva el comportamiento de toda versión de StrayMark anterior a `fw-4.3.0`.
 
 Cuando añades `china` a la lista:
 
-- Cuatro tipos de documento específicos de China están disponibles vía `devtrail new`: `PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`.
-- Seis nuevos checkers de cumplimiento se ejecutan con `devtrail compliance` (o vía `--region china` / `--standard china-*`).
+- Cuatro tipos de documento específicos de China están disponibles vía `straymark new`: `PIPIA`, `CACFILE`, `TC260RA`, `AILABEL`.
+- Seis nuevos checkers de cumplimiento se ejecutan con `straymark compliance` (o vía `--region china` / `--standard china-*`).
 - Doce reglas de validación scope-aware se activan (`CROSS-004` a `CROSS-011`, `TYPE-003` a `TYPE-006`).
-- Cinco nuevas guías de gobernanza referenciadas desde `.devtrail/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, más guías por framework para TC260, PIPL/PIPIA, registro CAC, y etiquetado GB 45438) — todas disponibles en EN, ES y zh-CN.
+- Cinco nuevas guías de gobernanza referenciadas desde `.straymark/00-governance/` (`CHINA-REGULATORY-FRAMEWORK.md`, más guías por framework para TC260, PIPL/PIPIA, registro CAC, y etiquetado GB 45438) — todas disponibles en EN, ES y zh-CN.
 
 Un proyecto sin `china` en `regional_scope` no se ve afectado: ningún archivo nuevo, ningún prompt nuevo, ninguna regla nueva. Añadir `china` después es totalmente reversible.
 
@@ -420,15 +420,15 @@ Para agregar un nuevo tipo de documento:
 
 1. **Crear la plantilla**
    ```
-   .devtrail/templates/TEMPLATE-NUEVOTIPO.md
+   .straymark/templates/TEMPLATE-NUEVOTIPO.md
    ```
 
 2. **Actualizar docs de gobernanza**
 
    Agregar el nuevo tipo a:
-   - `.devtrail/00-governance/DOCUMENTATION-POLICY.md`
-   - `.devtrail/00-governance/AGENT-RULES.md`
-   - `.devtrail/QUICK-REFERENCE.md`
+   - `.straymark/00-governance/DOCUMENTATION-POLICY.md`
+   - `.straymark/00-governance/AGENT-RULES.md`
+   - `.straymark/QUICK-REFERENCE.md`
 
 3. **Actualizar configs de agente**
 
@@ -437,7 +437,7 @@ Para agregar un nuevo tipo de documento:
 4. **Actualizar validación**
 
    Agregar el nuevo prefijo de tipo a:
-   - Reglas de validación en el CLI (`devtrail validate`)
+   - Reglas de validación en el CLI (`straymark validate`)
    - `.github/workflows/docs-validation.yml`
 
 ### Personalizar Estructura de Carpetas
@@ -461,11 +461,11 @@ Puedes renombrar carpetas, pero actualiza todas las referencias en:
 Si usas Claude Code, verifica el cumplimiento de documentación con el skill integrado:
 
 ```bash
-/devtrail-status
+/straymark-status
 ```
 
 Este skill muestra:
-- Qué documentos DevTrail fueron creados recientemente
+- Qué documentos StrayMark fueron creados recientemente
 - Qué archivos modificados pueden necesitar documentación
 - Estado general de cumplimiento de documentación
 
@@ -475,18 +475,18 @@ Después de la adopción, verifica tu configuración:
 
 ```bash
 # Ejecutar la validación (multiplataforma)
-devtrail validate
+straymark validate
 ```
 
 ### Lista de Verificación
 
-- [ ] Estructura de carpetas `.devtrail/` existe
+- [ ] Estructura de carpetas `.straymark/` existe
 - [ ] Al menos un archivo de config de agente existe (`CLAUDE.md`, `GEMINI.md`, etc.)
-- [ ] Documentos de gobernanza presentes en `.devtrail/00-governance/`
-- [ ] Plantillas presentes en `.devtrail/templates/`
-- [ ] Estrategia de branching Git documentada en `.devtrail/03-implementation/`
+- [ ] Documentos de gobernanza presentes en `.straymark/00-governance/`
+- [ ] Plantillas presentes en `.straymark/templates/`
+- [ ] Estrategia de branching Git documentada en `.straymark/03-implementation/`
 - [ ] `QUICK-REFERENCE.md` es accesible
-- [ ] `devtrail validate` se ejecuta sin errores
+- [ ] `straymark validate` se ejecuta sin errores
 - [ ] (Opcional) Hook pre-commit está instalado
 - [ ] (Opcional) Flujo de trabajo de GitHub Actions está habilitado
 
@@ -496,15 +496,15 @@ devtrail validate
 
 A partir de `fw-4.9.0`, cuando co-implementas Charters con un asistente IA en el loop (Claude Code, Gemini Code, Cursor), puedes opcionalmente correr una auditoría externa multi-modelo al cierre del Charter. Dos skills envuelven la orquestación subyacente del CLI:
 
-- **`/devtrail-audit-prompt CHARTER-XX`** — escribe el audit prompt unificado en el path canónico `.devtrail/audits/<id>/audit-prompt.md`. El operador abre N CLIs auditoras y corre `/devtrail-audit-execute` en cada una. Sin copy/paste.
-- **`/devtrail-audit-execute [CHARTER-XX]`** *(fw-4.9.0+)* — corre dentro de una CLI auditora (gemini-cli, claude-cli, copilot-cli, codex-cli). Lee el prompt, audita con tool use citando `path:línea`, escribe un report con el id del modelo en el nombre.
-- **`/devtrail-audit-review CHARTER-XX`** — consolida N reports en un `review.md` de seis secciones (Resumen ejecutivo / Alcance / Evaluación por auditor / Plan de remediación P0-P4 / Descartados / Calificación de auditores) y mergea el YAML `external_audit:` en la telemetría del Charter.
+- **`/straymark-audit-prompt CHARTER-XX`** — escribe el audit prompt unificado en el path canónico `.straymark/audits/<id>/audit-prompt.md`. El operador abre N CLIs auditoras y corre `/straymark-audit-execute` en cada una. Sin copy/paste.
+- **`/straymark-audit-execute [CHARTER-XX]`** *(fw-4.9.0+)* — corre dentro de una CLI auditora (gemini-cli, claude-cli, copilot-cli, codex-cli). Lee el prompt, audita con tool use citando `path:línea`, escribe un report con el id del modelo en el nombre.
+- **`/straymark-audit-review CHARTER-XX`** — consolida N reports en un `review.md` de seis secciones (Resumen ejecutivo / Alcance / Evaluación por auditor / Plan de remediación P0-P4 / Descartados / Calificación de auditores) y mergea el YAML `external_audit:` en la telemetría del Charter.
 
-El agente **proactivamente ofrecerá** la auditoría en un momento específico del workflow — cuando la implementación está lista, el drift check está limpio, y `charter close` no se ha invocado. La recomendación es SÍ/NO basada en la superficie de riesgo y complejidad del Charter (heurísticas en `.devtrail/00-governance/AGENT-RULES.md` §12).
+El agente **proactivamente ofrecerá** la auditoría en un momento específico del workflow — cuando la implementación está lista, el drift check está limpio, y `charter close` no se ha invocado. La recomendación es SÍ/NO basada en la superficie de riesgo y complejidad del Charter (heurísticas en `.straymark/00-governance/AGENT-RULES.md` §12).
 
 **La auditoría externa es completamente opcional** y **nunca enforced**. El scope declarativo del Charter + drift check + disciplina AILOG ya proporcionan cierre riguroso. La auditoría agrega señal cross-modelo cuando el Charter tocó superficie de seguridad, introdujo componentes nuevos, o tiene funciones de alta complejidad en el diff. Declina libremente si el costo (2-3 auditores LLM) no se ajusta al valor de tu caso.
 
-Para los comandos CLI subyacentes (PREPARE / CALIBRATE / FINALIZE / `--merge-into`), ver [`CLI-REFERENCE.md` § devtrail charter audit](./CLI-REFERENCE.md#devtrail-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir).
+Para los comandos CLI subyacentes (PREPARE / CALIBRATE / FINALIZE / `--merge-into`), ver [`CLI-REFERENCE.md` § straymark charter audit](./CLI-REFERENCE.md#straymark-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir).
 
 ---
 
@@ -512,34 +512,34 @@ Para los comandos CLI subyacentes (PREPARE / CALIBRATE / FINALIZE / `--merge-int
 
 ### Preguntas Generales
 
-**P: ¿DevTrail reemplaza mi documentación existente?**
+**P: ¿StrayMark reemplaza mi documentación existente?**
 
-R: No. DevTrail es para *documentación del proceso de desarrollo* (decisiones, cambios, revisiones). Mantén tu carpeta `docs/` existente para documentación orientada al usuario, referencias de API y guías.
+R: No. StrayMark es para *documentación del proceso de desarrollo* (decisiones, cambios, revisiones). Mantén tu carpeta `docs/` existente para documentación orientada al usuario, referencias de API y guías.
 
-**P: ¿Necesito usar asistentes de codificación con IA para beneficiarme de DevTrail?**
+**P: ¿Necesito usar asistentes de codificación con IA para beneficiarme de StrayMark?**
 
-R: No. DevTrail funciona también para equipos solo de humanos. Las características de auditoría de IA (AILOG, AIDEC, ETH) se vuelven especialmente valiosas al usar asistentes de IA, pero ADR, REQ, TDE y otros tipos de documentos son útiles para cualquier equipo.
+R: No. StrayMark funciona también para equipos solo de humanos. Las características de auditoría de IA (AILOG, AIDEC, ETH) se vuelven especialmente valiosas al usar asistentes de IA, pero ADR, REQ, TDE y otros tipos de documentos son útiles para cualquier equipo.
 
-**P: ¿Cuánto overhead agrega DevTrail?**
+**P: ¿Cuánto overhead agrega StrayMark?**
 
-R: DevTrail sigue un principio de "documentación mínima viable". Solo los cambios significativos requieren documentación. Los cambios triviales (erratas, formato) están explícitamente excluidos.
+R: StrayMark sigue un principio de "documentación mínima viable". Solo los cambios significativos requieren documentación. Los cambios triviales (erratas, formato) están explícitamente excluidos.
 
 ### Preguntas Técnicas
 
-**P: ¿Por qué usar `.devtrail/` en lugar de `docs/`?**
+**P: ¿Por qué usar `.straymark/` en lugar de `docs/`?**
 
-R: La carpeta `docs/` se usa comúnmente para documentación orientada al usuario, GitHub Pages o docs de API generados. Usar `.devtrail/` evita conflictos y separa claramente la documentación de desarrollo de la documentación de usuario.
+R: La carpeta `docs/` se usa comúnmente para documentación orientada al usuario, GitHub Pages o docs de API generados. Usar `.straymark/` evita conflictos y separa claramente la documentación de desarrollo de la documentación de usuario.
 
-**P: ¿Puedo usar DevTrail con monorepos?**
+**P: ¿Puedo usar StrayMark con monorepos?**
 
 R: Sí. Puedes:
-- Tener un `.devtrail/` en la raíz para todo el monorepo
-- Tener carpetas `.devtrail/` separadas en cada paquete/servicio
+- Tener un `.straymark/` en la raíz para todo el monorepo
+- Tener carpetas `.straymark/` separadas en cada paquete/servicio
 - Usar un enfoque híbrido con gobernanza compartida en la raíz
 
 **P: ¿Cómo manejo información sensible?**
 
-R: DevTrail prohíbe explícitamente documentar credenciales, tokens o secretos. Los scripts de validación verifican patrones sensibles comunes y te advierten. Para decisiones genuinamente sensibles, documenta la *existencia* de la decisión sin los detalles sensibles.
+R: StrayMark prohíbe explícitamente documentar credenciales, tokens o secretos. Los scripts de validación verifican patrones sensibles comunes y te advierten. Para decisiones genuinamente sensibles, documenta la *existencia* de la decisión sin los detalles sensibles.
 
 ### Preguntas de Adopción
 
@@ -551,16 +551,16 @@ R: Comienza pequeño:
 3. Demuestra tiempo ahorrado al revisar decisiones antiguas
 4. Expande gradualmente a otros tipos de documentos
 
-**P: ¿Cómo manejo documentos creados antes de adoptar DevTrail?**
+**P: ¿Cómo manejo documentos creados antes de adoptar StrayMark?**
 
 R: Tienes tres opciones:
-1. **Migrar**: Convertir documentos antiguos al formato DevTrail (recomendado para docs importantes)
-2. **Referenciar**: Mantener docs antiguos en su lugar, referenciarlos desde docs DevTrail
-3. **Archivar**: Mover docs antiguos a una carpeta de archivo, comenzar de nuevo con DevTrail
+1. **Migrar**: Convertir documentos antiguos al formato StrayMark (recomendado para docs importantes)
+2. **Referenciar**: Mantener docs antiguos en su lugar, referenciarlos desde docs StrayMark
+3. **Archivar**: Mover docs antiguos a una carpeta de archivo, comenzar de nuevo con StrayMark
 
 **P: ¿Qué pasa si mi asistente de IA no sigue las reglas?**
 
-R: Las reglas de DevTrail son instrucciones, no cumplimiento forzado. Si un asistente de IA crea documentación no conforme:
+R: Las reglas de StrayMark son instrucciones, no cumplimiento forzado. Si un asistente de IA crea documentación no conforme:
 1. El hook pre-commit detectará errores de validación
 2. CI/CD marcará problemas en PRs
 3. Puedes corregir manualmente y educar a la IA en el siguiente prompt
@@ -571,15 +571,15 @@ R: Las reglas de DevTrail son instrucciones, no cumplimiento forzado. Si un asis
 
 - **Referencia CLI**: [CLI-REFERENCE.md](CLI-REFERENCE.md) — referencia detallada de comandos
 - **Flujos de Trabajo**: [WORKFLOWS.md](WORKFLOWS.md) — patrones de uso diario recomendados
-- **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/devtrail/issues)
-- **Discusiones**: [GitHub Discussions](https://github.com/StrangeDaysTech/devtrail/discussions)
+- **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
+- **Discusiones**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 - **Contribuir**: Ver [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
 
 <div align="center">
 
-**DevTrail** — Porque cada cambio cuenta una historia.
+**StrayMark** — Porque cada cambio cuenta una historia.
 
 [Volver al README](../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -1,6 +1,6 @@
-# DevTrail - Referencia CLI
+# StrayMark - Referencia CLI
 
-**Referencia completa de la herramienta de línea de comandos `devtrail`.**
+**Referencia completa de la herramienta de línea de comandos `straymark`.**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -20,66 +20,66 @@
 
 ## Instalación
 
-Instala el CLI de DevTrail usando uno de los métodos a continuación. Para instrucciones completas de configuración, consulta el [README](../README.md#inicio-rápido).
+Instala el CLI de StrayMark usando uno de los métodos a continuación. Para instrucciones completas de configuración, consulta el [README](../README.md#inicio-rápido).
 
 **Instalación rápida (binario precompilado):**
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 **Desde el código fuente:**
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
 ---
 
 ## Versionado
 
-DevTrail usa **tags de versión independientes** para cada componente:
+StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.10.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.10.0` | El binario `devtrail` |
+| CLI | `cli-` | `cli-3.10.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
 **Verificar versiones instaladas:**
 
 ```bash
-devtrail about    # Muestra versión CLI + versión framework (si está instalado)
-devtrail status   # Muestra estado completo de la instalación incluyendo versiones
+straymark about    # Muestra versión CLI + versión framework (si está instalado)
+straymark status   # Muestra estado completo de la instalación incluyendo versiones
 ```
 
 ---
 
 ## Comandos
 
-### `devtrail init [path] [--hooks]`
+### `straymark init [path] [--hooks]`
 
-Inicializa DevTrail en un directorio de proyecto.
+Inicializa StrayMark en un directorio de proyecto.
 
 **Argumentos y flags:**
 
 | Argumento/Flag | Por defecto | Descripción |
 |----------------|-------------|-------------|
 | `path` | `.` (directorio actual) | Directorio del proyecto destino |
-| `--hooks` *(cli-3.7.0+)* | off | Tras `init`, instala el hook pre-PR del framework (`.devtrail/hooks/pre-pr.sh`) como `.git/hooks/pre-push`. Ejecuta `devtrail charter drift` automáticamente antes de cada push. Opt-in por principio #6 (disciplina cognitiva > productividad cruda). Se rehúsa a sobreescribir un `pre-push` ya existente; se omite silenciosamente si no es un repositorio git. |
+| `--hooks` *(cli-3.7.0+)* | off | Tras `init`, instala el hook pre-PR del framework (`.straymark/hooks/pre-pr.sh`) como `.git/hooks/pre-push`. Ejecuta `straymark charter drift` automáticamente antes de cada push. Opt-in por principio #6 (disciplina cognitiva > productividad cruda). Se rehúsa a sobreescribir un `pre-push` ya existente; se omite silenciosamente si no es un repositorio git. |
 
 **Qué hace:**
 
 1. Descarga el último release del framework (`fw-*`) desde GitHub
-2. Crea la estructura de directorios `.devtrail/`
-3. Crea `DEVTRAIL.md` con las reglas de gobernanza
+2. Crea la estructura de directorios `.straymark/`
+3. Crea `STRAYMARK.md` con las reglas de gobernanza
 4. Configura archivos de directivas de agentes IA (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 5. Copia workflows de CI/CD
 6. *(`--hooks`)* instala el hook pre-PR
@@ -87,27 +87,27 @@ Inicializa DevTrail en un directorio de proyecto.
 **Ejemplo:**
 
 ```bash
-$ devtrail init .
-✔ Downloaded DevTrail fw-4.10.0
-✔ Created .devtrail/ directory structure
-✔ Created DEVTRAIL.md
+$ straymark init .
+✔ Downloaded StrayMark fw-4.10.0
+✔ Created .straymark/ directory structure
+✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
-DevTrail initialized successfully!
-Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
+StrayMark initialized successfully!
+Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```
 
 ---
 
-### `devtrail update`
+### `straymark update`
 
 Actualiza **ambos** framework y CLI a sus últimas versiones. Equivale a ejecutar `update-framework` seguido de `update-cli`.
 
-Si `.devtrail/` no existe en el directorio actual, la actualización del framework se omite con una advertencia.
+Si `.straymark/` no existe en el directorio actual, la actualización del framework se omite con una advertencia.
 
 **Ejemplo:**
 
 ```bash
-$ devtrail update
+$ straymark update
 Updating framework...
 ✔ Framework updated to fw-4.10.0
 Updating CLI...
@@ -116,7 +116,7 @@ Updating CLI...
 
 ---
 
-### `devtrail update-framework`
+### `straymark update-framework`
 
 Actualiza solo los archivos del framework. Busca el último release `fw-*` en GitHub.
 
@@ -125,61 +125,61 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 **Ejemplo:**
 
 ```bash
-$ devtrail update-framework
+$ straymark update-framework
 ✔ Framework updated to fw-4.10.0
 ```
 
 ---
 
-### `devtrail update-cli`
+### `straymark update-cli`
 
-Auto-actualiza el binario `devtrail`. Detecta automáticamente el método de instalación y usa el mecanismo de actualización apropiado:
+Auto-actualiza el binario `straymark`. Detecta automáticamente el método de instalación y usa el mecanismo de actualización apropiado:
 
 - **Binario precompilado** (instalado via `install.sh` / `install.ps1`): Descarga el último binario de GitHub Releases
-- **Cargo** (instalado via `cargo install`): Ejecuta `cargo install --force devtrail-cli`
+- **Cargo** (instalado via `cargo install`): Ejecuta `cargo install --force straymark-cli`
 
 Usa `--method` para forzar el método: `--method=github` o `--method=cargo`.
 
 **Ejemplo:**
 
 ```bash
-$ devtrail update-cli
+$ straymark update-cli
 ✔ CLI updated to cli-3.5.2
 
-$ devtrail update-cli --method=cargo
+$ straymark update-cli --method=cargo
 Compiling from source, this may take a few minutes...
 ✔ CLI updated to cli-3.5.2
 ```
 
 ---
 
-### `devtrail remove [--full]`
+### `straymark remove [--full]`
 
-Elimina DevTrail del proyecto actual.
+Elimina StrayMark del proyecto actual.
 
 **Flags:**
 
 | Flag | Descripción |
 |------|-------------|
-| `--full` | Elimina todo, incluyendo documentos creados por el usuario en `.devtrail/`. Pide confirmación. |
+| `--full` | Elimina todo, incluyendo documentos creados por el usuario en `.straymark/`. Pide confirmación. |
 
-**Comportamiento por defecto** (sin `--full`): elimina la estructura del framework pero preserva los documentos que creaste dentro de `.devtrail/`.
+**Comportamiento por defecto** (sin `--full`): elimina la estructura del framework pero preserva los documentos que creaste dentro de `.straymark/`.
 
 **Ejemplo:**
 
 ```bash
-$ devtrail remove
-✔ DevTrail framework removed. User documents preserved in .devtrail/.
+$ straymark remove
+✔ StrayMark framework removed. User documents preserved in .straymark/.
 
-$ devtrail remove --full
-⚠ This will delete all DevTrail files including your documents.
+$ straymark remove --full
+⚠ This will delete all StrayMark files including your documents.
 Continue? [y/N]: y
-✔ DevTrail completely removed.
+✔ StrayMark completely removed.
 ```
 
 ---
 
-### `devtrail status [path]`
+### `straymark status [path]`
 
 Muestra el estado de la instalación y estadísticas de documentación.
 
@@ -201,8 +201,8 @@ Muestra el estado de la instalación y estadísticas de documentación.
 **Ejemplo:**
 
 ```bash
-$ devtrail status
-DevTrail Status
+$ straymark status
+StrayMark Status
 ───────────────
 Path:              /home/user/my-project
 Framework version: fw-4.10.0
@@ -224,9 +224,9 @@ Documents:
 
 ---
 
-### `devtrail repair [path]`
+### `straymark repair [path]`
 
-Repara una instalación de DevTrail rota restaurando directorios y archivos del framework faltantes.
+Repara una instalación de StrayMark rota restaurando directorios y archivos del framework faltantes.
 
 **Argumentos:**
 
@@ -238,29 +238,29 @@ Repara una instalación de DevTrail rota restaurando directorios y archivos del 
 
 1. Verifica directorios faltantes y los restaura con `.gitkeep`
 2. Descarga el release del framework **una sola vez** si se necesitan archivos (templates, governance, config)
-3. Re-inyecta directivas si falta `DEVTRAIL.md`
+3. Re-inyecta directivas si falta `STRAYMARK.md`
 4. Recalcula checksums después de la reparación
 5. Nunca modifica ni elimina documentos generados por el usuario
 
 **Ejemplo:**
 
 ```bash
-$ devtrail repair
-Repairing DevTrail in /home/user/mi-proyecto
+$ straymark repair
+Repairing StrayMark in /home/user/mi-proyecto
   → Found 1 issue(s) to repair
 → Restoring 1 missing directory...
-✓ Restored .devtrail/templates/
+✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
 ✓ Restored 16 file(s) from framework
 
-✓ DevTrail repaired successfully!
+✓ StrayMark repaired successfully!
 ```
 
 ---
 
-### `devtrail validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
+### `straymark validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
 
-Valida documentos DevTrail verificando cumplimiento y corrección.
+Valida documentos StrayMark verificando cumplimiento y corrección.
 
 **Argumentos y flags:**
 
@@ -289,9 +289,9 @@ Cuando `regional_scope` incluye `china`, se activan doce reglas adicionales (`CR
 
 ---
 
-### `devtrail new [path] [-t <tipo>] [--title <titulo>]`
+### `straymark new [path] [-t <tipo>] [--title <titulo>]`
 
-Crea un nuevo documento DevTrail a partir de una plantilla.
+Crea un nuevo documento StrayMark a partir de una plantilla.
 
 **Argumentos y flags:**
 
@@ -307,30 +307,30 @@ Si no se especifica `--doc-type` o `--title`, se solicitan de forma interactiva.
 
 ```bash
 # Creación interactiva
-$ devtrail new
+$ straymark new
 
 # Crear un AILOG con título (no-interactivo)
-$ devtrail new -t ailog --title "Implementar autenticación JWT"
+$ straymark new -t ailog --title "Implementar autenticación JWT"
 
 # Crear un ADR
-$ devtrail new --doc-type adr --title "Elegir PostgreSQL como base de datos"
+$ straymark new --doc-type adr --title "Elegir PostgreSQL como base de datos"
 ```
 
 **Ejemplo de salida:**
 
 ```
-$ devtrail new -t ailog --title "Refactorizar módulo de pagos"
+$ straymark new -t ailog --title "Refactorizar módulo de pagos"
 
-  ✔ Created: .devtrail/07-ai-audit/agent-logs/AILOG-2026-04-01-001-refactorizar-modulo-de-pagos.md
+  ✔ Created: .straymark/07-ai-audit/agent-logs/AILOG-2026-04-01-001-refactorizar-modulo-de-pagos.md
 
   Next steps:
     1. Edit the document to fill in details
-    2. Commit: git add .devtrail/07-ai-audit/agent-logs/AILOG-2026-04-01-001-refactorizar-modulo-de-pagos.md
+    2. Commit: git add .straymark/07-ai-audit/agent-logs/AILOG-2026-04-01-001-refactorizar-modulo-de-pagos.md
 ```
 
 ---
 
-### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
+### `straymark approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
 
 *Disponible desde **cli-3.7.0** + **fw-4.6.0**. `--quiet` y warning de alto riesgo añadidos en cli-3.8.0.*
 
@@ -356,7 +356,7 @@ Registra una aprobación humana formal sobre un documento con `review_required: 
 
 ```bash
 # Driven por flags (CI / scripts)
-$ devtrail approve AIDEC-2026-05-02-001 \
+$ straymark approve AIDEC-2026-05-02-001 \
     --outcome approved \
     --reviewer pepe@example.com \
     --notes "Revisado contra ADR-007. LGTM."
@@ -364,38 +364,38 @@ $ devtrail approve AIDEC-2026-05-02-001 \
   ✔ AIDEC-2026-05-02-001 marked as approved.
     Reviewer: pepe@example.com
     Date:     2026-05-02
-    File:     .devtrail/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
+    File:     .straymark/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
 
 # Ciclo iterativo: revisions_requested → re-aprobación
-$ devtrail approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
+$ straymark approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
 # (autor itera)
-$ devtrail approve AIDEC-... --outcome approved --reviewer reviewer@x.io
+$ straymark approve AIDEC-... --outcome approved --reviewer reviewer@x.io
 # Frontmatter muestra la última (approved); el cuerpo conserva AMBOS bloques cronológicamente.
 
 # Visibilidad del backlog
-$ devtrail validate --check-pending-reviews --max-pending-days 14
+$ straymark validate --check-pending-reviews --max-pending-days 14
 ```
 
-> Ver `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval" para la definición canónica del flujo (semántica de cierre, formato del cuerpo, convención multi-revisor).
+> Ver `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval" para la definición canónica del flujo (semántica de cierre, formato del cuerpo, convención multi-revisor).
 
 ---
 
-### `devtrail charter <subcomando>`
+### `straymark charter <subcomando>`
 
-Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-ante y validadas ex-post. Un Charter empareja scope declarativo (archivos a tocar, riesgos, comandos de verificación ejecutables) con el ancla de auditoría ex-post (drift detection, auditoría multi-modelo). Los Charters viven en `docs/charters/NN-slug.md` (a nivel del project root, **no** bajo `.devtrail/`).
+Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-ante y validadas ex-post. Un Charter empareja scope declarativo (archivos a tocar, riesgos, comandos de verificación ejecutables) con el ancla de auditoría ex-post (drift detection, auditoría multi-modelo). Los Charters viven en `docs/charters/NN-slug.md` (a nivel del project root, **no** bajo `.straymark/`).
 
-> **Nota histórica.** En el experimento Sentinel `/plan-audit` que cristalizó este patrón (abril 2026, 6 ciclos), los Charters se llamaban *Plans*. El CLI DevTrail usa **Charter** going-forward para evitar la colisión nominal con el `plan.md` de GitHub SpecKit. Los archivos históricos de Sentinel preservan "Plan" deliberadamente. El alcance conceptual completo y la justificación del rename viven en `Propuesta/que-es-un-charter.md`.
+> **Nota histórica.** En el experimento Sentinel `/plan-audit` que cristalizó este patrón (abril 2026, 6 ciclos), los Charters se llamaban *Plans*. El CLI StrayMark usa **Charter** going-forward para evitar la colisión nominal con el `plan.md` de GitHub SpecKit. Los archivos históricos de Sentinel preservan "Plan" deliberadamente. El alcance conceptual completo y la justificación del rename viven en `Propuesta/que-es-un-charter.md`.
 
 **Subcomandos:**
 
-- `devtrail charter new` — crea un nuevo Charter desde el template del framework
-- `devtrail charter list` — enumera Charters con filtros opcionales
-- `devtrail charter status` — muestra detalle de un Charter, o los 5 más recientes
-- `devtrail charter close` *(cli-3.7.0+)* — registra la telemetría post-ejecución y mueve el Charter a `closed`
-- `devtrail charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware
-- `devtrail charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
+- `straymark charter new` — crea un nuevo Charter desde el template del framework
+- `straymark charter list` — enumera Charters con filtros opcionales
+- `straymark charter status` — muestra detalle de un Charter, o los 5 más recientes
+- `straymark charter close` *(cli-3.7.0+)* — registra la telemetría post-ejecución y mueve el Charter a `closed`
+- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware
+- `straymark charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
 
-#### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <titulo>] [path]`
+#### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <titulo>] [path]`
 
 Crea un Charter desde el template del framework en `docs/charters/NN-slug.md`. Si no se pasa `--title`, se solicita interactivamente. Los dos flags de origen son mutuamente excluyentes a nivel de clap.
 
@@ -413,16 +413,16 @@ Cuando ningún flag de origen se pasa, ambos `originating_ailogs` y `originating
 
 ```bash
 # Standalone (sin origen) — prompt interactivo de título
-$ devtrail charter new --type M
+$ straymark charter new --type M
 
 # Modo mantenimiento / post-MVP — Charter rooteado en un AILOG existente
-$ devtrail charter new -t S --from-ailog AILOG-2026-04-28-021 --title "thresholds por servicio"
+$ straymark charter new -t S --from-ailog AILOG-2026-04-28-021 --title "thresholds por servicio"
 
 # Modo greenfield — Charter implementando un spec de SpecKit
-$ devtrail charter new -t L --from-spec specs/001-pagos/spec.md --title "integrar provider de pagos"
+$ straymark charter new -t L --from-spec specs/001-pagos/spec.md --title "integrar provider de pagos"
 ```
 
-#### `devtrail charter list [--status declared|in-progress|closed|all] [--origin ailog|spec|any] [path]`
+#### `straymark charter list [--status declared|in-progress|closed|all] [--origin ailog|spec|any] [path]`
 
 Enumera Charters como tabla.
 
@@ -434,7 +434,7 @@ Enumera Charters como tabla.
 
 Los archivos que no parsean se reportan como warnings en stderr sin abortar el comando — la tabla muestra lo que puede.
 
-#### `devtrail charter status [CHARTER-ID] [--path <dir>]`
+#### `straymark charter status [CHARTER-ID] [--path <dir>]`
 
 Con un ID: imprime el detalle completo del Charter (frontmatter, ubicación del archivo, lista de secciones del cuerpo). Sin ID: imprime los 5 Charters más recientes por NN descendente.
 
@@ -443,9 +443,9 @@ Con un ID: imprime el detalle completo del Charter (frontmatter, ubicación del 
 | `CHARTER-ID` | — | Identificador del Charter. Acepta el `charter_id` completo (`CHARTER-01-test`), el prefijo `CHARTER-NN` (`CHARTER-01`), o solo el NN numérico (`01` o `1`). El match numérico es permisivo respecto al zero-padding. |
 | `--path` | `.` | Directorio del proyecto. Es flag (no positional) para evitar colisión con el positional opcional `CHARTER-ID`. |
 
-#### `devtrail charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
+#### `straymark charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
 
-Registra la telemetría post-ejecución y mueve el status del Charter a `closed`. La telemetría se escribe en `.devtrail/charters/CHARTER-NN.telemetry.yaml` (archivo lateral, **no** embebido en el frontmatter del Charter — el frontmatter es declarativo ex-ante; la telemetría es voluminosa ex-post). El shape se valida contra `.devtrail/schemas/charter-telemetry.schema.v0.json`.
+Registra la telemetría post-ejecución y mueve el status del Charter a `closed`. La telemetría se escribe en `.straymark/charters/CHARTER-NN.telemetry.yaml` (archivo lateral, **no** embebido en el frontmatter del Charter — el frontmatter es declarativo ex-ante; la telemetría es voluminosa ex-post). El shape se valida contra `.straymark/schemas/charter-telemetry.schema.v0.json`.
 
 Dos modos:
 
@@ -465,7 +465,7 @@ Dos modos:
 **Ejemplo:**
 
 ```bash
-$ devtrail charter close CHARTER-01
+$ straymark charter close CHARTER-01
 
   Closing CHARTER-01-test-charter
     Title: Test charter
@@ -478,13 +478,13 @@ $ devtrail charter close CHARTER-01
   ...
 
   ✔ Charter CHARTER-01 closed.
-    Telemetry: .devtrail/charters/CHARTER-01.telemetry.yaml
+    Telemetry: .straymark/charters/CHARTER-01.telemetry.yaml
     Status updated: in-progress/declared → closed
 ```
 
-#### `devtrail charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
 
-Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del framework `.devtrail/scripts/check-charter-drift.sh` (cero falsos positivos validados empíricamente en PLAN-05 retrospectivo + PLAN-06 prospectivo en Sentinel). El valor agregado del CLI sobre el script crudo es la **AILOG-awareness**: los paths reportados como "declarados pero no modificados" se silencian cuando aparecen en la sección `## Risk` / `## Riesgos` / `## 风险` de algún AILOG referenciado por `originating_ailogs` del Charter. Usa `--no-ailog-suppress` para deshabilitarlo.
+Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del framework `.straymark/scripts/check-charter-drift.sh` (cero falsos positivos validados empíricamente en PLAN-05 retrospectivo + PLAN-06 prospectivo en Sentinel). El valor agregado del CLI sobre el script crudo es la **AILOG-awareness**: los paths reportados como "declarados pero no modificados" se silencian cuando aparecen en la sección `## Risk` / `## Riesgos` / `## 风险` de algún AILOG referenciado por `originating_ailogs` del Charter. Usa `--no-ailog-suppress` para deshabilitarlo.
 
 | Argumento/Flag | Default | Descripción |
 |---|---|---|
@@ -498,7 +498,7 @@ Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del fr
 **Ejemplo:**
 
 ```bash
-$ devtrail charter drift CHARTER-01 --range origin/main..HEAD
+$ straymark charter drift CHARTER-01 --range origin/main..HEAD
 === Charter drift check ===
   Charter: docs/charters/01-test.md
   Range:   origin/main..HEAD
@@ -522,29 +522,29 @@ El chequeo de drift resuelve dos formas de wildcard en `## Files to modify`:
 
 | Forma | Ejemplo | Caso de uso |
 |---|---|---|
-| Elipsis | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | Cualquier path modificado con ese prefijo satisface el wildcard. Usado históricamente cuando un número desconocido de AILOGs serían creados durante la ejecución. |
-| Glob | `` `AILOG-*.md` `` o `` `src/services/foo-*.rs` `` | Cualquier path modificado que matchee el glob (`*` → `.*`) satisface el wildcard. Usado para declaraciones bulk de Charter donde un set parametrizado es tocado. Añadido en fw-4.9.0 tras la fricción surgida en Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)). |
+| Elipsis | `` `.straymark/07-ai-audit/agent-logs/AILOG-...md` `` | Cualquier path modificado con ese prefijo satisface el wildcard. Usado históricamente cuando un número desconocido de AILOGs serían creados durante la ejecución. |
+| Glob | `` `AILOG-*.md` `` o `` `src/services/foo-*.rs` `` | Cualquier path modificado que matchee el glob (`*` → `.*`) satisface el wildcard. Usado para declaraciones bulk de Charter donde un set parametrizado es tocado. Añadido en fw-4.9.0 tras la fricción surgida en Sentinel CHARTER-04 ([issue #81](https://github.com/StrangeDaysTech/straymark/issues/81)). |
 
 Ambas formas se manejan en ambas direcciones: un wildcard declarado suprime tanto warnings de "declarado pero no modificado" (cuando al menos un archivo matching fue modificado) como warnings de "modificado pero no declarado" (cuando un path modificado matchea un wildcard declarado).
 
 #### Por diseño: rutas de gobernanza siempre están en scope
 
-Los paths bajo `docs/charters/*` y `.devtrail/07-ai-audit/*` **nunca** se reportan como "modificado pero no declarado". Es opinionated por diseño — esos paths son siempre legítimos cuando el Charter mismo o el AILOG de ejecución son tocados. Validado empíricamente en Sentinel CHARTER-04: un `git add -A` accidental stageó archivos no-tracked del usuario (`.claude/skills/`, `cmd/sentinel/sentinel`); la regla suprimió correctamente el ruido de gobernanza sin esconder la expansión genuina de archivos del proyecto ([issue #81 W2](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)).
+Los paths bajo `docs/charters/*` y `.straymark/07-ai-audit/*` **nunca** se reportan como "modificado pero no declarado". Es opinionated por diseño — esos paths son siempre legítimos cuando el Charter mismo o el AILOG de ejecución son tocados. Validado empíricamente en Sentinel CHARTER-04: un `git add -A` accidental stageó archivos no-tracked del usuario (`.claude/skills/`, `cmd/sentinel/sentinel`); la regla suprimió correctamente el ruido de gobernanza sin esconder la expansión genuina de archivos del proyecto ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
 
-Si corres un Charter cuyo scope explícito es churn de gobernanza (p.ej. un Charter de aprobación bulk que toca solo `.devtrail/07-ai-audit/`), el chequeo reportará 0 archivos modificados y necesitarás verificar el scope leyendo el AILOG. Un flag `--strict-scope` que deshabilite la regla "siempre en scope" está sobre la mesa para una minor futura si un adopter real reporta la asimetría como fricción.
+Si corres un Charter cuyo scope explícito es churn de gobernanza (p.ej. un Charter de aprobación bulk que toca solo `.straymark/07-ai-audit/`), el chequeo reportará 0 archivos modificados y necesitarás verificar el scope leyendo el AILOG. Un flag `--strict-scope` que deshabilite la regla "siempre en scope" está sobre la mesa para una minor futura si un adopter real reporta la asimetría como fricción.
 
-#### `devtrail charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
+#### `straymark charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
 
-*Disponible desde **cli-3.8.0** + **fw-4.7.0**. Flujo unificado v1 shippeado en **cli-3.10.0** + **fw-4.9.0** — reemplaza los 3 pasos v0 (PREPARE/CALIBRATE/FINALIZE) por 2 (PREPARE/MERGE-REPORTS), unifica la plantilla del auditor, y mueve los paths canónicos a `.devtrail/audits/`.*
+*Disponible desde **cli-3.8.0** + **fw-4.7.0**. Flujo unificado v1 shippeado en **cli-3.10.0** + **fw-4.9.0** — reemplaza los 3 pasos v0 (PREPARE/CALIBRATE/FINALIZE) por 2 (PREPARE/MERGE-REPORTS), unifica la plantilla del auditor, y mueve los paths canónicos a `.straymark/audits/`.*
 
-Orquesta una revisión externa multi-modelo de la ejecución de un Charter. **Orchestration-only** — el CLI prepara la plantilla unificada del audit, valida los reports de auditores contra el schema, y emite/mergea el bloque YAML `external_audit`. **NO invoca APIs de LLM.** El operador corre N CLIs auditoras (gemini-cli, claude-cli, copilot-cli, codex-cli — la que tenga) configuradas con acceso read-only al filesystem; cada una invoca el skill `/devtrail-audit-execute` para leer el prompt, auditar con tool use citando `path:line`, y escribir el report.
+Orquesta una revisión externa multi-modelo de la ejecución de un Charter. **Orchestration-only** — el CLI prepara la plantilla unificada del audit, valida los reports de auditores contra el schema, y emite/mergea el bloque YAML `external_audit`. **NO invoca APIs de LLM.** El operador corre N CLIs auditoras (gemini-cli, claude-cli, copilot-cli, codex-cli — la que tenga) configuradas con acceso read-only al filesystem; cada una invoca el skill `/straymark-audit-execute` para leer el prompt, auditar con tool use citando `path:line`, y escribir el report.
 
 Dos pasos, cada uno invocable independientemente:
 
 | Paso | Flag | Qué pasa |
 |---|---|---|
-| 1. PREPARE | `--prepare` (default) | Resuelve la plantilla unificada del audit contra el Charter + git diff + AILOGs origen. La escribe en `.devtrail/audits/<CHARTER-ID>/audit-prompt.md`. |
-| 2. MERGE-REPORTS | `--merge-reports` | Lee todos los archivos `report-*.md` en `.devtrail/audits/<CHARTER-ID>/` (uno por auditor que terminó). Valida cada uno contra `audit-output.schema.v0.json`. Emite el array YAML `external_audit` — combina con `--merge-into <PATH>` para anexarlo directamente a la telemetría del Charter. |
+| 1. PREPARE | `--prepare` (default) | Resuelve la plantilla unificada del audit contra el Charter + git diff + AILOGs origen. La escribe en `.straymark/audits/<CHARTER-ID>/audit-prompt.md`. |
+| 2. MERGE-REPORTS | `--merge-reports` | Lee todos los archivos `report-*.md` en `.straymark/audits/<CHARTER-ID>/` (uno por auditor que terminó). Valida cada uno contra `audit-output.schema.v0.json`. Emite el array YAML `external_audit` — combina con `--merge-into <PATH>` para anexarlo directamente a la telemetría del Charter. |
 
 | Argumento/Flag | Default | Descripción |
 |---|---|---|
@@ -557,68 +557,68 @@ Dos pasos, cada uno invocable independientemente:
 
 **Flags v0 deprecated (ocultos en `--help`):**
 
-- `--calibrate` — emite warning y sale con error. El paso v0 calibrate se reemplaza por la skill `/devtrail-audit-review` que reconcilia N reports inline con acceso al filesystem (sin prompt paste-based separado).
+- `--calibrate` — emite warning y sale con error. El paso v0 calibrate se reemplaza por la skill `/straymark-audit-review` que reconcilia N reports inline con acceso al filesystem (sin prompt paste-based separado).
 - `--finalize` — alias deprecated de `--merge-reports` con comportamiento backwards-compat. Emite warning y rutea por la nueva ruta.
 
 ##### Recomendación de heterogeneidad (no enforced en v0)
 
 El par de auditores debería ser de **familias de modelo distintas**: uno Anthropic + uno Google + uno OpenAI, en cualquier combinación, nunca dos de la misma familia. La heterogeneidad inter-familia es lo que hace que la convergencia en findings sea de alta señal — auditores de la misma familia comparten blind spots.
 
-v1 soporta **N≥2 auditores** (ya no fijo a 2). El operador puede optar por 3 o 4 auditores para Charters de alto riesgo, incluyendo modelos especializados. La skill `/devtrail-audit-review` itera sobre todos los archivos `report-*.md` en el audit dir.
+v1 soporta **N≥2 auditores** (ya no fijo a 2). El operador puede optar por 3 o 4 auditores para Charters de alto riesgo, incluyendo modelos especializados. La skill `/straymark-audit-review` itera sobre todos los archivos `report-*.md` en el audit dir.
 
-El rol calibrador se mueve de una plantilla paste-based (v0) al agente principal in-conversation vía la skill `/devtrail-audit-review` — su tarea es definicional (reconciliar veredictos ya producidos), por lo que la heterogeneidad respecto al implementador NO es requerida.
+El rol calibrador se mueve de una plantilla paste-based (v0) al agente principal in-conversation vía la skill `/straymark-audit-review` — su tarea es definicional (reconciliar veredictos ya producidos), por lo que la heterogeneidad respecto al implementador NO es requerida.
 
 ##### Layout canónico producido (v1)
 
 ```
-.devtrail/audits/CHARTER-NN/
+.straymark/audits/CHARTER-NN/
 ├── audit-prompt.md                          # resuelto por --prepare (single unified prompt)
-├── report-claude-sonnet-4-6.md              # escrito por /devtrail-audit-execute en claude-cli
-├── report-gemini-2-5-pro.md                 # escrito por /devtrail-audit-execute en gemini-cli
+├── report-claude-sonnet-4-6.md              # escrito por /straymark-audit-execute en claude-cli
+├── report-gemini-2-5-pro.md                 # escrito por /straymark-audit-execute en gemini-cli
 ├── report-gpt-5-3-codex.md                  # 3er auditor opcional
-├── review.md                                # escrito por /devtrail-audit-review (análisis consolidado de 6 secciones)
-└── external-audit-pending.yaml              # escrito por /devtrail-audit-review cuando la telemetría aún no existe (Branch B)
+├── review.md                                # escrito por /straymark-audit-review (análisis consolidado de 6 secciones)
+└── external-audit-pending.yaml              # escrito por /straymark-audit-review cuando la telemetría aún no existe (Branch B)
 ```
 
-El directorio está namespaceado bajo `.devtrail/` para evitar colisiones con carpetas `audit/` que el adoptante haya definido. El shape `<UNIT-TYPE>-<UNIT-ID>` deja espacio para futuras categorías de unidad de auditoría más allá de Charter (ej. `MODULE-payments/`, `RELEASE-v2.0/`) sin reestructurar.
+El directorio está namespaceado bajo `.straymark/` para evitar colisiones con carpetas `audit/` que el adoptante haya definido. El shape `<UNIT-TYPE>-<UNIT-ID>` deja espacio para futuras categorías de unidad de auditoría más allá de Charter (ej. `MODULE-payments/`, `RELEASE-v2.0/`) sin reestructurar.
 
-Los adopters pueden `git add` el directorio entero `.devtrail/audits/` para un audit trail completamente versionado, o `.gitignore` si prefieren un ciclo efímero.
+Los adopters pueden `git add` el directorio entero `.straymark/audits/` para un audit trail completamente versionado, o `.gitignore` si prefieren un ciclo efímero.
 
 **Ejemplo (v1, con los wrappers de skills — recomendado para flujos IDE-driven):**
 
 ```bash
 # En el IDE principal (Claude Code, Gemini Code, Cursor, ...):
-> /devtrail-audit-prompt CHARTER-05
-  → corre `devtrail charter audit CHARTER-05 --prepare`
-  → escribe .devtrail/audits/CHARTER-05/audit-prompt.md
+> /straymark-audit-prompt CHARTER-05
+  → corre `straymark charter audit CHARTER-05 --prepare`
+  → escribe .straymark/audits/CHARTER-05/audit-prompt.md
   → instruye al operador abrir CLIs auditoras
 
 # En claude-cli (con acceso read al repo):
-> /devtrail-audit-execute CHARTER-05
-  → escribe .devtrail/audits/CHARTER-05/report-claude-sonnet-4-6.md
+> /straymark-audit-execute CHARTER-05
+  → escribe .straymark/audits/CHARTER-05/report-claude-sonnet-4-6.md
   → recuerda al operador esperar a TODAS las auditorías antes de review
 
 # En gemini-cli:
-> /devtrail-audit-execute CHARTER-05
-  → escribe .devtrail/audits/CHARTER-05/report-gemini-2-5-pro.md
+> /straymark-audit-execute CHARTER-05
+  → escribe .straymark/audits/CHARTER-05/report-gemini-2-5-pro.md
 
 # De vuelta en el IDE principal, después de que TODAS las auditorías terminen:
-> /devtrail-audit-review CHARTER-05
+> /straymark-audit-review CHARTER-05
   → lee N reports, verifica cada finding contra el código
-  → escribe .devtrail/audits/CHARTER-05/review.md (consolidado de 6 secciones)
-  → corre `devtrail charter audit CHARTER-05 --merge-reports --merge-into <telemetría>`
+  → escribe .straymark/audits/CHARTER-05/review.md (consolidado de 6 secciones)
+  → corre `straymark charter audit CHARTER-05 --merge-reports --merge-into <telemetría>`
   → external_audit YAML mergeado en la telemetría del Charter
 ```
 
-> **¿Por qué orchestration-only?** Implementar 3 HTTP clients (OpenAI / Google / Anthropic) son 1-2 semanas + mantenimiento perpetuo. v1 audit-skills extiende el orchestration-only a un segundo modo (CLI auditor-side con tool use enforcement) donde el operador corre sus propias CLIs auditoras y los prompts de DevTrail enforzan la disciplina (`citar path:línea de archivos efectivamente abiertos`). DevTrail no maneja API keys, no invoca APIs, no mantiene HTTP clients.
+> **¿Por qué orchestration-only?** Implementar 3 HTTP clients (OpenAI / Google / Anthropic) son 1-2 semanas + mantenimiento perpetuo. v1 audit-skills extiende el orchestration-only a un segundo modo (CLI auditor-side con tool use enforcement) donde el operador corre sus propias CLIs auditoras y los prompts de StrayMark enforzan la disciplina (`citar path:línea de archivos efectivamente abiertos`). StrayMark no maneja API keys, no invoca APIs, no mantiene HTTP clients.
 
-> **Alternativa con skill *(fw-4.9.0+, expandida en fw-4.9.0)*.** Tres skills envuelven el CLI para flujos IDE-driven: `/devtrail-audit-prompt CHARTER-ID` (llama a `--prepare`), `/devtrail-audit-execute CHARTER-ID` (corre en CLIs auditoras para leer el prompt y escribir un report), y `/devtrail-audit-review CHARTER-ID` (consolida N reports en `review.md` y mergea YAML). Con estas skills el operador nunca copia/pega prompts ni reports — el intercambio sucede vía paths canónicos del filesystem bajo `.devtrail/audits/`. Ver la sección [Skills](#skills) más abajo. El CLI sigue siendo la fuente única de verdad — las skills solo añaden UX-inline.
+> **Alternativa con skill *(fw-4.9.0+, expandida en fw-4.9.0)*.** Tres skills envuelven el CLI para flujos IDE-driven: `/straymark-audit-prompt CHARTER-ID` (llama a `--prepare`), `/straymark-audit-execute CHARTER-ID` (corre en CLIs auditoras para leer el prompt y escribir un report), y `/straymark-audit-review CHARTER-ID` (consolida N reports en `review.md` y mergea YAML). Con estas skills el operador nunca copia/pega prompts ni reports — el intercambio sucede vía paths canónicos del filesystem bajo `.straymark/audits/`. Ver la sección [Skills](#skills) más abajo. El CLI sigue siendo la fuente única de verdad — las skills solo añaden UX-inline.
 
 ---
 
-### `devtrail compliance [path] [--standard <nombre>] [--region <nombre>] [--all] [--output <formato>]`
+### `straymark compliance [path] [--standard <nombre>] [--region <nombre>] [--all] [--output <formato>]`
 
-Verifica cumplimiento regulatorio. Por defecto evalúa los estándares cuya región esté incluida en `regional_scope` de `.devtrail/config.yml` (default `[global, eu]`). Seis frameworks chinos disponibles opt-in cuando `china` se añade a `regional_scope`.
+Verifica cumplimiento regulatorio. Por defecto evalúa los estándares cuya región esté incluida en `regional_scope` de `.straymark/config.yml` (default `[global, eu]`). Seis frameworks chinos disponibles opt-in cuando `china` se añade a `regional_scope`.
 
 **Argumentos y flags:**
 
@@ -645,19 +645,19 @@ Precedencia: `--standard` > `--all` > `--region` > el `regional_scope` del proye
 
 ```bash
 # Default: solo estándares cuya región esté en regional_scope
-$ devtrail compliance
+$ straymark compliance
 
 # Los seis frameworks chinos (requiere regional_scope: china)
-$ devtrail compliance --region china
+$ straymark compliance --region china
 
 # Un solo framework chino
-$ devtrail compliance --standard china-pipl --output json
+$ straymark compliance --standard china-pipl --output json
 
 # Todos los estándares ignorando regional_scope
-$ devtrail compliance --all
+$ straymark compliance --all
 ```
 
-> **Activación**: para evaluar los frameworks chinos automáticamente, añadir a `.devtrail/config.yml`:
+> **Activación**: para evaluar los frameworks chinos automáticamente, añadir a `.straymark/config.yml`:
 >
 > ```yaml
 > regional_scope:
@@ -668,7 +668,7 @@ $ devtrail compliance --all
 
 ---
 
-### `devtrail metrics [path] [--period <periodo>] [--output <formato>]`
+### `straymark metrics [path] [--period <periodo>] [--output <formato>]`
 
 Muestra métricas de gobernanza y estadísticas de documentación.
 
@@ -690,7 +690,7 @@ Muestra métricas de gobernanza y estadísticas de documentación.
 
 ---
 
-### `devtrail analyze [path] [--threshold <N>] [--output <formato>] [--top <N>]`
+### `straymark analyze [path] [--threshold <N>] [--output <formato>] [--top <N>]`
 
 Analiza la complejidad del código fuente usando métricas cognitivas y ciclomáticas, impulsado por [arborist-metrics](https://crates.io/crates/arborist-metrics).
 
@@ -705,9 +705,9 @@ Analiza la complejidad del código fuente usando métricas cognitivas y ciclomá
 
 **Lenguajes soportados:** Rust, Python, JavaScript, TypeScript, Java, Go, C, C++, C#, PHP, Kotlin, Swift
 
-**Resolución de umbral:** flag CLI → `.devtrail/config.yml` → predeterminado (8)
+**Resolución de umbral:** flag CLI → `.straymark/config.yml` → predeterminado (8)
 
-**Configuración** (opcional, en `.devtrail/config.yml`):
+**Configuración** (opcional, en `.straymark/config.yml`):
 
 ```yaml
 complexity:
@@ -718,22 +718,22 @@ complexity:
 
 ```bash
 # Analizar directorio actual
-$ devtrail analyze
+$ straymark analyze
 
 # Umbral personalizado y top 10
-$ devtrail analyze --threshold 5 --top 10
+$ straymark analyze --threshold 5 --top 10
 
 # Salida JSON para integración CI
-$ devtrail analyze --output json
+$ straymark analyze --output json
 
 # Analizar un proyecto específico
-$ devtrail analyze /ruta/al/proyecto
+$ straymark analyze /ruta/al/proyecto
 ```
 
 **Ejemplo de salida:**
 
 ```
-  DevTrail Analyze
+  StrayMark Analyze
   /home/user/project
   Threshold: cognitive complexity > 8
 
@@ -752,13 +752,13 @@ $ devtrail analyze /ruta/al/proyecto
     → Average cognitive complexity: 3.8
 ```
 
-> **Nota:** Este comando funciona sin `devtrail init`. Opera sobre archivos fuente, no documentos DevTrail. La feature `analyze` se puede desactivar en compilación con `--no-default-features`.
+> **Nota:** Este comando funciona sin `straymark init`. Opera sobre archivos fuente, no documentos StrayMark. La feature `analyze` se puede desactivar en compilación con `--no-default-features`.
 
-> **Trigger de documentación:** Los agentes de IA usan `devtrail analyze --output json` como método primario para determinar cuándo crear documentos AILOG. Si `summary.above_threshold > 0` en la salida JSON, el agente debe crear un AILOG. Cuando el CLI no está disponible, los agentes usan la heurística de >20 líneas de lógica de negocio como alternativa.
+> **Trigger de documentación:** Los agentes de IA usan `straymark analyze --output json` como método primario para determinar cuándo crear documentos AILOG. Si `summary.above_threshold > 0` en la salida JSON, el agente debe crear un AILOG. Cuando el CLI no está disponible, los agentes usan la heurística de >20 líneas de lógica de negocio como alternativa.
 
 ---
 
-### `devtrail audit [path] [--from <fecha>] [--to <fecha>] [--system <nombre>] [--output <formato>]`
+### `straymark audit [path] [--from <fecha>] [--to <fecha>] [--system <nombre>] [--output <formato>]`
 
 Genera reportes de trazas de auditoría con línea temporal, mapa de trazabilidad y resumen de cumplimiento.
 
@@ -790,9 +790,9 @@ Genera reportes de trazas de auditoría con línea temporal, mapa de trazabilida
 
 ---
 
-### `devtrail explore [path]`
+### `straymark explore [path]`
 
-Explora y lee la documentación de DevTrail interactivamente en una interfaz de terminal (TUI).
+Explora y lee la documentación de StrayMark interactivamente en una interfaz de terminal (TUI).
 
 **Argumentos:**
 
@@ -809,7 +809,7 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 **Orden de resolución del idioma** (desde cli-3.5.2):
 
 1. Flag `--lang <código>`, cuando se especifica
-2. Campo `language` en `.devtrail/config.yml`, cuando el archivo existe (un valor explícito — incluso `language: en` — se respeta como una decisión deliberada del usuario)
+2. Campo `language` en `.straymark/config.yml`, cuando el archivo existe (un valor explícito — incluso `language: en` — se respeta como una decisión deliberada del usuario)
 3. Variables de entorno `$LC_ALL` / `$LANG`, mapeadas a un idioma soportado (p.ej., `zh_CN.UTF-8` → `zh-CN`, `es_MX.UTF-8` → `es`). Chino tradicional (`zh_TW` / `zh_HK`) y otros locales no soportados pasan al siguiente fallback.
 4. `en`
 
@@ -821,7 +821,7 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 - Navegación entre documentos relacionados mediante hipervínculos
 - Búsqueda por nombre de archivo, título, tags o fecha
 - Modo pantalla completa, con `j` / `k` como teclas alternas para `↓` / `↑`
-- Consciente de localización: los docs del framework (`QUICK-REFERENCE`, `AGENT-RULES`, guías regulatorias de China, etc.) se sirven en el idioma definido por `language` en `.devtrail/config.yml` o por `--lang`
+- Consciente de localización: los docs del framework (`QUICK-REFERENCE`, `AGENT-RULES`, guías regulatorias de China, etc.) se sirven en el idioma definido por `language` en `.straymark/config.yml` o por `--lang`
 
 **Atajos de teclado:**
 
@@ -840,29 +840,29 @@ Explora y lee la documentación de DevTrail interactivamente en una interfaz de 
 **Ejemplos:**
 
 ```bash
-$ devtrail explore                       # usa config.language (default en)
-$ devtrail explore --lang zh-CN          # navegar docs del framework en chino simplificado
-$ devtrail explore --lang es             # override de sesión a español
+$ straymark explore                       # usa config.language (default en)
+$ straymark explore --lang zh-CN          # navegar docs del framework en chino simplificado
+$ straymark explore --lang es             # override de sesión a español
 ```
 
 > **Nota:** El comando `explore` requiere la feature `tui` (habilitada por defecto). Para compilar sin ella: `cargo build --no-default-features`.
 
 ---
 
-### `devtrail about`
+### `straymark about`
 
 Muestra información de versión, autoría y licencia.
 
 **Ejemplo:**
 
 ```bash
-$ devtrail about
-DevTrail CLI
+$ straymark about
+StrayMark CLI
   CLI version:       cli-3.5.2
   Framework version: fw-4.10.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
-  Repository:        https://github.com/StrangeDaysTech/devtrail
+  Repository:        https://github.com/StrangeDaysTech/straymark
   Website:           https://strangedays.tech
 ```
 
@@ -870,7 +870,7 @@ DevTrail CLI
 
 ## Skills
 
-DevTrail incluye un conjunto de skills (slash commands) para usar dentro de un asistente IA (Claude Code, Gemini Code, Cursor, runtimes de agente genérico). Cada skill se instala en 3 formas paralelas durante `devtrail init`:
+StrayMark incluye un conjunto de skills (slash commands) para usar dentro de un asistente IA (Claude Code, Gemini Code, Cursor, runtimes de agente genérico). Cada skill se instala en 3 formas paralelas durante `straymark init`:
 
 - `dist/.claude/skills/<skill>/SKILL.md` (Claude — frontmatter con `allowed-tools`)
 - `dist/.gemini/skills/<skill>/SKILL.md` (Gemini — frontmatter sin `allowed-tools`)
@@ -878,26 +878,26 @@ DevTrail incluye un conjunto de skills (slash commands) para usar dentro de un a
 
 | Skill | Propósito | Archivos producidos |
 |---|---|---|
-| `/devtrail-status` | Verificar cumplimiento de documentación para cambios recientes. | ninguno (read-only) |
-| `/devtrail-new` | Crear cualquier tipo de documento interactivamente. Sugiere el más adecuado al contexto. | `.devtrail/<dir-tipo>/<TIPO>-YYYY-MM-DD-NNN-*.md` |
-| `/devtrail-ailog` | Atajo de creación rápida de AILOG. | `.devtrail/07-ai-audit/agent-logs/AILOG-*.md` |
-| `/devtrail-aidec` | Atajo de creación rápida de AIDEC. | `.devtrail/07-ai-audit/decisions/AIDEC-*.md` |
-| `/devtrail-adr` | Atajo de creación rápida de ADR. | `.devtrail/04-architecture/decisions/ADR-*.md` |
-| `/devtrail-mcard` | Flujo interactivo de creación de Model Card. | `.devtrail/09-ai-models/MCARD-*.md` |
-| `/devtrail-sec` | Flujo interactivo SEC (security assessment). | `.devtrail/08-security/SEC-*.md` |
-| `/devtrail-audit-prompt CHARTER-ID` *(fw-4.9.0+, refactorizada en fw-4.9.0)* | Genera la plantilla unificada del audit prompt para un Charter en el path canónico. Envuelve `devtrail charter audit --prepare`. El operador entonces abre N CLIs auditoras en el mismo repo e invoca `/devtrail-audit-execute` en cada una — sin copy/paste. | `.devtrail/audits/<CHARTER-ID>/audit-prompt.md` |
-| `/devtrail-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **Corre dentro de una CLI auditora** (gemini-cli, claude-cli, copilot-cli, codex-cli, ...). Lee el prompt preparado del disco, audita con tool use citando `path:línea`, escribe un report con el id del modelo en el nombre. El argumento CHARTER-ID es opcional — auto-descubre prompts que aún no tienen report de este modelo. | `.devtrail/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
-| `/devtrail-audit-review CHARTER-ID` *(fw-4.9.0+, expandida en fw-4.9.0)* | Contraparte de `/devtrail-audit-prompt`. Lee N reports en `.devtrail/audits/<CHARTER-ID>/`, verifica cada finding contra el código real (Explore agents en paralelo), produce un `review.md` consolidado de seis secciones (Resumen ejecutivo, Alcance, Evaluación por auditor, Plan de remediación P0-P4, Hallazgos descartados, Calificación de auditores), y corre `devtrail charter audit --merge-reports --merge-into` para anexar `external_audit:` en la telemetría del Charter. Si la telemetría aún no existe (Charter no cerrado), escribe `external-audit-pending.yaml` para merge posterior al close. | `.devtrail/audits/<CHARTER-ID>/review.md`, array `external_audit:` mergeado en telemetría (o pending YAML) |
+| `/straymark-status` | Verificar cumplimiento de documentación para cambios recientes. | ninguno (read-only) |
+| `/straymark-new` | Crear cualquier tipo de documento interactivamente. Sugiere el más adecuado al contexto. | `.straymark/<dir-tipo>/<TIPO>-YYYY-MM-DD-NNN-*.md` |
+| `/straymark-ailog` | Atajo de creación rápida de AILOG. | `.straymark/07-ai-audit/agent-logs/AILOG-*.md` |
+| `/straymark-aidec` | Atajo de creación rápida de AIDEC. | `.straymark/07-ai-audit/decisions/AIDEC-*.md` |
+| `/straymark-adr` | Atajo de creación rápida de ADR. | `.straymark/04-architecture/decisions/ADR-*.md` |
+| `/straymark-mcard` | Flujo interactivo de creación de Model Card. | `.straymark/09-ai-models/MCARD-*.md` |
+| `/straymark-sec` | Flujo interactivo SEC (security assessment). | `.straymark/08-security/SEC-*.md` |
+| `/straymark-audit-prompt CHARTER-ID` *(fw-4.9.0+, refactorizada en fw-4.9.0)* | Genera la plantilla unificada del audit prompt para un Charter en el path canónico. Envuelve `straymark charter audit --prepare`. El operador entonces abre N CLIs auditoras en el mismo repo e invoca `/straymark-audit-execute` en cada una — sin copy/paste. | `.straymark/audits/<CHARTER-ID>/audit-prompt.md` |
+| `/straymark-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **Corre dentro de una CLI auditora** (gemini-cli, claude-cli, copilot-cli, codex-cli, ...). Lee el prompt preparado del disco, audita con tool use citando `path:línea`, escribe un report con el id del modelo en el nombre. El argumento CHARTER-ID es opcional — auto-descubre prompts que aún no tienen report de este modelo. | `.straymark/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
+| `/straymark-audit-review CHARTER-ID` *(fw-4.9.0+, expandida en fw-4.9.0)* | Contraparte de `/straymark-audit-prompt`. Lee N reports en `.straymark/audits/<CHARTER-ID>/`, verifica cada finding contra el código real (Explore agents en paralelo), produce un `review.md` consolidado de seis secciones (Resumen ejecutivo, Alcance, Evaluación por auditor, Plan de remediación P0-P4, Hallazgos descartados, Calificación de auditores), y corre `straymark charter audit --merge-reports --merge-into` para anexar `external_audit:` en la telemetría del Charter. Si la telemetría aún no existe (Charter no cerrado), escribe `external-audit-pending.yaml` para merge posterior al close. | `.straymark/audits/<CHARTER-ID>/review.md`, array `external_audit:` mergeado en telemetría (o pending YAML) |
 
 ### Skill vs CLI
 
-Las tres skills de auditoría son **wrappers** sobre los comandos del CLI y la disciplina del flujo. Los paths canónicos bajo `.devtrail/audits/`, la plantilla unificada del prompt, la validación de schema, y el shape de `external_audit` viven en el CLI + framework — las skills manejan la parte UX-inline: dispatchan al operador a través del audit cycle sin gestión manual de archivos. **El operador nunca copia/pega prompts ni reports** — las skills intercambian artefactos vía los paths canónicos del filesystem.
+Las tres skills de auditoría son **wrappers** sobre los comandos del CLI y la disciplina del flujo. Los paths canónicos bajo `.straymark/audits/`, la plantilla unificada del prompt, la validación de schema, y el shape de `external_audit` viven en el CLI + framework — las skills manejan la parte UX-inline: dispatchan al operador a través del audit cycle sin gestión manual de archivos. **El operador nunca copia/pega prompts ni reports** — las skills intercambian artefactos vía los paths canónicos del filesystem.
 
-Adoptantes que usen DevTrail sin asistente IA en el loop pueden manejar el mismo workflow directamente vía `devtrail charter audit` (`--prepare` / `--merge-reports [--merge-into <path>]`). El audit prompt en `.devtrail/audits/<id>/audit-prompt.md` funciona igualmente bien pegado en un LLM de chat si no hay CLI auditora disponible — la skill solo automatiza el intercambio de archivos.
+Adoptantes que usen StrayMark sin asistente IA en el loop pueden manejar el mismo workflow directamente vía `straymark charter audit` (`--prepare` / `--merge-reports [--merge-into <path>]`). El audit prompt en `.straymark/audits/<id>/audit-prompt.md` funciona igualmente bien pegado en un LLM de chat si no hay CLI auditora disponible — la skill solo automatiza el intercambio de archivos.
 
 ### Audit checkpoint *(fw-4.9.0+)*
 
-`.devtrail/00-governance/AGENT-RULES.md` §12 codifica un checkpoint del workflow donde el agente proactivamente ofrece la auditoría en un momento específico — cuando la implementación del Charter está lista, drift está limpio, y `charter close` no se ha invocado aún. La recomendación es SÍ/NO basada en heurísticas (superficie de seguridad, componentes nuevos, riesgos AILOG, complejidad). La auditoría externa es **completamente opcional**; el checkpoint es **soft** — nunca bloquea `charter close`, nunca enforced (decisión de diseño v0+v1 permanente).
+`.straymark/00-governance/AGENT-RULES.md` §12 codifica un checkpoint del workflow donde el agente proactivamente ofrece la auditoría en un momento específico — cuando la implementación del Charter está lista, drift está limpio, y `charter close` no se ha invocado aún. La recomendación es SÍ/NO basada en heurísticas (superficie de seguridad, componentes nuevos, riesgos AILOG, complejidad). La auditoría externa es **completamente opcional**; el checkpoint es **soft** — nunca bloquea `charter close`, nunca enforced (decisión de diseño v0+v1 permanente).
 
 ---
 
@@ -920,7 +920,7 @@ Adoptantes que usen DevTrail sin asistente IA en el loop pueden manejar el mismo
 
 <div align="center">
 
-**DevTrail** — Porque cada cambio cuenta una historia.
+**StrayMark** — Porque cada cambio cuenta una historia.
 
 [Volver a docs](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/i18n/es/adopters/WORKFLOWS.md
+++ b/docs/i18n/es/adopters/WORKFLOWS.md
@@ -1,6 +1,6 @@
-# DevTrail - Flujos de Trabajo Recomendados
+# StrayMark - Flujos de Trabajo Recomendados
 
-**Patrones y cadencias para usar DevTrail en el día a día.**
+**Patrones y cadencias para usar StrayMark en el día a día.**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -12,7 +12,7 @@
 
 1. [Después de la Configuración Inicial](#después-de-la-configuración-inicial)
 2. [Desarrollo Diario](#desarrollo-diario)
-3. [Mantener DevTrail Actualizado](#mantener-devtrail-actualizado)
+3. [Mantener StrayMark Actualizado](#mantener-straymark-actualizado)
 4. [Verificar el Estado del Proyecto](#verificar-el-estado-del-proyecto)
 5. [Usar Skills (Documentación Activa)](#usar-skills-documentación-activa)
 6. [Patrones de Equipo](#patrones-de-equipo)
@@ -22,12 +22,12 @@
 
 ## Después de la Configuración Inicial
 
-Ejecutaste `devtrail init .` e hiciste commit del resultado. ¿Ahora qué?
+Ejecutaste `straymark init .` e hiciste commit del resultado. ¿Ahora qué?
 
 1. **Abre tu proyecto** con tu asistente de codificación IA (Claude Code, Cursor, Gemini CLI, etc.)
-2. El asistente **leerá automáticamente** las directivas de DevTrail (`CLAUDE.md`, `GEMINI.md`, etc.)
-3. A partir de este punto, el asistente **crea documentación** en `.devtrail/` como parte de su flujo de trabajo normal
-4. **No se necesita configuración adicional** — DevTrail funciona de forma pasiva a través de los archivos de directivas
+2. El asistente **leerá automáticamente** las directivas de StrayMark (`CLAUDE.md`, `GEMINI.md`, etc.)
+3. A partir de este punto, el asistente **crea documentación** en `.straymark/` como parte de su flujo de trabajo normal
+4. **No se necesita configuración adicional** — StrayMark funciona de forma pasiva a través de los archivos de directivas
 
 ---
 
@@ -36,7 +36,7 @@ Ejecutaste `devtrail init .` e hiciste commit del resultado. ¿Ahora qué?
 ### El Ciclo Pasivo
 
 1. Trabaja normalmente con tu asistente IA — escribe features, corrige bugs, refactoriza
-2. La IA crea documentos en `.devtrail/` según las reglas de gobernanza:
+2. La IA crea documentos en `.straymark/` según las reglas de gobernanza:
    - **AILOG** para implementaciones significativas (>10 líneas cambiadas)
    - **AIDEC** al elegir entre alternativas
    - **ADR** para decisiones arquitectónicas
@@ -55,27 +55,27 @@ Usa el sistema activo (skills) cuando:
 
 ---
 
-## Mantener DevTrail Actualizado
+## Mantener StrayMark Actualizado
 
 ### Cadencia Recomendada
 
 - **Mensualmente** o cuando veas un nuevo release en GitHub
-- Consulta la [página de releases](https://github.com/StrangeDaysTech/devtrail/releases) para changelogs
+- Consulta la [página de releases](https://github.com/StrangeDaysTech/straymark/releases) para changelogs
 
 ### Comandos de Actualización
 
 | Objetivo | Comando |
 |----------|---------|
-| Actualizar framework y CLI | `devtrail update` |
-| Actualizar solo plantillas y docs de gobernanza | `devtrail update-framework` |
-| Actualizar solo el binario CLI | `devtrail update-cli` |
+| Actualizar framework y CLI | `straymark update` |
+| Actualizar solo plantillas y docs de gobernanza | `straymark update-framework` |
+| Actualizar solo el binario CLI | `straymark update-cli` |
 
 Framework y CLI tienen **versiones independientes** — puedes actualizar uno sin el otro. Ver [Entender las Versiones](#entender-las-versiones).
 
 ### Después de Actualizar
 
 1. Revisa los cambios en archivos de directivas y docs de gobernanza
-2. Haz commit de los archivos actualizados: `git add .devtrail/ && git commit -m "chore: update DevTrail framework"`
+2. Haz commit de los archivos actualizados: `git add .straymark/ && git commit -m "chore: update StrayMark framework"`
 3. Si personalizaste archivos del framework, verifica si hay conflictos
 
 ---
@@ -85,7 +85,7 @@ Framework y CLI tienen **versiones independientes** — puedes actualizar uno si
 ### Estado via CLI
 
 ```bash
-devtrail status
+straymark status
 ```
 
 Muestra: versión del framework, versión del CLI, integridad de la estructura de directorios y estadísticas de documentos por tipo. Úsalo para verificar que la instalación está saludable.
@@ -93,10 +93,10 @@ Muestra: versión del framework, versión del CLI, integridad de la estructura d
 ### Cumplimiento de Documentación (Skill)
 
 ```bash
-/devtrail-status
+/straymark-status
 ```
 
-El skill `/devtrail-status` (disponible en Claude Code y Gemini CLI) analiza:
+El skill `/straymark-status` (disponible en Claude Code y Gemini CLI) analiza:
 
 - Qué cambios de código recientes carecen de documentación correspondiente
 - Cumplimiento de documentos contra las reglas de gobernanza
@@ -106,7 +106,7 @@ El skill `/devtrail-status` (disponible en Claude Code y Gemini CLI) analiza:
 
 ## Usar Skills (Documentación Activa)
 
-DevTrail tiene dos sistemas de documentación:
+StrayMark tiene dos sistemas de documentación:
 
 | Sistema | Cómo funciona | Cuándo usar |
 |---------|---------------|-------------|
@@ -117,20 +117,20 @@ DevTrail tiene dos sistemas de documentación:
 
 | Skill | Propósito |
 |-------|-----------|
-| `/devtrail-status` | Verificar cumplimiento de documentación |
-| `/devtrail-new` | Crear cualquier tipo de documento (sugiere el más adecuado) |
-| `/devtrail-ailog` | Creación rápida de AILOG |
-| `/devtrail-aidec` | Creación rápida de AIDEC |
-| `/devtrail-adr` | Creación rápida de ADR |
-| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+, refactorizada en fw-4.9.0)* | Genera el audit prompt unificado en el path canónico `.devtrail/audits/<id>/audit-prompt.md`. Envuelve `devtrail charter audit --prepare`. El operador entonces abre N CLIs auditoras y corre `/devtrail-audit-execute` en cada una — sin copy/paste. |
-| `/devtrail-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **Corre dentro de una CLI auditora** (gemini-cli, claude-cli, copilot-cli, codex-cli). Lee el prompt del disco, audita con tool use citando `path:línea`, escribe un report con el id del modelo. Argumento opcional — auto-descubre prompts pendientes de este modelo. |
-| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+, expandida en fw-4.9.0)* | Contraparte de `audit-prompt`. Lee N reports, verifica findings contra el código real, produce `review.md` consolidado de 6 secciones (Resumen ejecutivo / Alcance / Evaluación por auditor / Plan de remediación P0-P4 / Descartados / Calificación de auditores), y mergea YAML `external_audit:` en la telemetría. |
+| `/straymark-status` | Verificar cumplimiento de documentación |
+| `/straymark-new` | Crear cualquier tipo de documento (sugiere el más adecuado) |
+| `/straymark-ailog` | Creación rápida de AILOG |
+| `/straymark-aidec` | Creación rápida de AIDEC |
+| `/straymark-adr` | Creación rápida de ADR |
+| `/straymark-audit-prompt CHARTER-XX` *(fw-4.8.0+, refactorizada en fw-4.9.0)* | Genera el audit prompt unificado en el path canónico `.straymark/audits/<id>/audit-prompt.md`. Envuelve `straymark charter audit --prepare`. El operador entonces abre N CLIs auditoras y corre `/straymark-audit-execute` en cada una — sin copy/paste. |
+| `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **Corre dentro de una CLI auditora** (gemini-cli, claude-cli, copilot-cli, codex-cli). Lee el prompt del disco, audita con tool use citando `path:línea`, escribe un report con el id del modelo. Argumento opcional — auto-descubre prompts pendientes de este modelo. |
+| `/straymark-audit-review CHARTER-XX` *(fw-4.8.0+, expandida en fw-4.9.0)* | Contraparte de `audit-prompt`. Lee N reports, verifica findings contra el código real, produce `review.md` consolidado de 6 secciones (Resumen ejecutivo / Alcance / Evaluación por auditor / Plan de remediación P0-P4 / Descartados / Calificación de auditores), y mergea YAML `external_audit:` en la telemetría. |
 
 Para detalles completos de skills, consulta el [README](../README.md#skills).
 
 ### Charter audit checkpoint *(fw-4.8.0+)*
 
-Cuando estés co-implementando un Charter, el agente proactivamente ofrecerá una auditoría externa en un momento específico: cuando la implementación esté lista, el drift esté limpio, y `charter close` aún no se haya invocado. La recomendación es SÍ/NO basada en la superficie de riesgo y complejidad del Charter (heurísticas completas en `.devtrail/00-governance/AGENT-RULES.md` §12).
+Cuando estés co-implementando un Charter, el agente proactivamente ofrecerá una auditoría externa en un momento específico: cuando la implementación esté lista, el drift esté limpio, y `charter close` aún no se haya invocado. La recomendación es SÍ/NO basada en la superficie de riesgo y complejidad del Charter (heurísticas completas en `.straymark/00-governance/AGENT-RULES.md` §12).
 
 La auditoría externa es **completamente opcional** y **nunca enforced**. El scope declarativo del Charter + drift check + disciplina AILOG ya proporcionan cierre riguroso sin ella. La auditoría agrega señal cross-modelo cuando el Charter tocó superficie de seguridad, introdujo componentes nuevos, o tiene funciones de alta complejidad en el diff. Declina libremente si el costo (2-3 auditores LLM) no se ajusta al valor de tu caso.
 
@@ -140,13 +140,13 @@ La auditoría externa es **completamente opcional** y **nunca enforced**. El sco
 
 ### Revisión de PRs
 
-- Verifica que los cambios de código significativos incluyan documentos correspondientes en `.devtrail/`
+- Verifica que los cambios de código significativos incluyan documentos correspondientes en `.straymark/`
 - Revisa cualquier documento con `review_required: true`
 - Verifica que los AILOGs describan con precisión lo que hizo la IA
 
 ### Onboarding de Nuevos Miembros
 
-1. Apúntalos a `.devtrail/QUICK-REFERENCE.md` para una vista rápida
+1. Apúntalos a `.straymark/QUICK-REFERENCE.md` para una vista rápida
 2. Pídeles que lean los ADRs recientes para entender el contexto arquitectónico
 3. Muéstrales AILOGs de features recientes para ver cómo funciona la documentación en la práctica
 
@@ -172,15 +172,15 @@ Si tu proyecto opera en China continental o procesa información personal de usu
 
 ### Configuración Inicial
 
-1. Edita `.devtrail/config.yml` y añade `china` a `regional_scope`:
+1. Edita `.straymark/config.yml` y añade `china` a `regional_scope`:
    ```yaml
    regional_scope:
      - global
      - eu      # si también está sujeto a EU
      - china
    ```
-2. Ejecuta `devtrail compliance --region china` para ver el baseline (todos los checks fallarán hasta crear los documentos correspondientes).
-3. Lee las guías instaladas en `.devtrail/00-governance/`:
+2. Ejecuta `straymark compliance --region china` para ver el baseline (todos los checks fallarán hasta crear los documentos correspondientes).
+3. Lee las guías instaladas en `.straymark/00-governance/`:
    - `CHINA-REGULATORY-FRAMEWORK.md` — visión general y matriz de cobertura
    - `TC260-IMPLEMENTATION-GUIDE.md` — clasificación de riesgo en 5 niveles
    - `PIPL-PIPIA-GUIDE.md` — cuándo se requiere PIPIA y qué debe contener
@@ -200,7 +200,7 @@ Conjunto de documentos a crear juntos (cross-linked vía `related:`):
 | `PIPIA` | Evaluación de impacto de info personal (Art. 55-56) | Cuando se procesa info personal |
 | `SBOM` | Inventario de datos de entrenamiento + cumplimiento GB/T 45652 | Siempre |
 
-`devtrail compliance --region china` confirma que el conjunto está completo.
+`straymark compliance --region china` confirma que el conjunto está completo.
 
 ### Cuando Ocurre un Incidente
 
@@ -211,7 +211,7 @@ csl_severity_level: relatively_major   # o particularly_serious | major | genera
 csl_report_deadline_hours: 4           # 1 para particularly_serious, 4 para relatively_major
 ```
 
-`devtrail validate` aplica la coherencia severidad-deadline (`CROSS-008`, `CROSS-009`). Los incidentes major+ deben cerrarse (status `accepted`) en 30 días para que el check `CSL-003` apruebe.
+`straymark validate` aplica la coherencia severidad-deadline (`CROSS-008`, `CROSS-009`). Los incidentes major+ deben cerrarse (status `accepted`) en 30 días para que el check `CSL-003` apruebe.
 
 ### Transferencia Transfronteriza de Datos
 
@@ -221,20 +221,20 @@ Cuando un proceso involucra transferencia de información personal fuera de Chin
 
 ```bash
 # Antes de mergear una rama de feature que toca servicios IA
-devtrail validate                    # cross-rules incluyendo CROSS-004..011
-devtrail compliance --region china   # score por framework
+straymark validate                    # cross-rules incluyendo CROSS-004..011
+straymark compliance --region china   # score por framework
 ```
 
 ---
 
 ## Entender las Versiones
 
-DevTrail usa **versionado independiente** para sus dos componentes:
+StrayMark usa **versionado independiente** para sus dos componentes:
 
 | Componente | Prefijo de tag | Contiene | Se actualiza con |
 |------------|---------------|----------|-----------------|
-| **Framework** | `fw-` | Plantillas, docs de gobernanza, directivas, scripts | `devtrail update-framework` |
-| **CLI** | `cli-` | El binario `devtrail` | `devtrail update-cli` |
+| **Framework** | `fw-` | Plantillas, docs de gobernanza, directivas, scripts | `straymark update-framework` |
+| **CLI** | `cli-` | El binario `straymark` | `straymark update-cli` |
 
 ### ¿Por Qué Versiones Independientes?
 
@@ -245,8 +245,8 @@ DevTrail usa **versionado independiente** para sus dos componentes:
 ### Verificar Tus Versiones
 
 ```bash
-devtrail about     # Verificación rápida de versiones
-devtrail status    # Reporte completo de salud incluyendo versiones
+straymark about     # Verificación rápida de versiones
+straymark status    # Reporte completo de salud incluyendo versiones
 ```
 
 Para información detallada del CLI, consulta la [Referencia CLI](CLI-REFERENCE.md#versionado).
@@ -255,7 +255,7 @@ Para información detallada del CLI, consulta la [Referencia CLI](CLI-REFERENCE.
 
 <div align="center">
 
-**DevTrail** — Porque cada cambio cuenta una historia.
+**StrayMark** — Porque cada cambio cuenta una historia.
 
 [Volver a docs](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/i18n/zh-CN/CODE_OF_CONDUCT.md
+++ b/docs/i18n/zh-CN/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 ## 我们的承诺
 
-作为成员、贡献者和领导者，我们承诺让参与 DevTrail 社区成为一种无骚扰的体验，无论年龄、体型、可见或不可见的残疾、种族、性别特征、性别认同和表达、经验水平、教育程度、社会经济地位、国籍、个人外貌、种姓、肤色、宗教或性认同和性取向。
+作为成员、贡献者和领导者，我们承诺让参与 StrayMark 社区成为一种无骚扰的体验，无论年龄、体型、可见或不可见的残疾、种族、性别特征、性别认同和表达、经验水平、教育程度、社会经济地位、国籍、个人外貌、种姓、肤色、宗教或性认同和性取向。
 
 我们承诺以有助于建设开放、包容、多元、友好和健康社区的方式行事和互动。
 
@@ -53,7 +53,7 @@
 
 如果你经历或目睹了不可接受的行为，或有任何其他顾虑，请通过以下方式联系项目团队进行举报：
 
-**GitHub Issues**: [在此举报](https://github.com/StrangeDaysTech/devtrail/issues)
+**GitHub Issues**: [在此举报](https://github.com/StrangeDaysTech/straymark/issues)
 
 所有举报将被及时、公正地审查和调查。
 
@@ -101,7 +101,7 @@
 
 ## 申诉
 
-如果你认为被不实或不公正地指控违反本行为准则，可以在 [GitHub Issues](https://github.com/StrangeDaysTech/devtrail/issues) 上开启详细的 Issue 进行申诉。申诉将由与做出原始决定不同的社区领导者审查。
+如果你认为被不实或不公正地指控违反本行为准则，可以在 [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues) 上开启详细的 Issue 进行申诉。申诉将由与做出原始决定不同的社区领导者审查。
 
 ## 归属
 
@@ -127,7 +127,7 @@
 ---
 
 <p align="center">
-  <strong>DevTrail</strong><br>
+  <strong>StrayMark</strong><br>
   共同构建包容的社区<br>
   <a href="https://strangedays.tech">Strange Days Tech, S.A.S.</a>
 </p>

--- a/docs/i18n/zh-CN/CONTRIBUTING.md
+++ b/docs/i18n/zh-CN/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# 为 DevTrail 做贡献
+# 为 StrayMark 做贡献
 
-感谢你有兴趣为 DevTrail 做贡献！本文档提供贡献者的指南和相关信息。
+感谢你有兴趣为 StrayMark 做贡献！本文档提供贡献者的指南和相关信息。
 
 **语言**: [English](../../../CONTRIBUTING.md) | [Español](../es/CONTRIBUTING.md) | 简体中文
 
@@ -35,7 +35,7 @@
 3. CLA 只需签署一次——涵盖你对本项目的所有未来贡献。
 4. 签署后，CLA Assistant 将更新 PR 检查状态，你的贡献即可进入审查流程。
 
-如果你对 CLA 有疑问，请开启一个[讨论](https://github.com/StrangeDaysTech/devtrail/discussions)。
+如果你对 CLA 有疑问，请开启一个[讨论](https://github.com/StrangeDaysTech/straymark/discussions)。
 
 ---
 
@@ -96,17 +96,17 @@
 
 1. **Fork 仓库**
 
-   在 [GitHub 仓库页面](https://github.com/StrangeDaysTech/devtrail) 点击 "Fork"。
+   在 [GitHub 仓库页面](https://github.com/StrangeDaysTech/straymark) 点击 "Fork"。
 
 2. **克隆你的 Fork**
    ```bash
-   git clone https://github.com/your-username/devtrail.git
-   cd devtrail
+   git clone https://github.com/your-username/straymark.git
+   cd straymark
    ```
 
 3. **安装 pre-commit 钩子**
    ```bash
-   echo 'devtrail validate --staged' > .git/hooks/pre-commit
+   echo 'straymark validate --staged' > .git/hooks/pre-commit
    chmod +x .git/hooks/pre-commit
    ```
 
@@ -125,7 +125,7 @@
 
 6. **进行修改并验证**
    ```bash
-   devtrail validate
+   straymark validate
    ```
 
 ---
@@ -134,7 +134,7 @@
 
 ### 提交前
 
-- [ ] 成功运行 `devtrail validate`
+- [ ] 成功运行 `straymark validate`
 - [ ] 根据需要更新文档
 - [ ] 将自己添加到 CONTRIBUTORS.md（如适用）
 - [ ] 编写清晰的 PR 描述
@@ -178,7 +178,7 @@ chore(ci): update GitHub Actions workflow
 这些变更是如何测试的？
 
 ## 检查清单
-- [ ] `devtrail validate` 通过
+- [ ] `straymark validate` 通过
 - [ ] 文档已更新
 - [ ] 未包含敏感信息
 ```
@@ -215,7 +215,7 @@ created: YYYY-MM-DD
 
 ### 文件命名
 
-DevTrail 文档：
+StrayMark 文档：
 ```
 [TYPE]-[YYYY-MM-DD]-[NNN]-[description].md
 ```
@@ -239,13 +239,13 @@ DevTrail 文档：
 如果你要提议新的文档类型：
 
 1. **创建模板**
-   - 将 `TEMPLATE-NEWTYPE.md` 添加到 `dist/.devtrail/templates/`
+   - 将 `TEMPLATE-NEWTYPE.md` 添加到 `dist/.straymark/templates/`
    - 遵循现有模板模式
 
 2. **更新治理文档**
-   - `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md`
-   - `dist/.devtrail/00-governance/AGENT-RULES.md`
-   - `dist/.devtrail/QUICK-REFERENCE.md`
+   - `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md`
+   - `dist/.straymark/00-governance/AGENT-RULES.md`
+   - `dist/.straymark/QUICK-REFERENCE.md`
 
 3. **更新 Agent 配置**
    - `dist/dist-templates/directives/`（分发模板）
@@ -278,7 +278,7 @@ DevTrail 文档：
 
 ## CLI 开发
 
-DevTrail CLI 使用 Rust 编写，位于 `cli/` 目录。
+StrayMark CLI 使用 Rust 编写，位于 `cli/` 目录。
 
 ### 编译
 
@@ -310,13 +310,13 @@ cli/src/
 ├── main.rs              # 入口点 + clap CLI 定义
 ├── commands/
 │   ├── mod.rs           # 子命令路由
-│   ├── init.rs          # devtrail init [path]
-│   ├── update.rs        # devtrail update (组合)
-│   ├── update_framework.rs # devtrail update-framework
-│   ├── update_cli.rs    # devtrail update-cli
-│   ├── remove.rs        # devtrail remove [--full]
-│   ├── status.rs        # devtrail status [path]
-│   └── about.rs         # devtrail about
+│   ├── init.rs          # straymark init [path]
+│   ├── update.rs        # straymark update (组合)
+│   ├── update_framework.rs # straymark update-framework
+│   ├── update_cli.rs    # straymark update-cli
+│   ├── remove.rs        # straymark remove [--full]
+│   ├── status.rs        # straymark status [path]
+│   └── about.rs         # straymark about
 ├── config.rs            # 配置和校验和管理
 ├── download.rs          # GitHub Releases API（前缀过滤）
 ├── inject.rs            # 指令文件注入（标记）
@@ -334,8 +334,8 @@ cli/src/
 
 如果你对贡献有疑问：
 
-1. 查看现有 [Issues](https://github.com/StrangeDaysTech/devtrail/issues)
-2. 查看 [Discussions](https://github.com/StrangeDaysTech/devtrail/discussions)
+1. 查看现有 [Issues](https://github.com/StrangeDaysTech/straymark/issues)
+2. 查看 [Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 3. 开启新的 Discussion 提问
 4. 为特定 Bug 或功能开启 Issue
 
@@ -349,10 +349,10 @@ cli/src/
 - 重要贡献的发布说明
 - CONTRIBUTORS.md（针对持续贡献者）
 
-感谢你帮助改进 DevTrail！
+感谢你帮助改进 StrayMark！
 
 ---
 
-*DevTrail — 因为每一次变更都值得被记录。*
+*StrayMark — 因为每一次变更都值得被记录。*
 
 [Strange Days Tech](https://strangedays.tech)

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -1,17 +1,17 @@
 <div align="center">
 
-# DevTrail
+# StrayMark
 
 **你的 AI 辅助项目所需的认知纪律**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../../LICENSE)
-[![Crates.io](https://img.shields.io/crates/v/devtrail-cli.svg)](https://crates.io/crates/devtrail-cli)
+[![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](../../../dist/.devtrail/QUICK-REFERENCE.md)
+[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](../../../dist/.straymark/QUICK-REFERENCE.md)
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
 [快速开始](#快速开始) •
-[适用人群](#devtrail-的适用人群) •
+[适用人群](#straymark-的适用人群) •
 [设计原则](#设计原则) •
 [功能特性](#功能特性) •
 [合规性](#合规性) •
@@ -31,7 +31,7 @@ AI Agent 写代码很快。但写出的代码并不连贯。经过足够多的�
 
 ## 解决方案
 
-DevTrail 是一个**框架 + CLI**，将资深软件工程工作的认知纪律——明确的范围、声明的决策、命名的风险、记录的备选方案、可审计的轨迹——外化为与代码并存的版本化文件。
+StrayMark 是一个**框架 + CLI**，将资深软件工程工作的认知纪律——明确的范围、声明的决策、命名的风险、记录的备选方案、可审计的轨迹——外化为与代码并存的版本化文件。
 
 > **"没有记录痕迹的重大变更不应发生——并且 Agent 的决策空间应受约束。"**
 
@@ -39,32 +39,32 @@ DevTrail 是一个**框架 + CLI**，将资深软件工程工作的认知纪律�
 
 ---
 
-## DevTrail 的适用人群
+## StrayMark 的适用人群
 
-DevTrail 的主要用户是**在非平凡系统上编排 AI Agent 的资深工程师**——具备扎实技术判断力、借助 Agent 完成自己单独无法实际完成的工作、并需要外化的认知纪律以防止 Agent 引入系统性混乱的人。
+StrayMark 的主要用户是**在非平凡系统上编排 AI Agent 的资深工程师**——具备扎实技术判断力、借助 Agent 完成自己单独无法实际完成的工作、并需要外化的认知纪律以防止 Agent 引入系统性混乱的人。
 
-如果你符合这个画像，DevTrail 的流程、默认值和语言都是为你量身打造的。
+如果你符合这个画像，StrayMark 的流程、默认值和语言都是为你量身打造的。
 
-DevTrail 还服务于三类次要受众，建立在主用户基础之上——绝不以牺牲主用户为代价：
+StrayMark 还服务于三类次要受众，建立在主用户基础之上——绝不以牺牲主用户为代价：
 
 - **技术负责人和架构师**：标准化团队与 AI 助手的协作方式。
 - **合规官和审计师**：需要受治理 AI 开发的证据（ISO 42001、EU AI Act、NIST AI RMF、PIPL、TC260……）。
 - **受监管环境的采用者**（金融、医疗、公共部门、中国）：将可追溯性内建到工作流，而非事后补建。
 
-DevTrail **并不**试图成为：LLM 网关、模型评估器、"代码 10 倍快"的生产力外壳，或工程判断的替代品。详见下文 [诚实的边界](#诚实的边界)。
+StrayMark **并不**试图成为：LLM 网关、模型评估器、"代码 10 倍快"的生产力外壳，或工程判断的替代品。详见下文 [诚实的边界](#诚实的边界)。
 
 ---
 
 ## 设计原则
 
-DevTrail 的产品决策基于十二条明确的原则。它们按层级排序：当两条原则发生冲突时，靠前的胜出。
+StrayMark 的产品决策基于十二条明确的原则。它们按层级排序：当两条原则发生冲突时，靠前的胜出。
 
 1. **工具服务于手艺，而非产品自身。** 衡量标准是工程师是否能产出令自己自豪的工作——而不是采用率、留存或营收。
 2. **主要用户是编排 Agent 的资深工程师。** 不是 VP，不是 CISO，也不是合规官。
 3. **核心严格开源，毫无附加条件。** Framework、CLI 和 TUI 均为 MIT 许可，没有为推动付费而被阉割的功能。
 4. **法规合规是副作用，而非产品目标。** ISO 42001、EU AI Act、NIST AI RMF 是有用的框架；它们不是目标。
 5. **Schema 驱动优先于功能驱动。** 核心实体（Stage Closure Bundle、Charter、Document）首先以版本化 schema 定义，然后再构建功能。
-6. **认知纪律优先于原始生产力。** DevTrail 对抗的是 AI 快速产出代码在严肃项目中带来的混乱——而不是速度本身。
+6. **认知纪律优先于原始生产力。** StrayMark 对抗的是 AI 快速产出代码在严肃项目中带来的混乱——而不是速度本身。
 7. **Local-first，Cloud 作为放大器。** CLI 完全离线可用。Cloud 可以增加价值（跨仓聚合、签名证据），但绝不会成为核心的门槛。
 8. **项目记忆存活于仓库中，而非外部数据库。** AILOG、ADR、AIDEC、Charter 和 Bundle 是与代码并存的版本化文件，使用 markdown + JSON Schema。
 9. **简洁优先于能力。** 当两种设计满足同一目标时，更简单的胜出。模式在真实项目中得到验证后才结晶化，不在之前。
@@ -72,7 +72,7 @@ DevTrail 的产品决策基于十二条明确的原则。它们按层级排序�
 11. **社区维护工具，而非反过来。** 贡献和反馈被认真对待，但不会变成民主决策。
 12. **产品的速度等于学习的速度。** 不过早结晶化；schema 标记为 `v0`，直到在第二个领域得到验证。
 
-完整文档（包含来自验证周期的实证注解）见 [`Propuesta/devtrail-design-principles.md`](https://github.com/StrangeDaysTech/devtrail/blob/main/Propuesta/devtrail-design-principles.md)。
+完整文档（包含来自验证周期的实证注解）见 [`Propuesta/straymark-design-principles.md`](https://github.com/StrangeDaysTech/straymark/blob/main/Propuesta/straymark-design-principles.md)。
 
 ---
 
@@ -125,21 +125,21 @@ DevTrail 的产品决策基于十二条明确的原则。它们按层级排序�
 
 将纪律转化为可执行反馈的内置命令：
 
-- **`devtrail charter <new|list|status|close|drift|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/devtrail-audit-prompt` 和 `/devtrail-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
-- **`devtrail approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
-- **`devtrail validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `docs/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
-- **`devtrail metrics`** — 治理 KPI、审查率、风险分布、趋势
-- **`devtrail analyze`** — 代码复杂度分析（认知复杂度 + 圈复杂度），由 [arborist-metrics](https://github.com/StrangeDaysTech/arborist) 驱动——我们的开源 Rust 多语言代码度量库
-- **`devtrail audit`** — 审计跟踪报告，含时间线、可追溯性映射和 HTML 导出
-- **`devtrail compliance`** — 作为已记录工作的副作用产出法规合规评分（EU AI Act、ISO 42001、NIST AI RMF；六项中国框架通过 `--region china` 按选项启用）
-- **`devtrail explore`** — 用于浏览项目文档图谱的交互式 TUI，包含章程视图（生命周期状态、来源 AILOG/spec、文件位置）
+- **`straymark charter <new|list|status|close|drift|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
+- **`straymark approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
+- **`straymark validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `docs/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
+- **`straymark metrics`** — 治理 KPI、审查率、风险分布、趋势
+- **`straymark analyze`** — 代码复杂度分析（认知复杂度 + 圈复杂度），由 [arborist-metrics](https://github.com/StrangeDaysTech/arborist) 驱动——我们的开源 Rust 多语言代码度量库
+- **`straymark audit`** — 审计跟踪报告，含时间线、可追溯性映射和 HTML 导出
+- **`straymark compliance`** — 作为已记录工作的副作用产出法规合规评分（EU AI Act、ISO 42001、NIST AI RMF；六项中国框架通过 `--region china` 按选项启用）
+- **`straymark explore`** — 用于浏览项目文档图谱的交互式 TUI，包含章程视图（生命周期状态、来源 AILOG/spec、文件位置）
 - **Pre-commit 钩子** + **GitHub Actions** 用于 CI/CD 验证
 
 ---
 
 ## 诚实的边界
 
-DevTrail **不会**：
+StrayMark **不会**：
 
 - 评估、对比或排名 LLM；
 - 充当 LLM 网关或路由层；
@@ -147,17 +147,17 @@ DevTrail **不会**：
 - 自动颁发法规合规认证——它产出证据，而不是认证；
 - 替代资深工程师的判断。
 
-如果你的问题属于以上任一类，DevTrail 不是合适的工具。
+如果你的问题属于以上任一类，StrayMark 不是合适的工具。
 
 ---
 
 ## 合规性
 
-DevTrail 外化的纪律——明确的范围、声明的决策、命名的风险、记录的备选方案——作为副作用，会产出与主流 AI 治理框架清晰映射的证据。因此，合规性被定位为*认真做工程工作的结果*，而非产品本身（原则 #4）。
+StrayMark 外化的纪律——明确的范围、声明的决策、命名的风险、记录的备选方案——作为副作用，会产出与主流 AI 治理框架清晰映射的证据。因此，合规性被定位为*认真做工程工作的结果*，而非产品本身（原则 #4）。
 
 ### 标准对齐
 
-| 标准 | DevTrail 集成 |
+| 标准 | StrayMark 集成 |
 |------|---------------|
 | **ISO/IEC 42001:2023** | 核心标准——AI 管理系统治理 |
 | **EU AI Act** | 风险分类、事件报告、透明度 |
@@ -170,11 +170,11 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 
 ### 中国法规支持
 
-DevTrail 现在以 **opt-in**（自愿启用）的方式覆盖六项中国 AI / 数据法规：**TC260《人工智能安全治理框架 v2.0》**（五级风险分级）、**《个人信息保护法》(PIPL)** 及其配套的 **PIPIA**（个人信息保护影响评估，留存 ≥ 3 年）、**强制性国家标准 GB 45438-2025**《网络安全技术 人工智能生成合成内容标识方法》（显式 + 隐式标识）、**CAC 算法备案**（包括省级 + 国家级双重备案）、**GB/T 45652-2025** 预训练与微调数据安全，以及自 2026-01-01 生效的 **《网络安全法》修订** 与《国家网络安全事件报告管理办法》（1 小时 / 4 小时 + 72 小时评估 + 30 天事后审查的报告窗口）。
+StrayMark 现在以 **opt-in**（自愿启用）的方式覆盖六项中国 AI / 数据法规：**TC260《人工智能安全治理框架 v2.0》**（五级风险分级）、**《个人信息保护法》(PIPL)** 及其配套的 **PIPIA**（个人信息保护影响评估，留存 ≥ 3 年）、**强制性国家标准 GB 45438-2025**《网络安全技术 人工智能生成合成内容标识方法》（显式 + 隐式标识）、**CAC 算法备案**（包括省级 + 国家级双重备案）、**GB/T 45652-2025** 预训练与微调数据安全，以及自 2026-01-01 生效的 **《网络安全法》修订** 与《国家网络安全事件报告管理办法》（1 小时 / 4 小时 + 72 小时评估 + 30 天事后审查的报告窗口）。
 
 #### 启用方式
 
-在 `.devtrail/config.yml` 中添加：
+在 `.straymark/config.yml` 中添加：
 
 ```yaml
 regional_scope:
@@ -185,10 +185,10 @@ regional_scope:
 
 #### 启用后获得
 
-- **4 个中国专属文档类型**：`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`（均经 `devtrail new` 生成，模板已翻译为中文，位于 `.devtrail/templates/i18n/zh-CN/`）。
-- **6 个合规检查器**：通过 `devtrail compliance --region china` 一次性运行，或单独运行 `--standard china-tc260 | china-pipl | china-gb45438 | china-cac | china-gb45652 | china-csl`。
+- **4 个中国专属文档类型**：`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`（均经 `straymark new` 生成，模板已翻译为中文，位于 `.straymark/templates/i18n/zh-CN/`）。
+- **6 个合规检查器**：通过 `straymark compliance --region china` 一次性运行，或单独运行 `--standard china-tc260 | china-pipl | china-gb45438 | china-cac | china-gb45652 | china-csl`。
 - **12 条新的验证规则**（`CROSS-004…011`、`TYPE-003…006`）：自动校验跨文档引用一致性，例如：`cac_filing_required: true` 必须关联 CACFILE；`csl_severity_level: particularly_serious` 必须配合 `csl_report_deadline_hours: 1`；PIPIA 的 `pipl_retention_until` 必须至少为 `created` + 3 年。
-- **5 份中文治理指南**，位于 `.devtrail/00-governance/i18n/zh-CN/`：`CHINA-REGULATORY-FRAMEWORK.md`、`TC260-IMPLEMENTATION-GUIDE.md`、`PIPL-PIPIA-GUIDE.md`、`CAC-FILING-GUIDE.md`、`GB-45438-LABELING-GUIDE.md`。
+- **5 份中文治理指南**，位于 `.straymark/00-governance/i18n/zh-CN/`：`CHINA-REGULATORY-FRAMEWORK.md`、`TC260-IMPLEMENTATION-GUIDE.md`、`PIPL-PIPIA-GUIDE.md`、`CAC-FILING-GUIDE.md`、`GB-45438-LABELING-GUIDE.md`。
 
 #### 适用人群
 
@@ -209,62 +209,62 @@ regional_scope:
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 或从源码通过 Cargo 安装：
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
-> **注意：** `devtrail update-cli` 会自动检测你的安装方式。预编译二进制安装会从 GitHub Releases 更新；Cargo 安装会通过 `cargo install` 更新。你可以使用 `--method=github` 或 `--method=cargo` 来覆盖默认行为。
+> **注意：** `straymark update-cli` 会自动检测你的安装方式。预编译二进制安装会从 GitHub Releases 更新；Cargo 安装会通过 `cargo install` 更新。你可以使用 `--method=github` 或 `--method=cargo` 来覆盖默认行为。
 
 然后在你的项目中初始化：
 
 ```bash
 cd your-project
-devtrail init .
+straymark init .
 ```
 
-CLI 会下载最新的 DevTrail 版本，设置框架，并自动配置你的 AI Agent 指令文件。
+CLI 会下载最新的 StrayMark 版本，设置框架，并自动配置你的 AI Agent 指令文件。
 
 ### 版本管理
 
-DevTrail 为每个组件使用独立的版本标签：
+StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.10.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.10.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.10.0` | `straymark` 二进制文件 |
 
-使用 `devtrail status` 或 `devtrail about` 查看已安装的版本。
+使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
 ### CLI 命令
 
 | 命令 | 描述 |
 |------|------|
-| `devtrail init [path]` | 在项目中初始化 DevTrail |
-| `devtrail update` | 更新框架和 CLI |
-| `devtrail update-framework` | 仅更新框架 |
-| `devtrail update-cli` | 更新 CLI 二进制文件 |
-| `devtrail remove [--full]` | 从项目中移除 DevTrail |
-| `devtrail status [path]` | 显示安装状态和文档统计 |
-| `devtrail repair [path]` | 恢复缺失的目录和框架文件 |
-| `devtrail validate [path]` | 验证文档的合规性和正确性（`--include-charters` 同时校验 Charter；`--check-pending-reviews` 列出审批积压） |
-| `devtrail charter <子命令>` | 管理章程：`new`、`list`、`status`、`close`（记录遥测）、`drift`（带 AILOG-awareness 的偏差检测） |
-| `devtrail approve <doc-id>` | 在 `review_required: true` 的文档上记录一次正式的人工审批（frontmatter + 规范的 body 章节） |
-| `devtrail compliance [path]` | 检查法规合规（EU AI Act、ISO 42001、NIST） |
-| `devtrail metrics [path]` | 显示治理指标和文档统计 |
-| `devtrail analyze [path]` | 分析代码复杂度（认知复杂度 + 圈复杂度指标） |
-| `devtrail audit [path]` | 生成带时间线和可追溯性的审计跟踪报告 |
-| `devtrail explore [path]` | 在终端中交互式浏览文档（TUI） |
-| `devtrail about` | 显示版本和许可证信息 |
+| `straymark init [path]` | 在项目中初始化 StrayMark |
+| `straymark update` | 更新框架和 CLI |
+| `straymark update-framework` | 仅更新框架 |
+| `straymark update-cli` | 更新 CLI 二进制文件 |
+| `straymark remove [--full]` | 从项目中移除 StrayMark |
+| `straymark status [path]` | 显示安装状态和文档统计 |
+| `straymark repair [path]` | 恢复缺失的目录和框架文件 |
+| `straymark validate [path]` | 验证文档的合规性和正确性（`--include-charters` 同时校验 Charter；`--check-pending-reviews` 列出审批积压） |
+| `straymark charter <子命令>` | 管理章程：`new`、`list`、`status`、`close`（记录遥测）、`drift`（带 AILOG-awareness 的偏差检测） |
+| `straymark approve <doc-id>` | 在 `review_required: true` 的文档上记录一次正式的人工审批（frontmatter + 规范的 body 章节） |
+| `straymark compliance [path]` | 检查法规合规（EU AI Act、ISO 42001、NIST） |
+| `straymark metrics [path]` | 显示治理指标和文档统计 |
+| `straymark analyze [path]` | 分析代码复杂度（认知复杂度 + 圈复杂度指标） |
+| `straymark audit [path]` | 生成带时间线和可追溯性的审计跟踪报告 |
+| `straymark explore [path]` | 在终端中交互式浏览文档（TUI） |
+| `straymark about` | 显示版本和许可证信息 |
 
 参见 [CLI 参考手册](adopters/CLI-REFERENCE.md) 了解详细用法。
 
@@ -272,16 +272,16 @@ DevTrail 为每个组件使用独立的版本标签：
 
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
-# 前往 https://github.com/StrangeDaysTech/devtrail/releases
+# 前往 https://github.com/StrangeDaysTech/straymark/releases
 # 下载最新的 fw-* 发布（例如 fw-4.10.0）
 
 # 解压并复制到你的项目
-unzip devtrail-fw-*.zip -d your-project/
+unzip straymark-fw-*.zip -d your-project/
 cd your-project
 
 # 提交
-git add .devtrail/ DEVTRAIL.md
-git commit -m "chore: adopt DevTrail"
+git add .straymark/ STRAYMARK.md
+git commit -m "chore: adopt StrayMark"
 ```
 
 **参见 [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) 了解详细说明、迁移策略和团队推广计划。**
@@ -290,12 +290,12 @@ git commit -m "chore: adopt DevTrail"
 
 ## 文档
 
-DevTrail 文档按受众组织：
+StrayMark 文档按受众组织：
 
 | 路径 | 适用对象 | 从这里开始 |
 |------|----------|------------|
-| [**采用者**](adopters/) | 在项目中采用 DevTrail 的团队 | [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) |
-| [**贡献者**](../../../docs/contributors/) | 为 DevTrail 贡献代码的开发者 | [TRANSLATION-GUIDE.md](../../../docs/contributors/TRANSLATION-GUIDE.md) |
+| [**采用者**](adopters/) | 在项目中采用 StrayMark 的团队 | [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) |
+| [**贡献者**](../../../docs/contributors/) | 为 StrayMark 贡献代码的开发者 | [TRANSLATION-GUIDE.md](../../../docs/contributors/TRANSLATION-GUIDE.md) |
 
 **采用者**：按照[采用指南](adopters/ADOPTION-GUIDE.md)获取分步说明，查看 [CLI 参考手册](adopters/CLI-REFERENCE.md)了解命令详情，阅读[工作流指南](adopters/WORKFLOWS.md)了解日常使用模式。
 
@@ -305,18 +305,18 @@ DevTrail 文档按受众组织：
 
 | 文档 | 描述 |
 |------|------|
-| [**快速参考**](../../../dist/.devtrail/QUICK-REFERENCE.md) | 文档类型和命名规范的单页概览 |
-| [DEVTRAIL.md](../../../dist/DEVTRAIL.md) | 统一治理规则（唯一事实来源） |
+| [**快速参考**](../../../dist/.straymark/QUICK-REFERENCE.md) | 文档类型和命名规范的单页概览 |
+| [STRAYMARK.md](../../../dist/STRAYMARK.md) | 统一治理规则（唯一事实来源） |
 | [ADOPTION-GUIDE.md](adopters/ADOPTION-GUIDE.md) | 新/现有项目的采用指南 |
 | [CLI-REFERENCE.md](adopters/CLI-REFERENCE.md) | 完整的 CLI 命令参考 |
 | [WORKFLOWS.md](adopters/WORKFLOWS.md) | 推荐的日常工作流和团队模式 |
 
 ### 内部结构
 
-采用后，DevTrail 会在你的项目中创建一个 `.devtrail/` 目录用于开发治理：
+采用后，StrayMark 会在你的项目中创建一个 `.straymark/` 目录用于开发治理：
 
 ```
-.devtrail/
+.straymark/
 ├── 00-governance/           # 策略和规则
 ├── 01-requirements/         # REQ 文档
 ├── 02-design/decisions/     # ADR 文档
@@ -350,7 +350,7 @@ DevTrail 文档按受众组织：
 AI 助手在你的代码中工作时自动：
 
 ```yaml
-# 创建：.devtrail/07-ai-audit/agent-logs/AILOG-2025-01-27-001-implement-auth.md
+# 创建：.straymark/07-ai-audit/agent-logs/AILOG-2025-01-27-001-implement-auth.md
 ---
 id: AILOG-2025-01-27-001
 title: Implement JWT authentication
@@ -378,7 +378,7 @@ review_required: true
 在多个替代方案之间做出选择时，决策会被记录：
 
 ```yaml
-# 创建：.devtrail/07-ai-audit/decisions/AIDEC-2025-01-27-001-auth-strategy.md
+# 创建：.straymark/07-ai-audit/decisions/AIDEC-2025-01-27-001-auth-strategy.md
 ---
 id: AIDEC-2025-01-27-001
 title: Choose JWT over session-based auth
@@ -395,7 +395,7 @@ justification: "Stateless architecture requirement..."
 当 AI 遇到伦理考量时：
 
 ```yaml
-# 创建：.devtrail/07-ai-audit/ethical-reviews/ETH-2025-01-27-001-user-data.md
+# 创建：.straymark/07-ai-audit/ethical-reviews/ETH-2025-01-27-001-user-data.md
 ---
 id: ETH-2025-01-27-001
 title: User data collection scope
@@ -415,15 +415,15 @@ concerns:
 
 ```bash
 # 安装 pre-commit 钩子
-echo 'devtrail validate --staged' > .git/hooks/pre-commit
+echo 'straymark validate --staged' > .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
 ### 手动验证
 
 ```bash
-# 跨平台（任何安装了 devtrail 的操作系统）
-devtrail validate
+# 跨平台（任何安装了 straymark 的操作系统）
+straymark validate
 ```
 
 ### GitHub Actions
@@ -439,38 +439,38 @@ devtrail validate
 
 ## Skills
 
-DevTrail 包含面向 AI Agent 的 Skills，支持**主动创建文档**。
+StrayMark 包含面向 AI Agent 的 Skills，支持**主动创建文档**。
 
-> **双系统**：DevTrail 使用被动系统（Agent 通过上下文指令自动记录文档）和主动系统（用户调用 Skills 手动创建文档，或在 Agent 遗漏时补充）。
+> **双系统**：StrayMark 使用被动系统（Agent 通过上下文指令自动记录文档）和主动系统（用户调用 Skills 手动创建文档，或在 Agent 遗漏时补充）。
 
 ### 可用 Skills
 
 | Skill | 用途 | Claude | Gemini |
 |-------|------|--------|--------|
-| `/devtrail-status` | 检查文档合规状态 | ✅ | ✅ |
-| `/devtrail-new` | 创建任意类型的文档（统一入口） | ✅ | ✅ |
-| `/devtrail-ailog` | 快速创建 AILOG | ✅ | ✅ |
-| `/devtrail-aidec` | 快速创建 AIDEC | ✅ | ✅ |
-| `/devtrail-adr` | 快速创建 ADR | ✅ | ✅ |
-| `/devtrail-sec` | 创建安全评估 | ✅ | ✅ |
-| `/devtrail-mcard` | 创建模型/系统卡片 | ✅ | ✅ |
+| `/straymark-status` | 检查文档合规状态 | ✅ | ✅ |
+| `/straymark-new` | 创建任意类型的文档（统一入口） | ✅ | ✅ |
+| `/straymark-ailog` | 快速创建 AILOG | ✅ | ✅ |
+| `/straymark-aidec` | 快速创建 AIDEC | ✅ | ✅ |
+| `/straymark-adr` | 快速创建 ADR | ✅ | ✅ |
+| `/straymark-sec` | 创建安全评估 | ✅ | ✅ |
+| `/straymark-mcard` | 创建模型/系统卡片 | ✅ | ✅ |
 
 ### 使用示例
 
 ```bash
 # 检查文档状态
-/devtrail-status
+/straymark-status
 
 # 创建文档（Agent 建议类型）
-/devtrail-new
+/straymark-new
 
 # 指定文档类型
-/devtrail-new ailog
+/straymark-new ailog
 
 # 快捷方式
-/devtrail-ailog
-/devtrail-aidec
-/devtrail-adr
+/straymark-ailog
+/straymark-aidec
+/straymark-adr
 ```
 
 ### CLI 命令（手动使用）
@@ -479,13 +479,13 @@ DevTrail 包含面向 AI Agent 的 Skills，支持**主动创建文档**。
 
 ```bash
 # 交互式创建文档
-devtrail new
+straymark new
 
 # 直接创建指定类型
-devtrail new --doc-type ailog
+straymark new --doc-type ailog
 
 # 检查文档状态
-devtrail status
+straymark status
 ```
 
 ### Agent 报告
@@ -494,25 +494,25 @@ AI Agent 在每个任务结束时报告文档状态：
 
 | 状态 | 含义 |
 |------|------|
-| `DevTrail: Created AILOG-...` | 文档已创建 |
-| `DevTrail: No documentation required` | 变更较小 |
-| `DevTrail: Documentation pending` | 可能需要手动审查 |
+| `StrayMark: Created AILOG-...` | 文档已创建 |
+| `StrayMark: No documentation required` | 变更较小 |
+| `StrayMark: Documentation pending` | 可能需要手动审查 |
 
 ### 多 Agent 架构
 
-DevTrail 通过分层架构为多个 AI Agent 提供原生 Skill 支持：
+StrayMark 通过分层架构为多个 AI Agent 提供原生 Skill 支持：
 
 ```
 your-project/
 ├── .agent/workflows/       # 🌐 通用（Antigravity，未来 Agent）
-│   ├── devtrail-new.md
-│   ├── devtrail-status.md
+│   ├── straymark-new.md
+│   ├── straymark-status.md
 │   └── ...
 ├── .gemini/skills/         # 🔵 Gemini CLI (Google)
-│   ├── devtrail-new/SKILL.md
+│   ├── straymark-new/SKILL.md
 │   └── ...
 └── .claude/skills/         # 🟣 Claude Code (Anthropic)
-    ├── devtrail-new/SKILL.md
+    ├── straymark-new/SKILL.md
     └── ...
 ```
 
@@ -543,9 +543,9 @@ your-project/
 
 | 操作系统 | 验证方式 |
 |----------|----------|
-| Linux | `devtrail validate` |
-| macOS | `devtrail validate` |
-| Windows | `devtrail validate` |
+| Linux | `straymark validate` |
+| macOS | `straymark validate` |
+| Windows | `straymark validate` |
 
 ### CI/CD 平台
 
@@ -589,7 +589,7 @@ your-project/
 
 | 项目 | 描述 |
 |------|------|
-| **[DevTrail](https://github.com/StrangeDaysTech/devtrail)** | 你的 AI 辅助项目所需的认知纪律 |
+| **[StrayMark](https://github.com/StrangeDaysTech/straymark)** | 你的 AI 辅助项目所需的认知纪律 |
 | **[arborist-metrics](https://github.com/StrangeDaysTech/arborist)** | Rust 多语言代码复杂度分析库 — [crates.io](https://crates.io/crates/arborist-metrics) |
 
 [网站](https://strangedays.tech) • [GitHub](https://github.com/StrangeDaysTech)
@@ -600,8 +600,8 @@ your-project/
 
 <div align="center">
 
-**DevTrail** — 工程纪律，外化于代码。合规，作为副作用。
+**StrayMark** — 工程纪律，外化于代码。合规，作为副作用。
 
-[⬆ 回到顶部](#devtrail)
+[⬆ 回到顶部](#straymark)
 
 </div>

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -1,6 +1,6 @@
-# DevTrail - 采用指南
+# StrayMark - 采用指南
 
-**在新项目或现有项目中采用 DevTrail 的完整指南。**
+**在新项目或现有项目中采用 StrayMark 的完整指南。**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -10,7 +10,7 @@
 
 ## 目录
 
-1. [什么是 DevTrail？](#什么是-devtrail)
+1. [什么是 StrayMark？](#什么是-straymark)
 2. [适用对象](#适用对象)
 3. [收益](#收益)
 4. [标准合规](#标准合规)
@@ -22,9 +22,9 @@
 
 ---
 
-## 什么是 DevTrail？
+## 什么是 StrayMark？
 
-DevTrail 是一个**框架 + CLI**，将资深软件工程工作的认知纪律——明确的范围、声明的决策、命名的风险、记录的备选方案、可审计的轨迹——外化为与代码并存的版本化文件。其意图在于约束 Agent 的决策空间，使 AI 辅助的工作在多轮交互中保持连贯，而不是漂移成隐藏的技术债务。
+StrayMark 是一个**框架 + CLI**，将资深软件工程工作的认知纪律——明确的范围、声明的决策、命名的风险、记录的备选方案、可审计的轨迹——外化为与代码并存的版本化文件。其意图在于约束 Agent 的决策空间，使 AI 辅助的工作在多轮交互中保持连贯，而不是漂移成隐藏的技术债务。
 
 它提供：
 
@@ -39,15 +39,15 @@ DevTrail 是一个**框架 + CLI**，将资深软件工程工作的认知纪律�
 
 > **"没有记录痕迹的重大变更不应发生——并且 Agent 的决策空间应受约束。"**
 
-DevTrail 确保每一个有意义的变更——无论是人工还是 AI 做出的——都被记录、归属和可审计。这一纪律产出兼容 **ISO/IEC 42001**、**EU AI Act** 和 **NIST AI RMF** 的证据——但目标首先是工程质量；当纪律真正落地时，合规便是自然而然的副产品（参见 [`Propuesta/devtrail-design-principles.md`](https://github.com/StrangeDaysTech/devtrail/blob/main/Propuesta/devtrail-design-principles.md) 中的原则 #4）。
+StrayMark 确保每一个有意义的变更——无论是人工还是 AI 做出的——都被记录、归属和可审计。这一纪律产出兼容 **ISO/IEC 42001**、**EU AI Act** 和 **NIST AI RMF** 的证据——但目标首先是工程质量；当纪律真正落地时，合规便是自然而然的副产品（参见 [`Propuesta/straymark-design-principles.md`](https://github.com/StrangeDaysTech/straymark/blob/main/Propuesta/straymark-design-principles.md) 中的原则 #4）。
 
 ### 为什么是现在？
 
 AI Agent 写代码很快。但写出的代码并不连贯。经过足够多的轮次后，Agent 会失去主线：重新引入团队已经否决的模式、积累隐藏的技术债务、产出可以编译但与系统肌理不匹配的工作。Agent 越快，这些债务越难被察觉——直到一次回归、一次事故或一次重构把它们暴露出来。
 
-与此并行，法规底线也在抬升——**EU AI Act 将于 2026 年 8 月起强制执行**，**ISO/IEC 42001** 现已成为 AI 管理系统的国际标准。采用 DevTrail 首先解决的是工程问题；法规证据作为这种纪律的副产品被产出，在审计师询问时即可呈现。
+与此并行，法规底线也在抬升——**EU AI Act 将于 2026 年 8 月起强制执行**，**ISO/IEC 42001** 现已成为 AI 管理系统的国际标准。采用 StrayMark 首先解决的是工程问题；法规证据作为这种纪律的副产品被产出，在审计师询问时即可呈现。
 
-### DevTrail 不是什么
+### StrayMark 不是什么
 
 - 它不是文档生成器——它提供结构、模板和治理规则
 - 它不是代码注释或 API 文档的替代品
@@ -62,7 +62,7 @@ AI Agent 写代码很快。但写出的代码并不连贯。经过足够多的�
 
 ### 主要用户
 
-DevTrail 的主要用户是**在非平凡系统上编排 AI Agent 的资深工程师**——具备扎实技术判断力、借助 Agent 完成自己单独无法实际完成的工作、并需要外化的认知纪律以防止 Agent 引入系统性混乱的人。框架的流程、默认值和语言都是为这个角色量身打造的；次要受众建立在主用户基础之上，绝不以牺牲主用户为代价。
+StrayMark 的主要用户是**在非平凡系统上编排 AI Agent 的资深工程师**——具备扎实技术判断力、借助 Agent 完成自己单独无法实际完成的工作、并需要外化的认知纪律以防止 Agent 引入系统性混乱的人。框架的流程、默认值和语言都是为这个角色量身打造的；次要受众建立在主用户基础之上，绝不以牺牲主用户为代价。
 
 ### 目标用户
 
@@ -77,7 +77,7 @@ DevTrail 的主要用户是**在非平凡系统上编排 AI Agent 的资深工�
 
 ### 兼容的开发环境
 
-DevTrail 提供以下平台的配置文件：
+StrayMark 提供以下平台的配置文件：
 
 | 平台 | 配置文件 | 状态 |
 |------|----------|------|
@@ -89,9 +89,9 @@ DevTrail 提供以下平台的配置文件：
 
 ### 兼容的方法论
 
-DevTrail 适用于任何开发方法论：
+StrayMark 适用于任何开发方法论：
 
-| 方法论 | DevTrail 如何融入 |
+| 方法论 | StrayMark 如何融入 |
 |--------|-------------------|
 | **Agile/Scrum** | REQ 文档映射到用户故事；ADR 记录 Sprint 决策 |
 | **瀑布模型** | 从需求到实现的完整可追溯性 |
@@ -121,7 +121,7 @@ DevTrail 适用于任何开发方法论：
 | **AI 透明度** | 每个 AI 操作都带有置信度级别记录 |
 | **人工监督** | 关键决策需要人工批准 |
 | **伦理保障** | ETH 和 DPIA 文档将隐患标记给人类做决定 |
-| **治理指标** | `devtrail metrics` 跟踪审查率、风险分布和趋势 |
+| **治理指标** | `straymark metrics` 跟踪审查率、风险分布和趋势 |
 
 ### 法规合规（作为副作用）
 
@@ -130,18 +130,18 @@ DevTrail 适用于任何开发方法论：
 | **EU AI Act 就绪** | 内置风险分类、事件报告和透明度模板 |
 | **ISO 42001 兼容** | 文档结构符合认证审计要求 |
 | **NIST AI RMF 映射** | 明确覆盖 12 个 GenAI 风险类别和治理功能 |
-| **完整的审计跟踪** | `devtrail audit` 生成可导出的时间线和可追溯性报告 |
-| **合规评分** | `devtrail compliance` 提供基于百分比的法规差距分析 |
+| **完整的审计跟踪** | `straymark audit` 生成可导出的时间线和可追溯性报告 |
+| **合规评分** | `straymark compliance` 提供基于百分比的法规差距分析 |
 
 ---
 
 ## 标准合规
 
-DevTrail 外化的纪律——明确的范围、声明的决策、命名的风险、记录的备选方案——作为副作用，会产出与主流工程及 AI 治理框架清晰映射的证据。下表描述了 DevTrail 的文物*如何*与各项标准对齐；目标是工程工作，对齐则是其副产品：
+StrayMark 外化的纪律——明确的范围、声明的决策、命名的风险、记录的备选方案——作为副作用，会产出与主流工程及 AI 治理框架清晰映射的证据。下表描述了 StrayMark 的文物*如何*与各项标准对齐；目标是工程工作，对齐则是其副产品：
 
 ### 软件工程标准
 
-| 标准 | DevTrail 如何帮助 |
+| 标准 | StrayMark 如何帮助 |
 |------|-------------------|
 | **ISO/IEC/IEEE 29148:2018** | REQ 文档遵循结构化需求格式，包含外部接口和可追溯性 |
 | **ISO/IEC 25010:2023** | 在 ADR 和 REQ 非功能性需求中评估 9 个质量特性 |
@@ -150,9 +150,9 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 
 ### AI 管理与治理
 
-| 标准 | DevTrail 如何帮助 |
+| 标准 | StrayMark 如何帮助 |
 |------|-------------------|
-| **ISO/IEC 42001:2023** | 核心标准 — AI-GOVERNANCE-POLICY.md 将所有附录 A 控制项映射到 DevTrail 文档 |
+| **ISO/IEC 42001:2023** | 核心标准 — AI-GOVERNANCE-POLICY.md 将所有附录 A 控制项映射到 StrayMark 文档 |
 | **EU AI Act** | ETH 中的风险分类、INC 中的事件报告时间线、AILOG 中的法规字段 |
 | **NIST AI RMF 1.0 / 600-1** | ETH/AILOG 中的 12 个 GenAI 风险类别，MAP/MEASURE/MANAGE/GOVERN 覆盖 |
 | **ISO/IEC 23894:2023** | AI 风险管理与 ETH 和 AI-RISK-CATALOG 对齐 |
@@ -160,7 +160,7 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 
 ### 中国法规覆盖 *(通过 `regional_scope: china` opt-in)*
 
-| 标准 | DevTrail 如何帮助 |
+| 标准 | StrayMark 如何帮助 |
 |------|-------------------|
 | **TC260 人工智能安全治理框架 v2.0** | 五级风险分级(TC260RA),ETH/MCARD/AILOG/SEC 上的 `tc260_*` 字段 |
 | **PIPL — 个人信息保护法** | PIPIA 模板含第55-56条节,`pipl_*` 字段,留存 ≥ 3 年(`TYPE-003`) |
@@ -169,11 +169,11 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 | **GB/T 45652-2025** | SBOM 与 MCARD 的训练数据安全部分;`gb45652_training_data_compliance` 字段 |
 | **CSL 2026** | INC 扩展含 `csl_severity_level`、时限一致性规则(1h / 4h+72h+30d 窗口) |
 
-> 在 `.devtrail/config.yml` 的 `regional_scope` 中加入 `china` 即可启用。详见下方 *配置* 章节及安装在 `.devtrail/00-governance/` 下的 `CHINA-REGULATORY-FRAMEWORK.md` 指南。
+> 在 `.straymark/config.yml` 的 `regional_scope` 中加入 `china` 即可启用。详见下方 *配置* 章节及安装在 `.straymark/00-governance/` 下的 `CHINA-REGULATORY-FRAMEWORK.md` 指南。
 
 ### 架构文档
 
-| 标准 | DevTrail 如何帮助 |
+| 标准 | StrayMark 如何帮助 |
 |------|-------------------|
 | **ADR (Architecture Decision Records)** | 原生 ADR 支持，含扩展元数据和不可变规则 |
 | **arc42** | ADR 补充 arc42 决策文档 |
@@ -181,7 +181,7 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 
 ### 合规与治理
 
-| 法规 | DevTrail 如何帮助 |
+| 法规 | StrayMark 如何帮助 |
 |------|-------------------|
 | **GDPR** | ETH 文档用于隐私评估，DPIA 用于数据保护影响 |
 | **SOC 2** | 通过 AILOG 进行变更文档和访问记录 |
@@ -190,7 +190,7 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 
 ### 可观测性（可选）
 
-| 标准 | DevTrail 如何帮助 |
+| 标准 | StrayMark 如何帮助 |
 |------|-------------------|
 | **OpenTelemetry** | REQ、TES、INC 中的可选可观测性部分；`observabilidad` 标签用于仪表化变更 |
 
@@ -204,34 +204,34 @@ DevTrail 外化的纪律——明确的范围、声明的决策、命名的风�
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 或从源码通过 Cargo 安装：
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
 然后初始化并提交：
 
 ```bash
 cd your-project
-devtrail init .
+straymark init .
 
-git add .devtrail/ DEVTRAIL.md
-git commit -m "chore: adopt DevTrail"
+git add .straymark/ STRAYMARK.md
+git commit -m "chore: adopt StrayMark"
 ```
 
 CLI 自动完成：
-- 从 GitHub 下载最新的 DevTrail 版本
-- 设置 `.devtrail/` 目录结构
-- 创建包含治理规则的 `DEVTRAIL.md`
+- 从 GitHub 下载最新的 StrayMark 版本
+- 设置 `.straymark/` 目录结构
+- 创建包含治理规则的 `STRAYMARK.md`
 - 配置 AI Agent 指令（`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
 - 复制 CI/CD 工作流
 
@@ -239,17 +239,17 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/devtrail/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.10.0`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.10.0`）。
 
 2. **解压到你的项目**
    ```bash
-   unzip devtrail-fw-*.zip -d your-project/
+   unzip straymark-fw-*.zip -d your-project/
    ```
 
 3. **提交结构**
    ```bash
-   git add .devtrail/ DEVTRAIL.md
-   git commit -m "chore: adopt DevTrail for documentation governance"
+   git add .straymark/ STRAYMARK.md
+   git commit -m "chore: adopt StrayMark for documentation governance"
    ```
 
 ---
@@ -270,32 +270,32 @@ CLI 自动完成：
 
    | 当前状态 | 建议操作 |
    |----------|----------|
-   | 没有文档 | 从零开始使用 DevTrail |
-   | `docs/` 文件夹中有文档 | 保留 `docs/` 存放面向用户的文档，添加 `.devtrail/` 存放开发文档 |
-   | 已有 ADR | 迁移到 `.devtrail/02-design/decisions/`，使用新命名 |
+   | 没有文档 | 从零开始使用 StrayMark |
+   | `docs/` 文件夹中有文档 | 保留 `docs/` 存放面向用户的文档，添加 `.straymark/` 存放开发文档 |
+   | 已有 ADR | 迁移到 `.straymark/02-design/decisions/`，使用新命名 |
    | 混合文档 | 分类并逐步迁移 |
 
 ### 阶段 2：安装（第 1-2 天）
 
-1. **添加 DevTrail 结构**
+1. **添加 StrayMark 结构**
    ```bash
    # 使用 CLI（推荐）
-   devtrail init .
+   straymark init .
 
    # 或手动：从 GitHub Releases 下载最新的 fw-* 版本
-   # https://github.com/StrangeDaysTech/devtrail/releases
+   # https://github.com/StrangeDaysTech/straymark/releases
    ```
 
 2. **解决与现有 `docs/` 的冲突**
 
-   DevTrail 专门使用 `.devtrail/` 以避免冲突：
+   StrayMark 专门使用 `.straymark/` 以避免冲突：
 
    ```
    your-project/
    ├── docs/                    ← 保留用于 API 文档、用户指南等
    │   ├── api/
    │   └── user-guide/
-   ├── .devtrail/              ← 添加用于开发文档
+   ├── .straymark/              ← 添加用于开发文档
    │   ├── 00-governance/
    │   ├── 01-requirements/
    │   └── ...
@@ -309,10 +309,10 @@ CLI 自动完成：
    对于每个现有 ADR：
    ```bash
    # 旧：docs/adr/001-use-postgresql.md
-   # 新：.devtrail/02-design/decisions/ADR-2024-01-15-001-use-postgresql.md
+   # 新：.straymark/02-design/decisions/ADR-2024-01-15-001-use-postgresql.md
    ```
 
-   在 front-matter 中添加 DevTrail 元数据：
+   在 front-matter 中添加 StrayMark 元数据：
    ```yaml
    ---
    id: ADR-2024-01-15-001
@@ -333,7 +333,7 @@ CLI 自动完成：
 
    创建 AILOG 记录迁移过程：
    ```
-   .devtrail/07-ai-audit/agent-logs/AILOG-2025-01-27-001-devtrail-adoption.md
+   .straymark/07-ai-audit/agent-logs/AILOG-2025-01-27-001-straymark-adoption.md
    ```
 
 ### 阶段 4：团队采用（第 2-4 周）
@@ -344,23 +344,23 @@ CLI 自动完成：
    ```markdown
    ## Documentation
 
-   This project uses [DevTrail](https://github.com/StrangeDaysTech/devtrail) for documentation governance.
+   This project uses [StrayMark](https://github.com/StrangeDaysTech/straymark) for documentation governance.
 
-   - All significant changes must be documented in `.devtrail/`
+   - All significant changes must be documented in `.straymark/`
    - AI-assisted changes require AILOG entries
    - Architectural decisions require ADR documents
 
-   See `.devtrail/QUICK-REFERENCE.md` for document types and naming.
+   See `.straymark/QUICK-REFERENCE.md` for document types and naming.
    ```
 
 2. **启用 pre-commit 钩子（可选）**
    ```bash
    # 安装 pre-commit 钩子
-   echo 'devtrail validate --staged' > .git/hooks/pre-commit
+   echo 'straymark validate --staged' > .git/hooks/pre-commit
    chmod +x .git/hooks/pre-commit
 
    # 或使用 Husky
-   npx husky add .husky/pre-commit "devtrail validate --staged"
+   npx husky add .husky/pre-commit "straymark validate --staged"
    ```
 
 3. **启用 GitHub Actions（可选）**
@@ -371,7 +371,7 @@ CLI 自动完成：
 
 | 周次 | 重点 |
 |------|------|
-| 第 1 周 | 核心团队开始为新决策使用 DevTrail |
+| 第 1 周 | 核心团队开始为新决策使用 StrayMark |
 | 第 2 周 | 迁移关键的现有 ADR |
 | 第 3 周 | 在 CI/CD 中启用验证 |
 | 第 4 周 | 全团队采用；记录现有技术债务 |
@@ -382,7 +382,7 @@ CLI 自动完成：
 
 ### 区域法规范围(Regional Regulatory Scope)
 
-`.devtrail/config.yml` 控制 `devtrail compliance` 评估哪些合规框架,以及 `devtrail new` 暴露哪些文档类型:
+`.straymark/config.yml` 控制 `straymark compliance` 评估哪些合规框架,以及 `straymark new` 暴露哪些文档类型:
 
 ```yaml
 regional_scope:
@@ -391,14 +391,14 @@ regional_scope:
   - china    # TC260 v2.0、PIPL/PIPIA、GB 45438、CAC、GB/T 45652、CSL 2026
 ```
 
-**省略时的默认值**:`[global, eu]` — 保持 `fw-4.3.0` 之前所有 DevTrail 版本的行为。
+**省略时的默认值**:`[global, eu]` — 保持 `fw-4.3.0` 之前所有 StrayMark 版本的行为。
 
 将 `china` 加入列表时:
 
-- 通过 `devtrail new` 可使用 4 种中国专属文档类型:`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`。
-- `devtrail compliance` 运行 6 个新的合规检查器(也可通过 `--region china` / `--standard china-*`)。
+- 通过 `straymark new` 可使用 4 种中国专属文档类型:`PIPIA`、`CACFILE`、`TC260RA`、`AILABEL`。
+- `straymark compliance` 运行 6 个新的合规检查器(也可通过 `--region china` / `--standard china-*`)。
 - 启用 12 条范围感知的验证规则(`CROSS-004` 至 `CROSS-011`、`TYPE-003` 至 `TYPE-006`)。
-- 在 `.devtrail/00-governance/` 下提供 5 份新的治理指南(`CHINA-REGULATORY-FRAMEWORK.md`,以及 TC260、PIPL/PIPIA、CAC 备案、GB 45438 标识的逐项指南)— 全部提供 EN、ES、zh-CN 三种语言。
+- 在 `.straymark/00-governance/` 下提供 5 份新的治理指南(`CHINA-REGULATORY-FRAMEWORK.md`,以及 TC260、PIPL/PIPIA、CAC 备案、GB 45438 标识的逐项指南)— 全部提供 EN、ES、zh-CN 三种语言。
 
 `regional_scope` 中不含 `china` 的项目不受任何影响:无新增文件、无新提示、无新规则。后续添加 `china` 完全可逆。
 
@@ -428,15 +428,15 @@ agent: acme-corp-claude-v1   # 组织特定
 
 1. **创建模板**
    ```
-   .devtrail/templates/TEMPLATE-NEWTYPE.md
+   .straymark/templates/TEMPLATE-NEWTYPE.md
    ```
 
 2. **更新治理文档**
 
    在以下文件中添加新类型：
-   - `.devtrail/00-governance/DOCUMENTATION-POLICY.md`
-   - `.devtrail/00-governance/AGENT-RULES.md`
-   - `.devtrail/QUICK-REFERENCE.md`
+   - `.straymark/00-governance/DOCUMENTATION-POLICY.md`
+   - `.straymark/00-governance/AGENT-RULES.md`
+   - `.straymark/QUICK-REFERENCE.md`
 
 3. **更新 Agent 配置**
 
@@ -445,7 +445,7 @@ agent: acme-corp-claude-v1   # 组织特定
 4. **更新验证**
 
    在以下位置添加新类型：
-   - CLI 验证逻辑（`devtrail validate`）
+   - CLI 验证逻辑（`straymark validate`）
    - `.github/workflows/docs-validation.yml`
 
 ### 自定义文件夹结构
@@ -468,11 +468,11 @@ agent: acme-corp-claude-v1   # 组织特定
 如果使用 Claude Code，可以用内置 Skill 验证文档合规性：
 
 ```bash
-/devtrail-status
+/straymark-status
 ```
 
 此 Skill 显示：
-- 最近创建了哪些 DevTrail 文档
+- 最近创建了哪些 StrayMark 文档
 - 哪些修改过的文件可能需要文档
 - 整体文档合规状态
 
@@ -482,18 +482,18 @@ agent: acme-corp-claude-v1   # 组织特定
 
 ```bash
 # 运行验证（跨平台）
-devtrail validate
+straymark validate
 ```
 
 ### 检查清单
 
-- [ ] `.devtrail/` 文件夹结构存在
+- [ ] `.straymark/` 文件夹结构存在
 - [ ] 至少有一个 Agent 配置文件（`CLAUDE.md`、`GEMINI.md` 等）
-- [ ] 治理文档存在于 `.devtrail/00-governance/`
-- [ ] 模板存在于 `.devtrail/templates/`
-- [ ] Git 分支策略记录在 `.devtrail/03-implementation/`
+- [ ] 治理文档存在于 `.straymark/00-governance/`
+- [ ] 模板存在于 `.straymark/templates/`
+- [ ] Git 分支策略记录在 `.straymark/03-implementation/`
 - [ ] `QUICK-REFERENCE.md` 可访问
-- [ ] `devtrail validate` 无错误运行
+- [ ] `straymark validate` 无错误运行
 - [ ] （可选）Pre-commit 钩子已安装
 - [ ] （可选）GitHub Actions 工作流已启用
 
@@ -503,15 +503,15 @@ devtrail validate
 
 自 `fw-4.9.0` 起，当你与 AI 助手在循环中协作实现 Charter 时（Claude Code、Gemini Code、Cursor），你可以在 Charter 关闭时可选地运行外部多模型审计。两个 skills 封装底层 CLI 编排：
 
-- **`/devtrail-audit-prompt CHARTER-XX`** — 在规范路径 `.devtrail/audits/<id>/audit-prompt.md` 处写入统一审计 prompt。操作员打开 N 个审计员 CLI 并在每个中运行 `/devtrail-audit-execute`。无需复制/粘贴。
-- **`/devtrail-audit-execute [CHARTER-XX]`** *(fw-4.9.0+)* — 在审计员 CLI 中运行（gemini-cli、claude-cli、copilot-cli、codex-cli）。读取 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。
-- **`/devtrail-audit-review CHARTER-XX`** — 将 N 个 reports 合并为六节 `review.md`（执行摘要 / 范围 / 按审计员评估 / 修复计划 P0-P4 / 丢弃 / 审计员评分）并将 `external_audit:` YAML 合并到 Charter 遥测。
+- **`/straymark-audit-prompt CHARTER-XX`** — 在规范路径 `.straymark/audits/<id>/audit-prompt.md` 处写入统一审计 prompt。操作员打开 N 个审计员 CLI 并在每个中运行 `/straymark-audit-execute`。无需复制/粘贴。
+- **`/straymark-audit-execute [CHARTER-XX]`** *(fw-4.9.0+)* — 在审计员 CLI 中运行（gemini-cli、claude-cli、copilot-cli、codex-cli）。读取 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。
+- **`/straymark-audit-review CHARTER-XX`** — 将 N 个 reports 合并为六节 `review.md`（执行摘要 / 范围 / 按审计员评估 / 修复计划 P0-P4 / 丢弃 / 审计员评分）并将 `external_audit:` YAML 合并到 Charter 遥测。
 
-Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成、drift check 干净，且 `charter close` 尚未调用时。推荐基于 Charter 的风险面和复杂度给出 是/否（启发式见 `.devtrail/00-governance/AGENT-RULES.md` §12）。
+Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成、drift check 干净，且 `charter close` 尚未调用时。推荐基于 Charter 的风险面和复杂度给出 是/否（启发式见 `.straymark/00-governance/AGENT-RULES.md` §12）。
 
 **外部审计完全可选**且**永不强制**。Charter 的声明性范围 + drift check + AILOG 纪律已为关闭提供严格支撑。审计在 Charter 触及安全面、引入新组件或 diff 中存在高复杂度函数时增加跨模型信号。如果你的情况下成本（2-3 个 LLM 审计员）与价值不匹配，可以自由拒绝。
 
-底层 CLI 命令（PREPARE / CALIBRATE / FINALIZE / `--merge-into`）见 [`CLI-REFERENCE.md` § devtrail charter audit](./CLI-REFERENCE.md#devtrail-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir)。
+底层 CLI 命令（PREPARE / CALIBRATE / FINALIZE / `--merge-into`）见 [`CLI-REFERENCE.md` § straymark charter audit](./CLI-REFERENCE.md#straymark-charter-audit-charter-id-range-revrev-calibrate--finalize-path-dir)。
 
 ---
 
@@ -519,34 +519,34 @@ Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成�
 
 ### 通用问题
 
-**问：DevTrail 会替代我现有的文档吗？**
+**问：StrayMark 会替代我现有的文档吗？**
 
-答：不会。DevTrail 用于*开发过程文档*（决策、变更、审查）。保留你现有的 `docs/` 文件夹存放面向用户的文档、API 参考和指南。
+答：不会。StrayMark 用于*开发过程文档*（决策、变更、审查）。保留你现有的 `docs/` 文件夹存放面向用户的文档、API 参考和指南。
 
-**问：我不使用 AI 编码助手也能从 DevTrail 受益吗？**
+**问：我不使用 AI 编码助手也能从 StrayMark 受益吗？**
 
-答：可以。DevTrail 同样适用于纯人工团队。AI 审计功能（AILOG、AIDEC、ETH）在使用 AI 助手时特别有价值，但 ADR、REQ、TDE 和其他文档类型对任何团队都有用。
+答：可以。StrayMark 同样适用于纯人工团队。AI 审计功能（AILOG、AIDEC、ETH）在使用 AI 助手时特别有价值，但 ADR、REQ、TDE 和其他文档类型对任何团队都有用。
 
-**问：DevTrail 增加多少额外开销？**
+**问：StrayMark 增加多少额外开销？**
 
-答：DevTrail 遵循"最小可行文档"原则。只有重大变更需要文档。微小变更（错别字、格式）被明确排除在外。
+答：StrayMark 遵循"最小可行文档"原则。只有重大变更需要文档。微小变更（错别字、格式）被明确排除在外。
 
 ### 技术问题
 
-**问：为什么使用 `.devtrail/` 而不是 `docs/`？**
+**问：为什么使用 `.straymark/` 而不是 `docs/`？**
 
-答：`docs/` 文件夹通常用于面向用户的文档、GitHub Pages 或生成的 API 文档。使用 `.devtrail/` 避免冲突，并清晰地将开发文档与用户文档分开。
+答：`docs/` 文件夹通常用于面向用户的文档、GitHub Pages 或生成的 API 文档。使用 `.straymark/` 避免冲突，并清晰地将开发文档与用户文档分开。
 
-**问：可以在 Monorepo 中使用 DevTrail 吗？**
+**问：可以在 Monorepo 中使用 StrayMark 吗？**
 
 答：可以。你可以：
-- 在根目录放一个 `.devtrail/`，覆盖整个 Monorepo
-- 在每个包/服务中放单独的 `.devtrail/` 文件夹
+- 在根目录放一个 `.straymark/`，覆盖整个 Monorepo
+- 在每个包/服务中放单独的 `.straymark/` 文件夹
 - 使用混合方案，在根目录共享治理
 
 **问：如何处理敏感信息？**
 
-答：DevTrail 明确禁止记录凭据、令牌或密钥。验证脚本会检测常见的敏感模式并发出警告。对于确实敏感的决策，记录决策的*存在*而不包含敏感细节。
+答：StrayMark 明确禁止记录凭据、令牌或密钥。验证脚本会检测常见的敏感模式并发出警告。对于确实敏感的决策，记录决策的*存在*而不包含敏感细节。
 
 ### 采用问题
 
@@ -558,17 +558,17 @@ Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成�
 3. 展示回顾旧决策时节省的时间
 4. 逐步扩展到其他文档类型
 
-**问：如何处理采用 DevTrail 之前创建的文档？**
+**问：如何处理采用 StrayMark 之前创建的文档？**
 
 答：有三种选择：
-1. **迁移**：将旧文档转换为 DevTrail 格式（推荐用于重要文档）
-2. **引用**：保留旧文档，从 DevTrail 文档中引用它们
-3. **归档**：将旧文档移至归档文件夹，使用 DevTrail 重新开始
+1. **迁移**：将旧文档转换为 StrayMark 格式（推荐用于重要文档）
+2. **引用**：保留旧文档，从 StrayMark 文档中引用它们
+3. **归档**：将旧文档移至归档文件夹，使用 StrayMark 重新开始
 
 **问：如果我的 AI 助手不遵守规则怎么办？**
 
-答：DevTrail 规则是指令，而非强制执行。如果 AI 助手创建了不合规的文档：
-1. Pre-commit 钩子（`devtrail validate --staged`）会捕获验证错误
+答：StrayMark 规则是指令，而非强制执行。如果 AI 助手创建了不合规的文档：
+1. Pre-commit 钩子（`straymark validate --staged`）会捕获验证错误
 2. CI/CD 会在 PR 中标记问题
 3. 你可以手动修正并在下一次提示中指导 AI
 
@@ -578,8 +578,8 @@ Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成�
 
 - **CLI 参考手册**: [CLI-REFERENCE.md](CLI-REFERENCE.md) — 详细的命令参考
 - **工作流**: [WORKFLOWS.md](WORKFLOWS.md) — 推荐的日常使用模式
-- **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/devtrail/issues)
-- **讨论**: [GitHub Discussions](https://github.com/StrangeDaysTech/devtrail/discussions)
+- **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
+- **讨论**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 - **贡献**: 参见 [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ---
@@ -588,7 +588,7 @@ Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成�
 
 <div align="center">
 
-**DevTrail** — 因为每一次变更都值得被记录。
+**StrayMark** — 因为每一次变更都值得被记录。
 
 [返回 README](../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -1,6 +1,6 @@
-# DevTrail CLI 参考手册
+# StrayMark CLI 参考手册
 
-**`devtrail` 命令行工具的完整参考。**
+**`straymark` 命令行工具的完整参考。**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -20,66 +20,66 @@
 
 ## 安装
 
-使用以下方法之一安装 DevTrail CLI。完整安装说明参见 [README](../README.md#快速开始)。
+使用以下方法之一安装 StrayMark CLI。完整安装说明参见 [README](../README.md#快速开始)。
 
 **快速安装（预编译二进制文件）：**
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 ```
 
 **从源码安装：**
 
 ```bash
-cargo install devtrail-cli
+cargo install straymark-cli
 ```
 
 ---
 
 ## 版本管理
 
-DevTrail 为每个组件使用**独立的版本标签**：
+StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.10.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.10.0` | `devtrail` 二进制文件 |
+| CLI | `cli-` | `cli-3.10.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
 **检查已安装的版本：**
 
 ```bash
-devtrail about    # 显示 CLI 版本 + Framework 版本（如已安装）
-devtrail status   # 显示完整的安装状态，包括版本
+straymark about    # 显示 CLI 版本 + Framework 版本（如已安装）
+straymark status   # 显示完整的安装状态，包括版本
 ```
 
 ---
 
 ## 命令
 
-### `devtrail init [path] [--hooks]`
+### `straymark init [path] [--hooks]`
 
-在项目目录中初始化 DevTrail。
+在项目目录中初始化 StrayMark。
 
 **参数和标志：**
 
 | 参数/标志 | 默认值 | 描述 |
 |-----------|--------|------|
 | `path` | `.`（当前目录） | 目标项目目录 |
-| `--hooks` *(cli-3.7.0+)* | off | 在 `init` 后将框架的 pre-PR 钩子（`.devtrail/hooks/pre-pr.sh`）安装为 `.git/hooks/pre-push`。每次 push 之前自动运行 `devtrail charter drift`。Opt-in，遵循原则 #6（认知纪律 > 原始生产力）。如果已存在 `pre-push` 钩子则拒绝覆盖；非 git 仓库时静默跳过。 |
+| `--hooks` *(cli-3.7.0+)* | off | 在 `init` 后将框架的 pre-PR 钩子（`.straymark/hooks/pre-pr.sh`）安装为 `.git/hooks/pre-push`。每次 push 之前自动运行 `straymark charter drift`。Opt-in，遵循原则 #6（认知纪律 > 原始生产力）。如果已存在 `pre-push` 钩子则拒绝覆盖；非 git 仓库时静默跳过。 |
 
 **功能：**
 
 1. 从 GitHub 下载最新的 Framework 版本（`fw-*`）
-2. 创建 `.devtrail/` 目录结构
-3. 创建包含治理规则的 `DEVTRAIL.md`
+2. 创建 `.straymark/` 目录结构
+3. 创建包含治理规则的 `STRAYMARK.md`
 4. 配置 AI Agent 指令文件（`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
 5. 复制 CI/CD 工作流
 6. *(`--hooks`)* 安装 pre-PR 钩子
@@ -87,28 +87,28 @@ devtrail status   # 显示完整的安装状态，包括版本
 **示例：**
 
 ```bash
-$ devtrail init .
-✔ Downloaded DevTrail fw-4.10.0
-✔ Created .devtrail/ directory structure
-✔ Created DEVTRAIL.md
+$ straymark init .
+✔ Downloaded StrayMark fw-4.10.0
+✔ Created .straymark/ directory structure
+✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
 
-DevTrail initialized successfully!
-Next: git add .devtrail/ DEVTRAIL.md && git commit -m "chore: adopt DevTrail"
+StrayMark initialized successfully!
+Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```
 
 ---
 
-### `devtrail update`
+### `straymark update`
 
 将 Framework 和 CLI **同时**更新到最新版本。等同于依次运行 `update-framework` 和 `update-cli`。
 
-如果当前目录中不存在 `.devtrail/`，Framework 更新将被跳过并显示警告。
+如果当前目录中不存在 `.straymark/`，Framework 更新将被跳过并显示警告。
 
 **示例：**
 
 ```bash
-$ devtrail update
+$ straymark update
 Updating framework...
 ✔ Framework updated to fw-4.10.0
 Updating CLI...
@@ -117,7 +117,7 @@ Updating CLI...
 
 ---
 
-### `devtrail update-framework`
+### `straymark update-framework`
 
 仅更新 Framework 文件。在 GitHub 上查找最新的 `fw-*` 版本。
 
@@ -126,61 +126,61 @@ Updating CLI...
 **示例：**
 
 ```bash
-$ devtrail update-framework
+$ straymark update-framework
 ✔ Framework updated to fw-4.10.0
 ```
 
 ---
 
-### `devtrail update-cli`
+### `straymark update-cli`
 
-自动更新 `devtrail` 二进制文件。自动检测安装方式并使用相应的更新机制：
+自动更新 `straymark` 二进制文件。自动检测安装方式并使用相应的更新机制：
 
 - **预编译二进制文件**（通过 `install.sh` / `install.ps1` 安装）：从 GitHub Releases 下载最新二进制文件
-- **Cargo**（通过 `cargo install` 安装）：运行 `cargo install --force devtrail-cli`
+- **Cargo**（通过 `cargo install` 安装）：运行 `cargo install --force straymark-cli`
 
 使用 `--method` 覆盖自动检测：`--method=github` 或 `--method=cargo`。
 
 **示例：**
 
 ```bash
-$ devtrail update-cli
+$ straymark update-cli
 ✔ CLI updated to cli-3.5.2
 
-$ devtrail update-cli --method=cargo
+$ straymark update-cli --method=cargo
 Compiling from source, this may take a few minutes...
 ✔ CLI updated to cli-3.5.2
 ```
 
 ---
 
-### `devtrail remove [--full]`
+### `straymark remove [--full]`
 
-从当前项目中移除 DevTrail。
+从当前项目中移除 StrayMark。
 
 **标志：**
 
 | 标志 | 描述 |
 |------|------|
-| `--full` | 移除所有内容，包括你在 `.devtrail/` 中创建的文档。会请求确认。 |
+| `--full` | 移除所有内容，包括你在 `.straymark/` 中创建的文档。会请求确认。 |
 
-**默认行为**（不带 `--full`）：移除 Framework 结构但保留你在 `.devtrail/` 中创建的文档。
+**默认行为**（不带 `--full`）：移除 Framework 结构但保留你在 `.straymark/` 中创建的文档。
 
 **示例：**
 
 ```bash
-$ devtrail remove
-✔ DevTrail framework removed. User documents preserved in .devtrail/.
+$ straymark remove
+✔ StrayMark framework removed. User documents preserved in .straymark/.
 
-$ devtrail remove --full
-⚠ This will delete all DevTrail files including your documents.
+$ straymark remove --full
+⚠ This will delete all StrayMark files including your documents.
 Continue? [y/N]: y
-✔ DevTrail completely removed.
+✔ StrayMark completely removed.
 ```
 
 ---
 
-### `devtrail status [path]`
+### `straymark status [path]`
 
 显示安装状态和文档统计。
 
@@ -202,10 +202,10 @@ Continue? [y/N]: y
 **示例：**
 
 ```
-$ devtrail status
+$ straymark status
 
   ╔════════════════════════════════════════════════╗
-  ║ DevTrail Status                                ║
+  ║ StrayMark Status                                ║
   ╚════════════════════════════════════════════════╝
 
   Project
@@ -236,14 +236,14 @@ $ devtrail status
   │ Total                        │    30 │
   └──────────────────────────────┴───────┘
 
-  → Run devtrail explore to browse documentation interactively
+  → Run straymark explore to browse documentation interactively
 ```
 
 ---
 
-### `devtrail repair [path]`
+### `straymark repair [path]`
 
-通过恢复缺失的目录和 Framework 文件来修复损坏的 DevTrail 安装。
+通过恢复缺失的目录和 Framework 文件来修复损坏的 StrayMark 安装。
 
 **参数：**
 
@@ -255,31 +255,31 @@ $ devtrail status
 
 1. 检查缺失的目录并使用 `.gitkeep` 恢复
 2. 如果需要恢复文件（模板、治理文档、配置），**一次性**下载 Framework 版本
-3. 如果 `DEVTRAIL.md` 缺失，重新注入指令
+3. 如果 `STRAYMARK.md` 缺失，重新注入指令
 4. 修复后重新计算校验和
 5. 不会修改或删除用户生成的文档
 
 **示例：**
 
 ```bash
-$ devtrail repair
-Repairing DevTrail in /home/user/my-project
+$ straymark repair
+Repairing StrayMark in /home/user/my-project
   → Found 1 issue(s) to repair
 → Restoring 1 missing directory...
-✓ Restored .devtrail/templates/
+✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
   Using version: fw-4.10.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
-✓ DevTrail repaired successfully!
+✓ StrayMark repaired successfully!
 ```
 
 ---
 
-### `devtrail validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
+### `straymark validate [path] [--fix] [--staged] [--include-charters] [--check-pending-reviews [--max-pending-days N]]`
 
-验证 DevTrail 文档的合规性和正确性。
+验证 StrayMark 文档的合规性和正确性。
 
 **参数和标志：**
 
@@ -306,22 +306,22 @@ Repairing DevTrail in /home/user/my-project
 **示例：**
 
 ```bash
-$ devtrail validate
-  DevTrail Validate
+$ straymark validate
+  StrayMark Validate
   All 15 document(s) passed validation
   0 error(s), 0 warning(s) in 15 document(s)
 
-$ devtrail validate --fix
-  DevTrail Validate
+$ straymark validate --fix
+  StrayMark Validate
   Auto-fixing 2 issue(s)...
   ✓ Fixed 2 issue(s)
 ```
 
 ---
 
-### `devtrail new [path] [-t <type>] [--title <title>]`
+### `straymark new [path] [-t <type>] [--title <title>]`
 
-从模板创建新的 DevTrail 文档。
+从模板创建新的 StrayMark 文档。
 
 **参数和标志：**
 
@@ -337,30 +337,30 @@ $ devtrail validate --fix
 
 ```bash
 # 交互式 — 提示输入类型和标题
-$ devtrail new
+$ straymark new
 
 # 创建带标题的 AILOG（非交互式）
-$ devtrail new -t ailog --title "Implement JWT authentication"
+$ straymark new -t ailog --title "Implement JWT authentication"
 
 # 创建 ADR
-$ devtrail new --doc-type adr --title "Use PostgreSQL for persistence"
+$ straymark new --doc-type adr --title "Use PostgreSQL for persistence"
 ```
 
 **输出示例：**
 
 ```
-$ devtrail new -t ailog --title "Implement JWT authentication"
+$ straymark new -t ailog --title "Implement JWT authentication"
 
-  ✔ Created: .devtrail/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
+  ✔ Created: .straymark/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
 
   Next steps:
     1. Edit the document to fill in details
-    2. Commit: git add .devtrail/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
+    2. Commit: git add .straymark/07-ai-audit/agent-logs/AILOG-2026-04-01-001-implement-jwt-authentication.md
 ```
 
 ---
 
-### `devtrail approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
+### `straymark approve <doc-id> --outcome <outcome> --reviewer <id> [--at YYYY-MM-DD] [--notes "..."] [--path <dir>]`
 
 *自 **cli-3.7.0** + **fw-4.6.0** 起可用。`--quiet` 与高风险警告于 cli-3.8.0 加入。*
 
@@ -386,7 +386,7 @@ $ devtrail new -t ailog --title "Implement JWT authentication"
 
 ```bash
 # Flag 驱动（CI / 脚本）
-$ devtrail approve AIDEC-2026-05-02-001 \
+$ straymark approve AIDEC-2026-05-02-001 \
     --outcome approved \
     --reviewer pepe@example.com \
     --notes "Reviewed against ADR-007. LGTM."
@@ -394,38 +394,38 @@ $ devtrail approve AIDEC-2026-05-02-001 \
   ✔ AIDEC-2026-05-02-001 marked as approved.
     Reviewer: pepe@example.com
     Date:     2026-05-02
-    File:     .devtrail/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
+    File:     .straymark/07-ai-audit/decisions/AIDEC-2026-05-02-001-foo.md
 
 # 迭代评审周期：revisions_requested → 重新批准
-$ devtrail approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
+$ straymark approve AIDEC-... --outcome revisions_requested --reviewer reviewer@x.io
 # (作者迭代)
-$ devtrail approve AIDEC-... --outcome approved --reviewer reviewer@x.io
+$ straymark approve AIDEC-... --outcome approved --reviewer reviewer@x.io
 # Frontmatter 显示最新（approved）；正文按时间顺序保留两个块。
 
 # 积压可见性
-$ devtrail validate --check-pending-reviews --max-pending-days 14
+$ straymark validate --check-pending-reviews --max-pending-days 14
 ```
 
-> 完整流程定义（关闭语义、正文格式、多评审者约定）见 `dist/.devtrail/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval"。
+> 完整流程定义（关闭语义、正文格式、多评审者约定）见 `dist/.straymark/00-governance/DOCUMENTATION-POLICY.md` §3.5 "Recording Approval"。
 
 ---
 
-### `devtrail charter <子命令>`
+### `straymark charter <子命令>`
 
-管理**章程（Charter）**：事前声明、事后审计的有界工作单元。一个章程将声明性范围（要修改的文件、风险、可执行的验证命令）与事后审计锚点（漂移检测、多模型审计）配对。章程位于 `docs/charters/NN-slug.md`（项目根目录级别，**不在** `.devtrail/` 之下）。
+管理**章程（Charter）**：事前声明、事后审计的有界工作单元。一个章程将声明性范围（要修改的文件、风险、可执行的验证命令）与事后审计锚点（漂移检测、多模型审计）配对。章程位于 `docs/charters/NN-slug.md`（项目根目录级别，**不在** `.straymark/` 之下）。
 
-> **命名历史。**在使该模式定型的 Sentinel `/plan-audit` 实验中（2026 年 4 月，6 个周期），章程被称为 *Plans*。DevTrail CLI 从此版本开始使用 **Charter** 以避免与 GitHub SpecKit 的 `plan.md` 命名冲突。Sentinel 的历史文件刻意保留 "Plan" 命名。完整的概念范围与重命名理由见 `Propuesta/que-es-un-charter.md`。
+> **命名历史。**在使该模式定型的 Sentinel `/plan-audit` 实验中（2026 年 4 月，6 个周期），章程被称为 *Plans*。StrayMark CLI 从此版本开始使用 **Charter** 以避免与 GitHub SpecKit 的 `plan.md` 命名冲突。Sentinel 的历史文件刻意保留 "Plan" 命名。完整的概念范围与重命名理由见 `Propuesta/que-es-un-charter.md`。
 
 **子命令：**
 
-- `devtrail charter new` — 从框架模板创建新的章程
-- `devtrail charter list` — 用可选过滤器枚举章程
-- `devtrail charter status` — 显示章程详情，或最近的 5 个章程
-- `devtrail charter close` *(cli-3.7.0+)* — 记录执行后遥测并将章程移至 `closed`
-- `devtrail charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制
-- `devtrail charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
+- `straymark charter new` — 从框架模板创建新的章程
+- `straymark charter list` — 用可选过滤器枚举章程
+- `straymark charter status` — 显示章程详情，或最近的 5 个章程
+- `straymark charter close` *(cli-3.7.0+)* — 记录执行后遥测并将章程移至 `closed`
+- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制
+- `straymark charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
 
-#### `devtrail charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
+#### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
 从框架模板将章程创建到 `docs/charters/NN-slug.md`。如果未传入 `--title`，会以交互方式提示。两个来源标志在 clap 级别互斥。
 
@@ -439,7 +439,7 @@ $ devtrail validate --check-pending-reviews --max-pending-days 14
 
 未传入任何来源标志时，`originating_ailogs` 和 `originating_spec` 在生成的前置元数据中均保持注释状态——章程"无显式来源"地创建，由用户在状态变为 `in-progress` 之前手动填写。
 
-#### `devtrail charter list [--status declared|in-progress|closed|all] [--origin ailog|spec|any] [path]`
+#### `straymark charter list [--status declared|in-progress|closed|all] [--origin ailog|spec|any] [path]`
 
 以表格形式枚举章程。
 
@@ -451,7 +451,7 @@ $ devtrail validate --check-pending-reviews --max-pending-days 14
 
 无法解析的文件作为警告输出到 stderr，不会中断命令——表格显示能列出的内容。
 
-#### `devtrail charter status [CHARTER-ID] [--path <dir>]`
+#### `straymark charter status [CHARTER-ID] [--path <dir>]`
 
 带 ID：打印完整的章程详情（前置元数据、文件位置、正文章节列表）。无 ID：按 NN 降序打印最近的 5 个章程。
 
@@ -460,9 +460,9 @@ $ devtrail validate --check-pending-reviews --max-pending-days 14
 | `CHARTER-ID` | — | 章程标识符。接受完整的 `charter_id`（`CHARTER-01-test`）、`CHARTER-NN` 前缀（`CHARTER-01`），或仅数字 NN（`01` 或 `1`）。数字匹配对零填充宽容。 |
 | `--path` | `.` | 目标项目目录。使用标志（而非位置参数）以避免与可选位置参数 `CHARTER-ID` 混淆。 |
 
-#### `devtrail charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
+#### `straymark charter close <CHARTER-ID> [--from-template] [--non-interactive] [--path <dir>]`
 
-记录执行后遥测并将章程状态移至 `closed`。遥测被写入 `.devtrail/charters/CHARTER-NN.telemetry.yaml`（独立文件，**不**嵌入到章程的 frontmatter — frontmatter 是事前声明性的；遥测是事后大量数据）。形状根据 `.devtrail/schemas/charter-telemetry.schema.v0.json` 验证。
+记录执行后遥测并将章程状态移至 `closed`。遥测被写入 `.straymark/charters/CHARTER-NN.telemetry.yaml`（独立文件，**不**嵌入到章程的 frontmatter — frontmatter 是事前声明性的；遥测是事后大量数据）。形状根据 `.straymark/schemas/charter-telemetry.schema.v0.json` 验证。
 
 两种模式：
 
@@ -482,7 +482,7 @@ $ devtrail validate --check-pending-reviews --max-pending-days 14
 **示例：**
 
 ```bash
-$ devtrail charter close CHARTER-01
+$ straymark charter close CHARTER-01
 
   Closing CHARTER-01-test-charter
     Title: Test charter
@@ -495,13 +495,13 @@ $ devtrail charter close CHARTER-01
   ...
 
   ✔ Charter CHARTER-01 closed.
-    Telemetry: .devtrail/charters/CHARTER-01.telemetry.yaml
+    Telemetry: .straymark/charters/CHARTER-01.telemetry.yaml
     Status updated: in-progress/declared → closed
 ```
 
-#### `devtrail charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
 
-在章程关闭时检测文件 vs 提交漂移。封装框架的 `.devtrail/scripts/check-charter-drift.sh`（在 Sentinel PLAN-05 回顾性 + PLAN-06 前瞻性中实证验证零误报）。CLI 在原始脚本之上的附加价值是 **AILOG 感知**：报告为"已声明但未修改"的路径，如果出现在被章程 `originating_ailogs` 引用的任何 AILOG 的 `## Risk` / `## Riesgos` / `## 风险` 节中，则被静默。使用 `--no-ailog-suppress` 来禁用。
+在章程关闭时检测文件 vs 提交漂移。封装框架的 `.straymark/scripts/check-charter-drift.sh`（在 Sentinel PLAN-05 回顾性 + PLAN-06 前瞻性中实证验证零误报）。CLI 在原始脚本之上的附加价值是 **AILOG 感知**：报告为"已声明但未修改"的路径，如果出现在被章程 `originating_ailogs` 引用的任何 AILOG 的 `## Risk` / `## Riesgos` / `## 风险` 节中，则被静默。使用 `--no-ailog-suppress` 来禁用。
 
 | 参数/标志 | 默认值 | 描述 |
 |---|---|---|
@@ -515,7 +515,7 @@ $ devtrail charter close CHARTER-01
 **示例：**
 
 ```bash
-$ devtrail charter drift CHARTER-01 --range origin/main..HEAD
+$ straymark charter drift CHARTER-01 --range origin/main..HEAD
 === Charter drift check ===
   Charter: docs/charters/01-test.md
   Range:   origin/main..HEAD
@@ -539,20 +539,20 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 | 形式 | 示例 | 用例 |
 |---|---|---|
-| 省略号 | `` `.devtrail/07-ai-audit/agent-logs/AILOG-...md` `` | 任何带该前缀的修改路径满足通配符。历史上用于执行期间会创建未知数量 AILOG 的情况。 |
-| Glob | `` `AILOG-*.md` `` 或 `` `src/services/foo-*.rs` `` | 任何匹配该 glob（`*` → `.*`）的修改路径满足通配符。用于参数化集合被触动的批量章程声明。在 fw-4.9.0 中加入，源于 Sentinel CHARTER-04 暴露的摩擦（[issue #81](https://github.com/StrangeDaysTech/devtrail/issues/81)）。 |
+| 省略号 | `` `.straymark/07-ai-audit/agent-logs/AILOG-...md` `` | 任何带该前缀的修改路径满足通配符。历史上用于执行期间会创建未知数量 AILOG 的情况。 |
+| Glob | `` `AILOG-*.md` `` 或 `` `src/services/foo-*.rs` `` | 任何匹配该 glob（`*` → `.*`）的修改路径满足通配符。用于参数化集合被触动的批量章程声明。在 fw-4.9.0 中加入，源于 Sentinel CHARTER-04 暴露的摩擦（[issue #81](https://github.com/StrangeDaysTech/straymark/issues/81)）。 |
 
 两种形式都双向处理：声明的通配符既抑制"已声明但未修改"警告（当至少一个匹配文件被修改时），也抑制"已修改但未声明"警告（当一个修改路径匹配某个已声明通配符时）。
 
 #### 设计：治理路径始终在 scope 内
 
-`docs/charters/*` 和 `.devtrail/07-ai-audit/*` 下的路径**永远不会**被报告为"已修改但未声明"。这是有意的设计 — 当章程本身或执行的 AILOG 被触动时，这些路径总是合法的。在 Sentinel CHARTER-04 中实证验证：一次意外的 `git add -A` 暂存了无关的用户未跟踪文件（`.claude/skills/`、`cmd/sentinel/sentinel`）；该规则正确抑制了治理噪声而没有掩盖真正的项目文件扩展（[issue #81 W2](https://github.com/StrangeDaysTech/devtrail/issues/81#issuecomment-update)）。
+`docs/charters/*` 和 `.straymark/07-ai-audit/*` 下的路径**永远不会**被报告为"已修改但未声明"。这是有意的设计 — 当章程本身或执行的 AILOG 被触动时，这些路径总是合法的。在 Sentinel CHARTER-04 中实证验证：一次意外的 `git add -A` 暂存了无关的用户未跟踪文件（`.claude/skills/`、`cmd/sentinel/sentinel`）；该规则正确抑制了治理噪声而没有掩盖真正的项目文件扩展（[issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)）。
 
-如果你运行的章程显式 scope 是治理 churn（例如仅触动 `.devtrail/07-ai-audit/` 的批量批准章程），漂移检查将报告 0 个修改文件，你需要通过阅读 AILOG 来验证 scope。一个 `--strict-scope` 标志（禁用"始终在 scope"规则）在桌面上，用于未来 minor 版本，前提是真实的 adopter 报告这种不对称为摩擦。
+如果你运行的章程显式 scope 是治理 churn（例如仅触动 `.straymark/07-ai-audit/` 的批量批准章程），漂移检查将报告 0 个修改文件，你需要通过阅读 AILOG 来验证 scope。一个 `--strict-scope` 标志（禁用"始终在 scope"规则）在桌面上，用于未来 minor 版本，前提是真实的 adopter 报告这种不对称为摩擦。
 
-#### `devtrail charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
+#### `straymark charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
 
-*自 **cli-3.8.0** + **fw-4.7.0** 起可用。v1 统一流程在 **cli-3.10.0** + **fw-4.9.0** 中发布 — 用两步（PREPARE/MERGE-REPORTS）替换 v0 的三步（PREPARE/CALIBRATE/FINALIZE），统一审计员模板，并将规范路径迁移到 `.devtrail/audits/`。*
+*自 **cli-3.8.0** + **fw-4.7.0** 起可用。v1 统一流程在 **cli-3.10.0** + **fw-4.9.0** 中发布 — 用两步（PREPARE/MERGE-REPORTS）替换 v0 的三步（PREPARE/CALIBRATE/FINALIZE），统一审计员模板，并将规范路径迁移到 `.straymark/audits/`。*
 
 编排章程执行的多模型外部审计。**仅编排** — CLI 准备 prompts、根据 schema 验证 outputs，并打印可粘贴到章程遥测中的 findings。**它不调用 LLM API。** 操作员在自己选择的审计器（Copilot、Gemini、Claude 等）中运行 prompts，并将响应保存到规范路径。
 
@@ -574,7 +574,7 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 ##### 异质性建议（在 v0 中不强制）
 
-按照设计理由（`devtrail-cli-roadmap.md` §5.2），auditor pair 应该是**不同模型族**：一个 Anthropic + 一个 Google + 一个 OpenAI，任意组合，永远不要两个同族。跨族异质性是使 findings 上的趋同成为高信号的原因 — 同族审计员共享盲点。
+按照设计理由（`straymark-cli-roadmap.md` §5.2），auditor pair 应该是**不同模型族**：一个 Anthropic + 一个 Google + 一个 OpenAI，任意组合，永远不要两个同族。跨族异质性是使 findings 上的趋同成为高信号的原因 — 同族审计员共享盲点。
 
 Calibrator-reconciler 可以是任何家族（包括实现者的家族），因为它的任务是定义性的（在已产生的判定上应用 schema），而非发现性。异质性对 auditor pair 重要，对 calibrator 不重要。
 
@@ -593,12 +593,12 @@ audit/charters/CHARTER-NN/
 └── calibrator-reconciler.md           # 操作员粘贴 calibrator 的响应
 ```
 
-`prompts/` 子目录持久化 API 调用*之前*发送给每个 auditor 的内容（关闭关于审计可见性的 [RFC #82](https://github.com/StrangeDaysTech/devtrail/issues/82)）。Adopters 可以 `git add` 整个 `audit/` 目录得到完全版本化的审计轨迹，或 `.gitignore` 它（如果偏好周期是临时的）。
+`prompts/` 子目录持久化 API 调用*之前*发送给每个 auditor 的内容（关闭关于审计可见性的 [RFC #82](https://github.com/StrangeDaysTech/straymark/issues/82)）。Adopters 可以 `git add` 整个 `audit/` 目录得到完全版本化的审计轨迹，或 `.gitignore` 它（如果偏好周期是临时的）。
 
 **示例：**
 
 ```bash
-$ devtrail charter audit CHARTER-05
+$ straymark charter audit CHARTER-05
   Step 1/3: PREPARE (CHARTER-05)
   ✔ Wrote audit/charters/CHARTER-05/prompts/auditor-primary.prompt.md
   ✔ Wrote audit/charters/CHARTER-05/prompts/auditor-secondary.prompt.md
@@ -609,11 +609,11 @@ $ devtrail charter audit CHARTER-05
     2. Save the auditor responses to:
          audit/charters/CHARTER-05/auditor-primary.md
          audit/charters/CHARTER-05/auditor-secondary.md
-    3. Run: devtrail charter audit CHARTER-05 --calibrate
+    3. Run: straymark charter audit CHARTER-05 --calibrate
 
 # (操作员在 Copilot 中运行 auditor 1，保存响应。在 Gemini 中运行 auditor 2，保存响应。)
 
-$ devtrail charter audit CHARTER-05 --calibrate
+$ straymark charter audit CHARTER-05 --calibrate
   Step 2/3: CALIBRATE (CHARTER-05)
   ✔ Validated audit/charters/CHARTER-05/auditor-primary.md
   ✔ Validated audit/charters/CHARTER-05/auditor-secondary.md
@@ -623,11 +623,11 @@ $ devtrail charter audit CHARTER-05 --calibrate
     1. Run the calibrator prompt in a model of your choice (calibrator
        may be of any family).
     2. Save the response to: audit/charters/CHARTER-05/calibrator-reconciler.md
-    3. Run: devtrail charter audit CHARTER-05 --finalize
+    3. Run: straymark charter audit CHARTER-05 --finalize
 
 # (操作员在 Claude 中运行 calibrator，保存响应。)
 
-$ devtrail charter audit CHARTER-05 --finalize
+$ straymark charter audit CHARTER-05 --finalize
   Step 3/3: FINALIZE (CHARTER-05)
   ✔ Validated audit/charters/CHARTER-05/auditor-primary.md (5 findings)
   ✔ Validated audit/charters/CHARTER-05/auditor-secondary.md (4 findings)
@@ -655,13 +655,13 @@ $ devtrail charter audit CHARTER-05 --finalize
 
 > **为什么仅编排？** 实现 3 个 HTTP 客户端（OpenAI / Google / Anthropic）需要 1-2 周 + 当 API 变化时的永久维护。Phase 3 v0 是实验性的 — CLI 的价值是 canon（prompt 形状 + output schema + 与遥测的集成），而非 API 调用本身。当 adopter 报告真实需求时，v1 可能加入 HTTP 客户端；在此之前，人在环模式与激发 Phase 3 的 Sentinel 实证 `/plan-audit` 模式相符。
 
-> **Skill 替代方案 *(fw-4.9.0+)*。** 当与 AI 助手在循环中协作时（Claude Code、Gemini Code、Cursor 等），skills `/devtrail-audit-prompt CHARTER-ID` 和 `/devtrail-audit-review CHARTER-ID` 封装此命令并在对话中内联展示 prompts。Skills 还处理校准器步骤（驱动对话的 Agent 运行校准器）并触发 `--finalize --merge-into`，使得 `external_audit:` 数组直接追加到遥测中无需手动复制粘贴。详见下方的 [Skills](#skills) 章节。CLI 仍是唯一真相来源 — skills 仅添加 UX-inline。
+> **Skill 替代方案 *(fw-4.9.0+)*。** 当与 AI 助手在循环中协作时（Claude Code、Gemini Code、Cursor 等），skills `/straymark-audit-prompt CHARTER-ID` 和 `/straymark-audit-review CHARTER-ID` 封装此命令并在对话中内联展示 prompts。Skills 还处理校准器步骤（驱动对话的 Agent 运行校准器）并触发 `--finalize --merge-into`，使得 `external_audit:` 数组直接追加到遥测中无需手动复制粘贴。详见下方的 [Skills](#skills) 章节。CLI 仍是唯一真相来源 — skills 仅添加 UX-inline。
 
 ---
 
-### `devtrail compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
+### `straymark compliance [path] [--standard <name>] [--region <name>] [--all] [--output <format>]`
 
-检查法规合规状态。默认评估 `.devtrail/config.yml` 中 `regional_scope` 所列区域的标准(默认 `[global, eu]`)。在 `regional_scope` 中加入 `china` 后,六个中国法规框架可用。
+检查法规合规状态。默认评估 `.straymark/config.yml` 中 `regional_scope` 所列区域的标准(默认 `[global, eu]`)。在 `regional_scope` 中加入 `china` 后,六个中国法规框架可用。
 
 **参数和标志：**
 
@@ -688,19 +688,19 @@ $ devtrail charter audit CHARTER-05 --finalize
 
 ```bash
 # 默认:仅运行 regional_scope 中包含的区域的标准
-$ devtrail compliance
+$ straymark compliance
 
 # 六个中国框架(需要 regional_scope: china)
-$ devtrail compliance --region china
+$ straymark compliance --region china
 
 # 单一中国框架
-$ devtrail compliance --standard china-pipl --output json
+$ straymark compliance --standard china-pipl --output json
 
 # 强制运行全部标准,忽略 regional_scope
-$ devtrail compliance --all
+$ straymark compliance --all
 ```
 
-> **启用方式**:在 `.devtrail/config.yml` 中添加:
+> **启用方式**:在 `.straymark/config.yml` 中添加:
 >
 > ```yaml
 > regional_scope:
@@ -718,8 +718,8 @@ $ devtrail compliance --all
 **示例：**
 
 ```bash
-$ devtrail compliance --all
-  DevTrail Compliance
+$ straymark compliance --all
+  StrayMark Compliance
   /home/user/my-project
   12 document(s) analyzed
 
@@ -744,13 +744,13 @@ $ devtrail compliance --all
 
   Overall compliance: 78%
 
-$ devtrail compliance --standard eu-ai-act --output json
+$ straymark compliance --standard eu-ai-act --output json
 [{"standard":"EuAiAct","checks":[...],"score":75.0}]
 ```
 
 ---
 
-### `devtrail metrics [path] [--period <period>] [--output <format>]`
+### `straymark metrics [path] [--period <period>] [--output <format>]`
 
 显示治理指标和文档统计。
 
@@ -773,8 +773,8 @@ $ devtrail compliance --standard eu-ai-act --output json
 **示例：**
 
 ```bash
-$ devtrail metrics --period last-30-days
-  DevTrail Metrics
+$ straymark metrics --period last-30-days
+  StrayMark Metrics
   /home/user/my-project
   Period: Last 30 days — 2026-02-25 to 2026-03-27
 
@@ -805,7 +805,7 @@ $ devtrail metrics --period last-30-days
 
 ---
 
-### `devtrail analyze [path] [--threshold <N>] [--output <format>] [--top <N>]`
+### `straymark analyze [path] [--threshold <N>] [--output <format>] [--top <N>]`
 
 使用认知复杂度和圈复杂度指标分析代码复杂度，由 [arborist-metrics](https://crates.io/crates/arborist-metrics) 驱动。
 
@@ -820,9 +820,9 @@ $ devtrail metrics --period last-30-days
 
 **支持的语言：** Rust, Python, JavaScript, TypeScript, Java, Go, C, C++, C#, PHP, Kotlin, Swift
 
-**阈值解析顺序：** CLI 标志 → `.devtrail/config.yml` → 默认值 (8)
+**阈值解析顺序：** CLI 标志 → `.straymark/config.yml` → 默认值 (8)
 
-**配置**（可选，在 `.devtrail/config.yml` 中）：
+**配置**（可选，在 `.straymark/config.yml` 中）：
 
 ```yaml
 complexity:
@@ -833,22 +833,22 @@ complexity:
 
 ```bash
 # 分析当前目录
-$ devtrail analyze
+$ straymark analyze
 
 # 自定义阈值并显示前 10 名
-$ devtrail analyze --threshold 5 --top 10
+$ straymark analyze --threshold 5 --top 10
 
 # JSON 输出用于 CI 集成
-$ devtrail analyze --output json
+$ straymark analyze --output json
 
 # 分析指定项目
-$ devtrail analyze /path/to/project
+$ straymark analyze /path/to/project
 ```
 
 **输出示例：**
 
 ```
-  DevTrail Analyze
+  StrayMark Analyze
   /home/user/project
   Threshold: cognitive complexity > 8
 
@@ -867,13 +867,13 @@ $ devtrail analyze /path/to/project
     → Average cognitive complexity: 3.8
 ```
 
-> **注意：** 此命令无需 `devtrail init` 即可工作。它操作源文件，而非 DevTrail 文档。`analyze` 功能可在编译时通过 `--no-default-features` 禁用。
+> **注意：** 此命令无需 `straymark init` 即可工作。它操作源文件，而非 StrayMark 文档。`analyze` 功能可在编译时通过 `--no-default-features` 禁用。
 
-> **文档触发：** AI Agent 使用 `devtrail analyze --output json` 作为确定何时创建 AILOG 文档的主要方法。如果 JSON 输出中 `summary.above_threshold > 0`，Agent 应创建 AILOG。当 CLI 不可用时，Agent 回退到 >20 行业务逻辑的启发式规则。
+> **文档触发：** AI Agent 使用 `straymark analyze --output json` 作为确定何时创建 AILOG 文档的主要方法。如果 JSON 输出中 `summary.above_threshold > 0`，Agent 应创建 AILOG。当 CLI 不可用时，Agent 回退到 >20 行业务逻辑的启发式规则。
 
 ---
 
-### `devtrail audit [path] [--from <date>] [--to <date>] [--system <name>] [--output <format>]`
+### `straymark audit [path] [--from <date>] [--to <date>] [--system <name>] [--output <format>]`
 
 生成包含时间线、可追溯性映射和合规摘要的审计跟踪报告。
 
@@ -907,26 +907,26 @@ $ devtrail analyze /path/to/project
 
 ```bash
 # 完整审计报告
-$ devtrail audit
+$ straymark audit
 
 # 2026 年 Q1 审计
-$ devtrail audit --from 2026-01-01 --to 2026-03-31
+$ straymark audit --from 2026-01-01 --to 2026-03-31
 
 # 按系统过滤审计
-$ devtrail audit --system auth-service
+$ straymark audit --system auth-service
 
 # 生成 HTML 报告
-$ devtrail audit --from 2026-01-01 --to 2026-03-31 --output html > audit-q1.html
+$ straymark audit --from 2026-01-01 --to 2026-03-31 --output html > audit-q1.html
 
 # 为 PR 生成 Markdown
-$ devtrail audit --output markdown
+$ straymark audit --output markdown
 ```
 
 ---
 
-### `devtrail explore [path]`
+### `straymark explore [path]`
 
-在终端界面（TUI）中交互式浏览和阅读 DevTrail 文档。
+在终端界面（TUI）中交互式浏览和阅读 StrayMark 文档。
 
 **参数：**
 
@@ -943,7 +943,7 @@ $ devtrail audit --output markdown
 **语言解析顺序**（自 cli-3.5.2 起）：
 
 1. 提供 `--lang <代码>` 标志时优先
-2. `.devtrail/config.yml` 文件存在时使用其中的 `language` 字段（即便是显式的 `language: en` 也视为用户的明确选择）
+2. `.straymark/config.yml` 文件存在时使用其中的 `language` 字段（即便是显式的 `language: en` 也视为用户的明确选择）
 3. 环境变量 `$LC_ALL` / `$LANG`，映射到受支持的语言（如 `zh_CN.UTF-8` → `zh-CN`，`es_MX.UTF-8` → `es`）。繁体中文（`zh_TW` / `zh_HK`）及其他不受支持的 locale 会跳到下一项
 4. `en`
 
@@ -955,7 +955,7 @@ $ devtrail audit --output markdown
 - 通过超链接在关联文档间导航
 - 按文件名、标题、标签或日期搜索
 - 全屏文档模式，`j` / `k` 作为 `↓` / `↑` 的替代按键
-- 本地化感知：框架文档（`QUICK-REFERENCE`、`AGENT-RULES`、中国合规指南等）按 `.devtrail/config.yml` 中的 `language` 或 `--lang` 提供对应语言版本
+- 本地化感知：框架文档（`QUICK-REFERENCE`、`AGENT-RULES`、中国合规指南等）按 `.straymark/config.yml` 中的 `language` 或 `--lang` 提供对应语言版本
 
 **快捷键：**
 
@@ -974,29 +974,29 @@ $ devtrail audit --output markdown
 **示例：**
 
 ```bash
-$ devtrail explore                       # 使用 config.language（默认 en）
-$ devtrail explore --lang zh-CN          # 以简体中文浏览框架文档
-$ devtrail explore --lang es             # 会话内切换到西班牙语
+$ straymark explore                       # 使用 config.language（默认 en）
+$ straymark explore --lang zh-CN          # 以简体中文浏览框架文档
+$ straymark explore --lang es             # 会话内切换到西班牙语
 ```
 
 > **注意：** `explore` 命令需要 `tui` feature（默认启用）。如需不含此功能编译：`cargo build --no-default-features`。
 
 ---
 
-### `devtrail about`
+### `straymark about`
 
 显示版本、作者和许可证信息。
 
 **示例：**
 
 ```bash
-$ devtrail about
-DevTrail CLI
+$ straymark about
+StrayMark CLI
   CLI version:       cli-3.5.2
   Framework version: fw-4.10.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
-  Repository:        https://github.com/StrangeDaysTech/devtrail
+  Repository:        https://github.com/StrangeDaysTech/straymark
   Website:           https://strangedays.tech
 ```
 
@@ -1004,7 +1004,7 @@ DevTrail CLI
 
 ## Skills
 
-DevTrail 提供一组 skills（slash 命令）供 AI 助手内使用（Claude Code、Gemini Code、Cursor、通用 Agent 运行时）。每个 skill 在 `devtrail init` 时以 3 种平行形式安装：
+StrayMark 提供一组 skills（slash 命令）供 AI 助手内使用（Claude Code、Gemini Code、Cursor、通用 Agent 运行时）。每个 skill 在 `straymark init` 时以 3 种平行形式安装：
 
 - `dist/.claude/skills/<skill>/SKILL.md`（Claude — frontmatter 含 `allowed-tools`）
 - `dist/.gemini/skills/<skill>/SKILL.md`（Gemini — frontmatter 不含 `allowed-tools`）
@@ -1012,26 +1012,26 @@ DevTrail 提供一组 skills（slash 命令）供 AI 助手内使用（Claude Co
 
 | Skill | 用途 | 产生的文件 |
 |---|---|---|
-| `/devtrail-status` | 检查近期变更的文档合规状态。 | 无（read-only） |
-| `/devtrail-new` | 交互式创建任意类型的文档。从上下文建议最佳匹配。 | `.devtrail/<type-dir>/<TYPE>-YYYY-MM-DD-NNN-*.md` |
-| `/devtrail-ailog` | 快速 AILOG 创建快捷方式。 | `.devtrail/07-ai-audit/agent-logs/AILOG-*.md` |
-| `/devtrail-aidec` | 快速 AIDEC 创建快捷方式。 | `.devtrail/07-ai-audit/decisions/AIDEC-*.md` |
-| `/devtrail-adr` | 快速 ADR 创建快捷方式。 | `.devtrail/04-architecture/decisions/ADR-*.md` |
-| `/devtrail-mcard` | 交互式 Model Card 创建流程。 | `.devtrail/09-ai-models/MCARD-*.md` |
-| `/devtrail-sec` | 交互式 SEC（安全评估）流程。 | `.devtrail/08-security/SEC-*.md` |
-| `/devtrail-audit-prompt CHARTER-ID` *(fw-4.9.0+，在 fw-4.9.0 中重构)* | 在规范路径处生成章程的统一审计 prompt。封装 `devtrail charter audit --prepare`。操作员随后在同一仓库中打开 N 个审计员 CLI，在每个中调用 `/devtrail-audit-execute` — 无需复制/粘贴。 | `.devtrail/audits/<CHARTER-ID>/audit-prompt.md` |
-| `/devtrail-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **在审计员 CLI 中运行**（gemini-cli、claude-cli、copilot-cli、codex-cli 等）。从磁盘读取已准备的 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。CHARTER-ID 参数可选 — 自动发现尚未由此模型生成 report 的 prompts。 | `.devtrail/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
-| `/devtrail-audit-review CHARTER-ID` *(fw-4.9.0+，在 fw-4.9.0 中扩展)* | `/devtrail-audit-prompt` 的对应。读取 `.devtrail/audits/<CHARTER-ID>/` 下的 N 个 reports，对每个 finding 与实际代码进行交叉验证（并行 Explore agents），生成六节合并的 `review.md`（执行摘要、范围、按审计员评估、修复计划 P0-P4、丢弃的 findings、审计员评分），并运行 `devtrail charter audit --merge-reports --merge-into` 将 `external_audit:` 追加到章程遥测中。如果遥测尚不存在（章程未关闭），写入 `external-audit-pending.yaml` 供 close 时合并。 | `.devtrail/audits/<CHARTER-ID>/review.md`，`external_audit:` 数组合并入遥测（或 pending YAML） |
+| `/straymark-status` | 检查近期变更的文档合规状态。 | 无（read-only） |
+| `/straymark-new` | 交互式创建任意类型的文档。从上下文建议最佳匹配。 | `.straymark/<type-dir>/<TYPE>-YYYY-MM-DD-NNN-*.md` |
+| `/straymark-ailog` | 快速 AILOG 创建快捷方式。 | `.straymark/07-ai-audit/agent-logs/AILOG-*.md` |
+| `/straymark-aidec` | 快速 AIDEC 创建快捷方式。 | `.straymark/07-ai-audit/decisions/AIDEC-*.md` |
+| `/straymark-adr` | 快速 ADR 创建快捷方式。 | `.straymark/04-architecture/decisions/ADR-*.md` |
+| `/straymark-mcard` | 交互式 Model Card 创建流程。 | `.straymark/09-ai-models/MCARD-*.md` |
+| `/straymark-sec` | 交互式 SEC（安全评估）流程。 | `.straymark/08-security/SEC-*.md` |
+| `/straymark-audit-prompt CHARTER-ID` *(fw-4.9.0+，在 fw-4.9.0 中重构)* | 在规范路径处生成章程的统一审计 prompt。封装 `straymark charter audit --prepare`。操作员随后在同一仓库中打开 N 个审计员 CLI，在每个中调用 `/straymark-audit-execute` — 无需复制/粘贴。 | `.straymark/audits/<CHARTER-ID>/audit-prompt.md` |
+| `/straymark-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **在审计员 CLI 中运行**（gemini-cli、claude-cli、copilot-cli、codex-cli 等）。从磁盘读取已准备的 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。CHARTER-ID 参数可选 — 自动发现尚未由此模型生成 report 的 prompts。 | `.straymark/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
+| `/straymark-audit-review CHARTER-ID` *(fw-4.9.0+，在 fw-4.9.0 中扩展)* | `/straymark-audit-prompt` 的对应。读取 `.straymark/audits/<CHARTER-ID>/` 下的 N 个 reports，对每个 finding 与实际代码进行交叉验证（并行 Explore agents），生成六节合并的 `review.md`（执行摘要、范围、按审计员评估、修复计划 P0-P4、丢弃的 findings、审计员评分），并运行 `straymark charter audit --merge-reports --merge-into` 将 `external_audit:` 追加到章程遥测中。如果遥测尚不存在（章程未关闭），写入 `external-audit-pending.yaml` 供 close 时合并。 | `.straymark/audits/<CHARTER-ID>/review.md`，`external_audit:` 数组合并入遥测（或 pending YAML） |
 
 ### Skill vs CLI
 
-三个审计 skill 是 CLI 命令和流程纪律的**封装**。`.devtrail/audits/` 下的规范路径、统一的 prompt 模板、schema 验证、`external_audit` 形状全部在 CLI + framework 中 — skills 处理 UX-inline 部分：调度操作员通过审计周期，无需手动管理文件。**操作员从不复制/粘贴 prompts 或 reports** — skills 通过 `.devtrail/audits/` 下的规范文件系统路径交换 artefacts。
+三个审计 skill 是 CLI 命令和流程纪律的**封装**。`.straymark/audits/` 下的规范路径、统一的 prompt 模板、schema 验证、`external_audit` 形状全部在 CLI + framework 中 — skills 处理 UX-inline 部分：调度操作员通过审计周期，无需手动管理文件。**操作员从不复制/粘贴 prompts 或 reports** — skills 通过 `.straymark/audits/` 下的规范文件系统路径交换 artefacts。
 
-不在循环中使用 AI 助手的 adopter 可直接通过 `devtrail charter audit`（`--prepare` / `--merge-reports [--merge-into <path>]`）驱动相同工作流。`.devtrail/audits/<id>/audit-prompt.md` 中的审计 prompt 在没有审计员 CLI 时也可粘贴到 chat 类 LLM 中使用 — skill 只是自动化文件交换。
+不在循环中使用 AI 助手的 adopter 可直接通过 `straymark charter audit`（`--prepare` / `--merge-reports [--merge-into <path>]`）驱动相同工作流。`.straymark/audits/<id>/audit-prompt.md` 中的审计 prompt 在没有审计员 CLI 时也可粘贴到 chat 类 LLM 中使用 — skill 只是自动化文件交换。
 
 ### 审计检查点 *(fw-4.9.0+)*
 
-`.devtrail/00-governance/AGENT-RULES.md` §12 编码了一个工作流检查点，其中 Agent 在某个特定时刻主动提议审计 — 当 Charter 实现完成、drift 干净，且 `charter close` 尚未调用时。推荐基于启发式给出 是/否（安全面、新组件、AILOG 风险、复杂度）。外部审计**完全可选**；检查点是**软性**的 — 永不阻塞 `charter close`，永不强制（v0+v1 永久设计决策）。
+`.straymark/00-governance/AGENT-RULES.md` §12 编码了一个工作流检查点，其中 Agent 在某个特定时刻主动提议审计 — 当 Charter 实现完成、drift 干净，且 `charter close` 尚未调用时。推荐基于启发式给出 是/否（安全面、新组件、AILOG 风险、复杂度）。外部审计**完全可选**；检查点是**软性**的 — 永不阻塞 `charter close`，永不强制（v0+v1 永久设计决策）。
 
 ---
 
@@ -1054,7 +1054,7 @@ DevTrail 提供一组 skills（slash 命令）供 AI 助手内使用（Claude Co
 
 <div align="center">
 
-**DevTrail** — 因为每一次变更都值得被记录。
+**StrayMark** — 因为每一次变更都值得被记录。
 
 [返回文档](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
 

--- a/docs/i18n/zh-CN/adopters/WORKFLOWS.md
+++ b/docs/i18n/zh-CN/adopters/WORKFLOWS.md
@@ -1,6 +1,6 @@
-# DevTrail - 推荐工作流
+# StrayMark - 推荐工作流
 
-**日常使用 DevTrail 的模式和节奏。**
+**日常使用 StrayMark 的模式和节奏。**
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
@@ -12,7 +12,7 @@
 
 1. [初始设置之后](#初始设置之后)
 2. [日常开发](#日常开发)
-3. [保持 DevTrail 更新](#保持-devtrail-更新)
+3. [保持 StrayMark 更新](#保持-straymark-更新)
 4. [检查项目状态](#检查项目状态)
 5. [使用 Skills（主动文档）](#使用-skills主动文档)
 6. [团队模式](#团队模式)
@@ -22,12 +22,12 @@
 
 ## 初始设置之后
 
-你已运行 `devtrail init .` 并提交了结果。接下来呢？
+你已运行 `straymark init .` 并提交了结果。接下来呢？
 
 1. **用你的 AI 编码助手打开项目**（Claude Code、Cursor、Gemini CLI 等）
-2. 助手会**自动读取** DevTrail 指令（`CLAUDE.md`、`GEMINI.md` 等）
-3. 从此刻起，助手会在正常工作流中**在 `.devtrail/` 中创建文档**
-4. **无需额外配置** — DevTrail 通过指令文件被动运行
+2. 助手会**自动读取** StrayMark 指令（`CLAUDE.md`、`GEMINI.md` 等）
+3. 从此刻起，助手会在正常工作流中**在 `.straymark/` 中创建文档**
+4. **无需额外配置** — StrayMark 通过指令文件被动运行
 
 ---
 
@@ -36,7 +36,7 @@
 ### 被动循环
 
 1. 正常使用你的 AI 助手工作——编写功能、修复 Bug、重构
-2. AI 根据治理规则在 `.devtrail/` 中创建文档：
+2. AI 根据治理规则在 `.straymark/` 中创建文档：
    - **AILOG** 用于重大实现（>10 行变更）
    - **AIDEC** 在多个方案间选择时
    - **ADR** 用于架构决策
@@ -55,27 +55,27 @@
 
 ---
 
-## 保持 DevTrail 更新
+## 保持 StrayMark 更新
 
 ### 建议频率
 
 - **每月**或当你在 GitHub 上看到新版本时
-- 查看[发布页面](https://github.com/StrangeDaysTech/devtrail/releases)了解变更日志
+- 查看[发布页面](https://github.com/StrangeDaysTech/straymark/releases)了解变更日志
 
 ### 更新命令
 
 | 目标 | 命令 |
 |------|------|
-| 同时更新 Framework 和 CLI | `devtrail update` |
-| 仅更新模板和治理文档 | `devtrail update-framework` |
-| 仅更新 CLI 二进制文件 | `devtrail update-cli` |
+| 同时更新 Framework 和 CLI | `straymark update` |
+| 仅更新模板和治理文档 | `straymark update-framework` |
+| 仅更新 CLI 二进制文件 | `straymark update-cli` |
 
 Framework 和 CLI 有**独立的版本** — 你可以单独更新其中一个。参见[理解版本](#理解版本)。
 
 ### 更新之后
 
 1. 检查指令文件和治理文档的变更
-2. 提交更新的文件：`git add .devtrail/ && git commit -m "chore: update DevTrail framework"`
+2. 提交更新的文件：`git add .straymark/ && git commit -m "chore: update StrayMark framework"`
 3. 如果你自定义了 Framework 文件，检查是否有冲突
 
 ---
@@ -85,7 +85,7 @@ Framework 和 CLI 有**独立的版本** — 你可以单独更新其中一个�
 ### CLI 状态
 
 ```bash
-devtrail status
+straymark status
 ```
 
 显示：Framework 版本、CLI 版本、目录结构完整性和按类型统计的文档数据。用它来验证安装是否健康。
@@ -93,10 +93,10 @@ devtrail status
 ### 文档合规（Skill）
 
 ```bash
-/devtrail-status
+/straymark-status
 ```
 
-`/devtrail-status` Skill（在 Claude Code 和 Gemini CLI 中可用）分析：
+`/straymark-status` Skill（在 Claude Code 和 Gemini CLI 中可用）分析：
 
 - 哪些近期代码变更缺少对应的文档
 - 文档与治理规则的合规情况
@@ -106,7 +106,7 @@ devtrail status
 
 ## 使用 Skills（主动文档）
 
-DevTrail 有两个文档系统：
+StrayMark 有两个文档系统：
 
 | 系统 | 工作方式 | 何时使用 |
 |------|----------|----------|
@@ -117,20 +117,20 @@ DevTrail 有两个文档系统：
 
 | Skill | 用途 |
 |-------|------|
-| `/devtrail-status` | 检查文档合规状态 |
-| `/devtrail-new` | 创建任意类型的文档（建议最佳匹配） |
-| `/devtrail-ailog` | 快速创建 AILOG |
-| `/devtrail-aidec` | 快速创建 AIDEC |
-| `/devtrail-adr` | 快速创建 ADR |
-| `/devtrail-audit-prompt CHARTER-XX` *(fw-4.8.0+，在 fw-4.9.0 中重构)* | 在规范路径 `.devtrail/audits/<id>/audit-prompt.md` 处生成统一的审计 prompt。封装 `devtrail charter audit --prepare`。操作员随后打开 N 个审计员 CLI 并在每个中运行 `/devtrail-audit-execute` — 无需复制/粘贴。 |
-| `/devtrail-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **在审计员 CLI 中运行**（gemini-cli、claude-cli、copilot-cli、codex-cli）。从磁盘读取 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。参数可选 — 自动发现此模型待处理的 prompts。 |
-| `/devtrail-audit-review CHARTER-XX` *(fw-4.8.0+，在 fw-4.9.0 中扩展)* | `audit-prompt` 的对应。读取 N 个 reports，对 findings 与实际代码交叉验证，生成 `review.md` 六节合并分析（执行摘要 / 范围 / 按审计员评估 / 修复计划 P0-P4 / 丢弃 / 审计员评分），并将 `external_audit:` YAML 合并到遥测。 |
+| `/straymark-status` | 检查文档合规状态 |
+| `/straymark-new` | 创建任意类型的文档（建议最佳匹配） |
+| `/straymark-ailog` | 快速创建 AILOG |
+| `/straymark-aidec` | 快速创建 AIDEC |
+| `/straymark-adr` | 快速创建 ADR |
+| `/straymark-audit-prompt CHARTER-XX` *(fw-4.8.0+，在 fw-4.9.0 中重构)* | 在规范路径 `.straymark/audits/<id>/audit-prompt.md` 处生成统一的审计 prompt。封装 `straymark charter audit --prepare`。操作员随后打开 N 个审计员 CLI 并在每个中运行 `/straymark-audit-execute` — 无需复制/粘贴。 |
+| `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **在审计员 CLI 中运行**（gemini-cli、claude-cli、copilot-cli、codex-cli）。从磁盘读取 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。参数可选 — 自动发现此模型待处理的 prompts。 |
+| `/straymark-audit-review CHARTER-XX` *(fw-4.8.0+，在 fw-4.9.0 中扩展)* | `audit-prompt` 的对应。读取 N 个 reports，对 findings 与实际代码交叉验证，生成 `review.md` 六节合并分析（执行摘要 / 范围 / 按审计员评估 / 修复计划 P0-P4 / 丢弃 / 审计员评分），并将 `external_audit:` YAML 合并到遥测。 |
 
 完整 Skill 详情参见 [README](../README.md#skills)。
 
 ### Charter 审计检查点 *(fw-4.8.0+)*
 
-在与人共同实现 Charter 时，Agent 会在一个特定时刻主动提议外部审计：当实现完成、drift 干净，且 `charter close` 尚未调用时。推荐基于 Charter 的风险面和复杂度给出 是/否（完整启发式见 `.devtrail/00-governance/AGENT-RULES.md` §12）。
+在与人共同实现 Charter 时，Agent 会在一个特定时刻主动提议外部审计：当实现完成、drift 干净，且 `charter close` 尚未调用时。推荐基于 Charter 的风险面和复杂度给出 是/否（完整启发式见 `.straymark/00-governance/AGENT-RULES.md` §12）。
 
 外部审计**完全可选**且**永不强制**。Charter 的声明性范围 + drift check + AILOG 纪律已为关闭提供了足够严格的支撑。审计在 Charter 触及安全面、引入新组件或 diff 中存在高复杂度函数时增加跨模型信号。如果你的情况下成本（2-3 个 LLM 审计员）与价值不匹配，可以自由拒绝。
 
@@ -140,13 +140,13 @@ DevTrail 有两个文档系统：
 
 ### PR 审查
 
-- 检查重大代码变更是否包含 `.devtrail/` 中的对应文档
+- 检查重大代码变更是否包含 `.straymark/` 中的对应文档
 - 审查任何标记为 `review_required: true` 的文档
 - 验证 AILOG 是否准确描述了 AI 所做的工作
 
 ### 新成员入职
 
-1. 引导他们查看 `.devtrail/QUICK-REFERENCE.md` 快速了解概况
+1. 引导他们查看 `.straymark/QUICK-REFERENCE.md` 快速了解概况
 2. 让他们阅读近期 ADR 以理解架构背景
 3. 展示近期功能的 AILOG，让他们了解文档在实践中如何运作
 
@@ -172,15 +172,15 @@ DevTrail 有两个文档系统：
 
 ### 一次性设置
 
-1. 编辑 `.devtrail/config.yml` 并将 `china` 加入 `regional_scope`:
+1. 编辑 `.straymark/config.yml` 并将 `china` 加入 `regional_scope`:
    ```yaml
    regional_scope:
      - global
      - eu      # 如同时受 EU 约束
      - china
    ```
-2. 运行 `devtrail compliance --region china` 查看基线(在创建相应文档前所有检查都会失败)。
-3. 阅读 `.devtrail/00-governance/` 下安装的指南:
+2. 运行 `straymark compliance --region china` 查看基线(在创建相应文档前所有检查都会失败)。
+3. 阅读 `.straymark/00-governance/` 下安装的指南:
    - `CHINA-REGULATORY-FRAMEWORK.md` — 概览与覆盖矩阵
    - `TC260-IMPLEMENTATION-GUIDE.md` — 五级风险分级
    - `PIPL-PIPIA-GUIDE.md` — 何时需要 PIPIA 及其内容
@@ -200,7 +200,7 @@ DevTrail 有两个文档系统：
 | `PIPIA` | 个人信息影响评估(第55-56条) | 处理个人信息时 |
 | `SBOM` | 训练数据清单 + GB/T 45652 合规 | 始终 |
 
-`devtrail compliance --region china` 确认套件完整。
+`straymark compliance --region china` 确认套件完整。
 
 ### 发生事件时
 
@@ -211,7 +211,7 @@ csl_severity_level: relatively_major   # 或 particularly_serious | major | gene
 csl_report_deadline_hours: 4           # particularly_serious 为 1,relatively_major 为 4
 ```
 
-`devtrail validate` 强制严重程度-时限一致性(`CROSS-008`、`CROSS-009`)。major+ 事件须在 30 天内关闭(状态 `accepted`)以使 `CSL-003` 检查通过。
+`straymark validate` 强制严重程度-时限一致性(`CROSS-008`、`CROSS-009`)。major+ 事件须在 30 天内关闭(状态 `accepted`)以使 `CSL-003` 检查通过。
 
 ### 跨境数据传输
 
@@ -221,20 +221,20 @@ csl_report_deadline_hours: 4           # particularly_serious 为 1,relatively_m
 
 ```bash
 # 在合并涉及 AI 服务的功能分支之前
-devtrail validate                    # 跨规则,包括 CROSS-004..011
-devtrail compliance --region china   # 各框架得分
+straymark validate                    # 跨规则,包括 CROSS-004..011
+straymark compliance --region china   # 各框架得分
 ```
 
 ---
 
 ## 理解版本
 
-DevTrail 为两个组件使用**独立版本管理**：
+StrayMark 为两个组件使用**独立版本管理**：
 
 | 组件 | 标签前缀 | 包含内容 | 更新方式 |
 |------|----------|----------|----------|
-| **Framework** | `fw-` | 模板、治理文档、指令、脚本 | `devtrail update-framework` |
-| **CLI** | `cli-` | `devtrail` 二进制文件 | `devtrail update-cli` |
+| **Framework** | `fw-` | 模板、治理文档、指令、脚本 | `straymark update-framework` |
+| **CLI** | `cli-` | `straymark` 二进制文件 | `straymark update-cli` |
 
 ### 为什么使用独立版本？
 
@@ -245,8 +245,8 @@ DevTrail 为两个组件使用**独立版本管理**：
 ### 检查你的版本
 
 ```bash
-devtrail about     # 快速版本检查
-devtrail status    # 完整的健康报告，包含版本信息
+straymark about     # 快速版本检查
+straymark status    # 完整的健康报告，包含版本信息
 ```
 
 详细的 CLI 信息参见 [CLI 参考手册](CLI-REFERENCE.md#版本管理)。
@@ -255,7 +255,7 @@ devtrail status    # 完整的健康报告，包含版本信息
 
 <div align="center">
 
-**DevTrail** — 因为每一次变更都值得被记录。
+**StrayMark** — 因为每一次变更都值得被记录。
 
 [返回文档](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
 


### PR DESCRIPTION
## Summary

Rebrands the public repo-level docs that adopters read directly. 22 files touched via bulk sed: `DevTrail → StrayMark`, `devtrail → straymark`, `DEVTRAIL → STRAYMARK`.

## Files

- `README.md`
- `CLAUDE.md`
- `CODE_OF_CONDUCT.md` (3 langs)
- `CONTRIBUTING.md` (3 langs)
- `docs/README.md`
- `docs/adopters/{ADOPTION-GUIDE,CLI-REFERENCE,WORKFLOWS}.md` (3 langs)
- `docs/contributors/TRANSLATION-GUIDE.md`
- `CHANGELOG.md` preamble — one line updated: header now says *"StrayMark (formerly DevTrail; rebranded 2026-05-08)"* with a link to the ADR.

## What this PR does NOT do

- **CHANGELOG.md historical sections** (`## Framework 4.10.0`, `4.9.0`, ...) preserved literally with "DevTrail" name and old repo URLs intact — that's history.
- **`docs/decisions/ADR-2026-05-08-rebranding-straymark.md`** preserved with intentional refs to both names — it documents the before/after of the rebranding itself.
- **`.github/workflows/release-cli.yml` and `release-framework.yml`** — pending in PR 4 (workflows + asset prefixes).
- **README etymological paragraph** explaining what "StrayMark" means — deferred per operator instruction.
- **`.claude/settings.local.json`** — operator-private cached permissions, out of scope.

Refs [`ADR-2026-05-08-001`](docs/decisions/ADR-2026-05-08-rebranding-straymark.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)