### PR TITLE
fix(cli): align charter subcommand path to .straymark/charters/ (closes #119)

### DIFF
--- a/cli/src/charter.rs
+++ b/cli/src/charter.rs
@@ -6,8 +6,8 @@
 //! module provides typed access to a Charter document on disk.
 //!
 //! Conceptually distinct from `DocType` (governance documents): Charters live
-//! at `docs/charters/NN-slug.md` (project-root level), use sequential filenames
-//! without a date prefix, and their schema is its own contract. See
+//! at `.straymark/charters/NN-slug.md`, use sequential filenames without a date
+//! prefix, and their schema is its own contract. See
 //! `Propuesta/que-es-un-charter.md` for the conceptual scope.
 
 use anyhow::{anyhow, Context, Result};
@@ -120,12 +120,23 @@ pub fn parse_charter_str(path: &Path, content: &str) -> Result<Charter> {
     })
 }
 
-/// Discover all Charter files in a project. Charters live at `docs/charters/*.md`
-/// with filenames `NN-slug.md` (sequential prefix). Returns paths sorted by
-/// filename so callers get stable ordering. Files that don't match the
-/// `NN-slug.md` pattern are skipped (e.g., a stray `README.md`).
+/// Filesystem location of Charter documents, relative to the project root.
+///
+/// All `straymark charter` subcommands (new/list/status/audit/close/drift) and
+/// `straymark status` discover Charters here. Telemetry sidecars
+/// (`*.telemetry.yaml`) live alongside the declarative `.md` files in the same
+/// directory — declarative ex-ante and telemetry ex-post share one folder.
+pub fn charters_dir(project_root: &Path) -> PathBuf {
+    project_root.join(".straymark").join("charters")
+}
+
+/// Discover all Charter files in a project. Charters live at
+/// `.straymark/charters/*.md` with filenames `NN-slug.md` (sequential prefix).
+/// Returns paths sorted by filename so callers get stable ordering. Files that
+/// don't match the `NN-slug.md` pattern are skipped (e.g., a stray `README.md`
+/// or a `*.telemetry.yaml` sidecar).
 pub fn discover_charters(project_root: &Path) -> Vec<PathBuf> {
-    let dir = project_root.join("docs").join("charters");
+    let dir = charters_dir(project_root);
     if !dir.exists() {
         return Vec::new();
     }
@@ -298,7 +309,7 @@ pub fn display_origin(fm: &CharterFrontmatter) -> String {
 }
 
 /// Determine the next sequential Charter number for a project. Reads
-/// `docs/charters/` and returns `max(NN) + 1`, or 1 if no Charters exist yet.
+/// `.straymark/charters/` and returns `max(NN) + 1`, or 1 if no Charters exist yet.
 ///
 /// Note: this is intentionally racy on parallel branches (R2 in the Phase 1
 /// plan). Two contributors running `charter new` simultaneously can both
@@ -516,7 +527,7 @@ Body.
     #[test]
     fn discover_returns_sorted_charter_files_only() {
         let tmp = TempDir::new().unwrap();
-        let charters_dir = tmp.path().join("docs").join("charters");
+        let charters_dir = tmp.path().join(".straymark").join("charters");
         write(&charters_dir.join("03-third.md"), VALID_FRONTMATTER);
         write(&charters_dir.join("01-first.md"), VALID_FRONTMATTER);
         write(&charters_dir.join("02-second.md"), VALID_FRONTMATTER);
@@ -542,7 +553,7 @@ Body.
     #[test]
     fn next_number_is_max_plus_one() {
         let tmp = TempDir::new().unwrap();
-        let charters_dir = tmp.path().join("docs").join("charters");
+        let charters_dir = tmp.path().join(".straymark").join("charters");
         write(&charters_dir.join("01-a.md"), VALID_FRONTMATTER);
         write(&charters_dir.join("05-b.md"), VALID_FRONTMATTER);
         write(&charters_dir.join("03-c.md"), VALID_FRONTMATTER);
@@ -552,7 +563,7 @@ Body.
     #[test]
     fn next_number_skips_non_numbered_files() {
         let tmp = TempDir::new().unwrap();
-        let charters_dir = tmp.path().join("docs").join("charters");
+        let charters_dir = tmp.path().join(".straymark").join("charters");
         write(&charters_dir.join("01-a.md"), VALID_FRONTMATTER);
         write(&charters_dir.join("README.md"), "# Charters\n");
         write(&charters_dir.join("draft-no-number.md"), VALID_FRONTMATTER);
@@ -609,7 +620,7 @@ Body.
             .map(|rest| format!("{}.md", rest.to_lowercase()))
             .unwrap_or_else(|| format!("{}.md", id.to_lowercase()));
         Charter {
-            path: PathBuf::from(format!("docs/charters/{}", filename)),
+            path: PathBuf::from(format!(".straymark/charters/{}", filename)),
             frontmatter: fm,
             body: body.to_string(),
         }
@@ -767,7 +778,7 @@ Body.
     #[test]
     fn discover_and_parse_separates_good_and_bad() {
         let tmp = TempDir::new().unwrap();
-        let charters_dir = tmp.path().join("docs").join("charters");
+        let charters_dir = tmp.path().join(".straymark").join("charters");
         write(&charters_dir.join("01-good.md"), VALID_FRONTMATTER);
         // A file with leading digits + dash but broken frontmatter.
         write(

--- a/cli/src/commands/charter/audit.rs
+++ b/cli/src/commands/charter/audit.rs
@@ -98,7 +98,12 @@ pub fn run(
     // Resolve the Charter.
     let (charters, _errors) = charter::discover_and_parse(project_root);
     let charter = charter::find_by_id(&charters, charter_id)
-        .ok_or_else(|| anyhow!("Charter {} not found in docs/charters/", charter_id))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Charter {} not found in .straymark/charters/.\n  hint: run `straymark charter list` to see discovered Charters.",
+                charter_id
+            )
+        })?
         .clone();
 
     let canonical_id = canonical_charter_id(&charter.frontmatter.charter_id);

--- a/cli/src/commands/charter/close.rs
+++ b/cli/src/commands/charter/close.rs
@@ -20,7 +20,7 @@ use chrono::Local;
 use colored::Colorize;
 use std::path::{Path, PathBuf};
 
-use crate::charter::{self, Charter, CharterStatus};
+use crate::charter::{self, charters_dir, Charter, CharterStatus};
 use crate::prompts;
 use crate::telemetry_schema::TelemetrySchema;
 use crate::utils;
@@ -39,13 +39,19 @@ pub fn run(
     // Resolve the Charter.
     let (charters, _errors) = charter::discover_and_parse(project_root);
     let charter = charter::find_by_id(&charters, charter_id)
-        .ok_or_else(|| anyhow!("Charter {} not found in docs/charters/", charter_id))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Charter {} not found in .straymark/charters/.\n  hint: run `straymark charter list` to see discovered Charters.",
+                charter_id
+            )
+        })?
         .clone();
 
-    // Decide telemetry destination.
-    let charters_state_dir = straymark_dir.join("charters");
-    utils::ensure_dir(&charters_state_dir)?;
-    let telemetry_path = telemetry_path_for(&charters_state_dir, &charter);
+    // Decide telemetry destination — declarative .md and telemetry .yaml share
+    // the same directory by design (see charters_dir docstring).
+    let telemetry_dir = charters_dir(project_root);
+    utils::ensure_dir(&telemetry_dir)?;
+    let telemetry_path = telemetry_path_for(&telemetry_dir, &charter);
 
     // F7 (cli-3.8.0): differentiate first-run vs subsequent-run output.
     // Pre-existence check happens BEFORE any write so we can report

--- a/cli/src/commands/charter/drift.rs
+++ b/cli/src/commands/charter/drift.rs
@@ -45,7 +45,12 @@ pub fn run(
     // Resolve the Charter file.
     let (charters, _errors) = charter::discover_and_parse(project_root);
     let charter = charter::find_by_id(&charters, charter_id)
-        .ok_or_else(|| anyhow!("Charter {} not found in docs/charters/", charter_id))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Charter {} not found in .straymark/charters/.\n  hint: run `straymark charter list` to see discovered Charters.",
+                charter_id
+            )
+        })?
         .clone();
 
     let charter_path_rel = charter
@@ -356,7 +361,7 @@ mod tests {
     #[test]
     fn extract_omitted_handles_typical_output() {
         let stdout = r#"=== Charter drift check ===
-  Charter: docs/charters/01-foo.md
+  Charter: .straymark/charters/01-foo.md
   Range:   HEAD~1..HEAD
   Declared: 5 files
   Modified: 3 files

--- a/cli/src/commands/charter/list.rs
+++ b/cli/src/commands/charter/list.rs
@@ -168,7 +168,7 @@ mod tests {
 
     fn make(id: &str, status: CharterStatus, ailog: Option<Vec<String>>, spec: Option<String>) -> Charter {
         Charter {
-            path: PathBuf::from(format!("docs/charters/{}.md", id.to_lowercase())),
+            path: PathBuf::from(format!(".straymark/charters/{}.md", id.to_lowercase())),
             frontmatter: CharterFrontmatter {
                 charter_id: id.to_string(),
                 status,

--- a/cli/src/commands/charter/new.rs
+++ b/cli/src/commands/charter/new.rs
@@ -14,7 +14,7 @@ use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Input};
 use std::path::{Path, PathBuf};
 
-use crate::charter::next_charter_number;
+use crate::charter::{charters_dir, next_charter_number};
 use crate::config::StrayMarkConfig;
 use crate::utils;
 
@@ -114,10 +114,10 @@ pub fn run(
         ailog_context,
     );
 
-    // Write to docs/charters/.
-    let charters_dir = project_root.join("docs").join("charters");
-    utils::ensure_dir(&charters_dir)?;
-    let out_path = charters_dir.join(&filename);
+    // Write to .straymark/charters/.
+    let out_dir = charters_dir(project_root);
+    utils::ensure_dir(&out_dir)?;
+    let out_path = out_dir.join(&filename);
     if out_path.exists() {
         bail!(
             "Charter file already exists: {} (next number computed as {:02} but a file with this slug exists)",

--- a/cli/src/commands/charter/status.rs
+++ b/cli/src/commands/charter/status.rs
@@ -178,7 +178,7 @@ mod tests {
 
     fn make(id: &str, body: &str) -> Charter {
         Charter {
-            path: PathBuf::from(format!("docs/charters/{}.md", id.to_lowercase())),
+            path: PathBuf::from(format!(".straymark/charters/{}.md", id.to_lowercase())),
             frontmatter: CharterFrontmatter {
                 charter_id: id.to_string(),
                 status: CharterStatus::Declared,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -90,7 +90,7 @@ enum Commands {
         /// Validate only git-staged files (for pre-commit hooks)
         #[arg(long)]
         staged: bool,
-        /// Also validate Charters in docs/charters/ against the Charter schema
+        /// Also validate Charters in .straymark/charters/ against the Charter schema
         /// and referential integrity (originating_ailogs IDs exist;
         /// originating_spec path exists). Default: false, to avoid breaking
         /// projects that don't yet use the Charter pattern.

--- a/cli/src/tui/index.rs
+++ b/cli/src/tui/index.rs
@@ -207,11 +207,12 @@ impl DocIndex {
         }
 
         // Synthetic "Charters" group at the end. Charters live at
-        // <project_root>/docs/charters/, NOT under .straymark/. We append them
-        // as a 10th-style pseudo-group so the existing NavSelection tree
-        // model handles them without modification. The group is added only
-        // when at least one Charter exists — adopters who don't use the
-        // pattern see no empty stub.
+        // .straymark/charters/, alongside the rest of the framework state
+        // (declarative .md and telemetry .yaml share the directory). We
+        // append them as a 10th-style pseudo-group so the existing
+        // NavSelection tree model handles them without modification. The
+        // group is added only when at least one Charter exists — adopters
+        // who don't use the pattern see no empty stub.
         let project_root = straymark_dir.parent().unwrap_or(straymark_dir);
         let charter_files = scan_charters(project_root, &mut relations);
         if !charter_files.is_empty() {
@@ -221,7 +222,7 @@ impl DocIndex {
                 // with a real GROUP_DEFS entry that always uses NN-name.
                 name: "_charters".to_string(),
                 label: t("Charters", language).to_string(),
-                path: project_root.join("docs").join("charters"),
+                path: crate::charter::charters_dir(project_root),
                 subgroups: Vec::new(),
                 files: charter_files,
             });
@@ -754,7 +755,7 @@ mod tests {
         let project_root = tmp.path();
         let straymark_dir = project_root.join(".straymark");
         std::fs::create_dir_all(&straymark_dir).unwrap();
-        let charters_dir = project_root.join("docs").join("charters");
+        let charters_dir = project_root.join(".straymark").join("charters");
         std::fs::create_dir_all(&charters_dir).unwrap();
         std::fs::write(
             charters_dir.join("01-real.md"),
@@ -814,7 +815,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let straymark_dir = tmp.path().join(".straymark");
         std::fs::create_dir_all(&straymark_dir).unwrap();
-        // No docs/charters/ directory.
+        // No .straymark/charters/ directory.
 
         let index = DocIndex::build(&straymark_dir, "en");
         assert!(
@@ -829,7 +830,7 @@ mod tests {
         let project_root = tmp.path();
         let straymark_dir = project_root.join(".straymark");
         std::fs::create_dir_all(&straymark_dir).unwrap();
-        let charters_dir = project_root.join("docs").join("charters");
+        let charters_dir = project_root.join(".straymark").join("charters");
         std::fs::create_dir_all(&charters_dir).unwrap();
         std::fs::write(
             charters_dir.join("01-x.md"),

--- a/cli/tests/charter_audit_test.rs
+++ b/cli/tests/charter_audit_test.rs
@@ -46,7 +46,7 @@ fn audit_dir(dir: &Path, charter_id: &str) -> std::path::PathBuf {
 }
 
 fn write_charter(dir: &Path) {
-    let charters = dir.join("docs/charters");
+    let charters = dir.join(".straymark/charters");
     std::fs::create_dir_all(&charters).unwrap();
     let body = r#"---
 charter_id: CHARTER-01
@@ -148,7 +148,7 @@ fn audit_prepare_writes_unified_prompt_to_canonical_location() {
 
     // Placeholder substitution happened in the body (outside HTML comments).
     assert!(resolved.contains("CHARTER-01"));
-    assert!(resolved.contains("docs/charters/01-audit-test.md"));
+    assert!(resolved.contains(".straymark/charters/01-audit-test.md"));
     // Diff was inlined.
     assert!(resolved.contains("// edited") || resolved.contains("// initial"));
 

--- a/cli/tests/charter_close_test.rs
+++ b/cli/tests/charter_close_test.rs
@@ -181,7 +181,7 @@ fn charter_close_syncs_body_status_mirror_line() {
     setup_straymark(dir.path());
     create_charter(dir.path(), "Mirror Sync");
 
-    let charter_path = dir.path().join("docs/charters/01-mirror-sync.md");
+    let charter_path = dir.path().join(".straymark/charters/01-mirror-sync.md");
     let before = std::fs::read_to_string(&charter_path).unwrap();
     assert!(before.contains(":** declared. Effort:"), "{before}");
 
@@ -224,7 +224,7 @@ fn charter_close_writes_closed_at_when_absent() {
     let dir = TempDir::new().unwrap();
     setup_straymark(dir.path());
     create_charter(dir.path(), "Closed At Test");
-    let charter_path = dir.path().join("docs/charters/01-closed-at-test.md");
+    let charter_path = dir.path().join(".straymark/charters/01-closed-at-test.md");
     let before = std::fs::read_to_string(&charter_path).unwrap();
     assert!(!before.contains("closed_at:"), "scaffold should not pre-write closed_at");
 
@@ -268,7 +268,7 @@ fn charter_close_replaces_existing_closed_at_with_today() {
     let dir = TempDir::new().unwrap();
     setup_straymark(dir.path());
 
-    let charter_path = dir.path().join("docs/charters/01-stale.md");
+    let charter_path = dir.path().join(".straymark/charters/01-stale.md");
     let stale = r#"---
 charter_id: CHARTER-01
 status: in-progress
@@ -290,7 +290,7 @@ trigger: "test"
 
 1. ok.
 "#;
-    std::fs::create_dir_all(dir.path().join("docs/charters")).unwrap();
+    std::fs::create_dir_all(dir.path().join(".straymark/charters")).unwrap();
     std::fs::write(&charter_path, stale).unwrap();
 
     Command::cargo_bin("straymark")
@@ -319,7 +319,7 @@ fn charter_close_bumps_status_to_closed() {
     setup_straymark(dir.path());
     create_charter(dir.path(), "Status Bump");
 
-    let charter_path = dir.path().join("docs/charters/01-status-bump.md");
+    let charter_path = dir.path().join(".straymark/charters/01-status-bump.md");
     let before = std::fs::read_to_string(&charter_path).unwrap();
     assert!(before.contains("status: declared"));
 

--- a/cli/tests/charter_drift_test.rs
+++ b/cli/tests/charter_drift_test.rs
@@ -74,7 +74,7 @@ fn git(dir: &Path, args: &[&str]) {
 }
 
 fn write_charter_with_files(dir: &Path, declared: &[&str], originating_ailog: Option<&str>) {
-    let charters_dir = dir.join("docs").join("charters");
+    let charters_dir = dir.join(".straymark").join("charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     let mut content = String::from("---\ncharter_id: CHARTER-01\nstatus: declared\neffort_estimate: M\ntrigger: \"test trigger\"\n");
     if let Some(ailog) = originating_ailog {
@@ -436,7 +436,7 @@ fn charter_drift_resolves_glob_wildcards_in_declared_paths() {
     setup_straymark(dir.path());
 
     // Build a Charter that declares a glob.
-    let charters_dir = dir.path().join("docs").join("charters");
+    let charters_dir = dir.path().join(".straymark").join("charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     let charter = r#"---
 charter_id: CHARTER-01
@@ -500,7 +500,7 @@ fn charter_drift_ignores_path_references_in_change_column() {
     setup_straymark(dir.path());
 
     // Build a Charter where the "Change" column contains a backtick-quoted path.
-    let charters_dir = dir.path().join("docs").join("charters");
+    let charters_dir = dir.path().join(".straymark").join("charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     let charter = r#"---
 charter_id: CHARTER-01

--- a/cli/tests/charter_test.rs
+++ b/cli/tests/charter_test.rs
@@ -109,8 +109,8 @@ fn charter_new_no_origin_creates_file_with_defaults() {
         .success()
         .stdout(predicate::str::contains("Created:"));
 
-    let charters_dir = dir.path().join("docs").join("charters");
-    assert!(charters_dir.exists(), "docs/charters/ should exist");
+    let charters_dir = dir.path().join(".straymark").join("charters");
+    assert!(charters_dir.exists(), ".straymark/charters/ should exist");
     let entries: Vec<_> = std::fs::read_dir(&charters_dir).unwrap().flatten().collect();
     assert_eq!(entries.len(), 1, "should have exactly one Charter file");
 
@@ -147,7 +147,7 @@ fn charter_new_explicit_effort_is_substituted() {
         .assert()
         .success();
 
-    let path = dir.path().join("docs/charters/01-big-work.md");
+    let path = dir.path().join(".straymark/charters/01-big-work.md");
     let content = std::fs::read_to_string(&path).unwrap();
     assert!(content.contains("effort_estimate: L"), "{}", content);
     // Prose mirror line also reflects the chosen effort.
@@ -171,7 +171,7 @@ fn charter_new_with_from_ailog_uncomments_origin() {
         .assert()
         .success();
 
-    let path = dir.path().join("docs/charters/01-from-ailog.md");
+    let path = dir.path().join(".straymark/charters/01-from-ailog.md");
     let content = std::fs::read_to_string(&path).unwrap();
     // Frontmatter origin uncommented and populated.
     assert!(
@@ -206,7 +206,7 @@ fn charter_new_with_from_spec_uncomments_origin() {
         .assert()
         .success();
 
-    let path = dir.path().join("docs/charters/01-from-spec.md");
+    let path = dir.path().join(".straymark/charters/01-from-spec.md");
     let content = std::fs::read_to_string(&path).unwrap();
     assert!(
         content.contains("originating_spec: specs/001-test/spec.md"),
@@ -278,11 +278,11 @@ fn charter_new_increments_sequence_number() {
             .success();
 
         let expected_filename = format!("{:02}-{}.md", n, title.to_lowercase());
-        let path = dir.path().join("docs/charters").join(&expected_filename);
+        let path = dir.path().join(".straymark/charters").join(&expected_filename);
         assert!(path.exists(), "expected {} to exist", path.display());
     }
 
-    let entries: Vec<_> = std::fs::read_dir(dir.path().join("docs/charters"))
+    let entries: Vec<_> = std::fs::read_dir(dir.path().join(".straymark/charters"))
         .unwrap()
         .flatten()
         .collect();
@@ -337,7 +337,7 @@ fn charter_new_uses_es_template_when_config_says_es() {
         .success();
 
     let content =
-        std::fs::read_to_string(dir.path().join("docs/charters/01-hola-mundo.md")).unwrap();
+        std::fs::read_to_string(dir.path().join(".straymark/charters/01-hola-mundo.md")).unwrap();
     assert!(content.contains("ES body"), "expected ES template selected, got: {}", content);
     assert!(content.contains("# Charter: Hola Mundo"));
 }
@@ -397,7 +397,7 @@ fn charter_list_filter_status_declared() {
     setup_straymark_with_charter_template(dir.path());
     create_three_charters(dir.path());
     // Mark the first one as closed.
-    let p = dir.path().join("docs/charters/01-first.md");
+    let p = dir.path().join(".straymark/charters/01-first.md");
     let content = std::fs::read_to_string(&p).unwrap();
     std::fs::write(&p, content.replace("status: declared", "status: closed")).unwrap();
 
@@ -421,7 +421,7 @@ fn charter_list_filter_status_declared() {
 fn charter_list_filter_origin_ailog() {
     let dir = TempDir::new().unwrap();
     setup_straymark_with_charter_template(dir.path());
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
 
     // One Charter with --from-ailog (tested via the actual command).
@@ -620,7 +620,7 @@ fn validate_without_flag_skips_charter_checks() {
     // field) still passes `straymark validate` when --include-charters is absent.
     let dir = TempDir::new().unwrap();
     setup_straymark_full(dir.path());
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     // Write a Charter missing the required `trigger` field. Without
     // --include-charters the validator should not even look at it.
@@ -658,7 +658,7 @@ fn validate_with_flag_passes_for_valid_charter() {
 fn validate_with_flag_fails_on_missing_required_field() {
     let dir = TempDir::new().unwrap();
     setup_straymark_full(dir.path());
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     // Frontmatter is missing `trigger` — schema should reject.
     std::fs::write(
@@ -682,7 +682,7 @@ fn validate_with_flag_fails_on_invalid_status_enum() {
     let dir = TempDir::new().unwrap();
     setup_straymark_full(dir.path());
     create_charter_via_cli(dir.path(), "bad status", &[]);
-    let p = dir.path().join("docs/charters/01-bad-status.md");
+    let p = dir.path().join(".straymark/charters/01-bad-status.md");
     let content = std::fs::read_to_string(&p).unwrap();
     std::fs::write(&p, content.replace("status: declared", "status: unknown-state")).unwrap();
 
@@ -786,7 +786,7 @@ fn validate_fails_when_originating_spec_path_missing() {
 fn validate_warns_when_charter_schema_missing() {
     let dir = TempDir::new().unwrap();
     setup_straymark_with_charter_template(dir.path()); // no schema written
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     std::fs::write(
         charters_dir.join("01-x.md"),
@@ -865,11 +865,11 @@ fn create_three_charters(dir: &std::path::Path) {
 
 #[test]
 fn charter_new_does_not_overwrite_existing_file() {
-    // Edge case: if the user manually created docs/charters/01-foo.md and then
+    // Edge case: if the user manually created .straymark/charters/01-foo.md and then
     // tries `charter new --title "foo"`, we should refuse rather than clobber.
     let dir = TempDir::new().unwrap();
     setup_straymark_with_charter_template(dir.path());
-    let charters_dir = dir.path().join("docs").join("charters");
+    let charters_dir = dir.path().join(".straymark").join("charters");
     std::fs::create_dir_all(&charters_dir).unwrap();
     std::fs::write(charters_dir.join("01-foo.md"), "preexisting; not a Charter\n").unwrap();
     // The pre-existing file does not match the Charter naming pattern (still
@@ -919,7 +919,7 @@ fn charter_new_truncates_long_title_at_word_boundary() {
         .success();
 
     // The slug should not include a partial "true" fragment.
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     let entries: Vec<_> = std::fs::read_dir(&charters_dir).unwrap().flatten().collect();
     assert_eq!(entries.len(), 1);
     let filename = entries[0]
@@ -956,7 +956,7 @@ fn charter_new_slug_flag_overrides_title_derivation() {
         .assert()
         .success();
 
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     assert!(charters_dir.join("01-batching-listtimeseries-04-f3.md").exists());
 }
 
@@ -979,7 +979,7 @@ fn charter_new_slug_flag_normalizes_through_slugifier() {
         .assert()
         .success();
 
-    let charters_dir = dir.path().join("docs/charters");
+    let charters_dir = dir.path().join(".straymark/charters");
     assert!(charters_dir.join("01-upper-and-special.md").exists());
 }
 
@@ -1030,7 +1030,7 @@ Original handler was synchronous and blocked on DB I/O.
         .assert()
         .success();
 
-    let path = dir.path().join("docs/charters/01-follow-up-async-refactor.md");
+    let path = dir.path().join(".straymark/charters/01-follow-up-async-refactor.md");
     let content = std::fs::read_to_string(&path).unwrap();
 
     // Origin line embeds the extracted Summary lead.
@@ -1064,7 +1064,7 @@ fn charter_new_from_ailog_falls_back_when_ailog_not_found() {
         .assert()
         .success();
 
-    let path = dir.path().join("docs/charters/01-refers-to-missing-ailog.md");
+    let path = dir.path().join(".straymark/charters/01-refers-to-missing-ailog.md");
     let content = std::fs::read_to_string(&path).unwrap();
     assert!(content.contains("originating_ailogs: [AILOG-2026-04-28-999]"));
     assert!(
@@ -1092,5 +1092,5 @@ fn charter_new_empty_slug_flag_falls_back_to_title() {
         .assert()
         .success();
 
-    assert!(dir.path().join("docs/charters/01-hello-world.md").exists());
+    assert!(dir.path().join(".straymark/charters/01-hello-world.md").exists());
 }

--- a/dist/.straymark/scripts/check-charter-drift.sh
+++ b/dist/.straymark/scripts/check-charter-drift.sh
@@ -3,7 +3,8 @@
 #
 # Ported from Sentinel scripts/check-plan-drift.sh (validated empirically with
 # zero false positives across PLAN-05 retrospective + PLAN-06 prospective).
-# StrayMark surface: docs/charters/CHARTER-NN.md instead of docs/plans/NN-*.md.
+# StrayMark surface: Charters live at .straymark/charters/NN-slug.md (this is
+# the rebrand of Sentinel's docs/plans/NN-*.md layout).
 #
 # This script catches drifts of OMISSION (file declared in Charter, never touched)
 # and SCOPE EXPANSION (file modified but not declared). Both kinds were caught by
@@ -14,8 +15,8 @@
 #   .straymark/scripts/check-charter-drift.sh <charter-file> <git-range>
 #
 # Examples:
-#   .straymark/scripts/check-charter-drift.sh docs/charters/01-format-v4.md fd65e87..473f6e0
-#   .straymark/scripts/check-charter-drift.sh docs/charters/01-format-v4.md HEAD~1..HEAD
+#   .straymark/scripts/check-charter-drift.sh .straymark/charters/01-format-v4.md fd65e87..473f6e0
+#   .straymark/scripts/check-charter-drift.sh .straymark/charters/01-format-v4.md HEAD~1..HEAD
 #
 # Exit codes:
 #   0 — no drift detected (or only documented out-of-scope extras)
@@ -37,7 +38,7 @@ set -euo pipefail
 
 if [ $# -lt 2 ]; then
   echo "Usage: $0 <charter-file> <git-range>" >&2
-  echo "Example: $0 docs/charters/01-format-v4.md fd65e87..473f6e0" >&2
+  echo "Example: $0 .straymark/charters/01-format-v4.md fd65e87..473f6e0" >&2
   exit 2
 fi
 
@@ -143,7 +144,7 @@ modified_extra=""
 while IFS= read -r mod; do
   # Allow Charter-doc and AILOG paths through without alarm — those are always
   # in scope when the Charter itself or the AILOG of execution gets touched.
-  if [[ "$mod" == docs/charters/* || "$mod" == .straymark/07-ai-audit/* ]]; then
+  if [[ "$mod" == .straymark/charters/* || "$mod" == .straymark/07-ai-audit/* ]]; then
     continue
   fi
   if ! echo "$declared" | grep -qx "$mod"; then


### PR DESCRIPTION
## Summary

Fixes #119: `straymark charter {list,audit,close,drift,new}` hardcoded `docs/charters/` as the discovery root, while `straymark init` and `straymark status` already treated `.straymark/charters/` as canonical. Result: charters created via `charter new` were invisible to `straymark status`, and charters living under `.straymark/charters/` (the layout shipped by `fw-4.11.0`) were invisible to `charter list/audit/close`.

This PR unifies on **`.straymark/charters/`** as the single canonical Charter directory. Declarative `*.md` and telemetry `*.telemetry.yaml` sidecars now share one folder by design.

## Changes

- New `charter::charters_dir(project_root)` helper — single source of truth for the Charter path.
- `discover_charters` and `commands/charter/new.rs` route through the helper instead of building `docs/charters/` manually.
- `commands/charter/close.rs` reuses the same helper for telemetry destination.
- Error messages in `audit`/`close`/`drift` now name the searched path and hint at `straymark charter list` (the workaround the issue requested).
- `dist/.straymark/scripts/check-charter-drift.sh` matches against `.straymark/charters/*`.
- Tests updated: `cli/tests/charter_*.rs`, plus inline tests in `charter.rs`, `tui/index.rs`, `commands/charter/{list,status}.rs`.

## Test plan

- [x] `cargo test --release` — 479 passed, 0 failed
- [x] Smoke test: `straymark init` + `charter new` → file lands in `.straymark/charters/` → `charter list` finds it
- [x] Smoke test: `charter audit DOES-NOT-EXIST` produces the new helpful error message:
      ```
      error: Charter DOES-NOT-EXIST not found in .straymark/charters/.
        hint: run \`straymark charter list\` to see discovered Charters.
      ```
- [ ] CI green
- [ ] Manual: install this CLI on `straylight` (which already has `.straymark/charters/CHARTER-{01,02}.md`) and confirm `straymark charter list` enumerates them — closing the original reproduction.

## Breaking change note

Projects with charters in `docs/charters/` (the pre-rebrand Sentinel layout) will need to move them to `.straymark/charters/`. A clean `git mv docs/charters .straymark/charters` is sufficient. CLI is pre-1.0, so this is allowed under SemVer; no `--from=docs` migration helper is bundled — the manual `git mv` is one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)