### PR TITLE
fix(cli): cli-3.12.2 — Charter frontmatter visible in `straymark explore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.12.2 — `straymark explore` shows Charter frontmatter correctly
+
+Fixes a long-standing bug where the **Metadata** panel of `straymark explore` rendered every Charter as `Status: ? UNKNOWN` regardless of the actual `status:` value in the Charter frontmatter. Surfaced by [Sentinel](https://github.com/StrangeDaysTech/sentinel) while reviewing a closed Charter (`CHARTER-13`) in the TUI — the screen showed UNKNOWN even though the Charter's frontmatter clearly read `status: closed`.
+
+### Fixed (CLI)
+
+- **`cli/src/tui/document.rs`** — `Document::load` parsed every `.md` against `DocFrontMatter`, whose `status` enum only knows `draft|accepted|deprecated|superseded`. Charter frontmatter (`status: declared|in-progress|closed`) fell through to the `#[serde(other)] Unknown` variant, and the disjoint fields (`charter_id`, `effort_estimate`, `trigger`, `originating_ailogs`, `originating_spec`) were silently dropped. The loader now dispatches to `crate::charter::parse_charter` for paths under `.straymark/charters/NN-slug.md` and returns a typed `DocumentMetadata::Charter(_)` variant.
+- **`cli/src/tui/widgets/metadata_panel.rs`** — renders a Charter-specific layout when the variant is `Charter`: `Charter ID`, `Status` (with the correct vocabulary and color: yellow ○ declared / cyan ◐ in-progress / green ■ closed), `Effort` (XS/S/M/L color-graded), `Trigger` (truncated single-line), `Origin`, and `Related` links (materialized from `originating_ailogs` + `originating_spec`, navigable via `Enter` like any other related link).
+- **`cli/src/tui/ui.rs`** — `metadata_panel_height` now computes a sensible vertical reserve for both governance docs and Charters; previously it under-reserved for Charters and the panel could clip its lower fields.
+- **`cli/src/tui/app.rs`** — `tag_count`, `related_count`, and `metadata_enter` now go through the new `Document::tags()` / `Document::related()` helpers so the existing tag-search and follow-related-link interactions work for both variants without any further branching at the call site.
+
+### Changed (CLI)
+
+- **`cli/src/charter.rs`** — `is_charter_filename` is now `pub` so the TUI loader can use it for dispatch. No behavioral change.
+- **`cli/src/tui/i18n_strings.rs`** — adds `Charter ID:`, `Effort:`, `Trigger:`, `Origin:` translations (ES + zh-CN).
+
+### Empirical context
+
+The `Status: ? UNKNOWN` rendering was misleading because the frontmatter *did* parse — just against the wrong schema. `serde_yaml::from_str::<DocFrontMatter>` succeeded with every charter field defaulted and `status = Some(Unknown)` via `#[serde(other)]`, which is why the panel showed an explicit UNKNOWN instead of falling back to `No frontmatter`. The fix avoids re-parsing at render time by routing the schema choice at load time, keyed on the canonical `.straymark/charters/NN-slug.md` path — the same heuristic `discover_charters` uses to skip the adopter-maintained `README.md` status board.
+
+### Adopter guidance
+
+`straymark update-cli` brings the corrected binary. No project state changes required. The fix is purely TUI-side; `straymark charter` subcommands (`new`, `list`, `status`, `close`, `audit`, `drift`) were already on the correct schema and are not touched.
+
+---
+
 ## Framework 4.13.2 — Complete the Charter path migration to `.straymark/charters/`
 
 Completes the path migration that `fw-4.12.0` started ([#119](https://github.com/StrangeDaysTech/straymark/issues/119)). That release aligned all `straymark charter` CLI subcommands to `.straymark/charters/` (single source of truth via `charter::charters_dir(project_root)`) but missed three classes of artifact still pointing at the legacy `docs/charters/` path. Surfaced empirically by the Sentinel adopter during external-audit prep when reviewing the framework's pre-PR hook behavior.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
 | Framework | `fw-` | `fw-4.13.2` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.12.2` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.12.1"
+version = "3.12.2"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.12.1"
+version = "3.12.2"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/charter.rs
+++ b/cli/src/charter.rs
@@ -154,7 +154,7 @@ pub fn discover_charters(project_root: &Path) -> Vec<PathBuf> {
 
 /// True if the file matches the Charter filename pattern `NN-*.md` where NN is
 /// one or more digits.
-fn is_charter_filename(p: &Path) -> bool {
+pub fn is_charter_filename(p: &Path) -> bool {
     if p.extension().and_then(|e| e.to_str()) != Some("md") {
         return false;
     }

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -419,23 +419,20 @@ impl App {
             Some(MetaSelection::Tag(idx)) => {
                 // Search by this tag
                 if let Some(ref doc) = self.current_doc {
-                    if let Some(ref fm) = doc.frontmatter {
-                        if let Some(tag) = fm.tags.get(idx) {
-                            self.search_query = Some(tag.clone());
-                            self.meta_selection = None;
-                            self.active_panel = ActivePanel::Navigation;
-                        }
+                    if let Some(tag) = doc.tags().get(idx) {
+                        self.search_query = Some(tag.clone());
+                        self.meta_selection = None;
+                        self.active_panel = ActivePanel::Navigation;
                     }
                 }
             }
             Some(MetaSelection::Related(idx)) => {
                 if let Some(ref doc) = self.current_doc {
-                    if let Some(ref fm) = doc.frontmatter {
-                        if let Some(related_id) = fm.related.get(idx) {
-                            let id = related_id.clone();
-                            self.meta_selection = None;
-                            self.navigate_to_id(&id);
-                        }
+                    let related = doc.related();
+                    if let Some(related_id) = related.get(idx) {
+                        let id = related_id.clone();
+                        self.meta_selection = None;
+                        self.navigate_to_id(&id);
                     }
                 }
             }
@@ -447,8 +444,7 @@ impl App {
     fn tag_count(&self) -> usize {
         self.current_doc
             .as_ref()
-            .and_then(|doc| doc.frontmatter.as_ref())
-            .map(|fm| fm.tags.len())
+            .map(|doc| doc.tags().len())
             .unwrap_or(0)
     }
 
@@ -456,8 +452,7 @@ impl App {
     fn related_count(&self) -> usize {
         self.current_doc
             .as_ref()
-            .and_then(|doc| doc.frontmatter.as_ref())
-            .map(|fm| fm.related.len())
+            .map(|doc| doc.related().len())
             .unwrap_or(0)
     }
 

--- a/cli/src/tui/document.rs
+++ b/cli/src/tui/document.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 use std::path::Path;
 
+use crate::charter::{is_charter_filename, parse_charter, CharterFrontmatter};
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DocStatus {
@@ -74,30 +76,125 @@ pub struct DocFrontMatter {
     pub supersedes: Vec<String>,
 }
 
+/// Typed frontmatter the TUI knows how to render. Governance documents use the
+/// `Doc` variant (DocFrontMatter — status enum draft|accepted|…, plus tags /
+/// related / confidence / risk). Charters use the `Charter` variant because
+/// their schema (declared|in-progress|closed status, effort_estimate, trigger,
+/// originating_ailogs/spec) is disjoint from governance docs — see
+/// `crate::charter::CharterFrontmatter`. Dispatch happens in `Document::load`
+/// based on the file path so the panel can `match` instead of guessing.
+#[derive(Debug, Clone)]
+pub enum DocumentMetadata {
+    Doc(DocFrontMatter),
+    Charter(CharterFrontmatter),
+}
+
 #[derive(Debug, Clone)]
 pub struct Document {
-    pub frontmatter: Option<DocFrontMatter>,
+    pub frontmatter: Option<DocumentMetadata>,
     pub body: String,
     pub filename: String,
 }
 
 impl Document {
     pub fn load(path: &Path) -> Option<Self> {
-        let content = std::fs::read_to_string(path).ok()?;
         let filename = path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown")
             .to_string();
 
-        let (frontmatter, body) = parse_frontmatter(&content);
+        if is_charter_path(path) {
+            // Charter path → try the charter parser. If the frontmatter is
+            // malformed we still want to surface the document so the user can
+            // open it and fix the issue from the TUI, so fall back to reading
+            // the raw content with `frontmatter = None`.
+            match parse_charter(path) {
+                Ok(c) => {
+                    return Some(Self {
+                        frontmatter: Some(DocumentMetadata::Charter(c.frontmatter)),
+                        body: c.body,
+                        filename,
+                    });
+                }
+                Err(_) => {
+                    let content = std::fs::read_to_string(path).ok()?;
+                    return Some(Self {
+                        frontmatter: None,
+                        body: content,
+                        filename,
+                    });
+                }
+            }
+        }
 
+        let content = std::fs::read_to_string(path).ok()?;
+        let (fm, body) = parse_frontmatter(&content);
         Some(Self {
-            frontmatter,
+            frontmatter: fm.map(DocumentMetadata::Doc),
             body,
             filename,
         })
     }
+
+    /// Tags surfaced for tag-chip rendering and tag-search navigation. Charters
+    /// have no tags in their schema, so this returns an empty slice for them.
+    pub fn tags(&self) -> &[String] {
+        match &self.frontmatter {
+            Some(DocumentMetadata::Doc(fm)) => &fm.tags,
+            _ => &[],
+        }
+    }
+
+    /// Related identifiers shown in the "Related" section and follow-on
+    /// navigation. For governance docs this is the explicit `related:` list.
+    /// For Charters there is no `related:` field — instead, origin links
+    /// (`originating_ailogs` and `originating_spec`) are surfaced here so the
+    /// TUI can follow them with the same `MetaSelection::Related` machinery.
+    pub fn related(&self) -> Vec<String> {
+        match &self.frontmatter {
+            Some(DocumentMetadata::Doc(fm)) => fm.related.clone(),
+            Some(DocumentMetadata::Charter(fm)) => {
+                let mut out = Vec::new();
+                if let Some(ailogs) = &fm.originating_ailogs {
+                    out.extend(ailogs.iter().cloned());
+                }
+                if let Some(spec) = &fm.originating_spec {
+                    out.push(spec.clone());
+                }
+                out
+            }
+            None => Vec::new(),
+        }
+    }
+}
+
+/// True when `path` points to a Charter file under `.straymark/charters/` whose
+/// filename matches the `NN-slug.md` Charter pattern. Used to decide which
+/// frontmatter schema to apply in `Document::load`. Anything under that
+/// directory that isn't a numbered Charter (e.g., the status-board `README.md`
+/// adopters maintain by hand) is treated as a regular markdown file with no
+/// typed frontmatter.
+fn is_charter_path(path: &Path) -> bool {
+    if !is_charter_filename(path) {
+        return false;
+    }
+    let mut comps = path.components().rev();
+    // Skip the filename itself.
+    if comps.next().is_none() {
+        return false;
+    }
+    // Parent directory must be "charters" and grandparent must be ".straymark".
+    let parent = comps
+        .next()
+        .and_then(|c| c.as_os_str().to_str())
+        .map(|s| s.to_string());
+    let grand = comps
+        .next()
+        .and_then(|c| c.as_os_str().to_str())
+        .map(|s| s.to_string());
+    matches!(parent.as_deref(), Some("charters"))
+        && matches!(grand.as_deref(), Some(".straymark"))
 }
 
 fn parse_frontmatter(content: &str) -> (Option<DocFrontMatter>, String) {
@@ -124,6 +221,7 @@ fn parse_frontmatter(content: &str) -> (Option<DocFrontMatter>, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_parse_frontmatter() {
@@ -146,5 +244,85 @@ Some content here.
         assert_eq!(fm.id, "ADR-2025-06-15-001");
         assert_eq!(fm.status, Some(DocStatus::Accepted));
         assert!(body.starts_with("# Test Document"));
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn load_charter_uses_charter_variant() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join(".straymark").join("charters").join("01-foo.md");
+        write_file(
+            &p,
+            "---\ncharter_id: CHARTER-01-foo\nstatus: in-progress\neffort_estimate: M\ntrigger: \"x\"\n---\n\n# Charter: Foo\n",
+        );
+        let doc = Document::load(&p).unwrap();
+        match doc.frontmatter {
+            Some(DocumentMetadata::Charter(fm)) => {
+                assert_eq!(fm.charter_id, "CHARTER-01-foo");
+            }
+            other => panic!("expected Charter variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn load_non_charter_uses_doc_variant() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join("00-governance").join("ADR-2025-01-01-001.md");
+        write_file(
+            &p,
+            "---\nid: ADR-2025-01-01-001\ntitle: A Decision\nstatus: accepted\n---\n\n# Body\n",
+        );
+        let doc = Document::load(&p).unwrap();
+        match doc.frontmatter {
+            Some(DocumentMetadata::Doc(fm)) => {
+                assert_eq!(fm.id, "ADR-2025-01-01-001");
+                assert_eq!(fm.status, Some(DocStatus::Accepted));
+            }
+            other => panic!("expected Doc variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn load_charter_with_broken_frontmatter_falls_back_to_no_frontmatter() {
+        // Path looks like a charter but frontmatter is missing required fields.
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join(".straymark").join("charters").join("02-broken.md");
+        write_file(&p, "no frontmatter at all\nbody\n");
+        let doc = Document::load(&p).unwrap();
+        assert!(doc.frontmatter.is_none());
+        assert!(doc.body.contains("no frontmatter"));
+    }
+
+    #[test]
+    fn readme_in_charters_dir_is_not_treated_as_charter() {
+        // README.md doesn't match NN-slug.md so it should NOT use the charter
+        // parser even though it lives under .straymark/charters/.
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join(".straymark").join("charters").join("README.md");
+        write_file(&p, "# Charters status board\n");
+        let doc = Document::load(&p).unwrap();
+        assert!(doc.frontmatter.is_none());
+    }
+
+    #[test]
+    fn related_helper_materializes_charter_origin_links() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join(".straymark").join("charters").join("03-origins.md");
+        write_file(
+            &p,
+            "---\ncharter_id: CHARTER-03-origins\nstatus: declared\neffort_estimate: S\ntrigger: \"x\"\noriginating_ailogs:\n  - AILOG-2026-04-28-021\n  - AILOG-2026-04-28-022\noriginating_spec: specs/001/spec.md\n---\n\nBody.\n",
+        );
+        let doc = Document::load(&p).unwrap();
+        let related = doc.related();
+        assert_eq!(related.len(), 3);
+        assert_eq!(related[0], "AILOG-2026-04-28-021");
+        assert_eq!(related[2], "specs/001/spec.md");
+        assert!(doc.tags().is_empty());
     }
 }

--- a/cli/src/tui/i18n_strings.rs
+++ b/cli/src/tui/i18n_strings.rs
@@ -189,6 +189,14 @@ pub fn t<'a>(en: &'a str, lang: &str) -> &'a str {
         (" (Enter: search)", "zh-CN") => "（Enter: 搜索）",
         (" (Enter: follow)", "es") => " (Enter: seguir)",
         (" (Enter: follow)", "zh-CN") => "（Enter: 跳转）",
+        ("Charter ID:", "es") => "Charter ID:",
+        ("Charter ID:", "zh-CN") => "Charter ID:",
+        ("Effort:", "es") => "Esfuerzo:",
+        ("Effort:", "zh-CN") => "工作量:",
+        ("Trigger:", "es") => "Disparador:",
+        ("Trigger:", "zh-CN") => "触发条件:",
+        ("Origin:", "es") => "Origen:",
+        ("Origin:", "zh-CN") => "来源:",
 
         // ── Document panel ────────────────────────────────────────────
         ("Document", "es") => "Documento",

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -91,31 +91,56 @@ fn metadata_panel_height(app: &App) -> u16 {
 
     let mut lines: u16 = 0;
 
-    // Each field on its own line
-    if fm.status.is_some() {
-        lines += 1;
-    }
-    if fm.created.is_some() {
-        lines += 1;
-    }
-    if fm.agent.is_some() {
-        lines += 1;
-    }
-    if fm.confidence.is_some() {
-        lines += 1;
-    }
-    if fm.risk_level.is_some() {
-        lines += 1;
-    }
-    if fm.review_required == Some(true) {
-        lines += 1;
-    }
-    if !fm.tags.is_empty() {
-        lines += 1 + fm.tags.len() as u16; // header + one per tag
-    }
-    // Related: separator + header + one per link
-    if !fm.related.is_empty() {
-        lines += 2 + fm.related.len() as u16;
+    match fm {
+        crate::tui::document::DocumentMetadata::Doc(fm) => {
+            // Each field on its own line
+            if fm.status.is_some() {
+                lines += 1;
+            }
+            if fm.created.is_some() {
+                lines += 1;
+            }
+            if fm.agent.is_some() {
+                lines += 1;
+            }
+            if fm.confidence.is_some() {
+                lines += 1;
+            }
+            if fm.risk_level.is_some() {
+                lines += 1;
+            }
+            if fm.review_required == Some(true) {
+                lines += 1;
+            }
+            if !fm.tags.is_empty() {
+                lines += 1 + fm.tags.len() as u16; // header + one per tag
+            }
+            // Related: separator + header + one per link
+            if !fm.related.is_empty() {
+                lines += 2 + fm.related.len() as u16;
+            }
+        }
+        crate::tui::document::DocumentMetadata::Charter(fm) => {
+            // Charter ID + Status + Effort + Origin are always rendered.
+            // Trigger only when non-empty (always non-empty per schema, but
+            // guard anyway).
+            if !fm.charter_id.is_empty() {
+                lines += 1;
+            }
+            lines += 1; // Status
+            lines += 1; // Effort
+            if !fm.trigger.is_empty() {
+                lines += 1; // Trigger
+            }
+            lines += 1; // Origin (single-line summary)
+
+            // Materialized related = ailogs + spec.
+            let related_count = fm.originating_ailogs.as_ref().map(|v| v.len()).unwrap_or(0)
+                + fm.originating_spec.as_ref().map(|_| 1).unwrap_or(0);
+            if related_count > 0 {
+                lines += 2 + related_count as u16; // separator + header + entries
+            }
+        }
     }
 
     (base + lines).max(base + 1)

--- a/cli/src/tui/widgets/metadata_panel.rs
+++ b/cli/src/tui/widgets/metadata_panel.rs
@@ -4,8 +4,9 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
 
+use crate::charter::{CharterFrontmatter, CharterStatus, EffortEstimate};
 use crate::tui::app::{ActivePanel, App, MetaSelection};
-use crate::tui::document::{ConfidenceLevel, DocStatus, RiskLevel};
+use crate::tui::document::{ConfidenceLevel, DocFrontMatter, DocStatus, DocumentMetadata, RiskLevel};
 use crate::tui::i18n_strings::t;
 use crate::tui::theme;
 use crate::utils::{pad_right_visual, truncate_visual};
@@ -68,10 +69,9 @@ impl Widget for MetadataPanel<'_> {
             }
         };
 
-        let fm = match &doc.frontmatter {
-            Some(fm) => fm,
+        let lines: Vec<Line<'static>> = match &doc.frontmatter {
             None => {
-                let lines = vec![
+                vec![
                     Line::from(vec![
                         Span::styled(
                             format!(" {}  ", t("File:", lang)),
@@ -83,150 +83,18 @@ impl Widget for MetadataPanel<'_> {
                         format!(" {}", t("No frontmatter", lang)),
                         Style::default().fg(theme::TEXT_DIM),
                     )),
-                ];
-                Paragraph::new(lines)
-                    .wrap(Wrap { trim: false })
-                    .render(inner, buf);
-                return;
+                ]
             }
+            Some(DocumentMetadata::Doc(fm)) => doc_lines(fm, lang, self.app, inner.width),
+            Some(DocumentMetadata::Charter(fm)) => charter_lines(fm, lang, self.app, inner.width),
         };
 
-        let l = Style::default().fg(theme::TEXT_DIM);
-        let v = Style::default().fg(theme::TEXT);
-        let mut lines: Vec<Line<'static>> = vec![Line::from("")];
-
-        // Status
-        if let Some(ref status) = fm.status {
-            let (indicator, color) = status_style(status);
-            lines.push(Line::from(vec![
-                label_block(t("Status:", lang), l),
-                Span::styled(
-                    format!("{indicator} {status}"),
-                    Style::default().fg(color).add_modifier(Modifier::BOLD),
-                ),
-            ]));
-        }
-
-        // Created
-        if let Some(ref created) = fm.created {
-            lines.push(Line::from(vec![
-                label_block(t("Created:", lang), l),
-                Span::styled(created.clone(), v),
-            ]));
-        }
-
-        // Agent
-        if let Some(ref agent) = fm.agent {
-            lines.push(Line::from(vec![
-                label_block(t("Agent:", lang), l),
-                Span::styled(agent.clone(), v),
-            ]));
-        }
-
-        // Confidence
-        if let Some(ref confidence) = fm.confidence {
-            let (filled, total, color, label) = confidence_bar(confidence);
-            lines.push(Line::from(vec![
-                label_block(t("Confidence:", lang), l),
-                Span::styled(
-                    format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
-                    Style::default().fg(color),
-                ),
-                Span::styled(format!("  {label}"), Style::default().fg(color)),
-            ]));
-        }
-
-        // Risk
-        if let Some(ref risk) = fm.risk_level {
-            let (filled, total, color, label) = risk_bar(risk);
-            lines.push(Line::from(vec![
-                label_block(t("Risk:", lang), l),
-                Span::styled(
-                    format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
-                    Style::default().fg(color),
-                ),
-                Span::styled(format!("  {label}"), Style::default().fg(color)),
-            ]));
-        }
-
-        // Review required
-        if let Some(true) = fm.review_required {
-            lines.push(Line::from(vec![
-                label_block(t("Review:", lang), l),
-                Span::styled(
-                    t("⚠ REQUIRED", lang).to_string(),
-                    Style::default()
-                        .fg(theme::YELLOW)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ]));
-        }
-
-        // Tags
-        if !fm.tags.is_empty() {
-            let tag_hint = match self.app.meta_selection {
-                Some(MetaSelection::Tag(_)) => t(" (Enter: search)", lang),
-                _ => "",
-            };
-            lines.push(Line::from(vec![
-                Span::styled(format!(" {}", t("Tags:", lang)), l),
-                Span::styled(tag_hint.to_string(), Style::default().fg(theme::TEXT_DIM)),
-            ]));
-            let tag_style = Style::default()
-                .fg(theme::TEXT_DIM)
-                .bg(Color::Rgb(45, 45, 60));
-            let tag_selected_style = Style::default()
-                .fg(Color::Rgb(220, 224, 242))
-                .bg(Color::Rgb(45, 50, 80))
-                .add_modifier(Modifier::BOLD);
-            for (i, tag) in fm.tags.iter().enumerate() {
-                let is_sel = self.app.meta_selection == Some(MetaSelection::Tag(i));
-                let marker = if is_sel { " ▸ " } else { "   " };
-                let st = if is_sel { tag_selected_style } else { tag_style };
-                lines.push(Line::from(vec![
-                    Span::styled(marker, l),
-                    Span::styled(format!(" {tag} "), st),
-                ]));
-            }
-        }
-
-        // Separator before related
-        if !fm.related.is_empty() {
-            let sep_width = inner.width.saturating_sub(2) as usize;
-            lines.push(Line::from(Span::styled(
-                format!(" {}", "─".repeat(sep_width)),
-                Style::default().fg(theme::SUBTLE),
-            )));
-
-            let hint = match self.app.meta_selection {
-                Some(MetaSelection::Related(_)) => t(" (Enter: follow)", lang),
-                _ => "",
-            };
-            lines.push(Line::from(vec![
-                Span::styled(format!(" {}", t("Related:", lang)), l),
-                Span::styled(hint.to_string(), Style::default().fg(theme::TEXT_DIM)),
-            ]));
-
-            let max_link_width = inner.width.saturating_sub(4) as usize;
-            for (i, rel) in fm.related.iter().enumerate() {
-                let is_selected = self.app.meta_selection == Some(MetaSelection::Related(i));
-                let marker = if is_selected { " ▸ " } else { "   " };
-                let style = if is_selected {
-                    Style::default()
-                        .fg(Color::Rgb(220, 224, 242))
-                        .bg(Color::Rgb(45, 50, 80))
-                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-                } else {
-                    Style::default()
-                        .fg(theme::TEXT)
-                        .add_modifier(Modifier::UNDERLINED)
-                };
-                let display = truncate_visual(rel, max_link_width);
-                lines.push(Line::from(vec![
-                    Span::styled(marker, l),
-                    Span::styled(display, style),
-                ]));
-            }
+        // Empty/no-frontmatter cases bypass scroll arithmetic — just paint.
+        if doc.frontmatter.is_none() {
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .render(inner, buf);
+            return;
         }
 
         // Calculate scroll: find the line with ▸ marker to keep it visible
@@ -258,6 +126,253 @@ impl Widget for MetadataPanel<'_> {
     }
 }
 
+fn doc_lines(
+    fm: &DocFrontMatter,
+    lang: &str,
+    app: &App,
+    inner_width: u16,
+) -> Vec<Line<'static>> {
+    let l = Style::default().fg(theme::TEXT_DIM);
+    let v = Style::default().fg(theme::TEXT);
+    let mut lines: Vec<Line<'static>> = vec![Line::from("")];
+
+    // Status
+    if let Some(ref status) = fm.status {
+        let (indicator, color) = status_style(status);
+        lines.push(Line::from(vec![
+            label_block(t("Status:", lang), l),
+            Span::styled(
+                format!("{indicator} {status}"),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+
+    // Created
+    if let Some(ref created) = fm.created {
+        lines.push(Line::from(vec![
+            label_block(t("Created:", lang), l),
+            Span::styled(created.clone(), v),
+        ]));
+    }
+
+    // Agent
+    if let Some(ref agent) = fm.agent {
+        lines.push(Line::from(vec![
+            label_block(t("Agent:", lang), l),
+            Span::styled(agent.clone(), v),
+        ]));
+    }
+
+    // Confidence
+    if let Some(ref confidence) = fm.confidence {
+        let (filled, total, color, label) = confidence_bar(confidence);
+        lines.push(Line::from(vec![
+            label_block(t("Confidence:", lang), l),
+            Span::styled(
+                format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
+                Style::default().fg(color),
+            ),
+            Span::styled(format!("  {label}"), Style::default().fg(color)),
+        ]));
+    }
+
+    // Risk
+    if let Some(ref risk) = fm.risk_level {
+        let (filled, total, color, label) = risk_bar(risk);
+        lines.push(Line::from(vec![
+            label_block(t("Risk:", lang), l),
+            Span::styled(
+                format!("{}{}", "█".repeat(filled), "░".repeat(total - filled)),
+                Style::default().fg(color),
+            ),
+            Span::styled(format!("  {label}"), Style::default().fg(color)),
+        ]));
+    }
+
+    // Review required
+    if let Some(true) = fm.review_required {
+        lines.push(Line::from(vec![
+            label_block(t("Review:", lang), l),
+            Span::styled(
+                t("⚠ REQUIRED", lang).to_string(),
+                Style::default()
+                    .fg(theme::YELLOW)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+
+    // Tags
+    if !fm.tags.is_empty() {
+        let tag_hint = match app.meta_selection {
+            Some(MetaSelection::Tag(_)) => t(" (Enter: search)", lang),
+            _ => "",
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {}", t("Tags:", lang)), l),
+            Span::styled(tag_hint.to_string(), Style::default().fg(theme::TEXT_DIM)),
+        ]));
+        let tag_style = Style::default()
+            .fg(theme::TEXT_DIM)
+            .bg(Color::Rgb(45, 45, 60));
+        let tag_selected_style = Style::default()
+            .fg(Color::Rgb(220, 224, 242))
+            .bg(Color::Rgb(45, 50, 80))
+            .add_modifier(Modifier::BOLD);
+        for (i, tag) in fm.tags.iter().enumerate() {
+            let is_sel = app.meta_selection == Some(MetaSelection::Tag(i));
+            let marker = if is_sel { " ▸ " } else { "   " };
+            let st = if is_sel { tag_selected_style } else { tag_style };
+            lines.push(Line::from(vec![
+                Span::styled(marker, l),
+                Span::styled(format!(" {tag} "), st),
+            ]));
+        }
+    }
+
+    // Separator before related
+    if !fm.related.is_empty() {
+        push_related_block(
+            &mut lines,
+            &fm.related,
+            lang,
+            app,
+            inner_width,
+        );
+    }
+
+    lines
+}
+
+fn charter_lines(
+    fm: &CharterFrontmatter,
+    lang: &str,
+    app: &App,
+    inner_width: u16,
+) -> Vec<Line<'static>> {
+    let l = Style::default().fg(theme::TEXT_DIM);
+    let v = Style::default().fg(theme::TEXT);
+    let mut lines: Vec<Line<'static>> = vec![Line::from("")];
+
+    // Charter ID
+    if !fm.charter_id.is_empty() {
+        lines.push(Line::from(vec![
+            label_block(t("Charter ID:", lang), l),
+            Span::styled(fm.charter_id.clone(), v),
+        ]));
+    }
+
+    // Status (charter vocabulary)
+    let (indicator, status_color) = charter_status_style(&fm.status);
+    lines.push(Line::from(vec![
+        label_block(t("Status:", lang), l),
+        Span::styled(
+            format!("{indicator} {}", fm.status.as_str().to_uppercase()),
+            Style::default()
+                .fg(status_color)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    // Effort estimate
+    let (effort_color, effort_label) = effort_style(&fm.effort_estimate);
+    lines.push(Line::from(vec![
+        label_block(t("Effort:", lang), l),
+        Span::styled(
+            effort_label.to_string(),
+            Style::default().fg(effort_color).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    // Trigger (one-line, truncated to remaining width)
+    if !fm.trigger.is_empty() {
+        let max_width = (inner_width as usize)
+            .saturating_sub(LABEL_WIDTH + 2);
+        let trimmed = fm.trigger.replace('\n', " ");
+        lines.push(Line::from(vec![
+            label_block(t("Trigger:", lang), l),
+            Span::styled(truncate_visual(&trimmed, max_width), v),
+        ]));
+    }
+
+    // Origin (single-line summary). The materialized "Related" block below
+    // makes each origin link navigable; this top line just gives an at-a-glance
+    // hint of where the charter came from.
+    let origin = crate::charter::display_origin(fm);
+    let origin_style = if origin == "—" {
+        Style::default().fg(theme::TEXT_DIM)
+    } else {
+        v
+    };
+    let origin_max = (inner_width as usize).saturating_sub(LABEL_WIDTH + 2);
+    lines.push(Line::from(vec![
+        label_block(t("Origin:", lang), l),
+        Span::styled(truncate_visual(&origin, origin_max), origin_style),
+    ]));
+
+    // Related = originating_ailogs + originating_spec, surfaced through the
+    // same MetaSelection::Related mechanism docs use, so Enter still follows
+    // the link.
+    let mut related: Vec<String> = Vec::new();
+    if let Some(ailogs) = &fm.originating_ailogs {
+        related.extend(ailogs.iter().cloned());
+    }
+    if let Some(spec) = &fm.originating_spec {
+        related.push(spec.clone());
+    }
+    if !related.is_empty() {
+        push_related_block(&mut lines, &related, lang, app, inner_width);
+    }
+
+    lines
+}
+
+fn push_related_block(
+    lines: &mut Vec<Line<'static>>,
+    related: &[String],
+    lang: &str,
+    app: &App,
+    inner_width: u16,
+) {
+    let l = Style::default().fg(theme::TEXT_DIM);
+    let sep_width = inner_width.saturating_sub(2) as usize;
+    lines.push(Line::from(Span::styled(
+        format!(" {}", "─".repeat(sep_width)),
+        Style::default().fg(theme::SUBTLE),
+    )));
+
+    let hint = match app.meta_selection {
+        Some(MetaSelection::Related(_)) => t(" (Enter: follow)", lang),
+        _ => "",
+    };
+    lines.push(Line::from(vec![
+        Span::styled(format!(" {}", t("Related:", lang)), l),
+        Span::styled(hint.to_string(), Style::default().fg(theme::TEXT_DIM)),
+    ]));
+
+    let max_link_width = inner_width.saturating_sub(4) as usize;
+    for (i, rel) in related.iter().enumerate() {
+        let is_selected = app.meta_selection == Some(MetaSelection::Related(i));
+        let marker = if is_selected { " ▸ " } else { "   " };
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::Rgb(220, 224, 242))
+                .bg(Color::Rgb(45, 50, 80))
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else {
+            Style::default()
+                .fg(theme::TEXT)
+                .add_modifier(Modifier::UNDERLINED)
+        };
+        let display = truncate_visual(rel, max_link_width);
+        lines.push(Line::from(vec![
+            Span::styled(marker, l),
+            Span::styled(display, style),
+        ]));
+    }
+}
+
 fn status_style(status: &DocStatus) -> (&'static str, Color) {
     match status {
         DocStatus::Draft => ("○", theme::YELLOW),
@@ -265,6 +380,23 @@ fn status_style(status: &DocStatus) -> (&'static str, Color) {
         DocStatus::Deprecated => ("✗", theme::RED),
         DocStatus::Superseded => ("◌", theme::TEXT_DIM),
         DocStatus::Unknown => ("?", theme::TEXT_DIM),
+    }
+}
+
+fn charter_status_style(status: &CharterStatus) -> (&'static str, Color) {
+    match status {
+        CharterStatus::Declared => ("○", theme::YELLOW),
+        CharterStatus::InProgress => ("◐", theme::ACCENT),
+        CharterStatus::Closed => ("■", theme::GREEN),
+    }
+}
+
+fn effort_style(effort: &EffortEstimate) -> (Color, &'static str) {
+    match effort {
+        EffortEstimate::Xs => (theme::SUBTLE, "XS"),
+        EffortEstimate::S => (theme::GREEN, "S"),
+        EffortEstimate::M => (theme::YELLOW, "M"),
+        EffortEstimate::L => (theme::RED, "L"),
     }
 }
 
@@ -286,4 +418,3 @@ fn risk_bar(level: &RiskLevel) -> (usize, usize, Color, &'static str) {
         RiskLevel::Unknown => (0, 10, theme::TEXT_DIM, "unknown"),
     }
 }
-

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.13.2` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.1` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.12.2` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -238,7 +238,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.13.2` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.12.2` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.13.2` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.12.1` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.12.2` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -256,7 +256,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.13.2` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.12.2` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.13.2` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.12.1` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.12.2` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 


### PR DESCRIPTION
## Summary

- Fixes the long-standing bug in `straymark explore` where the **Metadata** panel rendered every Charter as `Status: ? UNKNOWN`, regardless of the actual `status:` value in the Charter frontmatter. Surfaced by [Sentinel](https://github.com/StrangeDaysTech/sentinel) while reviewing a closed Charter (`CHARTER-13-commshub-us2-channel-subscription-management`) in the TUI — the screen showed UNKNOWN even though the frontmatter clearly read `status: closed`.
- Root cause: `Document::load` parsed every `.md` against `DocFrontMatter`, whose `status` enum only knows `draft|accepted|deprecated|superseded`. Charter values (`declared|in-progress|closed`) fell through to `#[serde(other)] Unknown` and the disjoint Charter fields (`charter_id`, `effort_estimate`, `trigger`, `originating_ailogs`, `originating_spec`) were silently dropped.
- Fix routes the schema choice at load time, keyed on the canonical `.straymark/charters/NN-slug.md` path — the same heuristic `discover_charters` uses. The Metadata panel renders a Charter-specific layout (`Charter ID` / `Status` with the correct icon+color / `Effort` color-graded / `Trigger` truncated / `Origin` / `Related` materialized from `originating_ailogs` + `originating_spec`, navigable via Enter).

See the `CHANGELOG.md` entry `## CLI 3.12.2` for the field-by-field breakdown and rationale.

## Test plan

- [x] `cargo check` (clean, no warnings)
- [x] `cargo build` (clean)
- [x] `cargo test` — 281 unit + ~200 integration tests, 0 failed. Includes 5 new unit tests in `cli/src/tui/document.rs` covering: Charter variant dispatch, Doc variant preserved, broken-frontmatter fallback, `README.md` not treated as Charter, `related()` helper materializes Charter origin links.
- [ ] **Manual TUI verification on Sentinel** — open `straymark explore` in Sentinel, navigate to Charters → `CHARTER-13-...`, confirm Metadata panel now shows `Charter ID`, `Status: ■ CLOSED` (green), `Effort: M`, `Trigger: …`, and any `Related` entries are navigable with Enter.
- [ ] Regression check on governance docs (ADRs, RFCs, AILOGs etc.) — Metadata panel must render exactly as before (`DocStatus`, Confidence bar, Risk bar, Tags, Related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)