### PR TITLE
fix(framework): fw-4.13.2 — complete Charter path migration to .straymark/charters/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.13.2 — Complete the Charter path migration to `.straymark/charters/`
+
+Completes the path migration that `fw-4.12.0` started ([#119](https://github.com/StrangeDaysTech/straymark/issues/119)). That release aligned all `straymark charter` CLI subcommands to `.straymark/charters/` (single source of truth via `charter::charters_dir(project_root)`) but missed three classes of artifact still pointing at the legacy `docs/charters/` path. Surfaced empirically by the Sentinel adopter during external-audit prep when reviewing the framework's pre-PR hook behavior.
+
+### Fixed (Framework)
+
+- **`dist/.straymark/hooks/pre-pr.sh`** — load-bearing fix. The hook gated on `[ ! -d docs/charters ]` and the in-progress Charter glob was `docs/charters/*.md`. For any adopter on the canonical `.straymark/charters/` layout (i.e., everyone post-`fw-4.12.0`), the hook **silently exited 0 without running drift check** — `straymark init --hooks` installed a no-op. Now correctly scans `.straymark/charters/*.md` (3 hits in the script: comment + directory test + glob).
+- **`dist/.straymark/schemas/charter-telemetry.schema.v0.json`** — `charter_id.description` field referenced `docs/charters/` as the canonical Charter file location. Now matches `.straymark/charters/`.
+- **`dist/.straymark/templates/charter/charter-template.md`** (EN + ES) — step 3 of "Closing the charter" instructed *"Move the row in `docs/charters/README.md`"*; adopters following the template literally pointed at a non-existent path. Now `.straymark/charters/README.md`.
+
+### Changed (Framework — user-facing docs)
+
+- **`README.md` + ES + zh-CN** — `straymark validate --include-charters` description aligned to `.straymark/charters/`.
+- **`CLI-REFERENCE.md` + ES + zh-CN** — multiple references (flag descriptions, command prose, example outputs) aligned to `.straymark/charters/`. Includes the example outputs that the CLI itself emits — those showed the legacy path which would have confused operators comparing their actual CLI output against the docs.
+
+### Empirical context
+
+Surfaced while [Sentinel](https://github.com/StrangeDaysTech/sentinel) prepared an external audit cycle and noticed that the upstream `fw-4.13.1` install retained `docs/charters/` in schemas + templates + hook + docs even though the CLI binary itself was already on `.straymark/charters/`. The pre-PR hook bug was the most operationally consequential: any adopter running `straymark init --hooks` since `fw-4.12.0` had a silently-broken hook.
+
+### Not adding a migration helper
+
+This release does not introduce a CLI command to detect adopter projects still on the legacy `docs/charters/` layout — that migration was already declared a [pre-1.0 breaking change in `fw-4.12.0`](https://github.com/StrangeDaysTech/straymark/blob/main/CHANGELOG.md#framework-4120--cli-3120--charter-discoverability--path-alignment) with the documented one-command fix (`git mv docs/charters .straymark/charters`). The improved CLI error message added there continues to apply.
+
+### Adopter guidance
+
+- Existing `fw-4.13.1` adopters: `straymark update-framework` brings the corrected hook, schema, template, and docs. No charter file moves required (those already happened at `fw-4.12.0`). Operators using `--hooks` will see drift check actually run for the first time since the canonical-path adoption.
+- Operators who were on `docs/charters/` and never migrated: see the `fw-4.12.0` entry for the one-command migration.
+
+---
+
 ## Framework 4.13.1 — TDE trigger refinements + FU→TDE promotion path schema v0.1
 
 Lands Sentinel's empirical-validation feedback from [#128 comment](https://github.com/StrangeDaysTech/straymark/issues/128#issuecomment-4426059594) (3 TDEs filed in [StrangeDaysTech/sentinel#61](https://github.com/StrangeDaysTech/sentinel/pull/61), all 4 trigger criteria validated; two textual ambiguities + one schema gap surfaced). See [#135](https://github.com/StrangeDaysTech/straymark/issues/135) for the broader 4-tier roadmap; this release is **Tier 1** (governance-only, no CLI changes).

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Built-in commands that turn the discipline into actionable feedback:
 
 - **`straymark charter <new|list|status|close|drift|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression; `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
 - **`straymark approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
-- **`straymark validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `docs/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
+- **`straymark validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `.straymark/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
 - **`straymark metrics`** — Governance KPIs, review rates, risk distribution, trends
 - **`straymark analyze`** — Code complexity analysis (cognitive + cyclomatic) powered by [arborist-metrics](https://github.com/StrangeDaysTech/arborist), our open-source Rust library for multi-language code metrics
 - **`straymark audit`** — Audit trail reports with timeline, traceability maps, and HTML export
@@ -274,7 +274,7 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.13.1` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.13.2` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.13.1)
+# and download the latest fw-* release (e.g., fw-4.13.2)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -313,4 +313,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -306,4 +306,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -305,4 +305,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.13.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.1 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.2 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/hooks/pre-pr.sh
+++ b/dist/.straymark/hooks/pre-pr.sh
@@ -5,7 +5,7 @@
 # (e.g., from a Makefile target) when the operator prefers explicit invocation.
 #
 # Behavior:
-#   - For each Charter in docs/charters/*.md whose frontmatter has
+#   - For each Charter in .straymark/charters/*.md whose frontmatter has
 #     `status: in-progress`, run `straymark charter drift <id> --range
 #     <upstream>..HEAD`. AILOG-suppression in the CLI silences alerts on
 #     paths already documented as risks in the Charter's originating AILOGs.
@@ -32,11 +32,11 @@ fi
 
 UPSTREAM="${STRAYMARK_UPSTREAM:-origin/main}"
 
-if [ ! -d docs/charters ]; then
+if [ ! -d .straymark/charters ]; then
   exit 0  # repo doesn't use Charters
 fi
 
-charters=$(grep -l '^status: in-progress' docs/charters/*.md 2>/dev/null || true)
+charters=$(grep -l '^status: in-progress' .straymark/charters/*.md 2>/dev/null || true)
 if [ -z "$charters" ]; then
   exit 0  # nothing in-progress; nothing to check
 fi

--- a/dist/.straymark/schemas/charter-telemetry.schema.v0.json
+++ b/dist/.straymark/schemas/charter-telemetry.schema.v0.json
@@ -16,7 +16,7 @@
         "charter_id": {
           "type": "string",
           "pattern": "^CHARTER-[0-9]{2,}(-[a-z0-9-]+)?$",
-          "description": "Charter identifier this telemetry corresponds to. Must match the charter_id of an existing Charter file in docs/charters/."
+          "description": "Charter identifier this telemetry corresponds to. Must match the charter_id of an existing Charter file in .straymark/charters/."
         },
         "charter_title": {
           "type": "string",

--- a/dist/.straymark/templates/charter/charter-template.md
+++ b/dist/.straymark/templates/charter/charter-template.md
@@ -149,7 +149,7 @@ When closing this Charter:
    - This catches the rare case where drift is introduced post-merge (squash
      mangling, admin amendments, etc.) and the atomic step in #1 could not apply.
 
-3. **Move the row** in `docs/charters/README.md` to `## Closed` and reference the PR.
+3. **Move the row** in `.straymark/charters/README.md` to `## Closed` and reference the PR.
 
 4. **Status frontmatter** moves from `in-progress` to `closed` (and optionally
    `closed_at: YYYY-MM-DD` is added — the schema allows arbitrary additional fields).

--- a/dist/.straymark/templates/charter/i18n/es/charter-template.md
+++ b/dist/.straymark/templates/charter/i18n/es/charter-template.md
@@ -151,7 +151,7 @@ Al cerrar este Charter:
    - Esto atrapa el caso raro donde drift se introduce post-merge (squash mangling,
      amendments admin, etc.) y el step atomic en #1 no pudo aplicar.
 
-3. **Mover la fila** en `docs/charters/README.md` a `## Cerrados` y referenciar el PR.
+3. **Mover la fila** en `.straymark/charters/README.md` a `## Cerrados` y referenciar el PR.
 
 4. **Status del frontmatter** pasa de `in-progress` a `closed` (y opcionalmente
    se añade `closed_at: YYYY-MM-DD` — el schema permite campos adicionales arbitrarios).

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.13.1"
+version: "4.13.2"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.13.1`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.13.2`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.13.1` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.13.2` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.1
+✔ Downloaded StrayMark fw-4.13.2
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.1
+✔ Framework updated to fw-4.13.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.1
+✔ Framework updated to fw-4.13.2
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.1                 │
+  │ Framework │ fw-4.13.2                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.1
+  Using version: fw-4.13.2
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -288,7 +288,7 @@ Validate StrayMark documents for compliance and correctness.
 | `path` | `.` (current directory) | Target project directory |
 | `--fix` | — | Automatically fix simple issues (e.g., missing `review_required: true` for high-risk docs) |
 | `--staged` | — | Validate only staged (git-added) files. Ideal for pre-commit hooks. |
-| `--include-charters` | — | Also validate Charters in `docs/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Opt-in so projects that don't yet use the Charter pattern are unaffected. |
+| `--include-charters` | — | Also validate Charters in `.straymark/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Opt-in so projects that don't yet use the Charter pattern are unaffected. |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | List documents with `review_required: true` and no `review_outcome` older than `--max-pending-days`. **Warn-only** — never fails the validate exit code; useful for CI dashboards of the approval backlog. |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | Threshold in days for `--check-pending-reviews` |
 
@@ -412,7 +412,7 @@ $ straymark new -t ailog --title "Implement JWT authentication"
 
 ### `straymark charter <subcommand>`
 
-Manage **Charters**: bounded, auditable units of work declared ex-ante and validated ex-post. A Charter pairs declarative scope (files to touch, risks, executable verification) with ex-post audit anchoring (drift detection, multi-model audit). Charters live at `docs/charters/NN-slug.md` (project-root level, **not** under `.straymark/`).
+Manage **Charters**: bounded, auditable units of work declared ex-ante and validated ex-post. A Charter pairs declarative scope (files to touch, risks, executable verification) with ex-post audit anchoring (drift detection, multi-model audit). Charters live at `.straymark/charters/NN-slug.md` (project-root level, **not** under `.straymark/`).
 
 > **Naming history.** In the Sentinel `/plan-audit` experiment that crystallized this pattern (2026-04, 6 cycles), Charters were called *Plans*. The StrayMark CLI uses **Charter** going forward to disambiguate from GitHub SpecKit's `plan.md`. Sentinel's historical files preserve "Plan" deliberately. The full conceptual scope and the rename rationale live in `Propuesta/que-es-un-charter.md`.
 
@@ -427,7 +427,7 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
-Scaffold a Charter from the framework template into `docs/charters/NN-slug.md`. Prompts for the title interactively if not passed. The two origin flags are mutually exclusive at the clap level.
+Scaffold a Charter from the framework template into `.straymark/charters/NN-slug.md`. Prompts for the title interactively if not passed. The two origin flags are mutually exclusive at the clap level.
 
 | Argument/Flag | Default | Description |
 |---------------|---------|-------------|
@@ -457,7 +457,7 @@ $ straymark charter new -t L --from-spec specs/001-payments/spec.md --title "wir
 ```
 $ straymark charter new -t M --title "test charter"
 
-  ✔ Created: docs/charters/01-test-charter.md
+  ✔ Created: .straymark/charters/01-test-charter.md
 
   Next steps:
     1. Edit the Charter to fill in Context, Scope, Files to modify, Verification, Risks, Tasks.
@@ -566,7 +566,7 @@ Detect file-vs-commit drift at Charter close. Wraps the framework's `.straymark/
 ```bash
 $ straymark charter drift CHARTER-01 --range origin/main..HEAD
 === Charter drift check ===
-  Charter: docs/charters/01-test.md
+  Charter: .straymark/charters/01-test.md
   Range:   origin/main..HEAD
   Declared: 5 files
   Modified: 3 files
@@ -595,7 +595,7 @@ Both forms are handled in both directions: a declared wildcard suppresses both "
 
 #### Designed: governance paths are always in scope
 
-Paths under `docs/charters/*` and `.straymark/07-ai-audit/*` are **never** reported as "modified but not declared". This is opinionated by design — those paths are always legitimate when the Charter itself or the AILOG of execution is touched. Empirically validated in Sentinel CHARTER-04: a stray `git add -A` staged unrelated user-untracked files (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly suppressed the governance noise without hiding the genuine project-file expansion ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
+Paths under `.straymark/charters/*` and `.straymark/07-ai-audit/*` are **never** reported as "modified but not declared". This is opinionated by design — those paths are always legitimate when the Charter itself or the AILOG of execution is touched. Empirically validated in Sentinel CHARTER-04: a stray `git add -A` staged unrelated user-untracked files (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly suppressed the governance noise without hiding the genuine project-file expansion ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
 
 If you're running a Charter whose explicit scope is governance churn (e.g., a bulk approval Charter touching only `.straymark/07-ai-audit/`), the drift check will report 0 modified files and you'll need to verify scope by reading the AILOG. A `--strict-scope` flag that disables the always-in-scope rule is on the table for a future minor if a real adopter reports the asymmetry as a friction.
 
@@ -1053,7 +1053,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.1
+  Framework version: fw-4.13.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -142,7 +142,7 @@ Comandos integrados que convierten la disciplina en feedback accionable:
 
 - **`straymark charter <new|list|status|close|drift|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware; `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
 - **`straymark approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
-- **`straymark validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `docs/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
+- **`straymark validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `.straymark/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
 - **`straymark metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
 - **`straymark analyze`** — Análisis de complejidad de código (cognitiva + ciclomática) impulsado por [arborist-metrics](https://github.com/StrangeDaysTech/arborist), nuestra librería open-source en Rust para métricas de código multi-lenguaje
 - **`straymark audit`** — Reportes de auditoría con línea temporal, mapas de trazabilidad y exportación HTML
@@ -237,7 +237,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.13.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.13.2` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.13.1)
+# y descarga el último release fw-* (ej. fw-4.13.2)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.13.1`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.13.2`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.13.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.13.2` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.1
+✔ Downloaded StrayMark fw-4.13.2
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.1
+✔ Framework updated to fw-4.13.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.1
+✔ Framework updated to fw-4.13.2
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.13.1
+Framework version: fw-4.13.2
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -269,7 +269,7 @@ Valida documentos StrayMark verificando cumplimiento y corrección.
 | `path` | `.` (directorio actual) | Directorio del proyecto |
 | `--fix` | — | Corregir automáticamente problemas simples |
 | `--staged` | — | Validar solo archivos staged en Git (ideal para hooks pre-commit) |
-| `--include-charters` | — | Validar también los Charters en `docs/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.10.0. |
+| `--include-charters` | — | Validar también los Charters en `.straymark/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.10.0. |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | Lista documentos con `review_required: true` y sin `review_outcome` cuya antigüedad supere `--max-pending-days`. **Solo warn** — nunca falla el exit code de validate; útil para dashboards de CI sobre el backlog de aprobaciones. |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | Umbral en días para `--check-pending-reviews`. |
 
@@ -382,7 +382,7 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 
 ### `straymark charter <subcomando>`
 
-Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-ante y validadas ex-post. Un Charter empareja scope declarativo (archivos a tocar, riesgos, comandos de verificación ejecutables) con el ancla de auditoría ex-post (drift detection, auditoría multi-modelo). Los Charters viven en `docs/charters/NN-slug.md` (a nivel del project root, **no** bajo `.straymark/`).
+Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-ante y validadas ex-post. Un Charter empareja scope declarativo (archivos a tocar, riesgos, comandos de verificación ejecutables) con el ancla de auditoría ex-post (drift detection, auditoría multi-modelo). Los Charters viven en `.straymark/charters/NN-slug.md` (a nivel del project root, **no** bajo `.straymark/`).
 
 > **Nota histórica.** En el experimento Sentinel `/plan-audit` que cristalizó este patrón (abril 2026, 6 ciclos), los Charters se llamaban *Plans*. El CLI StrayMark usa **Charter** going-forward para evitar la colisión nominal con el `plan.md` de GitHub SpecKit. Los archivos históricos de Sentinel preservan "Plan" deliberadamente. El alcance conceptual completo y la justificación del rename viven en `Propuesta/que-es-un-charter.md`.
 
@@ -397,7 +397,7 @@ Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <titulo>] [path]`
 
-Crea un Charter desde el template del framework en `docs/charters/NN-slug.md`. Si no se pasa `--title`, se solicita interactivamente. Los dos flags de origen son mutuamente excluyentes a nivel de clap.
+Crea un Charter desde el template del framework en `.straymark/charters/NN-slug.md`. Si no se pasa `--title`, se solicita interactivamente. Los dos flags de origen son mutuamente excluyentes a nivel de clap.
 
 | Argumento/Flag | Default | Descripción |
 |----------------|---------|-------------|
@@ -500,7 +500,7 @@ Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del fr
 ```bash
 $ straymark charter drift CHARTER-01 --range origin/main..HEAD
 === Charter drift check ===
-  Charter: docs/charters/01-test.md
+  Charter: .straymark/charters/01-test.md
   Range:   origin/main..HEAD
   Declared: 5 files
   Modified: 3 files
@@ -529,7 +529,7 @@ Ambas formas se manejan en ambas direcciones: un wildcard declarado suprime tant
 
 #### Por diseño: rutas de gobernanza siempre están en scope
 
-Los paths bajo `docs/charters/*` y `.straymark/07-ai-audit/*` **nunca** se reportan como "modificado pero no declarado". Es opinionated por diseño — esos paths son siempre legítimos cuando el Charter mismo o el AILOG de ejecución son tocados. Validado empíricamente en Sentinel CHARTER-04: un `git add -A` accidental stageó archivos no-tracked del usuario (`.claude/skills/`, `cmd/sentinel/sentinel`); la regla suprimió correctamente el ruido de gobernanza sin esconder la expansión genuina de archivos del proyecto ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
+Los paths bajo `.straymark/charters/*` y `.straymark/07-ai-audit/*` **nunca** se reportan como "modificado pero no declarado". Es opinionated por diseño — esos paths son siempre legítimos cuando el Charter mismo o el AILOG de ejecución son tocados. Validado empíricamente en Sentinel CHARTER-04: un `git add -A` accidental stageó archivos no-tracked del usuario (`.claude/skills/`, `cmd/sentinel/sentinel`); la regla suprimió correctamente el ruido de gobernanza sin esconder la expansión genuina de archivos del proyecto ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
 
 Si corres un Charter cuyo scope explícito es churn de gobernanza (p.ej. un Charter de aprobación bulk que toca solo `.straymark/07-ai-audit/`), el chequeo reportará 0 archivos modificados y necesitarás verificar el scope leyendo el AILOG. Un flag `--strict-scope` que deshabilite la regla "siempre en scope" está sobre la mesa para una minor futura si un adopter real reporta la asimetría como fricción.
 
@@ -859,7 +859,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.1
+  Framework version: fw-4.13.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -142,7 +142,7 @@ StrayMark 的产品决策基于十二条明确的原则。它们按层级排序�
 
 - **`straymark charter <new|list|status|close|drift|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
 - **`straymark approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
-- **`straymark validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `docs/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
+- **`straymark validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `.straymark/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
 - **`straymark metrics`** — 治理 KPI、审查率、风险分布、趋势
 - **`straymark analyze`** — 代码复杂度分析（认知复杂度 + 圈复杂度），由 [arborist-metrics](https://github.com/StrangeDaysTech/arborist) 驱动——我们的开源 Rust 多语言代码度量库
 - **`straymark audit`** — 审计跟踪报告，含时间线、可追溯性映射和 HTML 导出
@@ -255,7 +255,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.13.2` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.13.1）
+# 下载最新的 fw-* 发布（例如 fw-4.13.2）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.13.1`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.13.2`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.1` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.13.2` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.1
+✔ Downloaded StrayMark fw-4.13.2
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.1
+✔ Framework updated to fw-4.13.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.1
+✔ Framework updated to fw-4.13.2
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.1                 │
+  │ Framework │ fw-4.13.2                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.1
+  Using version: fw-4.13.2
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -288,7 +288,7 @@ Repairing StrayMark in /home/user/my-project
 | `path` | `.`（当前目录） | 目标项目目录 |
 | `--fix` | — | 自动修复简单问题（例如为高风险文档添加缺失的 `review_required: true`） |
 | `--staged` | — | 仅验证已暂存（git add）的文件。适合 pre-commit 钩子。 |
-| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `docs/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.10.0 中加入。 |
+| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `.straymark/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.10.0 中加入。 |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | 列出所有 `review_required: true` 且没有 `review_outcome`、年龄超过 `--max-pending-days` 的文档。**仅警告** — 永不影响 validate 的退出码；适合用于 CI 仪表板上的审批积压视图。 |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | `--check-pending-reviews` 的天数阈值。 |
 
@@ -412,7 +412,7 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 
 ### `straymark charter <子命令>`
 
-管理**章程（Charter）**：事前声明、事后审计的有界工作单元。一个章程将声明性范围（要修改的文件、风险、可执行的验证命令）与事后审计锚点（漂移检测、多模型审计）配对。章程位于 `docs/charters/NN-slug.md`（项目根目录级别，**不在** `.straymark/` 之下）。
+管理**章程（Charter）**：事前声明、事后审计的有界工作单元。一个章程将声明性范围（要修改的文件、风险、可执行的验证命令）与事后审计锚点（漂移检测、多模型审计）配对。章程位于 `.straymark/charters/NN-slug.md`（项目根目录级别，**不在** `.straymark/` 之下）。
 
 > **命名历史。**在使该模式定型的 Sentinel `/plan-audit` 实验中（2026 年 4 月，6 个周期），章程被称为 *Plans*。StrayMark CLI 从此版本开始使用 **Charter** 以避免与 GitHub SpecKit 的 `plan.md` 命名冲突。Sentinel 的历史文件刻意保留 "Plan" 命名。完整的概念范围与重命名理由见 `Propuesta/que-es-un-charter.md`。
 
@@ -427,7 +427,7 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
-从框架模板将章程创建到 `docs/charters/NN-slug.md`。如果未传入 `--title`，会以交互方式提示。两个来源标志在 clap 级别互斥。
+从框架模板将章程创建到 `.straymark/charters/NN-slug.md`。如果未传入 `--title`，会以交互方式提示。两个来源标志在 clap 级别互斥。
 
 | 参数/标志 | 默认值 | 描述 |
 |-----------|--------|------|
@@ -517,7 +517,7 @@ $ straymark charter close CHARTER-01
 ```bash
 $ straymark charter drift CHARTER-01 --range origin/main..HEAD
 === Charter drift check ===
-  Charter: docs/charters/01-test.md
+  Charter: .straymark/charters/01-test.md
   Range:   origin/main..HEAD
   Declared: 5 files
   Modified: 3 files
@@ -546,7 +546,7 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 
 #### 设计：治理路径始终在 scope 内
 
-`docs/charters/*` 和 `.straymark/07-ai-audit/*` 下的路径**永远不会**被报告为"已修改但未声明"。这是有意的设计 — 当章程本身或执行的 AILOG 被触动时，这些路径总是合法的。在 Sentinel CHARTER-04 中实证验证：一次意外的 `git add -A` 暂存了无关的用户未跟踪文件（`.claude/skills/`、`cmd/sentinel/sentinel`）；该规则正确抑制了治理噪声而没有掩盖真正的项目文件扩展（[issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)）。
+`.straymark/charters/*` 和 `.straymark/07-ai-audit/*` 下的路径**永远不会**被报告为"已修改但未声明"。这是有意的设计 — 当章程本身或执行的 AILOG 被触动时，这些路径总是合法的。在 Sentinel CHARTER-04 中实证验证：一次意外的 `git add -A` 暂存了无关的用户未跟踪文件（`.claude/skills/`、`cmd/sentinel/sentinel`）；该规则正确抑制了治理噪声而没有掩盖真正的项目文件扩展（[issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)）。
 
 如果你运行的章程显式 scope 是治理 churn（例如仅触动 `.straymark/07-ai-audit/` 的批量批准章程），漂移检查将报告 0 个修改文件，你需要通过阅读 AILOG 来验证 scope。一个 `--strict-scope` 标志（禁用"始终在 scope"规则）在桌面上，用于未来 minor 版本，前提是真实的 adopter 报告这种不对称为摩擦。
 
@@ -993,7 +993,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.1
+  Framework version: fw-4.13.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
Completes the Charter path migration that #119/fw-4.12.0 started. That release aligned all \`straymark charter\` CLI subcommands to use \`.straymark/charters/\` as the canonical location (single source of truth via \`charter::charters_dir(project_root)\`) but **missed three classes of framework artifact** that continued to reference the legacy \`docs/charters/\` path. Surfaced by [Sentinel](https://github.com/StrangeDaysTech/sentinel) during external-audit prep — *"upstream framework v4.13.1 aún usa \`docs/charters/\` en sus templates/schema — inconsistencia upstream"*.

## What's in

### Fixed — load-bearing artifacts

| File | Hits | Symptom before fix |
|---|---:|---|
| \`dist/.straymark/hooks/pre-pr.sh\` | 3 | Hook gated on \`[ ! -d docs/charters ]\` and globbed \`docs/charters/*.md\`. For any post-\`fw-4.12.0\` adopter on the canonical layout, **the hook silently exited 0 without running drift check** — \`straymark init --hooks\` installed a no-op since 7 months ago. |
| \`dist/.straymark/schemas/charter-telemetry.schema.v0.json\` | 1 | \`charter_id.description\` referenced wrong canonical path |
| \`dist/.straymark/templates/charter/charter-template.md\` (EN + ES) | 2 | Step 3 of "Closing the charter" instructed adopters to update \`docs/charters/README.md\` — non-existent path on modern installs |

### Changed — user-facing docs

| File | Hits | What |
|---|---:|---|
| \`README.md\` + ES + zh-CN | 3 | \`straymark validate --include-charters\` description |
| \`docs/adopters/CLI-REFERENCE.md\` + ES + zh-CN | ~15 | Flag descriptions, command prose, example outputs (CLI-emitted strings — showing the wrong path would have confused operators comparing actual CLI output against docs) |

### Version bumps

- \`dist-manifest.yml\` 4.13.1 → 4.13.2
- 16 governance doc footers (8 docs × EN/ES/zh-CN)
- README + CLI-REFERENCE + ADOPTION-GUIDE versioning tables (3 langs)
- \`CHANGELOG.md\` — new \`## Framework 4.13.2\` section above \`## Framework 4.13.1\`

## Not in this PR

### No CLI helper for adopters still on legacy layout

The migration from \`docs/charters/\` to \`.straymark/charters/\` was already declared a **pre-1.0 breaking change in `fw-4.12.0`** with the documented one-command fix (\`git mv docs/charters .straymark/charters\`). The improved CLI error message in that release continues to apply. Sentinel migrated 7 months ago; no other known adopters.

### No regression test for the hook fix

The pre-PR hook is a POSIX bash script with no Rust test surface. Validation is through Sentinel adopter usage — Sentinel verified the corrected behavior locally before this PR landed (the audit-prep was what surfaced the bug). A test harness for shipped shell scripts is itself a separate scope decision and not motivated by N=1.

### Historical references in CHANGELOG.md and decision proposals preserved

\`CHANGELOG.md\` entries for \`fw-4.10/4.11/4.12\` legitimately reference \`docs/charters/\` as historical context. \`docs/decisions/proposals/2026-05-03-cli-roadmap.md\` is a historical proposal. Both preserved.

## Severity assessment

The hook bug is the most operationally consequential of the three load-bearing fixes:

- **Hook (silently broken)**: \`straymark init --hooks\` has been installing a no-op since \`fw-4.12.0\` released. Adopters opted into pre-push drift check but got nothing. **Critical for ops, low for correctness** — no false positives, no bad data, just an absence of the protection they opted into.
- **Schema description (cosmetic)**: misleading text in canonical schema. **Low for ops, medium for correctness** — adopters reading the schema may build wrong tooling assumptions.
- **Template (misleading instructions)**: adopters following step 3 literally would create a README at a non-existent path. **Low for ops, medium for correctness**.

Patch-level release is appropriate; no breaking changes.

## Adopter guidance

- \`straymark update-framework\` brings the corrected hook, schema, template, and docs in one operation.
- No charter file moves required (those already happened at \`fw-4.12.0\`).
- Operators using \`--hooks\` will see drift check actually run for the first time since the canonical-path adoption — expect to see post-push activity that was silently skipped before.

Refs: #119 (original \`fw-4.12.0\` migration), Sentinel external-audit feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)