### PR TITLE
PR 5/5 (rebrand) — bump fw-4.11.0 / cli-3.11.0 — StrayMark rebranding release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.11.0 / CLI 3.11.0 — StrayMark rebranding
+
+The project formerly known as DevTrail is now **StrayMark**. The decision was made on 2026-05-08 by the operator after external trademark conflict research, motivated by **legal certainty over the project's mark**. See [`ADR-2026-05-08-001`](docs/decisions/ADR-2026-05-08-rebranding-straymark.md) for the full record.
+
+This release ships the rebrand end-to-end across the **live state** of the project. **Historical state is preserved literally** — prior CHANGELOG entries, release titles, tags, the `devtrail-cli@3.10.0` crate (not yanked), and closed issues/PRs all retain the "DevTrail" name as historical record. The single Sentinel adopter (operator-owned) migrates manually via `mv .devtrail .straymark` + `git mv DEVTRAIL.md STRAYMARK.md` + updating refs in their `CLAUDE.md`/`AGENT.md`.
+
+### Changed (Framework + CLI)
+
+- **GitHub repository renamed**: `StrangeDaysTech/devtrail` → `StrangeDaysTech/straymark`. GitHub maintains automatic 301 redirects from the old URL for at least one year (so existing clones, badges, and external links continue to resolve).
+- **Framework root path**: `.devtrail/` → `.straymark/`, `DEVTRAIL.md` → `STRAYMARK.md`. Adopters reinstalling get the new layout; existing adopters migrate manually (no fallback logic in CLI).
+- **CLI binary**: `devtrail` → `straymark`.
+- **CLI crate (crates.io)**: published as `straymark-cli@3.11.0`. The legacy `devtrail-cli@3.10.0` is preserved on crates.io (not yanked) as historical record.
+- **Skills (3 platforms)**: `/devtrail-{ailog,aidec,adr,mcard,sec,status,new,audit-prompt,audit-execute,audit-review}` → `/straymark-*` across `.claude/skills/`, `.gemini/skills/`, `.agent/workflows/`.
+- **Asset filename prefixes**: `devtrail-fw-X.Y.Z.zip` → `straymark-fw-X.Y.Z.zip`, `devtrail-cli-vX.Y.Z-*` → `straymark-cli-vX.Y.Z-*`.
+- **Documentation rebranded** end-to-end: README, CLAUDE.md, governance docs (3 langs), adopter docs (3 langs), CONTRIBUTING, CODE_OF_CONDUCT, all framework distributables.
+- **Rust identifiers**: `DevTrailConfig` → `StrayMarkConfig`, `DevTrailDocument` → `StrayMarkDocument`, `GITHUB_REPO` const updated.
+
+### Preserved (immutable historical record)
+
+- All commits, commit messages, and git history.
+- Tags published before this release (`fw-4.10.0`, `cli-3.10.0`, and earlier) and their release titles ("DevTrail Framework X.Y.Z", "DevTrail CLI X.Y.Z").
+- Prior CHANGELOG entries below (`## Framework 4.10.0 — Follow-ups backlog pattern`, etc.) — preserved literally with the "DevTrail" name and old repo URLs.
+- All previously merged PRs, closed issues, and their bodies/comments.
+- `devtrail-cli@3.10.0` on crates.io.
+- Sentinel adopter's AILOGs and Charters that reference "DevTrail" — those are Sentinel's history, not this repo's.
+
+### Versioning continuity
+
+Versions continue the existing series — **no reset to 0.1.0**. The product trajectory is unbroken; only the name changes. Tag prefixes (`fw-`, `cli-`) are agnostic to the project name and continue unchanged.
+
+### Adopter impact
+
+Single known adopter (`StrangeDaysTech/sentinel`, operator-owned) migrates manually. No third-party adopters are known. Any silent adopters (improbable) are protected for at least one year by the GitHub redirect; the legacy `devtrail-cli@3.10.0` crate continues to be installable.
+
+The README does not yet include an etymological paragraph explaining the meaning of "StrayMark" — that is a deliberate follow-up, deferred from the rebranding execution per operator instruction.
+
+---
+
 ## Framework 4.10.0 — Follow-ups backlog pattern (governance docs)
 
 Documents the follow-ups backlog convention contributed by the Sentinel adopter via [issue #111](https://github.com/StrangeDaysTech/devtrail/issues/111). The pattern was empirically validated in `StrangeDaysTech/sentinel` CHARTER-12 (47 AILOGs accumulated across CHARTER-08 → CHARTER-11). Adopters reaching ~20+ AILOGs benefit from a central registry + per-AILOG drift detection script + agent integration in `CLAUDE.md` / `AGENT.md`.

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.10.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.10.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.11.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.11.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -292,7 +292,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.10.0)
+# and download the latest fw-* release (e.g., fw-4.11.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.10.0"
+version = "3.11.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -357,4 +357,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -307,4 +307,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -186,4 +186,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -227,4 +227,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -357,4 +357,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -300,4 +300,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -186,4 +186,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -202,4 +202,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -352,4 +352,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -299,4 +299,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -186,4 +186,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -202,4 +202,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.10.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.10.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.11.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.10.0"
+version: "4.11.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.10.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.11.0`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.10.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.10.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.11.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.11.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.10.0
+✔ Downloaded StrayMark fw-4.11.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.10.0
+✔ Framework updated to fw-4.11.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.10.0
+✔ Framework updated to fw-4.11.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.10.0                 │
+  │ Framework │ fw-4.11.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.10.0
+  Using version: fw-4.11.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1053,7 +1053,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.10.0
+  Framework version: fw-4.11.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -222,8 +222,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.10.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.10.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.11.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.11.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -255,7 +255,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.10.0)
+# y descarga el último release fw-* (ej. fw-4.11.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.10.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.11.0`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.10.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.10.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.11.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.11.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.10.0
+✔ Downloaded StrayMark fw-4.11.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.10.0
+✔ Framework updated to fw-4.11.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.10.0
+✔ Framework updated to fw-4.11.0
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.10.0
+Framework version: fw-4.11.0
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -859,7 +859,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.10.0
+  Framework version: fw-4.11.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -240,8 +240,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.10.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.10.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.11.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.11.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -273,7 +273,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.10.0）
+# 下载最新的 fw-* 发布（例如 fw-4.11.0）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.10.0`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.11.0`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.10.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.10.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.11.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.11.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.10.0
+✔ Downloaded StrayMark fw-4.11.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.10.0
+✔ Framework updated to fw-4.11.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.10.0
+✔ Framework updated to fw-4.11.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.10.0                 │
+  │ Framework │ fw-4.11.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.10.0
+  Using version: fw-4.11.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -993,7 +993,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.10.0
+  Framework version: fw-4.11.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

**First release after the DevTrail → StrayMark rebrand.** Versions continue the existing series (4.10.0 → 4.11.0 framework, 3.10.0 → 3.11.0 CLI) — no reset to 0.1.0; the product trajectory is unbroken, only the name changed.

This is the final PR of the rebranding sequence (PR 1 = ADR, PR 2 = cli source + dist paths + skills + framework docs, PR 3 = public docs, PR 4 = release workflows, this PR = release bump).

## Changes

- `dist/dist-manifest.yml` → 4.11.0
- `cli/Cargo.toml` → 3.11.0 (`Cargo.lock` updated)
- **Footer version banners** across governance docs (3 langs): `StrayMark v4.10.0` → `StrayMark v4.11.0`
- **Adopter doc version tables** (CLI-REFERENCE, README, ADOPTION-GUIDE in 3 langs): `fw-4.10.0` → `fw-4.11.0`, `cli-3.10.0` → `cli-3.11.0`
- Sample CLI output references in adopter docs (Downloaded, Framework updated to, Framework version, Using version, Framework │) — bumped to fw-4.11.0
- **CHANGELOG**: new section `## Framework 4.11.0 / CLI 3.11.0 — StrayMark rebranding` describing the rebrand end-to-end. Historical sections preserved literally with the "DevTrail" name.

## Preserved

- Skill version markers like `*(fw-4.9.0+)*` are **not** bumped — they indicate "since version" historical annotations and remain valid.
- All prior CHANGELOG sections, tags, release titles, closed issues/PRs, and `devtrail-cli@3.10.0` on crates.io.

## Post-merge actions (will execute after merge)

1. Push tag `fw-4.11.0` → `release-framework.yml` publishes `straymark-fw-4.11.0.zip`.
2. Push tag `cli-3.11.0` → `release-cli.yml` publishes binary archives with `straymark-cli-v3.11.0-*` prefix AND publishes `straymark-cli@3.11.0` on crates.io.

## Verification

- ✅ `cargo build` green on `straymark-cli v3.11.0`.
- ✅ `cargo test` 469 tests passing.
- ⏳ Post-tag: `gh release view fw-4.11.0` and `gh release view cli-3.11.0` show new assets; `cargo install straymark-cli` installs version 3.11.0; `straymark --version` reports 3.11.0; `straymark init` creates `.straymark/`.

Refs [`ADR-2026-05-08-001`](docs/decisions/ADR-2026-05-08-rebranding-straymark.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)