### PR TITLE
docs(changelog): errata for fw-4.11.0 — skill-dir cleanup missing from rebrand notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,35 @@ Single known adopter (`StrangeDaysTech/sentinel`, operator-owned) migrates manua
 
 The README does not yet include an etymological paragraph explaining the meaning of "StrayMark" — that is a deliberate follow-up, deferred from the rebranding execution per operator instruction.
 
+### Errata — migration step missing from original release notes *(documented 2026-05-12, after Sentinel adopter encountered it)*
+
+The "migrates manually via `mv .devtrail .straymark` + `git mv DEVTRAIL.md STRAYMARK.md` + updating refs in `CLAUDE.md`/`AGENT.md`" step above is **incomplete**. It does not mention the cleanup of the per-platform skill directories. Adopters that ran `straymark update-framework` (or applied the rebrand manually) ended up with **30 orphaned legacy items** sitting alongside the new ones:
+
+| Surface | Orphan pattern | Count |
+|---|---|---:|
+| `.gemini/skills/` | `devtrail-{adr,aidec,ailog,audit-{execute,prompt,review},mcard,new,sec,status}/` | 10 dirs |
+| `.claude/skills/` | same pattern | 10 dirs |
+| `.agent/workflows/` | `devtrail-*.md` | 10 files |
+
+The `name:` field **inside** each orphaned `SKILL.md` was rewritten to `straymark-*` during the rebrand (probably via mass sed), so each pair has identical `name` but two different directory paths. Gemini CLI surfaces this as 10 `⚠ Skill conflict detected: "straymark-X" from devtrail-X/SKILL.md is overriding the same skill from straymark-X/SKILL.md` warnings at startup. Claude Code and the `.agent/workflows/` consumer do not warn out loud but exhibit equivalent override behavior.
+
+**Complete migration steps** (amending the line above for any adopter migrating from a `fw-≤4.10.x` install):
+
+```bash
+# Renames already documented above
+mv .devtrail .straymark
+git mv DEVTRAIL.md STRAYMARK.md
+
+# Skill directory cleanup — missing from original release notes
+rm -rf .gemini/skills/devtrail-*
+rm -rf .claude/skills/devtrail-*
+rm .agent/workflows/devtrail-*.md
+
+# Update references in agent directive files (CLAUDE.md, GEMINI.md, etc.) as already documented
+```
+
+Sentinel applied this cleanup in `StrangeDaysTech/sentinel#62` (2026-05-12). No known third-party adopters, so the impact is bounded to the single project that already fixed it. This errata is preserved here as historical record for any future major rename or repository-level prefix change.
+
 ---
 
 ## Framework 4.10.0 — Follow-ups backlog pattern (governance docs)


### PR DESCRIPTION
## Why

Sentinel ran an external audit cycle via \`gemini-cli\` and surfaced **10 skill-conflict warnings** of the form:

\`\`\`
⚠ Skill conflict detected: "straymark-status" from .gemini/skills/devtrail-status/SKILL.md
  is overriding the same skill from .gemini/skills/straymark-status/SKILL.md
\`\`\`

Root cause: the \`fw-4.11.0\` DevTrail→StrayMark rebrand migration steps documented in CHANGELOG.md said *"adopter migrates manually via \`mv .devtrail .straymark\` + \`git mv DEVTRAIL.md STRAYMARK.md\` + updating refs in \`CLAUDE.md\`/\`AGENT.md\`"* — but **did not mention cleaning up the legacy \`devtrail-*\` skill directories** in \`.gemini/skills/\`, \`.claude/skills/\`, and \`.agent/workflows/\`. The rebrand rewrote the \`name:\` field *inside* each SKILL.md (probably via mass sed) but left the directory names with the legacy prefix.

Effect: each pair has identical \`name\` field but lives in two paths. Gemini CLI flags this loudly at startup. Claude Code and the \`.agent/workflows/\` consumer don't warn but exhibit equivalent override behavior.

## What

Adds an **Errata** subsection inside the existing fw-4.11.0 CHANGELOG entry (after \`### Adopter impact\`), with:

1. Description of the gap with the exact orphan patterns and counts (10 dirs × 3 surfaces = 30 items)
2. Why it triggers (in-place \`name:\` rewrite without directory rename)
3. Complete migration steps including the missing \`rm -rf .{gemini,claude}/skills/devtrail-*\` and \`rm .agent/workflows/devtrail-*.md\` lines
4. Cross-reference to the Sentinel cleanup PR ([StrangeDaysTech/sentinel#62](https://github.com/StrangeDaysTech/sentinel/pull/62)) where the operator applied the fix

## Why annotate the historical entry vs. create a new entry

The historical entry's audience is *future adopters reading the rebrand notes*. Adding the errata in-place ensures they see the corrected steps right where they look for them, rather than having to cross-reference a later entry.

The errata is timestamped (*"documented 2026-05-12, after Sentinel adopter encountered it"*) so the historical record is honest about when the gap was identified vs. when the original release shipped.

## Scope

- **Pure docs** — touches only \`CHANGELOG.md\`
- **No version bump** — \`fw-4.13.1\` is in flight in #136 and includes its own unrelated changes; this errata is an annotation of \`fw-4.11.0\`, not a new release
- **No CLI changes** — the rebrand was 7 months ago; building a CLI helper to detect orphan dirs would be over-engineering for the single-adopter case

## Adopter impact

Sentinel is the only known adopter and already fixed it in [sentinel#62](https://github.com/StrangeDaysTech/sentinel/pull/62). Any future major-rename event (improbable) will have the complete migration recipe in the historical CHANGELOG.

Refs: [sentinel#62](https://github.com/StrangeDaysTech/sentinel/pull/62) (Sentinel cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)