### PR TITLE
feat(framework+cli): fw-4.13.3 / cli-3.12.3 — audit prompt EN-canonical + CLI i18n wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.13.3 / CLI 3.12.3 — Audit prompt becomes EN-canonical + CLI wires i18n resolution
+
+Aligns the external-audit cycle with the framework's localization convention. Before this release, `dist/.straymark/audit-prompts/audit-prompt.md` was the **only** framework artifact whose canonical content lived in Spanish — every other template, skill, workflow, and governance doc had EN canonical at the root and `i18n/es/` (plus optionally `i18n/zh-CN/`) as overlays, resolved by `resolve_localized_path` (`cli/src/utils.rs:146`). The audit prompt was a Sentinel-derived artifact (parameterized but never translated to EN) and the CLI's `straymark charter audit` command hardcoded the canonical path without going through the i18n resolver — so even if an overlay file existed, the CLI would not have picked it up.
+
+Surfaced empirically when [Sentinel](https://github.com/StrangeDaysTech/sentinel) audited the `straymark explore` rendering and the user noted that audit-cycle templates were ES while all other templates and skills were EN.
+
+### Changed (Framework)
+
+- **`dist/.straymark/audit-prompts/audit-prompt.md`** — rewritten as EN canonical. The seven universal sections (ABSOLUTE RULE, Your role, Scope rules, Step 2 mandatory verification, Step 5 severity calibration, What you must NOT do, Output format) preserved verbatim from the Sentinel-derived original, translated to English. Placeholders (`{{charter_id}}`, `{{charter_title}}`, `{{charter_path}}`, `{{charter_content}}`, `{{git_range}}`, `{{git_diff}}`, `{{ailog_paths}}`, `{{ailog_contents}}`, `{{audit_role}}`, `{{schema_path}}`, `{{project_context}}`) intact and unchanged. HTML documentation header updated to describe the new EN-canonical / `i18n/es/` overlay layout instead of the v0 "future canonical path" note.
+- **`dist/.straymark/audit-prompts/i18n/es/audit-prompt.md`** (new) — the Spanish translation now lives here. Resolved automatically when `.straymark/config.yml` declares `language: es`. Spanish-speaking adopters (Sentinel) continue to receive a Spanish audit prompt.
+- **Etapa 12 Pub/Sub example generalized.** The Step 5 severity-calibration example previously cited Sentinel's "Etapa 12 Pub/Sub stub vs gochannel" case verbatim. Replaced with a generic equivalent ("declared deferral, not a defect" — a charter that introduces a thin adapter slated for replacement in a future Charter) that illustrates the same anti-inflation discipline without tying the prompt to Sentinel's stack. Applied identically to EN and ES.
+- **`dist/dist-manifest.yml`** — version bumped to `4.13.3`. `audit-prompts/i18n/` ships under `.straymark/` (already covered by the `.straymark/` entry in the manifest's `files:` list, no manifest change beyond the version field).
+- **Governance footers** updated to `v4.13.3` across `QUICK-REFERENCE.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `C4-DIAGRAM-GUIDE.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md` (EN + ES + zh-CN, plus the top-level `dist/.straymark/QUICK-REFERENCE.md`).
+
+### Changed (CLI)
+
+- **`cli/src/commands/charter/audit.rs`** — `prepare_unified_prompt` now reads the project's `language` from `.straymark/config.yml` via `StrayMarkConfig::resolve_language` (`cli/src/config.rs:93-101`) and resolves the template path through `resolve_localized_path` (`cli/src/utils.rs:146-154`), the same pattern used by `straymark new`, `straymark charter new`, and `straymark explore` for their localized assets. No new abstractions introduced — just wired the existing resolver to the existing config reader.
+- **Integration tests** (`cli/tests/charter_audit_test.rs`) — three new tests pin the wiring: `language: es` resolves the ES overlay; `language: zh-CN` with no overlay falls back to EN canonical; explicit `language: en` always picks the canonical EN file.
+
+### Empirical context
+
+The inconsistency was structural (single-artifact ES in an otherwise EN-canonical framework) rather than a bug — `straymark charter audit` worked, the prompt was a competent Spanish prompt, modern auditor LLMs handle it. The cost was twofold: (1) cross-model audit calibration suffers when reports come back in Spanish from Gemini/Claude/Copilot — the delta between auditors competes with normal Spanish phrasing variance instead of being a pure semantic signal; (2) any non-Spanish adopter received a Spanish prompt the first time they ran the audit cycle, which broke the framework's documented convention.
+
+### Adopter guidance
+
+- **Spanish-speaking adopters (Sentinel)**: after `straymark update-framework && straymark update-cli`, keep `language: es` in `.straymark/config.yml` — the ES prompt now resolves automatically via the i18n overlay. The only content difference from the previous version is the generalized example (the "Etapa 12 Pub/Sub" anecdote was replaced with a generic equivalent in the same Spanish voice).
+- **English (default) adopters**: receive the EN prompt out of the box. The prior Spanish artifact is no longer the canonical content at the root.
+- **zh-CN adopters**: fallback to EN canonical until someone contributes `dist/.straymark/audit-prompts/i18n/zh-CN/audit-prompt.md`. No CLI work required to enable that — `resolve_localized_path` already supports it.
+- **Adopters who locally edited their audit-prompt.md**: `straymark update-framework` will overwrite the canonical file with the new EN content. If you customized the prompt, either reapply your edits on top of the EN canonical (recommended — converges with the framework) or move your customization into your project's `i18n/<lang>/audit-prompt.md` overlay (which `straymark update-framework` does not touch).
+
+---
+
 ## CLI 3.12.2 — `straymark explore` shows Charter frontmatter correctly
 
 Fixes a long-standing bug where the **Metadata** panel of `straymark explore` rendered every Charter as `Status: ? UNKNOWN` regardless of the actual `status:` value in the Charter frontmatter. Surfaced by [Sentinel](https://github.com/StrangeDaysTech/sentinel) while reviewing a closed Charter (`CHARTER-13`) in the TUI — the screen showed UNKNOWN even though the Charter's frontmatter clearly read `status: closed`.

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.13.2` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.2` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.13.3` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.12.3` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.13.2)
+# and download the latest fw-* release (e.g., fw-4.13.3)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.12.2"
+version = "3.12.3"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.12.2"
+version = "3.12.3"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/commands/charter/audit.rs
+++ b/cli/src/commands/charter/audit.rs
@@ -187,9 +187,12 @@ fn run_prepare(
 
     let context = build_audit_context(project_root, charter, range)?;
 
-    let template_path = straymark_dir
-        .join("audit-prompts")
-        .join("audit-prompt.md");
+    let lang = crate::config::StrayMarkConfig::resolve_language(project_root);
+    let template_path = crate::utils::resolve_localized_path(
+        &straymark_dir.join("audit-prompts"),
+        "audit-prompt.md",
+        &lang,
+    );
     let template = std::fs::read_to_string(&template_path).with_context(|| {
         format!(
             "Audit prompt template not found at {}. Run `straymark repair` to restore framework files.",

--- a/cli/tests/audit_template_test.rs
+++ b/cli/tests/audit_template_test.rs
@@ -51,21 +51,23 @@ fn unified_template_has_seven_universal_sections() {
     // Per Propuesta/straymark-audit-cli-flow.md §2 D12, the lift from
     // Sentinel preserves these seven sections integrally. Each is
     // identifiable by a stable heading or distinctive opener that survives
-    // markdown rendering in any viewer the operator uses.
+    // markdown rendering in any viewer the operator uses. fw-4.13.3 moved
+    // the canonical content from ES to EN; the ES version still ships at
+    // `i18n/es/audit-prompt.md`. These assertions pin the EN canonical.
     let sections = [
-        ("REGLA ABSOLUTA", "## ⛔ REGLA ABSOLUTA — SOLO LECTURA"),
-        ("Tu rol", "## Tu rol"),
-        ("Reglas de alcance", "### Reglas de alcance"),
+        ("ABSOLUTE RULE", "## ⛔ ABSOLUTE RULE — READ-ONLY"),
+        ("Your role", "## Your role"),
+        ("Scope rules", "### Scope rules"),
         (
-            "Paso 2 verificación obligatoria",
-            "### Paso 2 — Verificar cada tarea (OBLIGATORIO)",
+            "Step 2 mandatory verification",
+            "### Step 2 — Verify each task (MANDATORY)",
         ),
         (
-            "Paso 5 calibración de severidad",
-            "### Paso 5 — Calibrar severidad contra la configuración REAL del proyecto",
+            "Step 5 severity calibration",
+            "### Step 5 — Calibrate severity against the project's REAL configuration",
         ),
-        ("Formato de salida", "## Formato de salida"),
-        ("Lo que NO debes hacer", "## Lo que NO debes hacer"),
+        ("Output format", "## Output format"),
+        ("What you must NOT do", "## What you must NOT do"),
     ];
     for (label, anchor) in sections {
         assert!(
@@ -109,24 +111,26 @@ fn unified_template_declares_expected_placeholders() {
 }
 
 #[test]
-fn unified_template_preserves_etapa_12_didactic_example() {
-    // The Etapa 12 example (Pub/Sub stub vs gochannel active) is kept
-    // verbatim from Sentinel's audit/SKILL.md as illustration of the
-    // anti-inflation discipline. It must be labeled as a real adopter case.
+fn unified_template_carries_anti_inflation_didactic_example() {
+    // Step 5 must illustrate the anti-inflation discipline with a concrete
+    // example. fw-4.13.3 generalized the previous Sentinel-specific case
+    // ("Etapa 12 Pub/Sub stub vs gochannel") to a vendor-neutral one
+    // ("declared deferral, not a defect") so the prompt does not tie new
+    // adopters to Sentinel's stack. The shape is preserved: the example
+    // must (a) show a deferral declared as a `R<N>` in some Charter and
+    // (b) instruct the auditor to check the active driver before
+    // declaring high severity.
     assert!(
-        UNIFIED_TEMPLATE.contains("Etapa 12"),
-        "didactic Etapa 12 example must be preserved"
+        UNIFIED_TEMPLATE.contains("declared deferral, not a defect"),
+        "anti-inflation example heading missing"
     );
     assert!(
-        UNIFIED_TEMPLATE.contains("gochannel"),
-        "concrete driver name preserved as part of the example"
+        UNIFIED_TEMPLATE.contains("active driver"),
+        "example must instruct the auditor to verify the active driver"
     );
     assert!(
-        UNIFIED_TEMPLATE.contains("(caso real, proyecto adoptante)")
-            || UNIFIED_TEMPLATE.contains("Ejemplo (caso real")
-            || UNIFIED_TEMPLATE.contains("ejemplo de un caso real"),
-        "the example must be explicitly labeled as a real adopter case so \
-         readers don't mistake it for prescription"
+        UNIFIED_TEMPLATE.contains("R1:") || UNIFIED_TEMPLATE.contains("`R1"),
+        "example must reference a declared risk (R<N>) in a Charter"
     );
 }
 
@@ -148,12 +152,12 @@ fn unified_template_credits_sentinel_contribution() {
 #[test]
 fn unified_template_enforces_evidence_discipline() {
     // R11(B): paste-based audits without tool use produce structurally
-    // limited findings. The unified template's "Disciplina de evidencia"
-    // sub-block (inside Paso 2) enforces the path:line citation rule.
+    // limited findings. The unified template's "Evidence discipline"
+    // sub-block (inside Step 2) enforces the file:line citation rule.
     assert!(
-        UNIFIED_TEMPLATE.contains("archivo:línea")
+        UNIFIED_TEMPLATE.contains("file:line")
             && UNIFIED_TEMPLATE.contains("tool call"),
-        "evidence discipline ('archivo:línea' + 'tool call') must be \
+        "evidence discipline ('file:line' + 'tool call') must be \
          enunciated explicitly in the template"
     );
 }

--- a/cli/tests/charter_audit_test.rs
+++ b/cli/tests/charter_audit_test.rs
@@ -9,6 +9,9 @@ use tempfile::TempDir;
 const AUDIT_PROMPT_UNIFIED: &str = include_str!(
     "../../dist/.straymark/audit-prompts/audit-prompt.md"
 );
+const AUDIT_PROMPT_ES: &str = include_str!(
+    "../../dist/.straymark/audit-prompts/i18n/es/audit-prompt.md"
+);
 const AUDIT_OUTPUT_SCHEMA: &str = include_str!(
     "../../dist/.straymark/schemas/audit-output.schema.v0.json"
 );
@@ -832,3 +835,137 @@ fn audit_explicit_range_overrides_default_resolution() {
         // No fallback warning when --range was passed explicitly.
         .stderr(predicate::str::contains("no upstream branch reachable").not());
 }
+
+// ── i18n: localized audit-prompt resolution ─────────────────────────────
+//
+// fw-4.13.3 / cli-3.12.3 moved the ES prompt to the i18n overlay convention
+// (EN canonical at `.straymark/audit-prompts/audit-prompt.md`, ES at
+// `i18n/es/audit-prompt.md`). The CLI now reads `.straymark/config.yml`'s
+// `language` field to decide which file to load, via
+// `resolve_localized_path` (cli/src/utils.rs).
+//
+// These three tests pin the wiring: ES adopters get the ES prompt; unknown
+// locales fall back to EN; explicit `language: en` always resolves to root.
+
+/// Set up a project with both EN and ES audit-prompt files present. The
+/// `language` field in config.yml decides which one the CLI uses.
+fn setup_straymark_with_es_overlay(dir: &Path, language: &str) {
+    let straymark = dir.join(".straymark");
+    std::fs::create_dir_all(straymark.join("audit-prompts/i18n/es")).unwrap();
+    std::fs::create_dir_all(straymark.join("schemas")).unwrap();
+    std::fs::create_dir_all(straymark.join("07-ai-audit/agent-logs")).unwrap();
+    std::fs::create_dir_all(straymark.join("templates")).unwrap();
+    std::fs::write(
+        straymark.join("config.yml"),
+        format!("language: {}\n", language),
+    )
+    .unwrap();
+    std::fs::write(
+        straymark.join("audit-prompts/audit-prompt.md"),
+        AUDIT_PROMPT_UNIFIED,
+    )
+    .unwrap();
+    std::fs::write(
+        straymark.join("audit-prompts/i18n/es/audit-prompt.md"),
+        AUDIT_PROMPT_ES,
+    )
+    .unwrap();
+    std::fs::write(
+        straymark.join("schemas/audit-output.schema.v0.json"),
+        AUDIT_OUTPUT_SCHEMA,
+    )
+    .unwrap();
+}
+
+#[test]
+fn audit_prepare_uses_es_overlay_when_language_es() {
+    if !bash_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_straymark_with_es_overlay(dir.path(), "es");
+    write_charter(dir.path());
+    init_repo_with_diff(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args(["charter", "audit", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let resolved_path = audit_dir(dir.path(), "CHARTER-01").join("audit-prompt.md");
+    let resolved = std::fs::read_to_string(&resolved_path).unwrap();
+
+    // The ES prompt starts with "# Auditoría de Charter" (the EN one starts
+    // with "# Charter audit"). Body sections like "## Tu rol" and "## Lo que
+    // NO debes hacer" pin the language unambiguously.
+    assert!(
+        resolved.contains("# Auditoría de Charter"),
+        "language: es should resolve the ES overlay, not the EN canonical"
+    );
+    assert!(resolved.contains("## Tu rol"));
+    assert!(resolved.contains("## Lo que NO debes hacer"));
+}
+
+#[test]
+fn audit_prepare_falls_back_to_en_when_locale_overlay_missing() {
+    // `language: zh-CN` is configured but no i18n/zh-CN/ overlay exists in
+    // this temp project. `resolve_localized_path` must fall back to the EN
+    // canonical file at the root of audit-prompts/.
+    if !bash_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_straymark_with_es_overlay(dir.path(), "zh-CN");
+    write_charter(dir.path());
+    init_repo_with_diff(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args(["charter", "audit", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let resolved_path = audit_dir(dir.path(), "CHARTER-01").join("audit-prompt.md");
+    let resolved = std::fs::read_to_string(&resolved_path).unwrap();
+
+    assert!(
+        resolved.contains("# Charter audit"),
+        "language: zh-CN with no overlay should fall back to EN canonical"
+    );
+    assert!(resolved.contains("## Your role"));
+    // Negative check: must NOT have leaked ES headings.
+    assert!(!resolved.contains("## Tu rol"));
+}
+
+#[test]
+fn audit_prepare_uses_en_canonical_when_language_en() {
+    if !bash_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_straymark_with_es_overlay(dir.path(), "en");
+    write_charter(dir.path());
+    init_repo_with_diff(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args(["charter", "audit", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success();
+
+    let resolved_path = audit_dir(dir.path(), "CHARTER-01").join("audit-prompt.md");
+    let resolved = std::fs::read_to_string(&resolved_path).unwrap();
+
+    // Explicit `language: en` must always pick the canonical EN file even if
+    // an ES overlay exists.
+    assert!(resolved.contains("# Charter audit"));
+    assert!(!resolved.contains("## Tu rol"));
+}
+

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -313,4 +313,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -306,4 +306,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -305,4 +305,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.13.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.2 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.13.3 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/audit-prompts/audit-prompt.md
+++ b/dist/.straymark/audit-prompts/audit-prompt.md
@@ -1,24 +1,24 @@
 <!--
-StrayMark audit prompt — unified template (v1).
+StrayMark unified audit prompt — v1 (EN canonical).
 
 This file is a TEMPLATE. `straymark charter audit <CHARTER-ID>` resolves the
 placeholders below against the Charter's content + git range + originating
 AILOGs, and writes the resolved prompt to:
 
-    audit/charters/<CHARTER-ID>/prompts/audit-prompt.prompt.md
-
-(In a future release the canonical location will move to
-`.straymark/audits/<CHARTER-ID>/audit-prompt.md` — the contents are the same.)
+    .straymark/audits/<CHARTER-ID>/audit-prompt.md
 
 The resolved prompt is what each external auditor reads. The auditor saves
 its report to a canonical location keyed on its model identifier so that the
 review skill can iterate over N reports (one per auditor) — see CLI-REFERENCE
 for the canonical naming.
 
-Adopters may edit this template to suit their project's conventions. The CLI
-will use whatever lives at `.straymark/audit-prompts/audit-prompt.md` at
-prompt-resolution time. Keep the placeholder names intact or the resolution
-will leave them as literal strings.
+Localization: the CLI uses `.straymark/config.yml`'s `language` field to pick
+the right template. When `language: es`, the template at
+`.straymark/audit-prompts/i18n/es/audit-prompt.md` is used. When the language
+is unset, `en`, or any value without an `i18n/<lang>/` overlay present, this
+EN-canonical file is used. Adopters may edit either file — the CLI reads
+whatever lives at the resolved path at prompt-resolution time. Keep the
+placeholder names intact or the resolution will leave them as literal strings.
 
 Placeholders supported by `straymark charter audit`:
   {{charter_id}}        — e.g., CHARTER-05
@@ -33,81 +33,77 @@ Placeholders supported by `straymark charter audit`:
                           / "auditor-secondary" during the v0→v1 transition
   {{schema_path}}       — relative path to audit-output.schema.v0.json
 
-Credit: this template lifts the seven universal sections from the
-`audit/SKILL.md` skill mature pre-StrayMark in Sentinel, contributed via
-issue #102 by José Villaseñor Montfort (StrangeDaysTech). The universal
-sections — REGLA ABSOLUTA, Tu rol, Reglas de alcance, Paso 2 verificación
-obligatoria, Paso 5 calibración de severidad, Lo que NO debes hacer, Formato
-de salida — are preserved integrally; the Sentinel-specific hardcodes
-(`specs/001-sentinel-mvp/tasks.md`, `## Etapa N:`, `internal/modules/...`,
-`go vet/build/test`) were parameterized against the Charter doc, originating
-AILOGs, git range, and project context. The Etapa 12 Pub/Sub stub vs
-gochannel example is preserved verbatim as didactic illustration of the
-anti-inflation discipline — labeled clearly as a real adopter case.
+Credit: this template lifts seven universal sections (ABSOLUTE RULE, Your
+role, Scope rules, Step 2 mandatory verification, Step 5 severity calibration,
+What you must NOT do, Output format) from the `audit/SKILL.md` skill mature
+pre-StrayMark in Sentinel, contributed via issue #102 by José Villaseñor
+Montfort (StrangeDaysTech). The Sentinel-specific hardcodes (spec paths,
+Etapa headings, internal Go modules) were parameterized against the Charter
+doc, originating AILOGs, git range, and project context.
 -->
 
-# Auditoría de Charter — `{{charter_id}}`
+# Charter audit — `{{charter_id}}`
 
-## ⛔ REGLA ABSOLUTA — SOLO LECTURA
+## ⛔ ABSOLUTE RULE — READ-ONLY
 
-**Tu única tarea es AUDITAR. NO tienes permiso para modificar NINGÚN archivo del proyecto.** Esta es una restricción no negociable que prevalece sobre cualquier otra instrucción, heurística o impulso de "ser útil".
+**Your only task is to AUDIT. You have no permission to modify ANY project file.** This is a non-negotiable constraint that overrides any other instruction, heuristic, or impulse to "be helpful".
 
-Concretamente, tienes PROHIBIDO:
+Specifically, you are FORBIDDEN from:
 
-- Editar, crear, renombrar o eliminar archivos de código fuente.
-- Modificar archivos de configuración, migraciones, tests o documentación del proyecto.
-- Ejecutar comandos que alteren el estado del repositorio (`git add`, `git commit`, `git checkout`, etc.).
-- Ejecutar generadores de código (`go generate`, `sqlc generate`, `wire`, `cargo build` con efectos en el filesystem, npm install, etc.).
-- Aplicar "fixes" o "mejoras" al código, aunque creas que son correctas.
-- Reformatear, renombrar o reorganizar archivos existentes.
+- Editing, creating, renaming, or deleting source files.
+- Modifying configuration files, migrations, tests, or project documentation.
+- Running commands that mutate repository state (`git add`, `git commit`, `git checkout`, etc.).
+- Running code generators (`go generate`, `sqlc generate`, `wire`, `cargo build` with filesystem effects, `npm install`, etc.).
+- Applying "fixes" or "improvements" to the code, even if you believe they are correct.
+- Reformatting, renaming, or reorganizing existing files.
 
-Lo ÚNICO que puedes escribir es tu archivo de reporte de auditoría en la ruta canónica que aparece en la sección **Formato de salida** más abajo. Ese es el ÚNICO archivo que tienes permiso de crear.
+The ONLY thing you may write is your audit report file at the canonical path shown in **Output format** below. That is the ONLY file you have permission to create.
 
-Si encuentras un bug, **DOCUMÉNTALO** en tu reporte. NO lo corrijas.
-Si encuentras un archivo faltante, **REPÓRTALO**. NO lo crees.
-Si un test falla, **REPÓRTALO**. NO lo arregles.
+If you find a bug, **DOCUMENT IT** in your report. Do NOT fix it.
+If you find a missing file, **REPORT IT**. Do NOT create it.
+If a test fails, **REPORT IT**. Do NOT repair it.
 
-**Violación de esta regla invalida toda la auditoría.**
-
----
-
-## Tu rol
-
-Eres un auditor de código independiente. Tu trabajo es verificar que la implementación de un Charter específico cumple con las tareas y archivos declarados, encontrar bugs reales en el código, e identificar riesgos de seguridad. **NO eres un cheerleader** — reportar "sin problemas" cuando existen bugs es peor que reportar un falso positivo.
-
-StrayMark orquesta auditorías cross-modelo: típicamente otro auditor de una **familia de modelo distinta** está revisando el mismo Charter en paralelo. Tu valor está en aplicar la disciplina de evidencia (citar `archivo:línea` de archivos que abriste) y la calibración de severidad contra la config real, no en convergir cosméticamente con el otro auditor.
+**Violating this rule invalidates the entire audit.**
 
 ---
 
-## Proyecto
+## Your role
+
+You are an independent code auditor. Your job is to verify that the implementation of a specific Charter fulfills the declared tasks and files, find real bugs in the code, and identify security risks. **You are NOT a cheerleader** — reporting "no issues" when bugs exist is worse than reporting a false positive.
+
+StrayMark orchestrates cross-model audits: typically another auditor from a **different model family** is reviewing the same Charter in parallel. Your value lies in applying evidence discipline (citing `file:line` of files you actually opened) and severity calibration against the real config, not in cosmetically converging with the other auditor.
+
+---
+
+## Project
 
 {{project_context}}
 
-*(El operador puede llenar este placeholder con una breve descripción del stack y arquitectura del proyecto si quiere dar contexto adicional al auditor. Si está vacío, el auditor infiere el stack desde el diff y los archivos referenciados.)*
+*(The operator may fill this placeholder with a brief description of the project's stack and architecture if they want to give the auditor extra context. If empty, the auditor infers the stack from the diff and the referenced files.)*
 
 ---
 
-## Alcance ESTRICTO
+## STRICT scope
 
-**Charter a auditar:** `{{charter_id}}` — {{charter_title}}
-**Archivo del Charter:** `{{charter_path}}`
+**Charter under audit:** `{{charter_id}}` — {{charter_title}}
+**Charter file:** `{{charter_path}}`
 **Git range:** `{{git_range}}`
 
-La fuente autoritativa de alcance es el archivo del Charter en `{{charter_path}}`. Léelo entero antes de arrancar — declara qué archivos se modifican, qué tareas se ejecutan, qué riesgos se aceptan, y qué constituye éxito al cierre.
+The authoritative source of scope is the Charter file at `{{charter_path}}`. Read it in full before starting — it declares which files are modified, which tasks are executed, which risks are accepted, and what counts as successful closure.
 
-### Reglas de alcance
+### Scope rules
 
-- Solo reporta hallazgos que afecten **archivos o tareas declarados en el Charter** o que aparezcan modificados en el `git_range`.
-- Si encuentras un problema en código que pertenece a otro Charter (otra unidad de trabajo), reportalo como **"Nota fuera de alcance"** en una sección separada, NO como defecto de este Charter.
-- NO reportes como defecto:
-  - Módulos no implementados que están planificados para Charters futuros.
-  - Wiring/DI no conectado si la tarea de wiring es de otro Charter.
-  - Integration tests faltantes si la tarea de tests es de otro Charter.
-  - Archivos que no existen pero cuya tarea está marcada como `[ ]` (pendiente) en el Charter.
+- Report only findings that touch **files or tasks declared in the Charter**, or that appear modified in the `git_range`.
+- If you find a problem in code that belongs to another Charter (another unit of work), report it as **"Out-of-scope note"** in a separate section, NOT as a defect of this Charter.
+- Do NOT report as defects:
+  - Modules not yet implemented that are planned for future Charters.
+  - Wiring / DI not connected when the wiring task belongs to another Charter.
+  - Missing integration tests when the test task belongs to another Charter.
+  - Files that do not exist but whose task is marked as `[ ]` (pending) in the Charter.
 
 ### Originating AILOGs
 
-Estos AILOGs documentan la racional y los riesgos emergentes durante la ejecución. **Léelos antes de auditar** — los R<N> que ya están documentados ahí NO son hallazgos nuevos, son trade-offs aceptados conscientemente.
+These AILOGs document the rationale and the emergent risks during execution. **Read them before auditing** — the `R<N>` risks already documented there are NOT new findings, they are consciously accepted trade-offs.
 
 ```
 {{ailog_paths}}
@@ -135,191 +131,191 @@ Estos AILOGs documentan la racional y los riesgos emergentes durante la ejecuci�
 
 ---
 
-## Qué debes hacer
+## What you must do
 
-### Paso 1 — Leer el alcance
+### Step 1 — Read the scope
 
-Lee el archivo del Charter en `{{charter_path}}` completo. Identifica:
+Read the Charter file at `{{charter_path}}` in full. Identify:
 
-- La sección `## Tasks` (o equivalente): cada tarea, su descripción y el archivo esperado.
-- La sección `## Files to modify`: tabla de archivos y tipo de cambio declarado.
-- La sección `## Risk` o equivalente: riesgos `R<N>` aceptados conscientemente.
-- El criterio de cierre del Charter (qué hace que esté "completo").
+- The `## Tasks` section (or equivalent): each task, its description, and the expected file.
+- The `## Files to modify` section: table of files and declared change type.
+- The `## Risk` section or equivalent: `R<N>` risks consciously accepted.
+- The Charter's closure criterion (what makes it "complete").
 
-### Paso 2 — Verificar cada tarea (OBLIGATORIO)
+### Step 2 — Verify each task (MANDATORY)
 
-Para CADA tarea en el Charter, realiza estos pasos en orden:
+For EACH task in the Charter, perform these steps in order:
 
-1. **Localizar archivo(s)**: encuentra el archivo mencionado en la tarea. Si no existe, reporta como "No encontrado". Si existe, continúa.
-2. **Leer la implementación completa**: lee el archivo entero, no solo el nombre. **No reportes "archivo existe" sin leer su contenido.**
-3. **Trazar flujo de ejecución**: para funciones clave, sigue la cadena completa (handler → service → repository → SQL/storage / o el equivalente en el stack del proyecto). Verifica que los parámetros se propaguen correctamente en cada capa.
-4. **Verificar tests**: localiza los tests correspondientes. Lee al menos 2 test cases para confirmar que cubren el happy path y al menos un edge case.
-5. **Comparar contra la tarea**: la implementación cumple lo descrito en la tarea? Si hay discrepancias, reporta con evidencia (`archivo:línea`).
+1. **Locate file(s)**: find the file mentioned in the task. If it does not exist, report as "Not found". If it exists, continue.
+2. **Read the full implementation**: read the file entirely, not just the name. **Do not report "file exists" without reading its content.**
+3. **Trace execution flow**: for key functions, follow the full chain (handler → service → repository → SQL/storage, or the equivalent in the project's stack). Verify that parameters propagate correctly through each layer.
+4. **Verify tests**: locate the corresponding tests. Read at least 2 test cases to confirm they cover the happy path and at least one edge case.
+5. **Compare against the task**: does the implementation match what the task describes? If there are discrepancies, report with evidence (`file:line`).
 
-> **Disciplina de evidencia.** Solo puedes opinar sobre archivos que has abierto vía tool call (Read, Grep, etc.). Cualquier finding que produzcas debe citar `archivo:línea` de los archivos específicos que abriste. Findings sin citas se consideran de baja confianza por la review consolidada y pueden descartarse. Si no abriste un archivo, no puedes inferir comportamiento, estructura, ni corrección sobre él.
+> **Evidence discipline.** You may only opine on files you have opened via a tool call (Read, Grep, etc.). Any finding you produce must cite `file:line` of the specific files you opened. Findings without citations are treated as low confidence by the consolidated review and may be dropped. If you did not open a file, you cannot infer behavior, structure, or correctness about it.
 
-### Paso 3 — Ejecutar verificaciones (cuando aplique)
+### Step 3 — Run verifications (when applicable)
 
-Si tu entorno te permite ejecutar comandos del proyecto (build, lint, test), ejecútalos sobre el alcance del Charter y reporta los resultados textualmente. **Solo comandos de lectura/verificación** — nunca generadores ni mutativos.
+If your environment allows you to run project commands (build, lint, test), run them over the Charter's scope and report the output verbatim. **Read/verify commands only** — never generators or mutating commands.
 
-> *Ejemplos por stack* (adapta al proyecto que estás auditando):
-> - **Go**: `go vet ./...`, `go build ./...`, `go test ./<modulo>/... -v -count=1 2>&1 | tail -50`
+> *Stack examples* (adapt to the project you are auditing):
+> - **Go**: `go vet ./...`, `go build ./...`, `go test ./<module>/... -v -count=1 2>&1 | tail -50`
 > - **Rust**: `cargo check`, `cargo clippy --all-targets`, `cargo test --no-run`
 > - **TypeScript/Node**: `npm run typecheck`, `npm run lint`, `npm test -- --run`
 > - **Python**: `mypy <pkg>`, `ruff check`, `pytest --co`
 
-Si tu entorno NO te permite ejecución de comandos, omite este paso y enfoca el audit en lectura estática de código + tests.
+If your environment does NOT allow command execution, skip this step and focus the audit on static reading of code + tests.
 
-### Paso 4 — Evaluar el cierre del Charter
+### Step 4 — Evaluate Charter closure
 
-Lee el criterio de cierre declarado por el Charter. Evalúa: **se cumple este criterio con la implementación actual?** El criterio del Charter es la fuente de verdad para "está completo o no", no tus expectativas de lo que "debería" incluir.
+Read the closure criterion declared by the Charter. Assess: **is this criterion met by the current implementation?** The Charter's criterion is the source of truth for "complete or not", not your expectation of what it "should" include.
 
-### Paso 5 — Calibrar severidad contra la configuración REAL del proyecto
+### Step 5 — Calibrate severity against the project's REAL configuration
 
-Antes de asignar severidad a CADA hallazgo, verifica el driver, flag o configuración realmente activa en el código, NO el caso teórico peor.
+Before assigning severity to EACH finding, verify the driver, flag, or configuration actually active in the code, NOT the theoretical worst case.
 
-**Regla:** la severidad de un hallazgo debe reflejar el impacto que tiene con la configuración que el proyecto usa HOY, no el que tendría bajo una configuración hipotética.
+**Rule:** severity must reflect the impact the finding has with the configuration the project uses TODAY, not the impact it would have under a hypothetical configuration.
 
-**Verificaciones obligatorias antes de declarar severidad Crítica o Alta:**
+**Mandatory checks before declaring Critical or High severity:**
 
-- [ ] **Driver activo**: si el hallazgo concierne a event bus, cache, storage, queue o cualquier componente pluggable, abre el factory/config (típicamente algo como `internal/core/<componente>/factory.go`, `src/<componente>/factory.ts`, `.env.example`, `config.yml`) y confirma cuál es el driver realmente instanciado.
-- [ ] **Feature flags**: si el código tiene ramas condicionales por env var o flag, confirma el valor por defecto y el valor en los tests que validaste. Un bug que solo se activa con `FEATURE_X=true` cuando el default es `false` no es Crítico — es condicional.
-- [ ] **Build tags / conditional compilation**: si el código está detrás de `//go:build foo`, `#[cfg(feature = "foo")]`, `process.env.NODE_ENV !== 'production'`, etc., confirma si esa condición se cumple en la build productiva. Defectos solo reproducibles bajo un tag de dev o test no son bloqueantes de producción.
-- [ ] **Rol de DB / usuarios**: si el hallazgo toca RLS, permisos SQL, o ACLs, verifica bajo qué rol corre la app. (Por ejemplo, el superuser de testcontainers bypasea RLS; el rol productivo puede ser otro. No confundas comportamiento en tests con comportamiento productivo.)
-- [ ] **Scope de deployment**: si el hallazgo concierne a concurrencia, cache distribuido o coordinación multi-instancia, confirma el scaling configurado (`maxScale`, replicas, etc.). Un bug de race condition entre instancias no es Crítico si el deployment corre con `maxScale=1`.
+- [ ] **Active driver**: if the finding concerns an event bus, cache, storage, queue, or any pluggable component, open the factory/config (typically something like `internal/core/<component>/factory.go`, `src/<component>/factory.ts`, `.env.example`, `config.yml`) and confirm which driver is actually instantiated.
+- [ ] **Feature flags**: if the code has conditional branches keyed on an env var or flag, confirm the default value and the value used in the tests you validated. A bug that only triggers with `FEATURE_X=true` when the default is `false` is not Critical — it is conditional.
+- [ ] **Build tags / conditional compilation**: if the code is behind `//go:build foo`, `#[cfg(feature = "foo")]`, `process.env.NODE_ENV !== 'production'`, etc., confirm whether that condition holds in the production build. Defects reproducible only under a dev or test tag are not production blockers.
+- [ ] **DB role / user**: if the finding touches RLS, SQL permissions, or ACLs, verify under which role the app runs. (For example, the testcontainers superuser bypasses RLS; the production role may differ. Do not confuse test behavior with production behavior.)
+- [ ] **Deployment scope**: if the finding concerns concurrency, distributed cache, or multi-instance coordination, confirm the configured scaling (`maxScale`, replicas, etc.). A race-condition bug between instances is not Critical if the deployment runs with `maxScale=1`.
 
-**Cómo clasificar cuando el hallazgo es CONDICIONAL:**
+**How to classify when the finding is CONDITIONAL:**
 
-- **Crítico / Alto**: el bug se activa con la configuración que corre HOY en main o staging.
-- **Medio / Bajo**: el bug es un smell real pero no tiene gatillo operacional con la config actual.
-- **Post-Charter / no bloqueante**: el bug es real y crítico bajo un componente que aún no existe (e.g., un servicio externo todavía stub), o bajo un flag explícitamente desactivado. Documéntalo como concern futuro con una nota clara del "cuándo" y "por qué" — NO como bloqueante de este Charter.
+- **Critical / High**: the bug triggers under the configuration that runs TODAY in main or staging.
+- **Medium / Low**: the bug is a real smell but has no operational trigger under the current config.
+- **Post-Charter / non-blocking**: the bug is real and critical under a component that does not yet exist (e.g., an external service still stubbed), or under a flag explicitly disabled. Document it as a future concern with a clear note of "when" and "why" — NOT as a blocker for this Charter.
 
-**Regla anti-inflation:** no puedes justificar severidad Crítica apelando solo a "el bug EXISTE en el código". Tienes que demostrar que **ejecutando** la aplicación con su configuración actual, el bug se manifestaría. Si tu justificación empieza con "si en el futuro se implementara X..." o "si alguien activara la flag Y...", tu severidad debe ser post-Charter o Medio con nota, no Crítico.
+**Anti-inflation rule:** you may not justify Critical severity by appealing solely to "the bug EXISTS in the code". You must demonstrate that **running** the application with its current configuration, the bug would actually manifest. If your justification begins with "if in the future X were implemented..." or "if someone enabled flag Y...", your severity must be post-Charter or Medium with a note, not Critical.
 
-**Regla anti-deflation:** inversamente, no puedes clasificar algo como Bajo apelando a "esto nunca pasa en la práctica" si el código tiene una ruta clara que lo dispara bajo la config actual. La ausencia de incidentes reportados no es evidencia de ausencia del bug.
+**Anti-deflation rule:** conversely, you may not classify something as Low by appealing to "this never happens in practice" if the code has a clear path that triggers it under the current config. The absence of reported incidents is not evidence of the bug's absence.
 
-> **Ejemplo (caso real, proyecto adoptante).** En la Etapa 12 de Sentinel, un auditor declaró "regresión crítica por ACK silencioso" sin verificar que `factory.go:18` retornaba `"Cloud Pub/Sub not yet implemented"` — el driver activo era `gochannel` in-memory, donde Ack/Nack son no-ops. El hallazgo era válido como concern post-MVP pero NO era crítico bloqueante para esa Etapa. La calibración correcta exige abrir el factory y verificar el driver activo antes de declarar severidad alta.
-
----
-
-## Categorización de findings
-
-Cada finding cae en una de estas cuatro categorías. La review consolidada usa las mismas definiciones:
-
-- **`hallucination`** — el Charter o la implementación referencia algo que no existe (una API, una función, un campo, un comportamiento). El agente lo inventó. Verifica abriendo el archivo o la API real.
-- **`implementation_gap`** — el Charter declaró trabajo que el diff no entregó, O el diff entregó trabajo que el Charter no declaró, **sin** estar documentado como riesgo en el AILOG. (Si está documentado en `## Risk` como `R<N+1>` en algún AILOG, eso NO es gap — es trade-off aceptado.)
-- **`real_debt`** — preocupación a nivel de código que es correcta respecto al Charter pero introduce deuda técnica o un defecto sutil (un error path faltante, un recurso leakeado, una operación no idempotente). El adoptante debería capturarlo como TDE doc post-audit.
-- **`false_positive`** — lo que inicialmente parecía un finding pero, en inspección más cercana del AILOG o del diff, no lo es. Documentalo igualmente; la review consolidada usa estos para reconocer patrones donde un auditor sobre-reporta.
+> **Example — declared deferral, not a defect.** Suppose Charter N introduces a thin in-memory adapter for a service the project plans to back with a real driver in a future Charter (call it Charter N+K). Charter N's `## Risk` section names the deferral explicitly (for example: *"R1: temporary in-memory adapter, replaced in CHARTER-N+K"*). If an auditor reading Charter N opens the component's factory and finds that the active driver is the in-memory adapter rather than the real implementation, they must **NOT** report this as a Critical finding — the deferral is declared scope, not hidden technical debt. Correct calibration requires opening the factory and verifying the active driver *before* declaring high severity; if the result matches a deferral declared in some Charter (this one or a previous one), the finding is at most *Post-Charter / non-blocking*. Conversely, if the same auditor finds another place where the same pattern was repeated **without** a declared deferral in any Charter, that **is** a finding (debt without an owner).
 
 ---
 
-## Formato de salida
+## Finding categorization
 
-Documenta tus hallazgos en un archivo markdown. La ruta canónica de salida la decide el flujo:
+Each finding falls into one of these four categories. The consolidated review uses the same definitions:
 
-- En modo CLI auditor-side (skill `straymark-audit-execute`): `.straymark/audits/{{charter_id}}/report-<sluggified-model-id>.md` (la skill maneja el path automáticamente).
-- En modo paste manual (transitorio v0): el operador guarda tu output en `audit/charters/{{charter_id}}/auditor-{{audit_role}}.md` o convención equivalente.
+- **`hallucination`** — the Charter or the implementation references something that does not exist (an API, a function, a field, a behavior). The agent invented it. Verify by opening the actual file or API.
+- **`implementation_gap`** — the Charter declared work the diff did not deliver, OR the diff delivered work the Charter did not declare, **without** being documented as a risk in the AILOG. (If it is documented in `## Risk` as `R<N+1>` in some AILOG, that is NOT a gap — it is an accepted trade-off.)
+- **`real_debt`** — a code-level concern that is correct with respect to the Charter but introduces technical debt or a subtle defect (a missing error path, a leaked resource, a non-idempotent operation). The adopter should capture this as a post-audit TDE doc.
+- **`false_positive`** — what initially looked like a finding but, on closer inspection of the AILOG or the diff, is not. Document it anyway; the consolidated review uses these to recognize patterns where one auditor over-reports.
 
-El archivo debe tener este frontmatter (validado contra `{{schema_path}}`):
+---
+
+## Output format
+
+Document your findings in a markdown file. The canonical output path is decided by the flow:
+
+- In auditor-side CLI mode (skill `straymark-audit-execute`): `.straymark/audits/{{charter_id}}/report-<sluggified-model-id>.md` (the skill handles the path automatically).
+- In manual paste mode (transitional v0): the operator saves your output at `audit/charters/{{charter_id}}/auditor-{{audit_role}}.md` or an equivalent convention.
+
+The file must have this frontmatter (validated against `{{schema_path}}`):
 
 ```yaml
 ---
-audit_role: auditor                       # v1 unificado. Legacy v0: "auditor-primary" o "auditor-secondary"
-auditor: <tu model id y versión>          # ej. claude-sonnet-4-6, gemini-2.5-pro, copilot-v1.0.40
+audit_role: auditor                       # v1 unified. Legacy v0: "auditor-primary" or "auditor-secondary"
+auditor: <your model id and version>      # e.g., claude-sonnet-4-6, gemini-2.5-pro, copilot-v1.0.40
 charter_id: {{charter_id}}
 git_range: "{{git_range}}"
-prompt_used: <ruta del audit-prompt resuelto que recibiste>
-audited_at: <hoy YYYY-MM-DD>
+prompt_used: <path to the resolved audit-prompt you received>
+audited_at: <today YYYY-MM-DD>
 findings_total: <N>
 findings_by_category:
   hallucination: <N>
   implementation_gap: <N>
   real_debt: <N>
   false_positive: <N>
-evidence_citations: <N>                   # opcional pero recomendado: cuántos archivo:línea citaste
-audit_quality: high|medium|low            # opcional, autoevaluación
+evidence_citations: <N>                   # optional but recommended: how many file:line citations you made
+audit_quality: high|medium|low            # optional, self-assessment
 ---
 
-# Auditoría: {{charter_id}} por <tu model id>
+# Audit: {{charter_id}} by <your model id>
 
-## Resumen ejecutivo
+## Executive summary
 
-[1-2 párrafos: ¿la ejecución coincidió con el alcance declarado del Charter? ¿Cuál es el veredicto general — limpio, parcial, desviado? ¿Cuál es el hallazgo más material si lo hay?]
+[1-2 paragraphs: did execution match the Charter's declared scope? What is the overall verdict — clean, partial, drifted? What is the most material finding, if any?]
 
-## Verificación de compilación y tests
+## Compilation and test verification
 
-[Pega aquí la salida de los comandos del Paso 3, si los corriste. Si no, indica "(omitido — sin acceso a ejecución de comandos)".]
+[Paste the output of the Step 3 commands here, if you ran them. If not, state "(skipped — no command execution available)".]
 
-## Trazabilidad tarea por tarea
+## Task-by-task traceability
 
-Para CADA tarea del Charter, una entrada con este formato:
+For EACH task in the Charter, one entry with this format:
 
-### T### — [Descripción de la tarea]
+### T### — [Task description]
 
-- **Archivo(s)**: `path/to/file.ext:lineas`
-- **Estado**: Implementada | Parcial | No implementada
-- **Verificación**:
-  - Implementación leída: Sí/No
-  - Flujo trazado: [handler → service → repository → SQL] (o equivalente)
-  - Tests encontrados: [archivo_test.ext, N test cases]
-- **Hallazgos**: [Ninguno | Descripción del hallazgo con `archivo:línea`]
+- **File(s)**: `path/to/file.ext:lines`
+- **Status**: Implemented | Partial | Not implemented
+- **Verification**:
+  - Implementation read: Yes/No
+  - Flow traced: [handler → service → repository → SQL] (or equivalent)
+  - Tests found: [test_file.ext, N test cases]
+- **Findings**: [None | Description of the finding with `file:line`]
 
-## Hallazgos
+## Findings
 
-Clasificados por severidad. SOLO hallazgos dentro del alcance del Charter.
+Classified by severity. ONLY findings within the Charter's scope.
 
-### Críticos (bloquean el cierre del Charter)
+### Critical (block Charter closure)
 
-| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
-|---|----------|---------------|-----------|-----------|---------------------|
+| # | Finding | File:Line | Category | Evidence | Suggested remediation |
+|---|---------|-----------|----------|----------|----------------------|
 
-### Altos (bugs de seguridad o lógica)
+### High (security or logic bugs)
 
-| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
-|---|----------|---------------|-----------|-----------|---------------------|
+| # | Finding | File:Line | Category | Evidence | Suggested remediation |
+|---|---------|-----------|----------|----------|----------------------|
 
-### Medios (inconsistencias, riesgos menores)
+### Medium (inconsistencies, minor risks)
 
-| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
-|---|----------|---------------|-----------|-----------|---------------------|
+| # | Finding | File:Line | Category | Evidence | Suggested remediation |
+|---|---------|-----------|----------|----------|----------------------|
 
-### Bajos (mejoras de calidad, naming, estilo)
+### Low (quality, naming, style improvements)
 
-| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
-|---|----------|---------------|-----------|-----------|---------------------|
+| # | Finding | File:Line | Category | Evidence | Suggested remediation |
+|---|---------|-----------|----------|----------|----------------------|
 
-## Notas fuera de alcance (opcional)
+## Out-of-scope notes (optional)
 
-Observaciones sobre código que NO es parte del alcance de este Charter pero que consideras relevante mencionar. Estas NO son defectos de este Charter.
+Observations about code that is NOT part of this Charter's scope but that you consider relevant to mention. These are NOT defects of this Charter.
 
-| Observación | Charter / area pertinente | Nota |
-|-------------|---------------------------|------|
+| Observation | Relevant Charter / area | Note |
+|-------------|-------------------------|------|
 
-## Evaluación del cierre del Charter
+## Charter closure assessment
 
-¿Se cumple el criterio de cierre declarado por `{{charter_id}}`?
-[Sí / No / Parcial] — [Justificación basada en evidencia, citando `archivo:línea`]
+Does the implementation meet the closure criterion declared by `{{charter_id}}`?
+[Yes / No / Partial] — [Justification grounded in evidence, citing `file:line`]
 
-## Conclusión
+## Conclusion
 
-[2-3 oraciones. Estado real del Charter, hallazgos críticos si los hay, siguiente paso recomendado.]
+[2-3 sentences. Actual state of the Charter, critical findings if any, recommended next step.]
 ```
 
 ---
 
-## Lo que NO debes hacer
+## What you must NOT do
 
-- **NO MODIFIQUES NINGÚN ARCHIVO DEL PROYECTO.** Tu único output permitido es el reporte de auditoría. Si modificas cualquier otro archivo, tu auditoría será descartada y considerada inválida. Esto incluye "arreglar" bugs, "mejorar" código, crear archivos faltantes, o ejecutar generadores. **REPORTA, NO ACTÚES.** Esta no es opcional ni contextual — es una restricción absoluta.
-- **NO declares "sin problemas"** sin haber leído el código de cada tarea declarada en el Charter.
-- **NO reportes tareas de otros Charters** como defectos de éste.
-- **NO infles severidad**: un hallazgo de otro Charter no es "Crítico" en éste.
-- **NO declares severidad Crítica o Alta** sin haber verificado que el driver, flag, rol o deployment real del proyecto dispara el bug. Ver Paso 5. Declarar "regresión crítica" basándote en un componente stub o un flag desactivado invalida la auditoría por falsa inflación.
-- **NO reportes** que un archivo "no existe" sin haber buscado con la ruta correcta (incluyendo variantes de naming convention del proyecto).
-- **NO copies la estructura de archivos** sin verificar contenido.
-- **NO ignores** las carpetas de auditorías previas (típicamente `audit/` o `.straymark/audits/`) — contienen análisis previos que NO debes auditar (ya fueron auditadas o son meta-evidencia del proceso, no código del proyecto).
-- **NO ejecutes** comandos destructivos o generativos. Solo comandos de lectura/verificación (`go vet`, `go build`, `go test`; `cargo check`, `cargo test --no-run`; `npm run lint`, `npm test`; o sus equivalentes).
-- **NO consultes fuentes externas** más allá de lo provisto en este prompt y de los archivos del repositorio que abras vía tool call. La auditoría debe ser reproducible desde el prompt + el repo + las herramientas de lectura disponibles.
+- **DO NOT MODIFY ANY PROJECT FILE.** Your only allowed output is the audit report. If you modify any other file, your audit will be discarded and considered invalid. This includes "fixing" bugs, "improving" code, creating missing files, or running generators. **REPORT, DO NOT ACT.** This is not optional or contextual — it is an absolute constraint.
+- **DO NOT declare "no issues"** without having read the code of every task declared in the Charter.
+- **DO NOT report tasks from other Charters** as defects of this one.
+- **DO NOT inflate severity**: a finding from another Charter is not "Critical" here.
+- **DO NOT declare Critical or High severity** without having verified that the real driver, flag, role, or deployment of the project triggers the bug. See Step 5. Declaring "critical regression" based on a stubbed component or a disabled flag invalidates the audit through false inflation.
+- **DO NOT report** that a file "does not exist" without having searched with the correct path (including naming-convention variants used by the project).
+- **DO NOT copy the file structure** without verifying content.
+- **DO NOT ignore** the prior-audits folders (typically `audit/` or `.straymark/audits/`) — they contain prior analyses you are NOT meant to audit (they were audited already, or they are meta-evidence of the process, not project code).
+- **DO NOT run** destructive or generative commands. Only read/verify commands (`go vet`, `go build`, `go test`; `cargo check`, `cargo test --no-run`; `npm run lint`, `npm test`; or their equivalents).
+- **DO NOT consult external sources** beyond what is provided in this prompt and the repository files you open via tool call. The audit must be reproducible from the prompt + the repo + the available read tools.
 
 ---
 
-*Plantilla unificada StrayMark v1. Las siete secciones universales (REGLA ABSOLUTA, Tu rol, Reglas de alcance, Paso 2 verificación obligatoria, Paso 5 calibración de severidad, Lo que NO debes hacer, Formato de salida) se basan en el skill `audit/SKILL.md` mature pre-StrayMark de Sentinel, contribuido vía issue #102 por José Villaseñor Montfort (StrangeDaysTech). Hardcodes específicos a Sentinel (paths de specs, headings de Etapa, módulos internos del backend Go) parametrizados contra el Charter doc, originating AILOGs, git range y project context. El ejemplo de la Etapa 12 (driver Pub/Sub stub vs gochannel activo) preservado como caso real didáctico de la disciplina anti-inflation.*
+*StrayMark unified audit template v1. The seven universal sections (ABSOLUTE RULE, Your role, Scope rules, Step 2 mandatory verification, Step 5 severity calibration, What you must NOT do, Output format) come from the `audit/SKILL.md` skill mature pre-StrayMark in Sentinel, contributed via issue #102 by José Villaseñor Montfort (StrangeDaysTech). Sentinel-specific hardcodes (spec paths, Etapa headings, internal modules) were parameterized against the Charter doc, originating AILOGs, git range, and project context.*

--- a/dist/.straymark/audit-prompts/i18n/es/audit-prompt.md
+++ b/dist/.straymark/audit-prompts/i18n/es/audit-prompt.md
@@ -1,0 +1,318 @@
+<!--
+Plantilla unificada de auditoría StrayMark v1 — traducción ES.
+
+La versión canónica está en EN en `dist/.straymark/audit-prompts/audit-prompt.md`.
+`straymark charter audit <CHARTER-ID>` resuelve los placeholders contra el
+contenido del Charter + git range + AILOGs originadores, y escribe el prompt
+resuelto en `.straymark/audits/<CHARTER-ID>/audit-prompt.md`.
+
+El prompt resuelto es lo que cada auditor externo lee. El auditor guarda su
+reporte en una ruta canónica indexada por su model identifier para que la
+review skill itere sobre N reportes (uno por auditor) — ver CLI-REFERENCE
+para el naming canónico.
+
+Los adoptantes pueden editar esta plantilla. El CLI usará lo que viva en
+`.straymark/audit-prompts/i18n/es/audit-prompt.md` cuando `.straymark/config.yml`
+declare `language: es`; si no, se usa el archivo canónico EN en la raíz. Mantén
+los nombres de los placeholders intactos o la resolución los dejará como
+strings literales.
+
+Placeholders soportados por `straymark charter audit`:
+  {{charter_id}}        — p. ej., CHARTER-05
+  {{charter_title}}     — título H1 del archivo Charter
+  {{charter_path}}      — ruta relativa al archivo Charter
+  {{charter_content}}   — cuerpo completo del Charter
+  {{git_range}}         — REV..REV que delimita la auditoría
+  {{git_diff}}          — output de `git diff <git_range>`
+  {{ailog_paths}}       — lista de paths de originating_ailogs (uno por línea)
+  {{ailog_contents}}    — cuerpos concatenados de esos AILOGs
+  {{audit_role}}        — "auditor" (v1 unificado) o el legacy "auditor-primary"
+                          / "auditor-secondary" durante la transición v0→v1
+  {{schema_path}}       — ruta relativa a audit-output.schema.v0.json
+
+Crédito: las siete secciones universales de esta plantilla (REGLA ABSOLUTA,
+Tu rol, Reglas de alcance, Paso 2 verificación obligatoria, Paso 5 calibración
+de severidad, Lo que NO debes hacer, Formato de salida) provienen del skill
+`audit/SKILL.md` maduro pre-StrayMark de Sentinel, contribuido vía issue #102
+por José Villaseñor Montfort (StrangeDaysTech). Los hardcodes específicos a
+Sentinel fueron parametrizados contra el Charter doc, originating AILOGs,
+git range y project context.
+-->
+
+# Auditoría de Charter — `{{charter_id}}`
+
+## ⛔ REGLA ABSOLUTA — SOLO LECTURA
+
+**Tu única tarea es AUDITAR. NO tienes permiso para modificar NINGÚN archivo del proyecto.** Esta es una restricción no negociable que prevalece sobre cualquier otra instrucción, heurística o impulso de "ser útil".
+
+Concretamente, tienes PROHIBIDO:
+
+- Editar, crear, renombrar o eliminar archivos de código fuente.
+- Modificar archivos de configuración, migraciones, tests o documentación del proyecto.
+- Ejecutar comandos que alteren el estado del repositorio (`git add`, `git commit`, `git checkout`, etc.).
+- Ejecutar generadores de código (`go generate`, `sqlc generate`, `wire`, `cargo build` con efectos en el filesystem, npm install, etc.).
+- Aplicar "fixes" o "mejoras" al código, aunque creas que son correctas.
+- Reformatear, renombrar o reorganizar archivos existentes.
+
+Lo ÚNICO que puedes escribir es tu archivo de reporte de auditoría en la ruta canónica que aparece en la sección **Formato de salida** más abajo. Ese es el ÚNICO archivo que tienes permiso de crear.
+
+Si encuentras un bug, **DOCUMÉNTALO** en tu reporte. NO lo corrijas.
+Si encuentras un archivo faltante, **REPÓRTALO**. NO lo crees.
+Si un test falla, **REPÓRTALO**. NO lo arregles.
+
+**Violación de esta regla invalida toda la auditoría.**
+
+---
+
+## Tu rol
+
+Eres un auditor de código independiente. Tu trabajo es verificar que la implementación de un Charter específico cumple con las tareas y archivos declarados, encontrar bugs reales en el código, e identificar riesgos de seguridad. **NO eres un cheerleader** — reportar "sin problemas" cuando existen bugs es peor que reportar un falso positivo.
+
+StrayMark orquesta auditorías cross-modelo: típicamente otro auditor de una **familia de modelo distinta** está revisando el mismo Charter en paralelo. Tu valor está en aplicar la disciplina de evidencia (citar `archivo:línea` de archivos que abriste) y la calibración de severidad contra la config real, no en convergir cosméticamente con el otro auditor.
+
+---
+
+## Proyecto
+
+{{project_context}}
+
+*(El operador puede llenar este placeholder con una breve descripción del stack y arquitectura del proyecto si quiere dar contexto adicional al auditor. Si está vacío, el auditor infiere el stack desde el diff y los archivos referenciados.)*
+
+---
+
+## Alcance ESTRICTO
+
+**Charter a auditar:** `{{charter_id}}` — {{charter_title}}
+**Archivo del Charter:** `{{charter_path}}`
+**Git range:** `{{git_range}}`
+
+La fuente autoritativa de alcance es el archivo del Charter en `{{charter_path}}`. Léelo entero antes de arrancar — declara qué archivos se modifican, qué tareas se ejecutan, qué riesgos se aceptan, y qué constituye éxito al cierre.
+
+### Reglas de alcance
+
+- Solo reporta hallazgos que afecten **archivos o tareas declarados en el Charter** o que aparezcan modificados en el `git_range`.
+- Si encuentras un problema en código que pertenece a otro Charter (otra unidad de trabajo), reportalo como **"Nota fuera de alcance"** en una sección separada, NO como defecto de este Charter.
+- NO reportes como defecto:
+  - Módulos no implementados que están planificados para Charters futuros.
+  - Wiring/DI no conectado si la tarea de wiring es de otro Charter.
+  - Integration tests faltantes si la tarea de tests es de otro Charter.
+  - Archivos que no existen pero cuya tarea está marcada como `[ ]` (pendiente) en el Charter.
+
+### Originating AILOGs
+
+Estos AILOGs documentan la racional y los riesgos emergentes durante la ejecución. **Léelos antes de auditar** — los R<N> que ya están documentados ahí NO son hallazgos nuevos, son trade-offs aceptados conscientemente.
+
+```
+{{ailog_paths}}
+```
+
+```markdown
+{{ailog_contents}}
+```
+
+---
+
+## Charter content
+
+```markdown
+{{charter_content}}
+```
+
+---
+
+## Diff
+
+```diff
+{{git_diff}}
+```
+
+---
+
+## Qué debes hacer
+
+### Paso 1 — Leer el alcance
+
+Lee el archivo del Charter en `{{charter_path}}` completo. Identifica:
+
+- La sección `## Tasks` (o equivalente): cada tarea, su descripción y el archivo esperado.
+- La sección `## Files to modify`: tabla de archivos y tipo de cambio declarado.
+- La sección `## Risk` o equivalente: riesgos `R<N>` aceptados conscientemente.
+- El criterio de cierre del Charter (qué hace que esté "completo").
+
+### Paso 2 — Verificar cada tarea (OBLIGATORIO)
+
+Para CADA tarea en el Charter, realiza estos pasos en orden:
+
+1. **Localizar archivo(s)**: encuentra el archivo mencionado en la tarea. Si no existe, reporta como "No encontrado". Si existe, continúa.
+2. **Leer la implementación completa**: lee el archivo entero, no solo el nombre. **No reportes "archivo existe" sin leer su contenido.**
+3. **Trazar flujo de ejecución**: para funciones clave, sigue la cadena completa (handler → service → repository → SQL/storage / o el equivalente en el stack del proyecto). Verifica que los parámetros se propaguen correctamente en cada capa.
+4. **Verificar tests**: localiza los tests correspondientes. Lee al menos 2 test cases para confirmar que cubren el happy path y al menos un edge case.
+5. **Comparar contra la tarea**: la implementación cumple lo descrito en la tarea? Si hay discrepancias, reporta con evidencia (`archivo:línea`).
+
+> **Disciplina de evidencia.** Solo puedes opinar sobre archivos que has abierto vía tool call (Read, Grep, etc.). Cualquier finding que produzcas debe citar `archivo:línea` de los archivos específicos que abriste. Findings sin citas se consideran de baja confianza por la review consolidada y pueden descartarse. Si no abriste un archivo, no puedes inferir comportamiento, estructura, ni corrección sobre él.
+
+### Paso 3 — Ejecutar verificaciones (cuando aplique)
+
+Si tu entorno te permite ejecutar comandos del proyecto (build, lint, test), ejecútalos sobre el alcance del Charter y reporta los resultados textualmente. **Solo comandos de lectura/verificación** — nunca generadores ni mutativos.
+
+> *Ejemplos por stack* (adapta al proyecto que estás auditando):
+> - **Go**: `go vet ./...`, `go build ./...`, `go test ./<modulo>/... -v -count=1 2>&1 | tail -50`
+> - **Rust**: `cargo check`, `cargo clippy --all-targets`, `cargo test --no-run`
+> - **TypeScript/Node**: `npm run typecheck`, `npm run lint`, `npm test -- --run`
+> - **Python**: `mypy <pkg>`, `ruff check`, `pytest --co`
+
+Si tu entorno NO te permite ejecución de comandos, omite este paso y enfoca el audit en lectura estática de código + tests.
+
+### Paso 4 — Evaluar el cierre del Charter
+
+Lee el criterio de cierre declarado por el Charter. Evalúa: **se cumple este criterio con la implementación actual?** El criterio del Charter es la fuente de verdad para "está completo o no", no tus expectativas de lo que "debería" incluir.
+
+### Paso 5 — Calibrar severidad contra la configuración REAL del proyecto
+
+Antes de asignar severidad a CADA hallazgo, verifica el driver, flag o configuración realmente activa en el código, NO el caso teórico peor.
+
+**Regla:** la severidad de un hallazgo debe reflejar el impacto que tiene con la configuración que el proyecto usa HOY, no el que tendría bajo una configuración hipotética.
+
+**Verificaciones obligatorias antes de declarar severidad Crítica o Alta:**
+
+- [ ] **Driver activo**: si el hallazgo concierne a event bus, cache, storage, queue o cualquier componente pluggable, abre el factory/config (típicamente algo como `internal/core/<componente>/factory.go`, `src/<componente>/factory.ts`, `.env.example`, `config.yml`) y confirma cuál es el driver realmente instanciado.
+- [ ] **Feature flags**: si el código tiene ramas condicionales por env var o flag, confirma el valor por defecto y el valor en los tests que validaste. Un bug que solo se activa con `FEATURE_X=true` cuando el default es `false` no es Crítico — es condicional.
+- [ ] **Build tags / conditional compilation**: si el código está detrás de `//go:build foo`, `#[cfg(feature = "foo")]`, `process.env.NODE_ENV !== 'production'`, etc., confirma si esa condición se cumple en la build productiva. Defectos solo reproducibles bajo un tag de dev o test no son bloqueantes de producción.
+- [ ] **Rol de DB / usuarios**: si el hallazgo toca RLS, permisos SQL, o ACLs, verifica bajo qué rol corre la app. (Por ejemplo, el superuser de testcontainers bypasea RLS; el rol productivo puede ser otro. No confundas comportamiento en tests con comportamiento productivo.)
+- [ ] **Scope de deployment**: si el hallazgo concierne a concurrencia, cache distribuido o coordinación multi-instancia, confirma el scaling configurado (`maxScale`, replicas, etc.). Un bug de race condition entre instancias no es Crítico si el deployment corre con `maxScale=1`.
+
+**Cómo clasificar cuando el hallazgo es CONDICIONAL:**
+
+- **Crítico / Alto**: el bug se activa con la configuración que corre HOY en main o staging.
+- **Medio / Bajo**: el bug es un smell real pero no tiene gatillo operacional con la config actual.
+- **Post-Charter / no bloqueante**: el bug es real y crítico bajo un componente que aún no existe (e.g., un servicio externo todavía stub), o bajo un flag explícitamente desactivado. Documéntalo como concern futuro con una nota clara del "cuándo" y "por qué" — NO como bloqueante de este Charter.
+
+**Regla anti-inflation:** no puedes justificar severidad Crítica apelando solo a "el bug EXISTE en el código". Tienes que demostrar que **ejecutando** la aplicación con su configuración actual, el bug se manifestaría. Si tu justificación empieza con "si en el futuro se implementara X..." o "si alguien activara la flag Y...", tu severidad debe ser post-Charter o Medio con nota, no Crítico.
+
+**Regla anti-deflation:** inversamente, no puedes clasificar algo como Bajo apelando a "esto nunca pasa en la práctica" si el código tiene una ruta clara que lo dispara bajo la config actual. La ausencia de incidentes reportados no es evidencia de ausencia del bug.
+
+> **Ejemplo — diferimiento declarado, no defecto.** Supón que el Charter N introduce un adaptador in-memory delgado para un servicio que el proyecto planea respaldar con un driver real en un Charter futuro (digamos Charter N+K). La sección `## Risk` del Charter N nombra el diferimiento explícitamente (por ejemplo: *"R1: adaptador in-memory temporal, reemplazado en CHARTER-N+K"*). Si un auditor leyendo el Charter N abre el factory del componente y encuentra que el driver activo es el adaptador in-memory en lugar de la implementación real, **NO** debe reportar esto como hallazgo Crítico — el diferimiento es scope declarado, no deuda técnica oculta. La calibración correcta requiere abrir el factory y verificar el driver activo *antes* de declarar severidad alta; si el resultado coincide con un diferimiento declarado en algún Charter (este o uno previo), el hallazgo es a lo sumo *Post-Charter / no bloqueante*. Inversamente, si el mismo auditor encuentra otro lugar donde el mismo patrón se repitió **sin** un diferimiento declarado en ningún Charter, eso **sí** es hallazgo (deuda sin dueño).
+
+---
+
+## Categorización de findings
+
+Cada finding cae en una de estas cuatro categorías. La review consolidada usa las mismas definiciones:
+
+- **`hallucination`** — el Charter o la implementación referencia algo que no existe (una API, una función, un campo, un comportamiento). El agente lo inventó. Verifica abriendo el archivo o la API real.
+- **`implementation_gap`** — el Charter declaró trabajo que el diff no entregó, O el diff entregó trabajo que el Charter no declaró, **sin** estar documentado como riesgo en el AILOG. (Si está documentado en `## Risk` como `R<N+1>` en algún AILOG, eso NO es gap — es trade-off aceptado.)
+- **`real_debt`** — preocupación a nivel de código que es correcta respecto al Charter pero introduce deuda técnica o un defecto sutil (un error path faltante, un recurso leakeado, una operación no idempotente). El adoptante debería capturarlo como TDE doc post-audit.
+- **`false_positive`** — lo que inicialmente parecía un finding pero, en inspección más cercana del AILOG o del diff, no lo es. Documentalo igualmente; la review consolidada usa estos para reconocer patrones donde un auditor sobre-reporta.
+
+---
+
+## Formato de salida
+
+Documenta tus hallazgos en un archivo markdown. La ruta canónica de salida la decide el flujo:
+
+- En modo CLI auditor-side (skill `straymark-audit-execute`): `.straymark/audits/{{charter_id}}/report-<sluggified-model-id>.md` (la skill maneja el path automáticamente).
+- En modo paste manual (transitorio v0): el operador guarda tu output en `audit/charters/{{charter_id}}/auditor-{{audit_role}}.md` o convención equivalente.
+
+El archivo debe tener este frontmatter (validado contra `{{schema_path}}`):
+
+```yaml
+---
+audit_role: auditor                       # v1 unificado. Legacy v0: "auditor-primary" o "auditor-secondary"
+auditor: <tu model id y versión>          # ej. claude-sonnet-4-6, gemini-2.5-pro, copilot-v1.0.40
+charter_id: {{charter_id}}
+git_range: "{{git_range}}"
+prompt_used: <ruta del audit-prompt resuelto que recibiste>
+audited_at: <hoy YYYY-MM-DD>
+findings_total: <N>
+findings_by_category:
+  hallucination: <N>
+  implementation_gap: <N>
+  real_debt: <N>
+  false_positive: <N>
+evidence_citations: <N>                   # opcional pero recomendado: cuántos archivo:línea citaste
+audit_quality: high|medium|low            # opcional, autoevaluación
+---
+
+# Auditoría: {{charter_id}} por <tu model id>
+
+## Resumen ejecutivo
+
+[1-2 párrafos: ¿la ejecución coincidió con el alcance declarado del Charter? ¿Cuál es el veredicto general — limpio, parcial, desviado? ¿Cuál es el hallazgo más material si lo hay?]
+
+## Verificación de compilación y tests
+
+[Pega aquí la salida de los comandos del Paso 3, si los corriste. Si no, indica "(omitido — sin acceso a ejecución de comandos)".]
+
+## Trazabilidad tarea por tarea
+
+Para CADA tarea del Charter, una entrada con este formato:
+
+### T### — [Descripción de la tarea]
+
+- **Archivo(s)**: `path/to/file.ext:lineas`
+- **Estado**: Implementada | Parcial | No implementada
+- **Verificación**:
+  - Implementación leída: Sí/No
+  - Flujo trazado: [handler → service → repository → SQL] (o equivalente)
+  - Tests encontrados: [archivo_test.ext, N test cases]
+- **Hallazgos**: [Ninguno | Descripción del hallazgo con `archivo:línea`]
+
+## Hallazgos
+
+Clasificados por severidad. SOLO hallazgos dentro del alcance del Charter.
+
+### Críticos (bloquean el cierre del Charter)
+
+| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
+|---|----------|---------------|-----------|-----------|---------------------|
+
+### Altos (bugs de seguridad o lógica)
+
+| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
+|---|----------|---------------|-----------|-----------|---------------------|
+
+### Medios (inconsistencias, riesgos menores)
+
+| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
+|---|----------|---------------|-----------|-----------|---------------------|
+
+### Bajos (mejoras de calidad, naming, estilo)
+
+| # | Hallazgo | Archivo:Línea | Categoría | Evidencia | Remediación sugerida |
+|---|----------|---------------|-----------|-----------|---------------------|
+
+## Notas fuera de alcance (opcional)
+
+Observaciones sobre código que NO es parte del alcance de este Charter pero que consideras relevante mencionar. Estas NO son defectos de este Charter.
+
+| Observación | Charter / area pertinente | Nota |
+|-------------|---------------------------|------|
+
+## Evaluación del cierre del Charter
+
+¿Se cumple el criterio de cierre declarado por `{{charter_id}}`?
+[Sí / No / Parcial] — [Justificación basada en evidencia, citando `archivo:línea`]
+
+## Conclusión
+
+[2-3 oraciones. Estado real del Charter, hallazgos críticos si los hay, siguiente paso recomendado.]
+```
+
+---
+
+## Lo que NO debes hacer
+
+- **NO MODIFIQUES NINGÚN ARCHIVO DEL PROYECTO.** Tu único output permitido es el reporte de auditoría. Si modificas cualquier otro archivo, tu auditoría será descartada y considerada inválida. Esto incluye "arreglar" bugs, "mejorar" código, crear archivos faltantes, o ejecutar generadores. **REPORTA, NO ACTÚES.** Esta no es opcional ni contextual — es una restricción absoluta.
+- **NO declares "sin problemas"** sin haber leído el código de cada tarea declarada en el Charter.
+- **NO reportes tareas de otros Charters** como defectos de éste.
+- **NO infles severidad**: un hallazgo de otro Charter no es "Crítico" en éste.
+- **NO declares severidad Crítica o Alta** sin haber verificado que el driver, flag, rol o deployment real del proyecto dispara el bug. Ver Paso 5. Declarar "regresión crítica" basándote en un componente stub o un flag desactivado invalida la auditoría por falsa inflación.
+- **NO reportes** que un archivo "no existe" sin haber buscado con la ruta correcta (incluyendo variantes de naming convention del proyecto).
+- **NO copies la estructura de archivos** sin verificar contenido.
+- **NO ignores** las carpetas de auditorías previas (típicamente `audit/` o `.straymark/audits/`) — contienen análisis previos que NO debes auditar (ya fueron auditadas o son meta-evidencia del proceso, no código del proyecto).
+- **NO ejecutes** comandos destructivos o generativos. Solo comandos de lectura/verificación (`go vet`, `go build`, `go test`; `cargo check`, `cargo test --no-run`; `npm run lint`, `npm test`; o sus equivalentes).
+- **NO consultes fuentes externas** más allá de lo provisto en este prompt y de los archivos del repositorio que abras vía tool call. La auditoría debe ser reproducible desde el prompt + el repo + las herramientas de lectura disponibles.
+
+---
+
+*Plantilla unificada StrayMark v1 — traducción ES. Las siete secciones universales (REGLA ABSOLUTA, Tu rol, Reglas de alcance, Paso 2 verificación obligatoria, Paso 5 calibración de severidad, Lo que NO debes hacer, Formato de salida) provienen del skill `audit/SKILL.md` maduro pre-StrayMark de Sentinel, contribuido vía issue #102 por José Villaseñor Montfort (StrangeDaysTech). Hardcodes específicos a Sentinel (paths de specs, headings de Etapa, módulos internos) parametrizados contra el Charter doc, originating AILOGs, git range y project context.*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.13.2"
+version: "4.13.3"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ The CLI automatically:
 
 1. **Download the latest release**
 
-   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.13.2`).
+   Go to [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) and download the latest `fw-*` release ZIP (e.g., `fw-4.13.3`).
 
 2. **Extract to your project**
    ```bash

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.13.2` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.2` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.13.3` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.12.3` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.2
+✔ Downloaded StrayMark fw-4.13.3
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.2
+✔ Framework updated to fw-4.13.3
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.2
+✔ Framework updated to fw-4.13.3
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.2                 │
+  │ Framework │ fw-4.13.3                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.2
+  Using version: fw-4.13.3
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1053,7 +1053,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.2
+  Framework version: fw-4.13.3
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -237,8 +237,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.13.2` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.12.2` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.13.3` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.12.3` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.13.2)
+# y descarga el último release fw-* (ej. fw-4.13.3)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -230,7 +230,7 @@ El CLI automáticamente:
 
 1. **Descargar el último release**
 
-   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.13.2`).
+   Ve a [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases) y descarga el último release `fw-*` (ej. `fw-4.13.3`).
 
 2. **Extraer en tu proyecto**
    ```bash

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.13.2` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.12.2` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.13.3` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.12.3` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.2
+✔ Downloaded StrayMark fw-4.13.3
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.2
+✔ Framework updated to fw-4.13.3
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.2
+✔ Framework updated to fw-4.13.3
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.13.2
+Framework version: fw-4.13.3
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -859,7 +859,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.2
+  Framework version: fw-4.13.3
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -255,8 +255,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.2` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.12.2` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.13.3` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.12.3` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.13.2）
+# 下载最新的 fw-* 发布（例如 fw-4.13.3）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -239,7 +239,7 @@ CLI 自动完成：
 
 1. **下载最新版本**
 
-   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.13.2`）。
+   前往 [GitHub Releases](https://github.com/StrangeDaysTech/straymark/releases)，下载最新的 `fw-*` 版本 ZIP（例如 `fw-4.13.3`）。
 
 2. **解压到你的项目**
    ```bash

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.2` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.12.2` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.13.3` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.12.3` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.2
+✔ Downloaded StrayMark fw-4.13.3
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.2
+✔ Framework updated to fw-4.13.3
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.2
+✔ Framework updated to fw-4.13.3
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.2                 │
+  │ Framework │ fw-4.13.3                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.2
+  Using version: fw-4.13.3
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -993,7 +993,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.2
+  Framework version: fw-4.13.3
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

- Aligns `dist/.straymark/audit-prompts/audit-prompt.md` with the framework's localization convention: **EN canonical at the root, ES translation under `i18n/es/`** (same pattern used by every other template, skill, and governance doc).
- Wires `straymark charter audit` to resolve the audit-prompt template through `StrayMarkConfig::resolve_language` + `resolve_localized_path` — the same i18n pipeline already used by `straymark new`, `straymark charter new`, and `straymark explore`. Spanish-speaking adopters (Sentinel) continue to receive a Spanish prompt automatically via the overlay; English and all other adopters now receive English out of the box.
- **Generalizes the Sentinel-specific "Etapa 12 Pub/Sub stub vs gochannel" example** in Step 5 (severity calibration) to a vendor-neutral "declared deferral, not a defect" illustration. Same anti-inflation discipline, no tying of new adopters to Sentinel's stack. Applied identically to EN canonical and ES overlay.

See the combined `CHANGELOG.md` entry `## Framework 4.13.3 / CLI 3.12.3` for full rationale and adopter guidance.

## Test plan

- [x] `cargo check` (clean)
- [x] `cargo build` (clean)
- [x] `cargo test` — full suite green. Pre-existing `audit_template_test.rs` tests updated to assert EN anchors (canonical file is now EN); 3 new tests in `charter_audit_test.rs` pin the i18n resolution:
  - `audit_prepare_uses_es_overlay_when_language_es` — `language: es` resolves the ES overlay.
  - `audit_prepare_falls_back_to_en_when_locale_overlay_missing` — `language: zh-CN` with no overlay present falls back to EN canonical.
  - `audit_prepare_uses_en_canonical_when_language_en` — explicit `language: en` always resolves to root, even if an overlay exists.
- [ ] **Manual end-to-end on Sentinel** post-release: after `straymark update-framework && straymark update-cli`, run `straymark charter audit CHARTER-NN` and verify `.straymark/audits/CHARTER-NN/audit-prompt.md` is rendered in Spanish (Sentinel's `config.yml` has `language: es`). Confirm the generalized example replaces the Etapa 12 anecdote.
- [ ] **Manual end-to-end on a fresh EN install**: `straymark init` in a temp dir, scaffold a charter, run `straymark charter audit` — verify the resolved prompt starts with `# Charter audit` (English).

## Files touched

- **Framework**: `dist/.straymark/audit-prompts/audit-prompt.md` (rewritten as EN), `dist/.straymark/audit-prompts/i18n/es/audit-prompt.md` (new), `dist/dist-manifest.yml` (version bump), 16 governance doc footers (EN + ES + zh-CN).
- **CLI**: `cli/src/commands/charter/audit.rs` (i18n wiring), `cli/Cargo.toml` + `cli/Cargo.lock` (version bump), `cli/tests/charter_audit_test.rs` (3 new tests), `cli/tests/audit_template_test.rs` (existing tests retargeted to EN anchors).
- **Docs**: 6 versioning tables (README + CLI-REFERENCE × EN/ES/zh-CN), 3 ADOPTION-GUIDE examples, multiple CLI-REFERENCE example-output snippets that previously hardcoded `fw-4.13.2`. All bumped uniformly to `fw-4.13.3` / `cli-3.12.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)