### PR TITLE
chore: bump fw-4.12.0 / cli-3.12.0 — Charter discoverability + path alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.12.0 / CLI 3.12.0 — Charter discoverability + path alignment
+
+Closes the two Charter-related gaps surfaced by real adopters in the issue tracker: **Charter were structurally invisible to the CLI** ([#119](https://github.com/StrangeDaysTech/straymark/issues/119) — `straymark charter list/audit/close` hardcoded `docs/charters/` while the framework already validated `.straymark/charters/`) and **Charter were conceptually invisible to onboarding agents** ([#113](https://github.com/StrangeDaysTech/straymark/issues/113) — agents following the canonical entry points could not discover Charter as a workflow concept).
+
+### Added (Framework)
+
+- **`STRAYMARK.md` §15 — Charter as bounded units of work.** Dedicated section explaining what a Charter is, when to declare one, the lifecycle (`declared` → `in-progress` → `closed`), and how it relates to AILOG / ADR / SpecKit. Charter trigger row added to §6 (When to Document); Charter row added to §9 (Autonomy Limits), §10 (folder map), §11 (When to Load), §13 (Quick Type Reference).
+- **`SPECKIT-CHARTER-BRIDGE.md`** in `dist/.straymark/00-governance/` (EN + ES + zh-CN). Documents *when* a SpecKit feature yields a Charter (4 yes-conditions, 3 no-conditions), 4 granularity heuristics ("one Charter per shippable cut, NOT per User Story"), creation timing within the SpecKit pipeline, frontmatter linkage in both directions (`originating_spec` / `originating_charter`), 5 anti-patterns, 5 non-fit cases.
+- **Skill `/straymark-charter-new`** across the three skill surfaces (`.claude/skills/`, `.gemini/skills/`, `.agent/workflows/`). Drives `straymark charter new` with the right flags (`--from-spec` vs `--from-ailog` vs none, effort estimate). Skill explicitly does *not* flip status, run drift, or run audit — those have their own surfaces.
+- **Charter trigger** in the directive templates (`dist/dist-templates/directives/{CLAUDE.md,GEMINI.md,copilot-instructions.md}`) — agents see Charter alongside AILOG / AIDEC / ADR / ETH triggers in the pre-commit checklist.
+- **`Charters` block in `straymark status`** — declared / in-progress / closed counts (or a friendly hint when empty); colorized status keyed on lifecycle stage; surfaces unparseable Charter files as a warning row.
+
+### Changed (Framework)
+
+- **Charter templates moved to `dist/.straymark/templates/charter/`** subdirectory (with `i18n/es/` co-located inside). Visually distinguishable from auxiliary doc templates, addresses one of the contributing factors of #113 (templates indistinguishable from auxiliary).
+- **`QUICK-REFERENCE.md` (EN + ES + zh-CN)** — adds "Bounded Units of Work — Charter" subsection alongside the doc-type tables, `charters/` entry in the folder tree, Charter trigger row in When-to-Document, `/straymark-charter-new` in the skills table.
+- **`/straymark-status` and `/straymark-new` skills (×3 surfaces)** — `/straymark-status` now scans `.straymark/charters/` and surfaces gaps; `/straymark-new` recognizes Charter intent and *redirects* to `/straymark-charter-new` (Charter is not a `straymark new` doc type).
+
+### Fixed (CLI)
+
+- **`straymark charter list/audit/close/drift/new` honor `.straymark/charters/`** as the canonical Charter location, matching what `straymark init` and `straymark status` already validate. Eliminates 5 hardcoded `docs/charters/` references through a new `charter::charters_dir(project_root)` single source of truth.
+- **Improved error messages** in `audit/close/drift`: instead of opaque `Charter X not found in docs/charters/`, the CLI now reports the searched path and hints at `straymark charter list`:
+
+  ```
+  error: Charter CHARTER-02 not found in .straymark/charters/.
+    hint: run `straymark charter list` to see discovered Charters.
+  ```
+
+- **`dist/.straymark/scripts/check-charter-drift.sh`** matches against `.straymark/charters/*` instead of `docs/charters/*`.
+
+### Breaking change (CLI, pre-1.0)
+
+- Projects with charters under the legacy `docs/charters/` (Sentinel pre-rebrand layout) need to relocate them. Migration is one command: `git mv docs/charters .straymark/charters`. Pre-1.0 SemVer permits the change; the improved error message points operators at it.
+
+### Adopter guidance
+
+- Existing projects on `fw-4.11.0` get the new framework files (skills, templates, governance docs, directive triggers) via `straymark update-framework`.
+- Charter telemetry sidecars (`*.telemetry.yaml`) now share `.straymark/charters/` with the declarative `.md` files by design — no migration needed; `straymark charter close` already wrote them there in 4.11.0.
+
+---
+
 ## Framework 4.11.0 / CLI 3.11.0 — StrayMark rebranding
 
 The project formerly known as DevTrail is now **StrayMark**. The decision was made on 2026-05-08 by the operator after external trademark conflict research, motivated by **legal certainty over the project's mark**. See [`ADR-2026-05-08-001`](docs/decisions/ADR-2026-05-08-rebranding-straymark.md) for the full record.

--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.11.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.11.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.12.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.12.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -305,7 +305,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.11.0)
+# and download the latest fw-* release (e.g., fw-4.12.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.11.0"
+version = "3.12.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -357,4 +357,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -307,4 +307,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -186,4 +186,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -240,4 +240,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -357,4 +357,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -300,4 +300,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -186,4 +186,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -215,4 +215,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -352,4 +352,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -299,4 +299,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -186,4 +186,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -215,4 +215,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.11.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.11.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.12.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.11.0"
+version: "4.12.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.11.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.12.0`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.11.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.11.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.12.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.12.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.11.0
+✔ Downloaded StrayMark fw-4.12.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.11.0
+✔ Framework updated to fw-4.12.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.11.0
+✔ Framework updated to fw-4.12.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.11.0                 │
+  │ Framework │ fw-4.12.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.11.0
+  Using version: fw-4.12.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1053,7 +1053,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.11.0
+  Framework version: fw-4.12.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -235,8 +235,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.11.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.11.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.12.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.12.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -268,7 +268,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.11.0)
+# y descarga el último release fw-* (ej. fw-4.12.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.11.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.12.0`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.11.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.11.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.12.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.12.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.11.0
+✔ Downloaded StrayMark fw-4.12.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.11.0
+✔ Framework updated to fw-4.12.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.11.0
+✔ Framework updated to fw-4.12.0
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.11.0
+Framework version: fw-4.12.0
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -859,7 +859,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.11.0
+  Framework version: fw-4.12.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -253,8 +253,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.11.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.11.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.12.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.12.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -286,7 +286,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.11.0）
+# 下载最新的 fw-* 发布（例如 fw-4.12.0）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.11.0`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.12.0`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.11.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.11.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.12.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.12.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.11.0
+✔ Downloaded StrayMark fw-4.12.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.11.0
+✔ Framework updated to fw-4.12.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.11.0
+✔ Framework updated to fw-4.12.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.11.0                 │
+  │ Framework │ fw-4.12.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.11.0
+  Using version: fw-4.12.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -993,7 +993,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.11.0
+  Framework version: fw-4.12.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

Combined bump for the two PRs that just merged:

- **#121** (`fix(cli)`) → `cli-3.11.0` → `cli-3.12.0` (minor: bug fix + new feature, breaking change documented for legacy `docs/charters/` projects)
- **#122** (`feat(framework+cli)`) → `fw-4.11.0` → `fw-4.12.0` (minor: new skill `/straymark-charter-new`, new `STRAYMARK.md §15`, new `SPECKIT-CHARTER-BRIDGE.md` ×3 langs, templates reorganized into `templates/charter/`, directive triggers, `straymark status` Charter block)

Closes #119 and #113 once merged + tagged + released.

## Files updated

- `cli/Cargo.toml` + `Cargo.lock` (CLI version)
- `dist/dist-manifest.yml` (Framework version)
- `CHANGELOG.md` (new combined section)
- `README.md` + `docs/i18n/{es,zh-CN}/README.md` (versioning tables)
- `docs/adopters/CLI-REFERENCE.md` + i18n (versioning + sample outputs)
- `docs/adopters/ADOPTION-GUIDE.md` + i18n (release version refs)
- `dist/.straymark/00-governance/{QUICK-REFERENCE,AGENT-RULES,DOCUMENTATION-POLICY,C4-DIAGRAM-GUIDE,FOLLOW-UPS-BACKLOG-PATTERN}.md` × 3 langs (footer)
- `dist/.straymark/QUICK-REFERENCE.md` (footer)

## Test plan

- [x] `cargo build --release` clean (compiles as `straymark-cli v3.12.0`)
- [x] `cargo test --release` (479 passed, 0 failed)
- [x] No residual `fw-4.11.0` / `cli-3.11.0` / `StrayMark v4.11.0` strings outside CHANGELOG (preserved as historical) and ADR-2026-05-08 (rebrand record)
- [ ] CI green
- [ ] After merge: tag `fw-4.12.0` and `cli-3.12.0` to trigger release workflows

## Tagging order (post-merge)

```bash
git checkout main && git pull
git tag cli-3.12.0
git push origin cli-3.12.0
# wait for release-cli.yml to publish 4 binaries

git tag fw-4.12.0
git push origin fw-4.12.0
# wait for release-framework.yml to publish straymark-fw-4.12.0.zip
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)