### PR TITLE
PR 4/6 (rebrand) — release workflows + asset prefixes (devtrail-* → straymark-*)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -97,8 +97,8 @@ jobs:
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
-          BINARY=cli/target/${{ matrix.target }}/release/devtrail
-          ARCHIVE=devtrail-cli-v${{ needs.resolve-version.outputs.version }}-${{ matrix.target }}.tar.gz
+          BINARY=cli/target/${{ matrix.target }}/release/straymark
+          ARCHIVE=straymark-cli-v${{ needs.resolve-version.outputs.version }}-${{ matrix.target }}.tar.gz
           tar czf "$ARCHIVE" -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
@@ -106,10 +106,10 @@ jobs:
         if: matrix.archive == 'zip'
         shell: bash
         run: |
-          BINARY=cli/target/${{ matrix.target }}/release/devtrail.exe
-          ARCHIVE=devtrail-cli-v${{ needs.resolve-version.outputs.version }}-${{ matrix.target }}.zip
-          cp "$BINARY" devtrail.exe
-          7z a "$ARCHIVE" devtrail.exe
+          BINARY=cli/target/${{ matrix.target }}/release/straymark.exe
+          ARCHIVE=straymark-cli-v${{ needs.resolve-version.outputs.version }}-${{ matrix.target }}.zip
+          cp "$BINARY" straymark.exe
+          7z a "$ARCHIVE" straymark.exe
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Upload binary artifact
@@ -150,7 +150,7 @@ jobs:
           else
             echo "Creating release $TAG..."
             gh release create "$TAG" \
-              --title "DevTrail CLI $VERSION" \
+              --title "StrayMark CLI $VERSION" \
               --generate-notes \
               --latest \
               release/*

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -45,7 +45,7 @@ jobs:
           mkdir -p dist-staging
           cp -a dist/. dist-staging/
           cd dist-staging
-          zip -r "../devtrail-fw-${{ steps.version.outputs.version }}.zip" .
+          zip -r "../straymark-fw-${{ steps.version.outputs.version }}.zip" .
           cd ..
 
       - name: Create or update GitHub Release
@@ -54,7 +54,7 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           VERSION="${{ steps.version.outputs.version }}"
-          ASSET="devtrail-fw-${VERSION}.zip"
+          ASSET="straymark-fw-${VERSION}.zip"
 
           if gh release view "$TAG" > /dev/null 2>&1; then
             echo "Release $TAG exists, uploading asset..."
@@ -62,7 +62,7 @@ jobs:
           else
             echo "Creating release $TAG..."
             gh release create "$TAG" \
-              --title "DevTrail Framework $VERSION" \
+              --title "StrayMark Framework $VERSION" \
               --generate-notes \
               "$ASSET"
           fi


### PR DESCRIPTION
## Summary

Rebrands the two release workflows so that the next version bump (PR 6, `fw-4.11.0` / `cli-3.11.0`) produces assets with the `straymark-*` prefix.

## Changes

### `release-cli.yml`
- Binary path: `cli/target/<target>/release/straymark` (was `devtrail`)
- Archive name: `straymark-cli-v<VERSION>-<target>.{tar.gz|zip}`
- Windows binary copy: `straymark.exe`
- Release title: `"StrayMark CLI $VERSION"`
- `publish-crate` job already publishes `straymark-cli` (Cargo.toml renamed in PR 2).

### `release-framework.yml`
- Asset name: `straymark-fw-<VERSION>.zip`
- Release title: `"StrayMark Framework $VERSION"`

## Tag prefixes unchanged

`fw-X.Y.Z` and `cli-X.Y.Z` remain agnostic to the project name and continue across the rebrand for release history continuity.

## Verification

These workflows trigger only on tag push (`fw-*`, `cli-*`). PR 6 (next) bumps versions and pushes `fw-4.11.0` and `cli-3.11.0`, at which point CI will produce:
- `straymark-fw-4.11.0.zip`
- `straymark-cli-v3.11.0-{linux,darwin-x86_64,darwin-aarch64,windows}.{tar.gz,zip}`
- `straymark-cli@3.11.0` published on crates.io.

Refs [`ADR-2026-05-08-001`](docs/decisions/ADR-2026-05-08-rebranding-straymark.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)