### PR TITLE
docs(readme): banner width 600 → 100% to fill the README container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/straymark-banner.png" alt="StrayMark — by Strange Days Tech" width="600" />
+<img src="assets/straymark-banner.png" alt="StrayMark — by Strange Days Tech" width="100%" />
 
 # StrayMark
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="../../../assets/straymark-banner.png" alt="StrayMark — por Strange Days Tech" width="600" />
+<img src="../../../assets/straymark-banner.png" alt="StrayMark — por Strange Days Tech" width="100%" />
 
 # StrayMark
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="../../../assets/straymark-banner.png" alt="StrayMark — Strange Days Tech 出品" width="600" />
+<img src="../../../assets/straymark-banner.png" alt="StrayMark — Strange Days Tech 出品" width="100%" />
 
 # StrayMark
 


### PR DESCRIPTION
## Summary

Follow-up to #124. The fixed `width=\"600\"` cap left the banner looking small/cropped on desktop where the README container is ~1012 px wide, while mobile was already responsive (GitHub's default `max-width: 100%` already shrinks images to the viewport width regardless of `width`).

`width=\"100%\"` makes the banner fill the README content area on desktop (~1012 × 337 px at the 3:1 aspect) without changing mobile. The 3552 px source has plenty of resolution to stay sharp.

## Test plan

- [ ] Render `README.md` on GitHub desktop and confirm the banner fills the README content width with no horizontal scroll
- [ ] Render `README.md` on GitHub mobile and confirm no regression (still fits the viewport)
- [ ] Render `docs/i18n/es/README.md` and `docs/i18n/zh-CN/README.md` on GitHub desktop and confirm the relative path still resolves at the new width

🤖 Generated with [Claude Code](https://claude.com/claude-code)