### PR TITLE
chore: sync cli-3.12.1 to main (cherry-pick from stranded #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.12.1 — Validator accepts TDE `identified` status
+
+Closes [#130](https://github.com/StrangeDaysTech/straymark/issues/130). Latent in `cli-3.12.0` and earlier; fully exposed by the `fw-4.13.0` TDE activation trigger (which makes TDE creation likely). Surfaced empirically while verifying #128: a freshly-created TDE via `straymark new --doc-type tde` shipped with the canonical `status: identified` per `TEMPLATE-TDE.md` + `DOCUMENTATION-POLICY.md §6`, but `straymark validate` immediately rejected it with `META-003 Invalid status 'identified'`. Validator's hardcoded enumeration was missing the only non-`draft`/non-`accepted` default in the type matrix.
+
+### Fixed (CLI)
+
+- **`validation.rs:45`** — `VALID_STATUSES` now includes `identified` alongside `draft`, `review`, `accepted`, `superseded`, `deprecated`. No per-doc-type dispatch yet — flat list still applies to all 12+ document types, but every documented default now lives in the list. A per-type validation set is deferred to v1 against a second-adopter validation gate (same gate as the follow-ups CLI per `FOLLOW-UPS-BACKLOG-PATTERN.md`).
+- **`cli/tests/validate_test.rs`** — new regression test `test_validate_tde_document_valid()` exercises the canonical `status: identified` flow. The test fails against unpatched validators (proven during TDD) and would have caught the bug at `fw-4.13.0` ship time.
+
+### Changed (Framework)
+
+- **`DOCUMENTATION-POLICY.md §3 "Document Statuses"`** (EN + ES + zh-CN) — lifecycle diagram and table extended to document `identified` as the TDE-only entry state. Functionally equivalent to `draft` for lifecycle gating, semantically distinct so adopter analytics can distinguish "agent-discovered debt" from "human-drafted document". Reconciles §3 prose with the §6 per-type default table that already declared TDE → `identified`. Ships as part of `fw-4.13.0` — no separate framework bump.
+
+### Adopter guidance
+
+- Adopters on `cli-3.12.0` or earlier with one or more TDE documents in `06-evolution/technical-debt/` will see `straymark validate` start passing once they upgrade via `straymark update-cli`. No document edits required; the canonical `status: identified` is now accepted.
+- Operators who manually changed TDE documents to `status: draft` to work around the bug may revert to `status: identified` for semantic clarity, but the workaround keeps working too.
+
+---
+
 ## Framework 4.13.0 — TDE activation trigger
 
 Closes [#128](https://github.com/StrangeDaysTech/straymark/issues/128). The TDE (Technical Debt) document type had structural shape — template, destination folder, autonomy boundary — but no operational activation trigger in the agent-facing governance. Empirical signal from the Sentinel adopter (primary, fw-4.12.0): zero TDEs created across 13 closed Charters despite ≥7 instances of transversal debt being routed through parallel mechanisms (`R<N> (new, not in Charter)` in AILOG `§Risk`, or follow-ups in `follow-ups-backlog.md`). This release adds the trigger and the `R<N>` vs TDE disambiguation, plus a promotion path from the follow-ups backlog. Governance-docs-only — no CLI changes; the `straymark debt list/status/close` subcommand trio is deferred to v1 (same gate as the follow-ups CLI per `FOLLOW-UPS-BACKLOG-PATTERN.md`).

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.13.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.12.0"
+version = "3.12.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.12.0"
+version = "3.12.1"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -41,8 +41,18 @@ impl ValidationResult {
     }
 }
 
-/// Valid status values per DOCUMENTATION-POLICY.md
-const VALID_STATUSES: &[&str] = &["draft", "review", "accepted", "superseded", "deprecated"];
+/// Valid status values per DOCUMENTATION-POLICY.md §3 lifecycle + §6 per-type defaults.
+/// `identified` is the canonical TDE entry state (agent-driven discovery, awaits
+/// human prioritization); functionally equivalent to `draft` for lifecycle gating
+/// but semantically distinct in adopter analytics.
+const VALID_STATUSES: &[&str] = &[
+    "draft",
+    "identified",
+    "review",
+    "accepted",
+    "superseded",
+    "deprecated",
+];
 
 /// Valid risk levels
 const VALID_RISK_LEVELS: &[&str] = &["low", "medium", "high", "critical"];

--- a/cli/tests/validate_test.rs
+++ b/cli/tests/validate_test.rs
@@ -349,6 +349,29 @@ fn test_validate_dpia_document_valid() {
         .stdout(predicate::str::contains("passed validation"));
 }
 
+/// Regression test for issue #130: TDE documents ship with `status: identified`
+/// per TEMPLATE-TDE.md and DOCUMENTATION-POLICY.md §6 — the validator must accept
+/// it as a valid lifecycle entry state.
+#[test]
+fn test_validate_tde_document_valid() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+
+    create_doc(
+        dir.path(),
+        "06-evolution/technical-debt",
+        "TDE-2026-05-11-001-architectural-refactor.md",
+        "id: TDE-2026-05-11-001\ntitle: Architectural Refactor Debt\nstatus: identified\ncreated: 2026-05-11\nagent: claude-code-v1.0\nconfidence: high\nreview_required: false\nrisk_level: medium\ntype: architecture\nimpact: high\neffort: medium\ntags:\n  - architecture\nrelated: []\npriority: null\nassigned_to: null",
+    );
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("passed validation"));
+}
+
 /// F2.QA.02.01 — Also verify that MCARD and DPIA fail without review_required: true
 #[test]
 fn test_validate_mcard_requires_review() {

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -149,18 +149,24 @@ related:
 ## 3. Document Statuses
 
 ```
-draft ──────► accepted ──────► deprecated
-                │                   │
-                │                   ▼
-                └──────► superseded
+identified ──┐
+             ├──► draft ──────► accepted ──────► deprecated
+             │                       │                   │
+             │                       │                   ▼
+             │                       └──────► superseded
+             │
+             └──► (TDE-only entry state, see §6)
 ```
 
 | Status | Description |
 |--------|-------------|
+| `identified` | Entry state for agent-driven discovery types (TDE today). Functionally equivalent to `draft` for lifecycle gating — a human reviewer is expected to prioritize and promote it. Semantically distinct so adopter analytics can distinguish "agent found this debt" from "human is drafting a deliberate doc". |
 | `draft` | In draft, pending review |
 | `accepted` | Approved and current |
 | `deprecated` | Obsolete, but kept as reference |
 | `superseded` | Replaced by another document |
+
+The per-type default status mapping lives in §6 — most types enter at `draft` or `accepted`, but TDE enters at `identified` per the agent-autonomy boundary (agent identifies, human prioritizes).
 
 ---
 

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -149,18 +149,24 @@ related:
 ## 3. Estados de Documentos
 
 ```
-draft ──────► accepted ──────► deprecated
-                │                   │
-                │                   ▼
-                └──────► superseded
+identified ──┐
+             ├──► draft ──────► accepted ──────► deprecated
+             │                       │                   │
+             │                       │                   ▼
+             │                       └──────► superseded
+             │
+             └──► (estado de entrada TDE-only, ver §6)
 ```
 
 | Estado | Descripción |
 |--------|-------------|
+| `identified` | Estado de entrada para los tipos de descubrimiento dirigidos por agente (TDE hoy). Funcionalmente equivalente a `draft` para el lifecycle gating — se espera que un revisor humano lo priorice y lo promueva. Semánticamente distinto para que las analíticas del adopter puedan distinguir "el agente encontró esta deuda" de "un humano está redactando un documento deliberado". |
 | `draft` | En borrador, pendiente de revisión |
 | `accepted` | Aprobado y vigente |
 | `deprecated` | Obsoleto, pero se mantiene como referencia |
 | `superseded` | Reemplazado por otro documento |
+
+El mapeo de status por defecto por tipo vive en §6 — la mayoría de tipos entran en `draft` o `accepted`, pero TDE entra en `identified` por la frontera de autonomía del agente (el agente identifica, el humano prioriza).
 
 ---
 

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -149,18 +149,24 @@ related:
 ## 3. 文档状态
 
 ```
-draft ──────► accepted ──────► deprecated
-                │                   │
-                │                   ▼
-                └──────► superseded
+identified ──┐
+             ├──► draft ──────► accepted ──────► deprecated
+             │                       │                   │
+             │                       │                   ▼
+             │                       └──────► superseded
+             │
+             └──► (TDE 专用入口状态，见 §6)
 ```
 
 | 状态 | 说明 |
 |------|------|
+| `identified` | 由代理驱动发现的类型的入口状态（今日仅 TDE）。在生命周期校验上等同于 `draft`——期望人工审阅者来排定优先级并推进。语义上有所区分，以便 adopter 的分析能够区分"代理发现了此债务"与"人工正在起草一份有意识的文档"。 |
 | `draft` | 草稿中，待审核 |
 | `accepted` | 已批准且为当前有效版本 |
 | `deprecated` | 已废弃，但保留作为参考 |
 | `superseded` | 已被其他文档替代 |
+
+按类型的默认 status 映射位于 §6——大多数类型以 `draft` 或 `accepted` 进入，但 TDE 因代理自主权边界（代理识别、人工排序）以 `identified` 进入。
 
 ---
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.13.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -238,7 +238,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.13.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.12.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.13.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.12.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -256,7 +256,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.13.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.12.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.13.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.12.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 


### PR DESCRIPTION
Replaces closed #132 (had merge conflicts because GitHub squash-merged #129, breaking SHA continuity with the stacked feature branch).

## Why this PR

#131 (closes #130) merged to its stacked base (\`feat/tde-activation-trigger\`) instead of \`main\` — known artifact of stacked-PR pattern when the parent PR squash-merges first. The 14-file diff is stranded on the feature branch.

This PR cherry-picks the exact commit (#131's merge commit \`e128b28\`) onto a fresh branch off main. Cherry-pick was clean — no conflicts because the cherry-picked commit only touches files outside the #129 conflict zone (validator code, regression test, Cargo.toml/Cargo.lock, CLI versioning tables) and §3 prose in DOCUMENTATION-POLICY.md (which #129's squash didn't touch — #129 only changed the doc footer + §6 row).

## Verification

\`\`\`
$ grep '^version' cli/Cargo.toml
version = "3.12.1"

$ cd cli && cargo test --test validate_test test_validate_tde_document_valid
running 1 test
test test_validate_tde_document_valid ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
\`\`\`

## Post-merge

\`fw-4.13.0\` and \`cli-3.12.1\` tags can be pushed from \`main\` HEAD immediately. The release workflows (\`release-framework.yml\`, \`release-cli.yml\`) will compile assets:
- \`straymark-fw-4.13.0.zip\` (dist/ packaged)
- 4× \`straymark-cli-v3.12.1-{linux,darwin-x86_64,darwin-aarch64,windows}.{tar.gz,zip}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)