### PR TITLE
fix(rebrand): installer/SBOM/LICENSE residuals from fw-4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,16 @@ rm .agent/workflows/devtrail-*.md
 
 Sentinel applied this cleanup in `StrangeDaysTech/sentinel#62` (2026-05-12). No known third-party adopters, so the impact is bounded to the single project that already fixed it. This errata is preserved here as historical record for any future major rename or repository-level prefix change.
 
+### Errata — root-level installer / SBOM / LICENSE residuals *(documented 2026-05-12)*
+
+Four files in the repository root were missed by the rebrand sweep. The installer pair was the operationally consequential one — broken from the merge of `fw-4.11.0` until this errata:
+
+- **`install.sh` / `install.ps1`** — internals still referenced `REPO=StrangeDaysTech/devtrail`, `BINARY=devtrail` (or `devtrail.exe`), and the legacy asset name `devtrail-cli-v${VERSION}-${TARGET}.{tar.gz,zip}`. Meanwhile `release-cli.yml` had already been producing `straymark-cli-*` assets with the `straymark` binary, so any user piping the installer per the (already-rebranded) README/CLI-REFERENCE instructions hit a GitHub 404. Now aligned: `StrangeDaysTech/straymark`, `straymark`/`straymark.exe`, asset prefix `straymark-cli-`. Windows `LOCALAPPDATA` install path also moved from `DevTrail\bin` → `StrayMark\bin` (no shim — same policy applied to `.devtrail` → `.straymark` and to the skill-dir cleanup above).
+- **`devtrail.spdx` → `straymark.spdx`** — `git mv` plus content update of `DocumentName`, `DocumentNamespace`, `PackageName`, `PackageDownloadLocation`, `PackageHomePage`, `PackageCopyrightText` ("DevTrail Contributors" → "StrayMark Contributors"), and `PackageDescription`. `PackageVersion` advanced from the stale `1.0.0` to `3.12.1` to match the CLI binary the SBOM describes.
+- **`LICENSE`** — copyright line updated to "StrayMark Contributors" in the live state. The MIT text itself is unchanged.
+
+Historical entries elsewhere in this CHANGELOG and the `devtrail-cli@3.10.0` crate are preserved as historical record per the policy stated at the top of this file.
+
 ---
 
 ## Framework 4.10.0 — Follow-ups backlog pattern (governance docs)

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ SPDX-License-Identifier: MIT
 
 MIT License
 
-Copyright (c) 2025 Strange Days Tech, S.A.S. and DevTrail Contributors
+Copyright (c) 2025 Strange Days Tech, S.A.S. and StrayMark Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/install.ps1
+++ b/install.ps1
@@ -1,10 +1,10 @@
-# DevTrail CLI installer for Windows — https://github.com/StrangeDaysTech/devtrail
+# StrayMark CLI installer for Windows — https://github.com/StrangeDaysTech/straymark
 #
 # Usage:
-#   irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1 | iex
 #
 #   # Or with parameters:
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.ps1))) -Tag cli-1.0.0
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.ps1))) -Tag cli-1.0.0
 #
 # Compatible with PowerShell 5.1+ and PowerShell Core (pwsh).
 
@@ -15,22 +15,22 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$Repo = "StrangeDaysTech/devtrail"
-$Binary = "devtrail.exe"
+$Repo = "StrangeDaysTech/straymark"
+$Binary = "straymark.exe"
 $Target = "x86_64-pc-windows-msvc"
 
 function Write-Status($Message) {
-    Write-Host "devtrail-install: $Message"
+    Write-Host "straymark-install: $Message"
 }
 
 function Write-Err($Message) {
-    Write-Host "devtrail-install: ERROR: $Message" -ForegroundColor Red
+    Write-Host "straymark-install: ERROR: $Message" -ForegroundColor Red
 }
 
 # ── Verify platform ─────────────────────────────────────────────────────
 
 if ([System.Environment]::Is64BitOperatingSystem -eq $false) {
-    Write-Err "DevTrail requires a 64-bit Windows installation."
+    Write-Err "StrayMark requires a 64-bit Windows installation."
     exit 1
 }
 
@@ -43,7 +43,7 @@ if ($env:PROCESSOR_ARCHITECTURE -ne "AMD64" -and $env:PROCESSOR_ARCHITECTURE -ne
 # ── Defaults ─────────────────────────────────────────────────────────────
 
 if (-not $InstallDir) {
-    $InstallDir = Join-Path $env:LOCALAPPDATA "DevTrail\bin"
+    $InstallDir = Join-Path $env:LOCALAPPDATA "StrayMark\bin"
 }
 
 # ── GitHub API headers ───────────────────────────────────────────────────
@@ -103,11 +103,11 @@ try {
 
     # Build asset name and URL
     $versionNum = $Tag -replace "^cli-", ""
-    $asset = "devtrail-cli-v${versionNum}-${Target}.zip"
+    $asset = "straymark-cli-v${versionNum}-${Target}.zip"
     $url = "https://github.com/$Repo/releases/download/$Tag/$asset"
 
     # Create temp directory
-    $tempDir = Join-Path $env:TEMP "devtrail-install-$(Get-Random)"
+    $tempDir = Join-Path $env:TEMP "straymark-install-$(Get-Random)"
     New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
     $archivePath = Join-Path $tempDir $asset

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,21 @@
 #!/bin/sh
-# DevTrail CLI installer — https://github.com/StrangeDaysTech/devtrail
+# StrayMark CLI installer — https://github.com/StrangeDaysTech/straymark
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
 #   curl -fsSL ... | sh -s -- --tag cli-1.0.0 --to ~/.local/bin
 #
 # Compatible with bash, zsh, dash, and POSIX sh.
 
 set -eu
 
-REPO="StrangeDaysTech/devtrail"
-BINARY="devtrail"
+REPO="StrangeDaysTech/straymark"
+BINARY="straymark"
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 say() {
-    printf 'devtrail-install: %s\n' "$*"
+    printf 'straymark-install: %s\n' "$*"
 }
 
 err() {
@@ -57,7 +57,7 @@ download() {
 
 usage() {
     cat <<EOF
-DevTrail CLI installer
+StrayMark CLI installer
 
 USAGE:
     install.sh [OPTIONS]
@@ -71,7 +71,7 @@ ENVIRONMENT:
     GITHUB_TOKEN   GitHub API token to avoid rate limits
 
 EXAMPLES:
-    curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/devtrail/main/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh
     curl -fsSL ... | sh -s -- --tag cli-1.0.0
     curl -fsSL ... | sh -s -- --to /usr/local/bin
 EOF
@@ -200,7 +200,7 @@ main() {
     VERSION_NUM="${TAG#cli-}"
 
     # Build asset name and URL
-    ASSET="devtrail-cli-v${VERSION_NUM}-${TARGET}.tar.gz"
+    ASSET="straymark-cli-v${VERSION_NUM}-${TARGET}.tar.gz"
     URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
 
     say "downloading ${ASSET}..."

--- a/straymark.spdx
+++ b/straymark.spdx
@@ -1,21 +1,21 @@
 SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
-DocumentName: devtrail
-DocumentNamespace: https://github.com/StrangeDaysTech/devtrail
+DocumentName: straymark
+DocumentNamespace: https://github.com/StrangeDaysTech/straymark
 Creator: Organization: Strange Days Tech, S.A.S.
 Created: 2025-01-27T00:00:00Z
 
-PackageName: devtrail
+PackageName: straymark
 SPDXID: SPDXRef-Package
-PackageVersion: 1.0.0
-PackageDownloadLocation: https://github.com/StrangeDaysTech/devtrail
-PackageHomePage: https://github.com/StrangeDaysTech/devtrail
+PackageVersion: 3.12.1
+PackageDownloadLocation: https://github.com/StrangeDaysTech/straymark
+PackageHomePage: https://github.com/StrangeDaysTech/straymark
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
-PackageCopyrightText: Copyright (c) 2025 Strange Days Tech, S.A.S. and DevTrail Contributors
+PackageCopyrightText: Copyright (c) 2025 Strange Days Tech, S.A.S. and StrayMark Contributors
 PackageSummary: Documentation governance framework for AI-assisted software development.
-PackageDescription: DevTrail provides a documentation governance system that ensures traceability for all significant changes in software projects, whether made by humans or AI agents. Includes templates, validation scripts, and multi-agent support.
+PackageDescription: StrayMark provides a documentation governance system that ensures traceability for all significant changes in software projects, whether made by humans or AI agents. Includes templates, validation scripts, and multi-agent support.
 
 LicenseID: LicenseRef-MIT
 ExtractedText: <text>


### PR DESCRIPTION
## Summary

Cierra residuos del rebrand DevTrail → StrayMark (fw-4.11.0) en cuatro archivos de la raíz que el sweep original pasó por alto.

- **`install.sh` / `install.ps1`** estaban **rotos en producción** desde el merge del rebrand. El README + CLI-REFERENCE (EN/ES/zh-CN) ya apuntaban a `raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.{sh,ps1}`, pero internamente los scripts referenciaban `REPO=StrangeDaysTech/devtrail`, `BINARY=devtrail`, y descargaban `devtrail-cli-v*-*.{tar.gz,zip}`. Mientras tanto `release-cli.yml` ya producía `straymark-cli-*` con binario `straymark` → cualquier instalación piped daba 404.
- **`devtrail.spdx` → `straymark.spdx`** (vía `git mv`): `DocumentName`, `DocumentNamespace`, `PackageName`, URLs, `PackageCopyrightText` ("DevTrail Contributors" → "StrayMark Contributors"), `PackageDescription`. `PackageVersion` actualizado de `1.0.0` (stale) a `3.12.1` para alinearse con el binario CLI vigente.
- **`LICENSE`**: copyright a "StrayMark Contributors".
- **Windows `LOCALAPPDATA`**: `DevTrail\bin` → `StrayMark\bin` (sin shim — misma política que `.devtrail` → `.straymark` y que el cleanup de skill dirs).
- **`CHANGELOG.md`**: nueva subsección de errata dentro de `Framework 4.11.0` (mismo patrón que la errata previa en `a06ce28`). Entradas históricas intactas.

## Test plan

- [ ] CI verde
- [ ] `grep -nI -E 'devtrail|DevTrail' install.sh install.ps1 straymark.spdx LICENSE` → sin resultados
- [ ] `git show --stat HEAD` muestra `rename devtrail.spdx => straymark.spdx` (no delete+add)
- [ ] Smoke test (opcional, post-merge): `sh install.sh --tag cli-3.12.1 --to /tmp/sm-test && /tmp/sm-test/straymark about` → reporta `3.12.1`
- [ ] Validar entrada de errata en CHANGELOG (no rompe el frontmatter Keep-a-Changelog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)