### PR TITLE
feat(framework): fw-4.13.1 — TDE trigger refinements + FU promotion schema v0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.13.1 — TDE trigger refinements + FU→TDE promotion path schema v0.1
+
+Lands Sentinel's empirical-validation feedback from [#128 comment](https://github.com/StrangeDaysTech/straymark/issues/128#issuecomment-4426059594) (3 TDEs filed in [StrangeDaysTech/sentinel#61](https://github.com/StrangeDaysTech/sentinel/pull/61), all 4 trigger criteria validated; two textual ambiguities + one schema gap surfaced). See [#135](https://github.com/StrangeDaysTech/straymark/issues/135) for the broader 4-tier roadmap; this release is **Tier 1** (governance-only, no CLI changes).
+
+### Changed (Framework)
+
+- **`AGENT-RULES.md §3` "TDE vs `R<N> (new, not in Charter)`" — heritage trigger** (EN + ES + zh-CN). Disambiguates two TDE-worthy shapes that the prior wording conflated:
+  - **Strict heritage** — prior Charter introduced the debt; subsequent Charters propagate without re-introducing (legacy DB schema decision, deferred config). Inherited by transitive contact.
+  - **Pattern propagation** — prior Charter set a pattern; subsequent Charters re-introduce the same debt by following the pattern (handler shape that omits `RequireScope`, test scaffolding that bypasses HTTP middleware). Fix is at the pattern level, not at any single Charter.
+
+  Sentinel's TDE-002 case (CommsHub HTTP layer test coverage gap) was pattern-propagation, not strict heritage; the heuristic captured it correctly but the wording read as strict-only.
+
+- **`AGENT-RULES.md §3` multi-module trigger** (EN + ES + zh-CN). Reformulated from "applies to multiple modules or multiple Charters" to "applies to multiple modules **or Charter execution boundaries**". Captures governance-trail debt that spans sessions without spanning code modules — e.g., a deferred classification in CHARTER-04 that passes silently through CHARTER-08 → CHARTER-13 and only surfaces under a fresh CI gate. Sentinel's TDE-003 case (2 legacy MVP AILOGs pending human review).
+
+- **`FOLLOW-UPS-BACKLOG-PATTERN.md` "Promotion to TDE"** (EN + ES + zh-CN). Documents two equally-valid promotion shapes:
+  - **Promotion of existing entry** — open FU registered weeks/Charters ago, lived through ≥1 close, meets the criteria. Standard flow.
+  - **Retroactive promotion at creation** — debt recognized as TDE-worthy *during* a retrospective; TDE created first, FU added to the registry with `Status: promoted` from birth. Cross-references TDE back to the originating `R<N>` / calibrator finding / deferred classification.
+
+  Both produce the same end state (`Status: promoted`, `Promoted to: TDE-...`); drift script treats them identically.
+
+### Added (Framework)
+
+- **`FOLLOW-UPS-BACKLOG-PATTERN.md` frontmatter schema v0.1** (EN + ES + zh-CN). Canonicalizes operator-maintained counters in the registry header: `total_open`, `total_promoted`, `total_closed_in_session`, `total_phase_blocked`. `total_promoted` is the new entry, mirroring Sentinel's adopted convention. Operator-driven; the drift script does not update them automatically.
+
+### Empirical context
+
+Sentinel ran all 4 trigger criteria against 3 retrospective TDEs:
+
+| TDE | Triggers (of 4) | Notes |
+|-----|----------------:|-------|
+| TDE-001 (RequireScope architectural gap) | 4/4 unambiguous | Textbook trigger application |
+| TDE-002 (HTTP layer test coverage gap) | 3/4 clean + 1 marginal | "Heritage" marginal → wording refined in this release |
+| TDE-003 (legacy MVP AILOGs review) | 3/4 clean + 1 marginal | "Multi-module" marginal → wording refined in this release |
+
+Heuristic captured all 3 cases correctly **with the pre-4.13.1 wording**; refinements remove residual ambiguity for adopter N=2+.
+
+### Not in this release (per [#135](https://github.com/StrangeDaysTech/straymark/issues/135))
+
+- **Tier 2** (ship `check-followups-drift.sh` in `dist/.straymark/scripts/`) — deferred, no adoption friction signal yet
+- **Tier 3** (soft integration with `straymark charter close`) — deferred, no friction signal
+- **Tier 4** (`straymark followups list/status/promote/drift` CLI subcommand trio) — deferred indefinitely against second-adopter validation gate per design principle #12
+
+### Adopter guidance
+
+- Existing fw-4.13.0 adopters: `straymark update-framework` brings the refinements in. No document edits required — the changes are clarifications, not breaking schema changes. `total_promoted` is opt-in (omit the field if you don't use it; the registry still parses fine).
+
+---
+
 ## CLI 3.12.1 — Validator accepts TDE `identified` status
 
 Closes [#130](https://github.com/StrangeDaysTech/straymark/issues/130). Latent in `cli-3.12.0` and earlier; fully exposed by the `fw-4.13.0` TDE activation trigger (which makes TDE creation likely). Surfaced empirically while verifying #128: a freshly-created TDE via `straymark new --doc-type tde` shipped with the canonical `status: identified` per `TEMPLATE-TDE.md` + `DOCUMENTATION-POLICY.md §6`, but `straymark validate` immediately rejected it with `META-003 Invalid status 'identified'`. Validator's hardcoded enumeration was missing the only non-`draft`/non-`accepted` default in the type matrix.

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.13.0` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.13.1` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.13.0)
+# and download the latest fw-* release (e.g., fw-4.13.1)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -112,8 +112,10 @@ Two surfaces exist for emergent debt. They are not interchangeable — pick the 
 
 **Create a TDE document** when the debt:
 
-- Is *heritage from a prior Charter* (the gap predates the work currently in flight).
-- *Applies to multiple modules or multiple Charters* — fragmenting it into per-Charter `R<N>` entries loses the architectural shape.
+- Is *heritage from a prior Charter*. Two distinct shapes both qualify (both are TDE-worthy):
+  - **Strict heritage** — a prior Charter introduced the debt; subsequent Charters merely propagate it without re-introducing the underlying decision (e.g., a legacy DB schema choice; an early auth shortcut; a deferred config decision). The current Charter inherits the debt by transitive contact.
+  - **Pattern propagation** — a prior Charter set a pattern that subsequent Charters *re-introduce* by following it. The current Charter doesn't merely propagate; it re-creates the same debt by replicating the pattern (e.g., handler shape that omits `RequireScope`, test scaffolding that bypasses HTTP middleware). The fix is at the pattern level, not at any single Charter.
+- *Applies to multiple modules **or Charter execution boundaries*** — fragmenting it into per-Charter `R<N>` entries loses the architectural shape. "Charter execution boundaries" captures governance-trail debt that spans sessions without spanning code modules: e.g., a deferred classification in CHARTER-04 that passes silently through CHARTER-08 → CHARTER-13 and only surfaces under a fresh CI gate.
 - *Requires a dedicated Charter outside the current scope envelope* to remediate (not the current Charter, not the next one).
 - *Requires human prioritization or assignment* the agent cannot decide alone (impact × effort matrix, ownership, sprint placement).
 
@@ -377,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -313,4 +313,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -44,7 +44,12 @@ Single markdown file at the canonical path:
 ```yaml
 ---
 last_scan: 2026-05-06
+last_scan_range: AILOG-NNNN-NN-NN-NNN..AILOG-NNNN-NN-NN-NNN  # optional — first..last AILOG covered
 schema_version: v0
+total_open: 0           # count of entries currently `open`
+total_promoted: 0       # count of entries currently `promoted` (added in schema v0.1 — see "Promotion to TDE")
+total_closed_in_session: 0   # count of `closed` entries since last session (optional, operator-maintained)
+total_phase_blocked: 0  # count of `phase-blocked` entries (optional)
 buckets:
   - ready
   - time-triggered
@@ -57,6 +62,8 @@ fully_extracted_ailogs:
   # ... one entry per AILOG whose follow-ups have been processed
 ---
 ```
+
+The `total_*` counters are **operator-maintained metadata**. The drift script doesn't update them automatically — they live in the header so a session-start glance shows the registry's pulse without scrolling through buckets. `total_promoted` was canonicalized in schema v0.1 (Sentinel adopter empirical signal, fw-4.13.1) to mirror the existing `total_open` / `total_closed_in_session` / `total_phase_blocked` pattern.
 
 The `fully_extracted_ailogs` list is the **load-bearing metadata** for drift detection. Every AILOG whose `§Follow-ups` and `R<N>` entries have been transferred into the registry (or explicitly classified as superseded) belongs in this list. Drift detection compares this list against AILOGs that have follow-up content in the repo.
 
@@ -115,6 +122,17 @@ When any of these holds, promote the FU entry to a TDE document under `.straymar
 3. In the FU entry, set `Status: promoted`, set `Destination: TDE-YYYY-MM-DD-NNN`, and add `Promoted to: TDE-YYYY-MM-DD-NNN`. Move the entry to the `## Bucket: closed` section if you maintain one; otherwise leave it in place with the new status.
 
 The FU entry is **not deleted** after promotion — its presence in the registry is the audit trail showing where the TDE came from.
+
+### Two promotion shapes — promotion-of-existing vs retroactive-at-creation
+
+The workflow above covers the **standard case**: an `open` FU entry already exists in the registry and gets elevated to a TDE during periodic review. There is a second case that is equally valid and that emerged empirically from the Sentinel CHARTER-13 retrospective:
+
+- **Promotion of existing entry** — an FU was registered (typically via `--apply`) as `open` weeks or Charters ago, lived through ≥1 Charter close without resolution, and meets the four criteria above. Standard flow.
+- **Retroactive promotion at creation** — the debt is recognized as TDE-worthy *during* a retrospective (Charter close ceremony, audit cycle, RFC writeup) and never existed as an `open` FU. The TDE is created first; an FU entry is added to the registry *with `Status: promoted`* from birth, providing the audit trail back from the TDE to the originating context (an `R<N>` in an AILOG, a calibrator finding, a deferred classification).
+
+Both shapes produce the same end state in the registry: an entry with `Status: promoted` and a `Promoted to: TDE-YYYY-MM-DD-NNN` pointer. The difference is whether the entry pre-existed as `open` or was born `promoted`. The drift script treats them identically (it doesn't differentiate by birth status), and adopter analytics counting `total_promoted` get the same number either way.
+
+When in doubt, prefer creating the FU entry — even retroactively — because it cross-references the TDE back to the AILOG / R-number / source context that triggered the recognition. A TDE with `promoted_from_followup: FU-NNN` pointing to an entry that exists in the backlog is more navigable than one pointing to a fictional FU.
 
 ### When to promote
 
@@ -215,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -112,8 +112,10 @@ Existen dos superficies para la deuda emergente. No son intercambiables — elig
 
 **Crea un documento TDE** cuando la deuda:
 
-- Es *herencia de un Charter previo* (la brecha precede al trabajo actualmente en ejecución).
-- *Aplica a múltiples módulos o múltiples Charters* — fragmentarla en entradas `R<N>` por Charter pierde la forma arquitectónica.
+- Es *herencia de un Charter previo*. Dos formas distintas califican (ambas son TDE-worthy):
+  - **Herencia estricta** — un Charter previo introdujo la deuda; los Charters subsecuentes solo la propagan sin re-introducir la decisión subyacente (p. ej., una elección legacy de schema de BD; un atajo temprano de auth; una decisión de config diferida). El Charter actual hereda la deuda por contacto transitivo.
+  - **Propagación de patrón** — un Charter previo estableció un patrón que los Charters subsecuentes *re-introducen* siguiéndolo. El Charter actual no solo propaga; recrea la misma deuda replicando el patrón (p. ej., forma de handler que omite `RequireScope`; scaffolding de tests que bypasea middleware HTTP). El fix está al nivel del patrón, no de ningún Charter individual.
+- *Aplica a múltiples módulos **o a fronteras de ejecución de Charter*** — fragmentarla en entradas `R<N>` por Charter pierde la forma arquitectónica. "Fronteras de ejecución de Charter" captura deuda de rastro de gobernanza que atraviesa sesiones sin atravesar módulos de código: p. ej., una clasificación diferida en CHARTER-04 que pasa en silencio por CHARTER-08 → CHARTER-13 y solo aflora bajo una gate de CI nueva.
 - *Requiere un Charter dedicado fuera del envelope de scope actual* para remediarse (no el Charter actual, no el siguiente).
 - *Requiere priorización o asignación humana* que el agente no puede decidir solo (matriz impact × effort, ownership, sprint placement).
 
@@ -377,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -306,4 +306,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -44,7 +44,12 @@ Por debajo de ese volumen, la convención per-AILOG por sí sola es suficiente �
 ```yaml
 ---
 last_scan: 2026-05-06
+last_scan_range: AILOG-NNNN-NN-NN-NNN..AILOG-NNNN-NN-NN-NNN  # opcional — primer..último AILOG cubierto
 schema_version: v0
+total_open: 0           # cuenta de entradas actualmente `open`
+total_promoted: 0       # cuenta de entradas actualmente `promoted` (agregado en schema v0.1 — ver "Promoción a TDE")
+total_closed_in_session: 0   # cuenta de entradas `closed` desde la última sesión (opcional, operator-maintained)
+total_phase_blocked: 0  # cuenta de entradas `phase-blocked` (opcional)
 buckets:
   - ready
   - time-triggered
@@ -57,6 +62,8 @@ fully_extracted_ailogs:
   # ... una entrada por cada AILOG cuyos follow-ups han sido procesados
 ---
 ```
+
+Los contadores `total_*` son **metadatos operator-maintained**. El script de drift no los actualiza automáticamente — viven en el header para que un vistazo a inicio de sesión muestre el pulso del registro sin scrollear por buckets. `total_promoted` se canonicalizó en schema v0.1 (señal empírica del adopter Sentinel, fw-4.13.1) para reflejar el patrón existente de `total_open` / `total_closed_in_session` / `total_phase_blocked`.
 
 La lista `fully_extracted_ailogs` es el **metadato cargante** para la detección de drift. Todo AILOG cuyas entradas de `§Follow-ups` y `R<N>` han sido transferidas al registro (o explícitamente clasificadas como superseded) pertenece a esta lista. La detección de drift compara esta lista contra los AILOGs que tienen contenido de follow-ups en el repo.
 
@@ -115,6 +122,17 @@ Cuando cualquiera de estos se cumple, promueve la entrada FU a un documento TDE 
 3. En la entrada FU, establece `Status: promoted`, `Destination: TDE-YYYY-MM-DD-NNN`, y agrega `Promoted to: TDE-YYYY-MM-DD-NNN`. Mueve la entrada a la sección `## Bucket: closed` si mantienes una; si no, déjala en lugar con el nuevo status.
 
 La entrada FU **no se elimina** tras la promoción — su presencia en el registro es el rastro auditable que muestra de dónde vino el TDE.
+
+### Dos formas de promoción — promoción-de-existente vs retroactiva-en-la-creación
+
+El workflow anterior cubre el **caso estándar**: una entrada FU `open` ya existe en el registro y se eleva a un TDE durante revisión periódica. Existe un segundo caso igualmente válido que emergió empíricamente del retrospectivo de Sentinel CHARTER-13:
+
+- **Promoción de entrada existente** — un FU fue registrado (típicamente vía `--apply`) como `open` semanas o Charters atrás, vivió ≥1 cierre de Charter sin resolución, y cumple los cuatro criterios. Flujo estándar.
+- **Promoción retroactiva en la creación** — la deuda se reconoce como TDE-worthy *durante* un retrospectivo (ceremonia de cierre de Charter, ciclo de auditoría, redacción de RFC) y nunca existió como FU `open`. Se crea primero el TDE; se agrega una entrada FU al registro *con `Status: promoted`* desde el nacimiento, proporcionando el rastro auditable desde el TDE hacia el contexto originador (un `R<N>` en un AILOG, un finding del calibrador, una clasificación diferida).
+
+Ambas formas producen el mismo estado final en el registro: una entrada con `Status: promoted` y un puntero `Promoted to: TDE-YYYY-MM-DD-NNN`. La diferencia es si la entrada pre-existía como `open` o nació `promoted`. El script de drift las trata idénticamente (no diferencia por status de nacimiento), y las analíticas del adopter que cuentan `total_promoted` obtienen el mismo número en ambos casos.
+
+Ante la duda, prefiere crear la entrada FU — aunque sea retroactivamente — porque cross-referencia el TDE de vuelta al AILOG / número-R / contexto fuente que disparó el reconocimiento. Un TDE con `promoted_from_followup: FU-NNN` apuntando a una entrada que existe en el backlog es más navegable que uno apuntando a un FU ficticio.
 
 ### Cuándo promover
 
@@ -215,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -112,8 +112,10 @@ confidence: high | medium | low
 
 **创建 TDE 文档**，当该债务：
 
-- 是 *先前 Charter 的遗留*（该缺陷早于当前正在执行的工作）。
-- *横跨多个模块或多个 Charter* —— 将其拆分为各 Charter 的 `R<N>` 条目会丢失其架构形态。
+- 是 *先前 Charter 的遗留*。两种不同形态均符合（均为 TDE-worthy）：
+  - **严格遗留** —— 先前 Charter 引入了该债务；后续 Charter 仅传播之而不再引入其底层决策（例如：遗留 DB schema 选择；早期 auth 走捷径；延期的 config 决策）。当前 Charter 通过传递接触继承该债务。
+  - **模式传播** —— 先前 Charter 设立了某模式，后续 Charter 通过遵循该模式 *再次引入* 之。当前 Charter 不只是传播，而是通过复制模式重新制造同一债务（例如：遗漏 `RequireScope` 的 handler 形态；绕过 HTTP middleware 的测试脚手架）。修复需在模式层面，而非任一个单独 Charter。
+- *横跨多个模块**或 Charter 执行边界*** —— 将其拆分为各 Charter 的 `R<N>` 条目会丢失其架构形态。"Charter 执行边界"涵盖跨会话却未跨代码模块的治理轨迹债务：例如，CHARTER-04 中延期的某项分类，经 CHARTER-08 → CHARTER-13 悄然通过，直至新的 CI gate 才浮现。
 - *需要在当前 scope 包络之外的专用 Charter* 来修复（不是当前 Charter，也不是下一个）。
 - *需要人工决定优先级或分配*，代理无法独自决定（impact × effort 矩阵、所有权、Sprint 安排）。
 
@@ -372,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -305,4 +305,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -44,7 +44,12 @@ StrayMark 的 per-AILOG `§Follow-ups` 约定在写入时有效 — 创建 AILOG
 ```yaml
 ---
 last_scan: 2026-05-06
+last_scan_range: AILOG-NNNN-NN-NN-NNN..AILOG-NNNN-NN-NN-NNN  # 可选 —— 涵盖的首个..末尾 AILOG
 schema_version: v0
+total_open: 0           # 当前为 `open` 状态的条目计数
+total_promoted: 0       # 当前为 `promoted` 状态的条目计数(schema v0.1 新增 —— 见"提升为 TDE")
+total_closed_in_session: 0   # 上次会话以来 `closed` 条目计数(可选,operator-maintained)
+total_phase_blocked: 0  # `phase-blocked` 条目计数(可选)
 buckets:
   - ready
   - time-triggered
@@ -57,6 +62,8 @@ fully_extracted_ailogs:
   # ... 每个 follow-ups 已被处理的 AILOG 一个条目
 ---
 ```
+
+`total_*` 计数器是**operator-maintained 的元数据**。drift 脚本不会自动更新它们 —— 它们位于 header 之中,使会话开始时的扫视就能看到注册表的脉搏,无需在 bucket 中翻页。`total_promoted` 在 schema v0.1 中固化(Sentinel adopter 的经验信号,fw-4.13.1),与现有的 `total_open` / `total_closed_in_session` / `total_phase_blocked` 模式保持一致。
 
 `fully_extracted_ailogs` 列表是 drift 检测的**承重元数据**。所有 `§Follow-ups` 和 `R<N>` 条目已被转移到注册表(或被显式分类为 superseded)的 AILOG 都属于此列表。Drift 检测将此列表与 repo 中具有 follow-up 内容的 AILOG 进行比对。
 
@@ -115,6 +122,17 @@ closed、superseded 和 promoted 条目保留在文件中(可审计的历史)。
 3. 在 FU 条目中,设置 `Status: promoted`、`Destination: TDE-YYYY-MM-DD-NNN`,并添加 `Promoted to: TDE-YYYY-MM-DD-NNN`。如果你维护 `## Bucket: closed` 节,则将条目移过去;否则保持原位并更新状态。
 
 FU 条目在提升后**不会被删除** —— 它在注册表中的存在就是显示 TDE 来源的审计轨迹。
+
+### 两种提升形态 —— 提升已存在的 vs 创建时即追溯提升
+
+上述工作流涵盖**标准情况**:`open` 状态的 FU 条目已存在于注册表中,并在周期性审查期间被提升为 TDE。还有一种同样有效的情况,源自 Sentinel CHARTER-13 回顾的经验:
+
+- **提升已存在条目** —— FU 数周或数个 Charter 之前已被(通常通过 `--apply`)登记为 `open`,经历过 ≥1 次 Charter 关闭仍未解决,并满足上述四项标准。标准流程。
+- **创建时即追溯提升** —— 在回顾(Charter 关闭仪式、审计周期、RFC 撰写)*期间* 该债务被识别为值得作为 TDE,且从未作为 `open` FU 存在。先创建 TDE;在注册表中以 *`Status: promoted`* 状态新增一个 FU 条目,提供从 TDE 回溯到原始上下文(AILOG 中的某个 `R<N>`、calibrator 的 finding、被延期的分类)的审计轨迹。
+
+两种形态在注册表中产生相同的终态:一个 `Status: promoted` 且具有 `Promoted to: TDE-YYYY-MM-DD-NNN` 指针的条目。区别在于条目是预先以 `open` 存在,还是天生即为 `promoted`。drift 脚本一视同仁(不按出生状态区分);统计 `total_promoted` 的 adopter 分析在两种情况下得到相同数字。
+
+存疑时,优先创建 FU 条目 —— 即便是追溯创建 —— 因为它会把 TDE 交叉引用回触发该识别的 AILOG / R-号 / 源上下文。一个 `promoted_from_followup: FU-NNN` 指向 backlog 中实际存在的条目的 TDE,比指向一个虚构的 FU 更易导航。
 
 ### 何时提升
 
@@ -215,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.13.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.1 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.13.0"
+version: "4.13.1"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.13.0`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.13.1`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.13.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.13.1` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.0
+✔ Downloaded StrayMark fw-4.13.1
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.0
+✔ Framework updated to fw-4.13.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.0
+✔ Framework updated to fw-4.13.1
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.0                 │
+  │ Framework │ fw-4.13.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.0
+  Using version: fw-4.13.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1053,7 +1053,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.0
+  Framework version: fw-4.13.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -237,7 +237,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.13.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.13.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.13.0)
+# y descarga el último release fw-* (ej. fw-4.13.1)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.13.0`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.13.1`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.13.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.13.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.0
+✔ Downloaded StrayMark fw-4.13.1
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.0
+✔ Framework updated to fw-4.13.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.0
+✔ Framework updated to fw-4.13.1
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.13.0
+Framework version: fw-4.13.1
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -859,7 +859,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.0
+  Framework version: fw-4.13.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -255,7 +255,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.13.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.13.0）
+# 下载最新的 fw-* 发布（例如 fw-4.13.1）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.13.0`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.13.1`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.0` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.13.1` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.0
+✔ Downloaded StrayMark fw-4.13.1
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.0
+✔ Framework updated to fw-4.13.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.0
+✔ Framework updated to fw-4.13.1
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.0                 │
+  │ Framework │ fw-4.13.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.0
+  Using version: fw-4.13.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -993,7 +993,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.0
+  Framework version: fw-4.13.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
Implements **Tier 1** of #135. Closes the empirical-validation loop on #128 with the 4 refinements Sentinel proposed in [their PR #61 closing comment](https://github.com/StrangeDaysTech/straymark/issues/128#issuecomment-4426059594).

## Summary

Sentinel ran all 4 trigger criteria against 3 retrospective TDEs and validated the heuristic empirically. The pre-4.13.1 wording captured all 3 cases correctly, but two textual ambiguities and one schema gap surfaced and are landed here.

| TDE | Triggers (of 4) | Notes |
|-----|----------------:|-------|
| TDE-001 — RequireScope architectural gap | 4/4 unambiguous | Textbook trigger application |
| TDE-002 — HTTP layer test coverage gap | 3/4 clean + 1 marginal | "Heritage" marginal — refined here |
| TDE-003 — legacy MVP AILOGs review | 3/4 clean + 1 marginal | "Multi-module" marginal — refined here |

## What's in

### Governance refinements (EN + ES + zh-CN)

1. **\`AGENT-RULES.md §3\` heritage trigger** — distinguishes two TDE-worthy shapes:
   - **Strict heritage** — prior Charter introduced the debt; subsequent Charters propagate without re-introducing (legacy DB schema, deferred config). Inherited by transitive contact.
   - **Pattern propagation** — prior Charter set a pattern that subsequent Charters re-introduce by following (handler shape omitting \`RequireScope\`, test scaffolding bypassing HTTP middleware). Fix is at the pattern level.

   The prior wording read as strict-only. Sentinel's TDE-002 was pattern-propagation; heuristic captured it but the wording invited ambiguity.

2. **\`AGENT-RULES.md §3\` multi-module trigger** — reformulated from "applies to multiple modules or multiple Charters" to **"applies to multiple modules or Charter execution boundaries"**. Captures governance-trail debt that spans sessions without spanning code modules (TDE-003: 2 specific AILOG docs whose impact crosses CHARTER-04 → CHARTER-08 → CHARTER-13 deferral boundaries).

3. **\`FOLLOW-UPS-BACKLOG-PATTERN.md\` "Promotion to TDE"** — documents two equally-valid shapes:
   - **Promotion of existing entry** — \`open\` FU registered weeks ago, lives through ≥1 close, meets criteria. Standard flow.
   - **Retroactive promotion at creation** — debt recognized as TDE-worthy *during* a retrospective; TDE created first, FU added with \`Status: promoted\` from birth. Cross-references TDE back to the originating \`R<N>\` / calibrator finding / deferred classification.

   Both produce the same end state; drift script treats them identically. Sentinel's 3 cases were all retroactive.

4. **\`FOLLOW-UPS-BACKLOG-PATTERN.md\` frontmatter schema v0.1** — canonicalizes operator-maintained counters in the registry header: \`total_open\`, **\`total_promoted\`** (new), \`total_closed_in_session\`, \`total_phase_blocked\`. Sentinel adopted \`total_promoted\` independently — this lands the convention as canonical schema.

### Version bumps

- \`dist-manifest.yml\` 4.13.0 → 4.13.1
- 16 governance doc footers (8 docs × EN/ES/zh-CN)
- README + CLI-REFERENCE versioning tables + ADOPTION-GUIDE (3 langs)
- \`CHANGELOG.md\` — new \`## Framework 4.13.1\` section above \`## CLI 3.12.1\`

## What's NOT in this PR (per #135)

| Tier | Status | Reason |
|------|--------|--------|
| **Tier 2** — ship \`check-followups-drift.sh\` in \`dist/.straymark/scripts/\` | Deferred | No adoption friction signal yet |
| **Tier 3** — soft integration with \`charter close\` | Deferred | No friction signal — Sentinel runs the script manually without complaint |
| **Tier 4** — \`straymark followups\` CLI subcommand trio | Deferred indefinitely | Principle #12 — no premature crystallization until N≥2 adopters align on vocabulary |

## Verification

- [x] No CLI code touched — pure governance
- [x] \`grep "StrayMark v4.13.0"\` → no hits in dist/ (16 footers bumped)
- [x] \`grep "fw-4.13.0"\` → only in CHANGELOG.md (historical reference, intentional)
- [x] EN + ES + zh-CN i18n sweep complete for the 4 refinements

## Adopter guidance

Existing \`fw-4.13.0\` adopters: \`straymark update-framework\` brings the refinements in. No document edits required — clarifications, not breaking schema. \`total_promoted\` is opt-in (registry parses fine without it).

Closes (continuation of empirical validation): [#128 comment](https://github.com/StrangeDaysTech/straymark/issues/128#issuecomment-4426059594)  
Refs: #135 (4-tier roadmap), #129 (fw-4.13.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)