### PR TITLE
feat(framework+cli): fw-4.14.0 / cli-3.13.0 — Sentinel feedback cycle (closes #143, #145, #146 Proposal C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.14.0 / CLI 3.13.0 — Sentinel feedback cycle: shellcheck cleanup, regex extension, multi-batch AILOG ledger
+
+Closes three upstream issues filed by Sentinel during its CHARTER-17 cycle, all field-validated downstream and ready for upstream canonization. The unifying theme is **pre-announcement hardening**: each issue was discovered in real adopter usage, the fix is additive (zero ruptura para existing artifacts), and Sentinel can revert its local workaround once this release lands.
+
+### Added (Framework)
+
+- **`## Batch Ledger` section in `TEMPLATE-AILOG.md`** (EN + i18n/es + i18n/zh-CN) — opt-in canonical structure for AILOGs of Charters that span 3+ batches or >1 day of execution. Each batch entry starts as `(pending)`; `straymark charter batch-complete` substitutes the placeholder; `straymark charter drift` fails on any leftover at Charter close. Single-batch AILOGs continue to use `## Actions Performed` and skip the ledger entirely — the section is purely additive.
+- **Charter template §Tasks guidance** (EN + i18n/es + i18n/zh-CN) — new task #6 explicitly tells the Charter author to maintain a `## Batch Ledger` and run `batch-complete` per batch when execution is multi-batch. Single-batch Charters skip the step.
+
+### Changed (Framework)
+
+- **`dist/.github/workflows/docs-validation.yml`** — naming regex extended from `[0-9]{3}` to `[0-9]{3}[a-z]?` (closes [#145](https://github.com/StrangeDaysTech/straymark/issues/145)). The optional single-letter suffix resolves same-day same-sequence filename collisions without renumbering downstream entries (e.g. `AILOG-2026-05-02-028b` when `-028-` is taken). Lowercase only, single letter only — discourages multi-letter ad-hoc labels that would erode the convention.
+- **`dist/.github/workflows/docs-validation.yml`** — shellcheck cleanup (closes [#143](https://github.com/StrangeDaysTech/straymark/issues/143)). Removed unused `ERRORS=0` in the high-risk ETH compliance step; grouped repeated `echo ... >> "$GITHUB_STEP_SUMMARY"` blocks (SC2129) into `{ ... } >> "$..."` redirects for atomicity and readability; replaced `grep -v X | wc -l` with `grep -vc X` (SC2126); fixed `while read file` → `while IFS= read -r file` (SC2162). Adopters who add actionlint to their CI (e.g., Sentinel via `StrangeDaysTech/sentinel#72`) can now run `actionlint -color` cleanly without needing `-shellcheck=` or per-adopter `-ignore` patterns.
+- **`dist/.straymark/schemas/charter.schema.v0.json`** + **`dist/.straymark/schemas/charter-telemetry.schema.v0.json`** — `originating_ailogs` pattern extended to accept the optional letter suffix, in lockstep with the workflow regex.
+
+### Added (CLI)
+
+- **`straymark charter batch-complete <CHARTER-ID> <N>`** — new subcommand. Marks a Charter batch as complete in the originating AILOG's `## Batch Ledger`, substituting the `(pending)` placeholder. Three modes: interactive prompts by default (TTY-only, three short questions: files touched, tests, design note); one-shot via `--note "..."` (designed for agents and scripts); `--non-interactive` requires `--note` and aborts cleanly if missing. Refuses to overwrite an already-completed batch. Closes Proposal C of [#146](https://github.com/StrangeDaysTech/straymark/issues/146).
+- **`cli/src/ailog.rs`** (new module) — shared helpers for AILOG file discovery (`find_ailog_file`, `agent_logs_dir`) and `## Batch Ledger` parsing/editing (`parse_batch_ledger`, `pending_batches`, `write_batch_section`, `ensure_pending`). The file-discovery helpers were previously private to `commands/charter/drift.rs`; promoted to share with `batch_complete`.
+
+### Changed (CLI)
+
+- **`straymark charter drift`** — new **Batch Ledger gate**. When the Charter status is `in-progress` or `closed`, the command also checks every originating AILOG's `## Batch Ledger` for entries left as `(pending)` and fails with a clear diagnostic listing the missing batches. AILOGs without a ledger contribute nothing (the section is opt-in). New `--no-batch-ledger-check` flag bypasses the gate for adopters consolidating the ledger post-close. Charters in `declared` state never trip the gate (nothing has been executed yet).
+- **`cli/src/charter_schema.rs`** — `TEST_SCHEMA` literal updated to mirror the framework schema's `[0-9]{3}[a-z]?` pattern; three new tests pin the behavior (`accepts_ailog_id_with_letter_suffix`, `rejects_ailog_id_with_multiletter_suffix`, `rejects_ailog_id_with_uppercase_suffix`).
+
+### Deferred
+
+- **Proposal D of [#146](https://github.com/StrangeDaysTech/straymark/issues/146)** — cross-Charter `lessons-learned.md` index — intentionally **not** in this release. The artifact introduces a new canonical taxonomy (`LL-YYYY-MM-DD-NNN` IDs, frontmatter, promotion CLI, discovery integration with `explore`) and warrants a dedicated Charter post-announcement. Sentinel's local workaround for D stays in place; we'll revisit upstream after the web/announcement cycle lands.
+
+### Adopter guidance
+
+- `straymark update-framework` brings the new template sections and schema changes. Existing AILOGs without `## Batch Ledger` continue to work — the drift gate only activates when the section is present.
+- `straymark update-cli` brings the new `batch-complete` subcommand and the extended `drift` gate. Both are backward-compatible at the CLI surface (no existing flags renamed).
+- **Sentinel reconciliation path**: revert the local `actionlint -shellcheck=` flag, the local regex extension in `docs-validation.yml`, and the `CLAUDE.md` "Multi-batch Charter discipline (TRANSIENT)" subsection — all three are now load-bearing upstream.
+
+---
+
 ## Framework 4.13.4 — Close translation gaps (ISO-25010 reference + Charter template zh-CN)
 
 Framework-only patch that closes two translation coverage gaps surfaced by an audit of the project's i18n consistency. The audit confirmed that skills, workflows, schemas, and CLI-internal i18n are correctly aligned with the project principle (LLM-processed assets stay EN-only; human-primary artifacts get translated). Two specific files were the exception.

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.13.4` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.3` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.14.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.13.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.13.4)
+# and download the latest fw-* release (e.g., fw-4.14.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.12.3"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.12.3"
+version = "3.13.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/ailog.rs
+++ b/cli/src/ailog.rs
@@ -1,0 +1,396 @@
+//! AILOG helpers: file discovery and `## Batch Ledger` parsing/editing.
+//!
+//! Shared between `charter::drift` (close-time gate) and
+//! `charter::batch_complete` (per-batch update). The ledger format
+//! canonized in `dist/.straymark/templates/TEMPLATE-AILOG.md`:
+//!
+//! ```text
+//! ## Batch Ledger
+//!
+//! > (guidance blockquote — ignored by the parser)
+//!
+//! ### Batch 1 — [name from Charter §Tasks]
+//!
+//! (pending)
+//!
+//! ### Batch 2 — [name]
+//!
+//! (pending)
+//! ```
+//!
+//! A batch is "pending" iff its body — every line between the
+//! `### Batch <N>` heading and the next `###`/`##`/EOF, trimmed of
+//! surrounding whitespace — equals `(pending)` exactly, or is empty.
+
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Canonical sub-path (relative to project root) of the AILOG directory.
+pub fn agent_logs_dir(project_root: &Path) -> PathBuf {
+    project_root
+        .join(".straymark")
+        .join("07-ai-audit")
+        .join("agent-logs")
+}
+
+/// Find the AILOG file matching the given AILOG ID. Searches recursively
+/// and matches by filename prefix. The id may be bare
+/// (`AILOG-2026-05-02-028b`) or include a slug
+/// (`AILOG-2026-05-02-028b-foo`); both resolve to the same file.
+pub fn find_ailog_file(agent_logs_dir: &Path, ailog_id: &str) -> Option<PathBuf> {
+    let prefix: String = ailog_id
+        .split('-')
+        .take(5) // "AILOG", "YYYY", "MM", "DD", "NNN[a-z]?"
+        .collect::<Vec<_>>()
+        .join("-");
+    walk_for_prefix(agent_logs_dir, &prefix)
+}
+
+fn walk_for_prefix(dir: &Path, prefix: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = walk_for_prefix(&path, prefix) {
+                return Some(found);
+            }
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with(prefix) && name.ends_with(".md") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchEntry {
+    pub n: u32,
+    /// Full heading line, e.g. `### Batch 5 — Migration 022 + handlers`.
+    pub heading_line: String,
+    /// Byte offset of the first character of the body (line after the
+    /// heading + its trailing newline). Used by `write_batch_section`.
+    pub body_start: usize,
+    /// Byte offset one past the last character of the body (start of the
+    /// next `###`/`##` heading, or end-of-file).
+    pub body_end: usize,
+    /// Body content (between heading and next section), trimmed of
+    /// leading/trailing blank lines.
+    pub body: String,
+    pub is_pending: bool,
+}
+
+/// Parse the `## Batch Ledger` section. Returns `None` if the section
+/// is absent (signal to callers that the AILOG opted out of the ledger
+/// pattern).
+pub fn parse_batch_ledger(content: &str) -> Option<Vec<BatchEntry>> {
+    // Locate `## Batch Ledger` start.
+    let header_idx = find_section_offset(content, "## Batch Ledger")?;
+
+    // Locate end of the ledger section = next `## ` at column 0, or EOF.
+    let after_header = &content[header_idx..];
+    let ledger_end_rel = after_header
+        .match_indices('\n')
+        .filter_map(|(i, _)| {
+            // Skip the header's own line.
+            if i == 0 {
+                return None;
+            }
+            let line_start = i + 1;
+            let rest = &after_header[line_start..];
+            if rest.starts_with("## ") {
+                Some(line_start)
+            } else {
+                None
+            }
+        })
+        .next()
+        .unwrap_or(after_header.len());
+    let ledger_section = &after_header[..ledger_end_rel];
+
+    // Walk for `### Batch <N> — ...` sub-headings.
+    let mut entries: Vec<BatchEntry> = Vec::new();
+    let mut last_heading: Option<(u32, String, usize)> = None; // (n, heading_line, body_start_abs)
+
+    for (line_start_rel, line) in line_offsets(ledger_section) {
+        let abs_offset = header_idx + line_start_rel;
+        if let Some((n, _)) = parse_batch_heading(line) {
+            // Close the previous entry (if any) at this line's start.
+            if let Some((prev_n, prev_heading, prev_body_start)) = last_heading.take() {
+                let body_end_abs = abs_offset;
+                push_entry(&mut entries, content, prev_n, prev_heading, prev_body_start, body_end_abs);
+            }
+            // Body starts at the line AFTER the heading line.
+            let body_start_abs = abs_offset + line.len() + 1; // +1 for '\n'
+            last_heading = Some((n, line.to_string(), body_start_abs));
+        }
+    }
+    // Close the final entry at ledger_end.
+    if let Some((prev_n, prev_heading, prev_body_start)) = last_heading.take() {
+        let body_end_abs = header_idx + ledger_end_rel;
+        push_entry(&mut entries, content, prev_n, prev_heading, prev_body_start, body_end_abs);
+    }
+
+    Some(entries)
+}
+
+fn push_entry(
+    entries: &mut Vec<BatchEntry>,
+    content: &str,
+    n: u32,
+    heading_line: String,
+    body_start: usize,
+    body_end: usize,
+) {
+    let raw = &content[body_start..body_end];
+    let trimmed = raw.trim_matches(|c: char| c == '\n' || c == '\r').trim();
+    let is_pending = trimmed.is_empty() || trimmed == "(pending)";
+    entries.push(BatchEntry {
+        n,
+        heading_line,
+        body_start,
+        body_end,
+        body: trimmed.to_string(),
+        is_pending,
+    });
+}
+
+/// Return the batch numbers whose entries are still `(pending)`.
+pub fn pending_batches(content: &str) -> Vec<u32> {
+    match parse_batch_ledger(content) {
+        Some(entries) => entries.iter().filter(|e| e.is_pending).map(|e| e.n).collect(),
+        None => Vec::new(),
+    }
+}
+
+/// Replace the body of `### Batch <batch_number>` with `new_body` and write
+/// the file. Returns the previous body so the caller can decide whether to
+/// reject an overwrite.
+pub fn write_batch_section(
+    ailog_path: &Path,
+    batch_number: u32,
+    new_body: &str,
+) -> Result<BatchEntry> {
+    let content = std::fs::read_to_string(ailog_path)
+        .with_context(|| format!("Failed to read AILOG at {}", ailog_path.display()))?;
+
+    let entries = parse_batch_ledger(&content).ok_or_else(|| {
+        anyhow::anyhow!(
+            "AILOG at {} has no `## Batch Ledger` section.\n  hint: add the section (see TEMPLATE-AILOG.md) before running batch-complete.",
+            ailog_path.display()
+        )
+    })?;
+
+    let target = entries
+        .iter()
+        .find(|e| e.n == batch_number)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No `### Batch {}` heading in AILOG {}.\n  hint: add the heading to `## Batch Ledger` (the body should start as `(pending)`).",
+                batch_number,
+                ailog_path.display()
+            )
+        })?
+        .clone();
+
+    // Normalize body: ensure it starts with a blank line separator and ends
+    // with a trailing newline so the next section heading stays on its own
+    // line. The body slice [body_start..body_end] in the original content
+    // already includes the surrounding newlines; we replace it fully with
+    // "\n<new_body>\n\n".
+    let mut formatted = String::with_capacity(new_body.len() + 4);
+    formatted.push('\n');
+    formatted.push_str(new_body.trim());
+    formatted.push_str("\n\n");
+
+    let mut updated = String::with_capacity(content.len() + formatted.len());
+    updated.push_str(&content[..target.body_start]);
+    updated.push_str(&formatted);
+    updated.push_str(&content[target.body_end..]);
+
+    std::fs::write(ailog_path, updated)
+        .with_context(|| format!("Failed to write AILOG at {}", ailog_path.display()))?;
+    Ok(target)
+}
+
+/// Reject overwrite of an already-completed batch.
+pub fn ensure_pending(entry: &BatchEntry) -> Result<()> {
+    if !entry.is_pending {
+        bail!(
+            "Batch {} is already completed (body: `{}`). Refusing to overwrite — edit the AILOG manually if a correction is needed.",
+            entry.n,
+            truncate(&entry.body, 80)
+        );
+    }
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max).collect();
+        out.push('…');
+        out
+    }
+}
+
+fn find_section_offset(content: &str, heading: &str) -> Option<usize> {
+    let mut offset = 0;
+    for line in content.split_inclusive('\n') {
+        let trimmed_newline = line.trim_end_matches('\n').trim_end_matches('\r');
+        if trimmed_newline == heading {
+            return Some(offset);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+fn line_offsets(s: &str) -> impl Iterator<Item = (usize, &str)> {
+    let mut offset = 0;
+    s.split_inclusive('\n').map(move |line| {
+        let start = offset;
+        offset += line.len();
+        (start, line.trim_end_matches('\n').trim_end_matches('\r'))
+    })
+}
+
+fn parse_batch_heading(line: &str) -> Option<(u32, &str)> {
+    // Match `### Batch <N>` followed by space and optional ` — ...` or anything.
+    let rest = line.strip_prefix("### Batch ")?;
+    // The number is the leading digit run.
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    let n: u32 = digits.parse().ok()?;
+    Some((n, line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"# AILOG: Test
+
+## Actions Performed
+
+1. Stuff.
+
+## Batch Ledger
+
+> Use this section ...
+
+### Batch 1 — Setup
+
+Done on 2026-05-10. Files touched: a.rs, b.rs. Tests passing.
+
+### Batch 2 — Impl
+
+(pending)
+
+### Batch 3 — Tests
+
+(pending)
+
+## Modified Files
+
+| File | Lines |
+"#;
+
+    #[test]
+    fn parse_finds_three_batches() {
+        let entries = parse_batch_ledger(SAMPLE).expect("ledger present");
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].n, 1);
+        assert_eq!(entries[1].n, 2);
+        assert_eq!(entries[2].n, 3);
+    }
+
+    #[test]
+    fn parse_marks_pending_correctly() {
+        let entries = parse_batch_ledger(SAMPLE).unwrap();
+        assert!(!entries[0].is_pending, "Batch 1 is completed");
+        assert!(entries[1].is_pending, "Batch 2 is pending");
+        assert!(entries[2].is_pending, "Batch 3 is pending");
+    }
+
+    #[test]
+    fn pending_batches_returns_pending_only() {
+        assert_eq!(pending_batches(SAMPLE), vec![2, 3]);
+    }
+
+    #[test]
+    fn parse_returns_none_when_ledger_absent() {
+        let content = "# AILOG\n\n## Actions Performed\n\n1. Stuff.\n";
+        assert!(parse_batch_ledger(content).is_none());
+        assert!(pending_batches(content).is_empty());
+    }
+
+    #[test]
+    fn write_batch_section_replaces_pending_body() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("AILOG-2026-05-10-001-test.md");
+        std::fs::write(&path, SAMPLE).unwrap();
+
+        let prev = write_batch_section(&path, 2, "Implemented X and Y. Files: handler.go. Tests passing.").unwrap();
+        assert!(prev.is_pending);
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        let entries = parse_batch_ledger(&updated).unwrap();
+        assert!(!entries[1].is_pending, "Batch 2 should now be completed");
+        assert!(entries[1].body.contains("Implemented X"));
+        // Batch 3 must still be pending.
+        assert!(entries[2].is_pending, "Batch 3 must remain pending");
+        // Batch 1's body must still mention "Done on 2026-05-10".
+        assert!(entries[0].body.contains("Done on 2026-05-10"));
+    }
+
+    #[test]
+    fn write_batch_section_errors_when_batch_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("AILOG-2026-05-10-001-test.md");
+        std::fs::write(&path, SAMPLE).unwrap();
+
+        let err = write_batch_section(&path, 99, "x").unwrap_err();
+        assert!(err.to_string().contains("Batch 99"));
+    }
+
+    #[test]
+    fn write_batch_section_errors_when_ledger_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("AILOG-2026-05-10-001-test.md");
+        std::fs::write(&path, "# AILOG\n\nNo ledger.\n").unwrap();
+
+        let err = write_batch_section(&path, 1, "x").unwrap_err();
+        assert!(err.to_string().contains("Batch Ledger"));
+    }
+
+    #[test]
+    fn ensure_pending_rejects_completed_batch() {
+        let entry = BatchEntry {
+            n: 5,
+            heading_line: "### Batch 5".to_string(),
+            body_start: 0,
+            body_end: 0,
+            body: "Already done.".to_string(),
+            is_pending: false,
+        };
+        assert!(ensure_pending(&entry).is_err());
+    }
+
+    #[test]
+    fn find_ailog_file_matches_letter_suffix_id() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent_logs = tmp.path().join("agent-logs");
+        std::fs::create_dir_all(&agent_logs).unwrap();
+        let path = agent_logs.join("AILOG-2026-05-02-028b-collision.md");
+        std::fs::write(&path, "stub\n").unwrap();
+
+        let found = find_ailog_file(&agent_logs, "AILOG-2026-05-02-028b").unwrap();
+        assert_eq!(found, path);
+    }
+}

--- a/cli/src/charter_schema.rs
+++ b/cli/src/charter_schema.rs
@@ -226,7 +226,7 @@ mod tests {
                 "type": "array",
                 "items": {
                     "type": "string",
-                    "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}(-[a-z0-9-]+)?$"
+                    "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}[a-z]?(-[a-z0-9-]+)?$"
                 },
                 "minItems": 1
             },
@@ -273,6 +273,64 @@ originating_ailogs:
         );
         let issues = s.validate(&fm, Path::new("test.md"));
         assert!(issues.is_empty(), "unexpected issues: {:?}", issues);
+    }
+
+    #[test]
+    fn accepts_ailog_id_with_letter_suffix() {
+        // Optional single-letter suffix on the sequence number resolves
+        // same-day same-sequence filename collisions without renumbering
+        // downstream entries. Additive: existing IDs without suffix still pass.
+        let s = schema();
+        let fm = yaml(
+            r#"
+charter_id: CHARTER-02-collision
+status: declared
+effort_estimate: S
+trigger: "x"
+originating_ailogs:
+  - AILOG-2026-05-02-028b
+"#,
+        );
+        let issues = s.validate(&fm, Path::new("test.md"));
+        assert!(issues.is_empty(), "unexpected issues: {:?}", issues);
+    }
+
+    #[test]
+    fn rejects_ailog_id_with_multiletter_suffix() {
+        // Single letter only — discourages ad-hoc multi-letter labels that
+        // would erode the convention.
+        let s = schema();
+        let fm = yaml(
+            r#"
+charter_id: CHARTER-02-multiletter
+status: declared
+effort_estimate: S
+trigger: "x"
+originating_ailogs:
+  - AILOG-2026-05-02-028bc
+"#,
+        );
+        let issues = s.validate(&fm, Path::new("test.md"));
+        assert!(!issues.is_empty(), "expected pattern rejection for -028bc");
+    }
+
+    #[test]
+    fn rejects_ailog_id_with_uppercase_suffix() {
+        // Lowercase only — matches the existing [a-z0-9-]+ style elsewhere
+        // in the filename grammar.
+        let s = schema();
+        let fm = yaml(
+            r#"
+charter_id: CHARTER-02-upper
+status: declared
+effort_estimate: S
+trigger: "x"
+originating_ailogs:
+  - AILOG-2026-05-02-028B
+"#,
+        );
+        let issues = s.validate(&fm, Path::new("test.md"));
+        assert!(!issues.is_empty(), "expected pattern rejection for -028B");
     }
 
     #[test]

--- a/cli/src/commands/charter/batch_complete.rs
+++ b/cli/src/commands/charter/batch_complete.rs
@@ -1,0 +1,214 @@
+//! `straymark charter batch-complete <CHARTER-ID> <N>` — mark a Charter
+//! batch as complete in the AILOG `## Batch Ledger`.
+//!
+//! Default mode is interactive (TTY-only): prompts for files-touched,
+//! tests, and a design note, then formats the trio under the `### Batch <N>`
+//! heading. With `--note "..."` the command runs one-shot and writes the
+//! given string verbatim — designed for agents and scripts. With
+//! `--non-interactive` (requires `--note`), prompts are disabled outright
+//! so a missing `--note` aborts cleanly instead of hanging.
+//!
+//! Reads the originating AILOG from the Charter frontmatter
+//! `originating_ailogs[0]`. Rejects with a clear error if:
+//! - the Charter has no originating AILOG (cannot resolve target file)
+//! - the AILOG file is not found under `.straymark/07-ai-audit/agent-logs/`
+//! - the AILOG has no `## Batch Ledger` section
+//! - no `### Batch <N>` heading exists in the ledger
+//! - the target batch is already completed (refuses overwrite)
+//!
+//! Companion of `charter::drift`, which gates Charter close on any
+//! `### Batch N` left as `(pending)`.
+
+use anyhow::{anyhow, bail, Context, Result};
+use colored::Colorize;
+
+use crate::ailog;
+use crate::charter;
+use crate::prompts;
+use crate::utils;
+
+pub fn run(
+    path: &str,
+    charter_id: &str,
+    batch_number: u32,
+    note: Option<&str>,
+    non_interactive: bool,
+) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
+    let project_root = &resolved.path;
+
+    // Resolve Charter by ID.
+    let (charters, _errors) = charter::discover_and_parse(project_root);
+    let charter = charter::find_by_id(&charters, charter_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "Charter {} not found in .straymark/charters/.\n  hint: run `straymark charter list` to see discovered Charters.",
+                charter_id
+            )
+        })?
+        .clone();
+
+    let ailog_ids = match &charter.frontmatter.originating_ailogs {
+        Some(ids) if !ids.is_empty() => ids.clone(),
+        _ => bail!(
+            "Charter {} has no `originating_ailogs` in frontmatter.\n  hint: batch-complete writes to the originating AILOG; add it to the Charter or run the command directly on the AILOG file.",
+            charter.frontmatter.charter_id
+        ),
+    };
+    let ailog_id = &ailog_ids[0];
+    if ailog_ids.len() > 1 {
+        eprintln!(
+            "{} Charter has {} originating AILOGs; using the first one ({}).",
+            "note:".cyan().bold(),
+            ailog_ids.len(),
+            ailog_id
+        );
+    }
+
+    let agent_logs_dir = ailog::agent_logs_dir(project_root);
+    if !agent_logs_dir.exists() {
+        bail!(
+            "AILOG directory not found at {}. Run `straymark repair` to restore framework files.",
+            agent_logs_dir.display()
+        );
+    }
+    let ailog_path = ailog::find_ailog_file(&agent_logs_dir, ailog_id).ok_or_else(|| {
+        anyhow!(
+            "AILOG file for {} not found under {}.\n  hint: the file must be named `{}-<slug>.md`.",
+            ailog_id,
+            agent_logs_dir.display(),
+            ailog_id
+        )
+    })?;
+
+    let ailog_path_rel = ailog_path
+        .strip_prefix(project_root)
+        .unwrap_or(&ailog_path)
+        .to_path_buf();
+
+    // Pre-flight: confirm the batch exists AND is pending. We do this before
+    // any user input so the operator does not waste effort on a rejected
+    // batch.
+    let pre_content = std::fs::read_to_string(&ailog_path)
+        .with_context(|| format!("Failed to read AILOG at {}", ailog_path.display()))?;
+    let entries = ailog::parse_batch_ledger(&pre_content).ok_or_else(|| {
+        anyhow!(
+            "AILOG at {} has no `## Batch Ledger` section.\n  hint: add the section to the AILOG (see TEMPLATE-AILOG.md) before running batch-complete.\n  This Charter does not need the ledger if it is a single-batch effort — `## Actions Performed` is sufficient.",
+            ailog_path_rel.display()
+        )
+    })?;
+    let target = entries
+        .iter()
+        .find(|e| e.n == batch_number)
+        .ok_or_else(|| {
+            anyhow!(
+                "No `### Batch {}` heading in AILOG {}.\n  hint: add `### Batch {} — <name>` followed by `(pending)` to the `## Batch Ledger` section.\n  Existing batches: {}",
+                batch_number,
+                ailog_path_rel.display(),
+                batch_number,
+                if entries.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    entries.iter().map(|e| format!("Batch {}", e.n)).collect::<Vec<_>>().join(", ")
+                }
+            )
+        })?
+        .clone();
+    ailog::ensure_pending(&target)?;
+
+    println!(
+        "{} AILOG: {}",
+        "✔".green().bold(),
+        ailog_path_rel.display().to_string().dimmed()
+    );
+    println!(
+        "{} {}",
+        "✔".green().bold(),
+        target.heading_line.dimmed()
+    );
+
+    // Collect the new body.
+    let body = if let Some(n) = note {
+        n.to_string()
+    } else if non_interactive {
+        // --non-interactive requires --note; clap enforces this via `requires`,
+        // but we keep a defensive bail just in case.
+        bail!("--non-interactive requires --note");
+    } else {
+        prompts::require_interactive()?;
+        collect_interactively()?
+    };
+
+    if body.trim().is_empty() {
+        bail!(
+            "Refusing to write an empty batch body — that would leave the batch indistinguishable from `(pending)`. Pass `--note \"...\"` or fill the prompts."
+        );
+    }
+    if body.trim() == "(pending)" {
+        bail!(
+            "Refusing to write a `(pending)` body verbatim — that defeats the gate. Either supply real content or skip the command for this batch."
+        );
+    }
+
+    let _prev = ailog::write_batch_section(&ailog_path, batch_number, &body)?;
+    println!();
+    println!(
+        "{} `### Batch {}` written.",
+        "OK".green().bold(),
+        batch_number
+    );
+    println!(
+        "{} `git add {}` before pushing the batch commit so the AILOG ledger update lands atomically with the work it documents.",
+        "Reminder:".yellow().bold(),
+        ailog_path_rel.display()
+    );
+
+    Ok(())
+}
+
+/// Interactive flow: three short prompts (files, tests, design note), joined
+/// into a single batch body. Empty fields are skipped in the output.
+fn collect_interactively() -> Result<String> {
+    println!();
+    println!("{}", "Collecting batch notes — press Enter on blank line to skip a section.".dimmed());
+    println!();
+
+    let files = prompts::prompt_string(
+        "Files touched (one-line summary, e.g. `migrations/022.sql, handlers/x.go`)",
+        None,
+        true,
+    )?;
+    let tests = prompts::prompt_string(
+        "Tests added or status (e.g. `handler_x_test.go +12 -0, passing`)",
+        None,
+        true,
+    )?;
+    println!(
+        "{}",
+        "Design note / lessons (multiline; finish with `.` on a line by itself, or Ctrl-D):"
+            .dimmed()
+    );
+    let design = prompts::prompt_multiline("note")?;
+
+    let mut body = String::new();
+    let mut wrote = false;
+    if !files.trim().is_empty() {
+        body.push_str(&format!("- **Files**: {}", files.trim()));
+        wrote = true;
+    }
+    if !tests.trim().is_empty() {
+        if wrote {
+            body.push('\n');
+        }
+        body.push_str(&format!("- **Tests**: {}", tests.trim()));
+        wrote = true;
+    }
+    if !design.trim().is_empty() {
+        if wrote {
+            body.push_str("\n\n");
+        }
+        body.push_str(design.trim());
+    }
+    Ok(body)
+}

--- a/cli/src/commands/charter/drift.rs
+++ b/cli/src/commands/charter/drift.rs
@@ -26,7 +26,8 @@ use colored::Colorize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::charter::{self, Charter};
+use crate::ailog;
+use crate::charter::{self, Charter, CharterStatus};
 use crate::utils;
 
 const DEFAULT_RANGE: &str = "HEAD~1..HEAD";
@@ -36,6 +37,7 @@ pub fn run(
     charter_id: &str,
     range: Option<&str>,
     no_ailog_suppress: bool,
+    no_batch_ledger_check: bool,
 ) -> Result<()> {
     let resolved = utils::resolve_project_root(path)
         .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
@@ -172,10 +174,10 @@ pub fn run(
         }
     }
 
-    // Final exit code: if AILOG-suppression cleared all omitted paths, the
-    // script-reported exit is overridden to 0 (the user did the right thing
-    // by documenting the risk in an AILOG).
-    let final_exit = if raw_exit == 1 && omitted_after.is_empty() && !suppressions.is_empty() {
+    // Final exit code from file-vs-commit drift: if AILOG-suppression cleared
+    // all omitted paths, the script-reported exit is overridden to 0 (the user
+    // did the right thing by documenting the risk in an AILOG).
+    let drift_exit = if raw_exit == 1 && omitted_after.is_empty() && !suppressions.is_empty() {
         println!();
         println!(
             "{} all declared-omitted paths are documented in AILOGs — drift accepted.",
@@ -186,10 +188,80 @@ pub fn run(
         raw_exit
     };
 
+    // Batch Ledger gate (cli-3.13.0, GH #146): if the Charter is past `declared`
+    // and any AILOG `### Batch N` is still `(pending)`, reject. Skipped when:
+    //   - `--no-batch-ledger-check` flag is set
+    //   - Charter status is `declared` (nothing has been executed yet)
+    //   - the AILOG does not have a `## Batch Ledger` section (opt-in pattern)
+    let mut ledger_failures: Vec<(String, Vec<u32>)> = Vec::new();
+    if !no_batch_ledger_check
+        && !matches!(charter.frontmatter.status, CharterStatus::Declared)
+    {
+        if let Some(ids) = &charter.frontmatter.originating_ailogs {
+            ledger_failures = collect_pending_batch_failures(project_root, ids);
+        }
+    }
+
+    if !ledger_failures.is_empty() {
+        println!();
+        println!(
+            "{} {} AILOG(s) have `### Batch N` entries still marked `(pending)`:",
+            "WARNING:".red().bold(),
+            ledger_failures.len()
+        );
+        for (ailog_id, batches) in &ledger_failures {
+            let list = batches
+                .iter()
+                .map(|n| format!("Batch {}", n))
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("  - {}: {}", ailog_id, list);
+        }
+        println!();
+        println!(
+            "  Action: run `straymark charter batch-complete {} <N>` for each pending batch,\n          or pass `--no-batch-ledger-check` if the ledger is intentionally consolidated post-close.",
+            charter.frontmatter.charter_id
+        );
+    }
+
+    let final_exit = if !ledger_failures.is_empty() {
+        1
+    } else {
+        drift_exit
+    };
+
     if final_exit != 0 {
         std::process::exit(final_exit);
     }
     Ok(())
+}
+
+/// For each AILOG referenced by the Charter, parse its `## Batch Ledger` and
+/// collect (ailog_id, [pending batch numbers]) when at least one batch is
+/// pending. AILOGs without a ledger contribute nothing — the section is
+/// opt-in.
+fn collect_pending_batch_failures(
+    project_root: &Path,
+    ailog_ids: &[String],
+) -> Vec<(String, Vec<u32>)> {
+    let agent_logs_dir = ailog::agent_logs_dir(project_root);
+    if !agent_logs_dir.exists() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for ailog_id in ailog_ids {
+        let Some(path) = ailog::find_ailog_file(&agent_logs_dir, ailog_id) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let pending = ailog::pending_batches(&content);
+        if !pending.is_empty() {
+            out.push((ailog_id.clone(), pending));
+        }
+    }
+    out
 }
 
 /// Locate `bash` in PATH. Returns `None` if not found. We resolve it
@@ -263,10 +335,7 @@ fn compute_ailog_suppressions(
         _ => return Ok(hits),
     };
 
-    let agent_logs_dir = project_root
-        .join(".straymark")
-        .join("07-ai-audit")
-        .join("agent-logs");
+    let agent_logs_dir = ailog::agent_logs_dir(project_root);
     if !agent_logs_dir.exists() {
         return Ok(hits);
     }
@@ -274,7 +343,7 @@ fn compute_ailog_suppressions(
     // Collect Risk sections from all referenced AILOGs once.
     let mut risk_blobs: Vec<(String, String)> = Vec::new();
     for ailog_id in &ailog_ids {
-        if let Some(path) = find_ailog_file(&agent_logs_dir, ailog_id) {
+        if let Some(path) = ailog::find_ailog_file(&agent_logs_dir, ailog_id) {
             if let Ok(content) = std::fs::read_to_string(&path) {
                 if let Some(risk) = extract_risk_section(&content) {
                     risk_blobs.push((ailog_id.clone(), risk));
@@ -292,39 +361,6 @@ fn compute_ailog_suppressions(
         }
     }
     Ok(hits)
-}
-
-/// Find the AILOG file matching the given AILOG ID. Searches the agent-logs
-/// directory recursively and matches by filename prefix (since AILOG files are
-/// named `AILOG-YYYY-MM-DD-NNN-slug.md`).
-fn find_ailog_file(agent_logs_dir: &Path, ailog_id: &str) -> Option<PathBuf> {
-    // The id may be either bare (AILOG-2026-05-02-001) or include a slug
-    // (AILOG-2026-05-02-001-foo). We match the bare prefix.
-    let prefix: String = ailog_id
-        .split('-')
-        .take(5) // "AILOG", "YYYY", "MM", "DD", "NNN"
-        .collect::<Vec<_>>()
-        .join("-");
-    walk_for_prefix(agent_logs_dir, &prefix)
-}
-
-fn walk_for_prefix(dir: &Path, prefix: &str) -> Option<PathBuf> {
-    let entries = std::fs::read_dir(dir).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            if let Some(found) = walk_for_prefix(&path, prefix) {
-                return Some(found);
-            }
-            continue;
-        }
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if name.starts_with(prefix) && name.ends_with(".md") {
-                return Some(path);
-            }
-        }
-    }
-    None
 }
 
 /// Extract the `## Risk` / `## Riesgos` / `## 风险` section body from an AILOG.
@@ -432,31 +468,79 @@ bla.
         assert!(extract_risk_section(ailog).is_none());
     }
 
+    // Note: `find_ailog_file` tests now live in `crate::ailog` since the
+    // function was promoted to the shared module for use by `batch_complete`.
+
     #[test]
-    fn find_ailog_file_matches_prefix_with_slug() {
+    fn collect_pending_batch_failures_finds_pending_entries() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let agent_logs = tmp.path().join("agent-logs");
+        let agent_logs = tmp.path().join(".straymark/07-ai-audit/agent-logs");
         std::fs::create_dir_all(&agent_logs).unwrap();
-        let path = agent_logs.join("AILOG-2026-04-28-024-implement-baseline.md");
-        std::fs::write(&path, "stub\n").unwrap();
+        let ailog = agent_logs.join("AILOG-2026-05-13-001-test.md");
+        std::fs::write(
+            &ailog,
+            r#"# AILOG
+## Batch Ledger
 
-        let found = find_ailog_file(&agent_logs, "AILOG-2026-04-28-024").unwrap();
-        assert_eq!(found, path);
+### Batch 1 — Setup
 
-        // Also match when the full id with slug is given.
-        let found2 = find_ailog_file(&agent_logs, "AILOG-2026-04-28-024-implement-baseline").unwrap();
-        assert_eq!(found2, path);
+Done.
+
+### Batch 2 — Impl
+
+(pending)
+
+### Batch 3 — Tests
+
+(pending)
+"#,
+        )
+        .unwrap();
+
+        let report =
+            collect_pending_batch_failures(tmp.path(), &["AILOG-2026-05-13-001".to_string()]);
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].0, "AILOG-2026-05-13-001");
+        assert_eq!(report[0].1, vec![2, 3]);
     }
 
     #[test]
-    fn find_ailog_file_recurses_into_subdirs() {
+    fn collect_pending_batch_failures_skips_when_ledger_absent() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let nested = tmp.path().join("agent-logs").join("daemon");
-        std::fs::create_dir_all(&nested).unwrap();
-        let path = nested.join("AILOG-2026-05-01-002-foo.md");
-        std::fs::write(&path, "stub\n").unwrap();
+        let agent_logs = tmp.path().join(".straymark/07-ai-audit/agent-logs");
+        std::fs::create_dir_all(&agent_logs).unwrap();
+        let ailog = agent_logs.join("AILOG-2026-05-13-002-test.md");
+        std::fs::write(&ailog, "# AILOG\n\n## Actions Performed\n\n1. Stuff.\n").unwrap();
 
-        let found = find_ailog_file(&tmp.path().join("agent-logs"), "AILOG-2026-05-01-002").unwrap();
-        assert_eq!(found, path);
+        let report =
+            collect_pending_batch_failures(tmp.path(), &["AILOG-2026-05-13-002".to_string()]);
+        assert!(report.is_empty(), "no ledger → no gate");
+    }
+
+    #[test]
+    fn collect_pending_batch_failures_passes_when_all_filled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent_logs = tmp.path().join(".straymark/07-ai-audit/agent-logs");
+        std::fs::create_dir_all(&agent_logs).unwrap();
+        let ailog = agent_logs.join("AILOG-2026-05-13-003-test.md");
+        std::fs::write(
+            &ailog,
+            r#"# AILOG
+## Batch Ledger
+
+### Batch 1 — Setup
+
+Done.
+
+### Batch 2 — Impl
+
+Done too.
+"#,
+        )
+        .unwrap();
+
+        let report =
+            collect_pending_batch_failures(tmp.path(), &["AILOG-2026-05-13-003".to_string()]);
+        assert!(report.is_empty(), "all batches filled → no failures");
     }
 }

--- a/cli/src/commands/charter/mod.rs
+++ b/cli/src/commands/charter/mod.rs
@@ -7,6 +7,7 @@
 //! Phase 3 will add `audit` (multi-model external audit).
 
 pub mod audit;
+pub mod batch_complete;
 pub mod close;
 pub mod drift;
 pub mod list;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@ use colored::Colorize;
 
 #[cfg(feature = "analyze")]
 mod analysis_engine;
+mod ailog;
 mod audit_engine;
 mod audit_schema;
 mod charter;
@@ -309,6 +310,29 @@ enum CharterCommands {
         #[arg(long = "path", default_value = ".")]
         path: String,
     },
+    /// Mark a Charter batch as complete in the AILOG `## Batch Ledger`.
+    /// For multi-batch Charters (3+ batches or >1 day): substitutes the
+    /// `(pending)` placeholder under `### Batch <N>` with batch notes
+    /// captured interactively (default) or via --note (one-shot / scripted).
+    /// The `straymark charter drift` close-time gate rejects any batch left
+    /// as `(pending)`.
+    BatchComplete {
+        /// Charter identifier (CHARTER-NN, CHARTER-NN-slug, or just NN)
+        charter_id: String,
+        /// Batch number (1-based) — matches the `### Batch <N>` heading in the
+        /// AILOG `## Batch Ledger` section.
+        batch_number: u32,
+        /// Pre-filled batch note body. With this flag, the command writes the
+        /// note non-interactively and skips prompts. Use for scripts / agents.
+        #[arg(long)]
+        note: Option<String>,
+        /// Skip prompts. Requires --note (no batch content can be inferred).
+        #[arg(long, requires = "note")]
+        non_interactive: bool,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
     /// Orchestrate a multi-model external audit cycle (3-step: prepare,
     /// calibrate, finalize). Phase 3 v0 is orchestration-only — the CLI
     /// resolves prompts, validates auditor outputs, and prints findings
@@ -366,6 +390,12 @@ enum CharterCommands {
         /// even if documented in an AILOG).
         #[arg(long)]
         no_ailog_suppress: bool,
+        /// Disable the Batch Ledger gate (do not fail on `### Batch N (pending)`
+        /// entries in AILOGs referenced by this Charter). Use only when the
+        /// adopter has explicitly opted out of the ledger pattern for this
+        /// Charter (e.g., consolidating post-close).
+        #[arg(long)]
+        no_batch_ledger_check: bool,
         /// Project directory (default: current directory)
         #[arg(long = "path", default_value = ".")]
         path: String,
@@ -488,12 +518,27 @@ fn main() {
                 charter_id,
                 range,
                 no_ailog_suppress,
+                no_batch_ledger_check,
                 path,
             } => commands::charter::drift::run(
                 &path,
                 &charter_id,
                 range.as_deref(),
                 no_ailog_suppress,
+                no_batch_ledger_check,
+            ),
+            CharterCommands::BatchComplete {
+                charter_id,
+                batch_number,
+                note,
+                non_interactive,
+                path,
+            } => commands::charter::batch_complete::run(
+                &path,
+                &charter_id,
+                batch_number,
+                note.as_deref(),
+                non_interactive,
             ),
             CharterCommands::Audit {
                 charter_id,

--- a/cli/src/prompts.rs
+++ b/cli/src/prompts.rs
@@ -88,9 +88,7 @@ pub fn prompt_string_array(label: &str) -> Result<Vec<String>> {
 
 /// Prompt for a multi-line block. Reads lines from stdin until a line
 /// containing only `.` or EOF (Ctrl-D) is seen. Returns the joined lines
-/// without the terminator. Slated for use by `straymark approve --notes` in
-/// Phase 2 PR 5.
-#[allow(dead_code)]
+/// without the terminator.
 pub fn prompt_multiline(label: &str) -> Result<String> {
     use std::io::{self, BufRead, Write};
     print!("{label} (end with a single '.' on a line, or Ctrl-D):\n");

--- a/dist/.github/workflows/docs-validation.yml
+++ b/dist/.github/workflows/docs-validation.yml
@@ -86,7 +86,11 @@ jobs:
           # don't match any prefix and are silently skipped — no manual
           # exclude list to maintain.
           PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
-          VALID_PATTERN="^(${DOC_TYPE_PREFIXES})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}-[a-z0-9-]+\.md$"
+          # Optional single-letter suffix on the sequence number lets adopters
+          # resolve same-day same-sequence filename collisions without
+          # renumbering downstream entries (e.g. `-028b-` when `-028-` is
+          # already taken by an earlier-committed file on the same date).
+          VALID_PATTERN="^(${DOC_TYPE_PREFIXES})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}[a-z]?-[a-z0-9-]+\.md$"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             filename=$(basename "$file")
@@ -100,7 +104,9 @@ jobs:
             # File starts with a DocType prefix — validate the full pattern.
             if ! echo "$filename" | grep -qE "$VALID_PATTERN"; then
               echo "  ✗ Invalid naming: $filename"
-              echo "    Expected: [TYPE]-[YYYY-MM-DD]-[NNN]-[description].md"
+              echo "    Expected: [TYPE]-[YYYY-MM-DD]-[NNN]<a>-[description].md"
+              echo "    Where <a> is an optional single lowercase letter for same-day"
+              echo "    same-sequence collisions (e.g. -028b- when -028- is taken)."
               echo "    Valid TYPEs: ${DOC_TYPE_PREFIXES//|/, }"
               ERRORS=$((ERRORS + 1))
             else
@@ -326,8 +332,11 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           echo "📋 Checking compliance: high-risk documents must reference an ETH..."
-          ERRORS=0
 
+          # NOTE: Missing-ETH is intentionally a warning (not an error) — adopters
+          # may file the ETH later in a follow-up document. No ERRORS counter is
+          # kept because there is no exit-1 path; the warnings ride through the
+          # normal CI run and surface in the GitHub Actions UI.
           PREFIX_RE="^(${DOC_TYPE_PREFIXES})-"
 
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
@@ -410,16 +419,16 @@ jobs:
           IFS='|' read -ra TYPES <<< "$DOC_TYPE_PREFIXES"
 
           # Header
-          echo "## StrayMark Governance Metrics" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Generated: $(date -u +"%Y-%m-%d %H:%M UTC")" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-
-          # Document counts by type
-          echo "### Documents by Type" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Type | Count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|------|------:|" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## StrayMark Governance Metrics"
+            echo ""
+            echo "Generated: $(date -u +"%Y-%m-%d %H:%M UTC")"
+            echo ""
+            echo "### Documents by Type"
+            echo ""
+            echo "| Type | Count |"
+            echo "|------|------:|"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           TOTAL=0
           for TYPE in "${TYPES[@]}"; do
@@ -427,32 +436,34 @@ jobs:
             TOTAL=$((TOTAL + COUNT))
             echo "| $TYPE | $COUNT |" >> "$GITHUB_STEP_SUMMARY"
           done
-          echo "| **TOTAL** | **$TOTAL** |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Documents from the last 7 days
-          echo "### Recent Documents (last 7 days)" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
           WEEK_AGO=$(date -u -d "7 days ago" +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d 2>/dev/null || echo "0000-00-00")
           RECENT=$(find "$STRAYMARK_DIR" -name "*.md" -not -path "*/templates/*" -newer <(date -d "$WEEK_AGO" +%s 2>/dev/null || echo /dev/null) 2>/dev/null | wc -l || echo 0)
-          echo "Documents created/modified in the last 7 days: **$RECENT**" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Risk level distribution
-          echo "### Risk Level Distribution" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Risk Level | Count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|------------|------:|" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "| **TOTAL** | **$TOTAL** |"
+            echo ""
+            echo "### Recent Documents (last 7 days)"
+            echo ""
+            echo "Documents created/modified in the last 7 days: **$RECENT**"
+            echo ""
+            echo "### Risk Level Distribution"
+            echo ""
+            echo "| Risk Level | Count |"
+            echo "|------------|------:|"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           for RISK in low medium high critical; do
-            RISK_COUNT=$(grep -rl "^risk_level: *$RISK" "$STRAYMARK_DIR" --include="*.md" 2>/dev/null | grep -v templates | wc -l)
+            RISK_COUNT=$(grep -rl "^risk_level: *$RISK" "$STRAYMARK_DIR" --include="*.md" 2>/dev/null | grep -vc templates || echo 0)
             echo "| $RISK | $RISK_COUNT |" >> "$GITHUB_STEP_SUMMARY"
           done
-          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Review compliance rate
-          echo "### Review Compliance" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "### Review Compliance"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
           HIGH_RISK_DOCS=$(grep -rl "^risk_level: *\(high\|critical\)" "$STRAYMARK_DIR" --include="*.md" 2>/dev/null | grep -v templates || true)
           HIGH_COUNT=$(echo "$HIGH_RISK_DOCS" | grep -c . 2>/dev/null || echo 0)
           if [ "$HIGH_COUNT" -gt 0 ]; then
@@ -499,11 +510,13 @@ jobs:
           # List documents by folder
           for folder in .straymark/*/; do
             folder_name=$(basename "$folder")
-            echo "" >> .straymark/INDEX.md
-            echo "## ${folder_name}" >> .straymark/INDEX.md
-            echo "" >> .straymark/INDEX.md
+            {
+              echo ""
+              echo "## ${folder_name}"
+              echo ""
+            } >> .straymark/INDEX.md
 
-            find "$folder" -name "*.md" -type f | sort | while read file; do
+            find "$folder" -name "*.md" -type f | sort | while IFS= read -r file; do
               filename=$(basename "$file")
               # Extract title from front-matter or use filename
               title=$(grep "^title:" "$file" 2>/dev/null | sed 's/title: *//' | head -1 || echo "$filename")

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -313,4 +313,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -306,4 +306,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -305,4 +305,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.13.4 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.13.4 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/schemas/charter-telemetry.schema.v0.json
+++ b/dist/.straymark/schemas/charter-telemetry.schema.v0.json
@@ -39,7 +39,7 @@
             "properties": {
               "ailog_id": {
                 "type": "string",
-                "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}(-[a-z0-9-]+)?$"
+                "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}[a-z]?(-[a-z0-9-]+)?$"
               },
               "still_relevant_at_execution": { "type": "boolean" },
               "relevance_notes": { "type": "string" }

--- a/dist/.straymark/schemas/charter.schema.v0.json
+++ b/dist/.straymark/schemas/charter.schema.v0.json
@@ -32,7 +32,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}(-[a-z0-9-]+)?$"
+        "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}[a-z]?(-[a-z0-9-]+)?$"
       },
       "minItems": 1,
       "description": "AILOG IDs that motivated this Charter. Used in maintenance / post-MVP mode (the Sentinel case). Mutually exclusive with originating_spec; both may be absent if the Charter was scaffolded without an explicit origin."

--- a/dist/.straymark/templates/TEMPLATE-AILOG.md
+++ b/dist/.straymark/templates/TEMPLATE-AILOG.md
@@ -36,6 +36,24 @@ related: []
 2. [Action 2]
 3. [Action 3]
 
+## Batch Ledger
+
+> Use this section for Charters that span 3+ batches or >1 day of execution.
+> Update each batch entry **immediately after** its commit lands, using
+> `straymark charter batch-complete <CHARTER-ID> <N>`. Entries left as
+> `(pending)` at Charter close cause `straymark charter drift` to fail.
+>
+> Omit this section entirely for single-batch or single-session AILOGs —
+> `## Actions Performed` above is sufficient there.
+
+### Batch 1 — [name from Charter §Tasks]
+
+(pending)
+
+### Batch 2 — [name from Charter §Tasks]
+
+(pending)
+
 ## Modified Files
 
 | File | Lines Changed (+/-) | Change Description |

--- a/dist/.straymark/templates/charter/charter-template.md
+++ b/dist/.straymark/templates/charter/charter-template.md
@@ -120,15 +120,21 @@ follow-up insights are captured if the risk surfaces lessons for a later cycle.]
 3. [Implementation task 2].
 4. [...]
 5. AILOG (`risk_level: [low|medium|high]`, `review_required: [true|false]`).
-6. Local verification passes clean.
-7. **Auto-checklist drift** (when Phase 2 of the CLI roadmap ships):
+6. **For multi-batch execution (3+ batches or >1 day)**: maintain a
+   `## Batch Ledger` in the AILOG. After each batch commit, run
+   `straymark charter batch-complete <CHARTER-ID> <N>` to update the
+   ledger before pushing. The drift gate at close will reject any
+   `### Batch N` left as `(pending)`. Skip this step for single-batch
+   Charters — `## Actions Performed` in the AILOG suffices.
+7. Local verification passes clean.
+8. **Auto-checklist drift** (when Phase 2 of the CLI roadmap ships):
    `straymark charter drift CHARTER-NN <range>` to detect drifts between declared
    and modified files **before** commit. If it reports omissions, complete the work
    or document in the AILOG under `## Risk` as `R<N+1> (new, not in Charter)`. If it
    reports scope expansion, document in the AILOG the reason (mock updates, generated
    files, drift fix pre-existing, etc.). Until Phase 2 ships, run Sentinel's
    `check-plan-drift.sh` manually for the same effect.
-8. Commit + push + open PR.
+9. Commit + push + open PR.
 
 ## Charter Closure
 

--- a/dist/.straymark/templates/charter/i18n/es/charter-template.md
+++ b/dist/.straymark/templates/charter/i18n/es/charter-template.md
@@ -123,15 +123,21 @@ captura el follow-up si el riesgo destapa lecciones para un ciclo posterior.]
 3. [Tarea de implementación 2].
 4. [...]
 5. AILOG (`risk_level: [low|medium|high]`, `review_required: [true|false]`).
-6. Verification local pasa limpio.
-7. **Auto-checklist drift** (cuando entregue Fase 2 del CLI roadmap):
+6. **Para ejecución multi-batch (3+ lotes o >1 día)**: mantener una
+   `## Batch Ledger` en el AILOG. Después de cada commit de lote, correr
+   `straymark charter batch-complete <CHARTER-ID> <N>` para actualizar
+   la bitácora antes de pushear. El drift gate al cierre rechazará
+   cualquier `### Batch N` que quede como `(pending)`. Saltar este paso
+   en Charters de un solo lote — `## Acciones Realizadas` en el AILOG basta.
+7. Verification local pasa limpio.
+8. **Auto-checklist drift** (cuando entregue Fase 2 del CLI roadmap):
    `straymark charter drift CHARTER-NN <range>` para detectar drifts entre lo declarado
    y lo modificado **antes** del commit. Si reporta omisiones, completar el trabajo
    o documentar en AILOG bajo `## Risk` como `R<N+1> (nuevo, no en Charter)`. Si
    reporta scope expansion, documentar en AILOG el motivo (mock updates, generated
    files, drift fix pre-existente, etc.). Hasta que Fase 2 entregue, correr el
    `check-plan-drift.sh` de Sentinel manualmente para el mismo efecto.
-8. Commit + push + abrir PR.
+9. Commit + push + abrir PR.
 
 ## Cierre del Charter
 

--- a/dist/.straymark/templates/charter/i18n/zh-CN/charter-template.md
+++ b/dist/.straymark/templates/charter/i18n/zh-CN/charter-template.md
@@ -117,14 +117,20 @@ curl -X PUT "https://${SERVICE_HOST}/api/v1/.../..." \
 3. [实现任务 2].
 4. [...]
 5. AILOG (`risk_level: [low|medium|high]`, `review_required: [true|false]`).
-6. 本地验证通过且干净.
-7. **自动检查清单漂移**（当 CLI 路线图的第 2 阶段发布时）：
+6. **对于多批次执行（3+ 批次或 >1 天）**：在 AILOG 中维护
+   `## Batch Ledger`（批次台账）。每个批次的 commit 之后，运行
+   `straymark charter batch-complete <CHARTER-ID> <N>` 在推送前更新
+   台账。关闭时的 drift gate 将拒绝任何仍为 `(pending)` 的
+   `### Batch N`。对于单批次 Charter，请跳过此步骤——AILOG 中的
+   `## 执行的操作` 已足够。
+7. 本地验证通过且干净.
+8. **自动检查清单漂移**（当 CLI 路线图的第 2 阶段发布时）：
    `straymark charter drift CHARTER-NN <range>` 在提交**之前**检测声明的文件
    与修改的文件之间的漂移。如果它报告遗漏，请完成工作或在 AILOG 的
    `## Risk` 下记录为 `R<N+1> (new, not in Charter)`。如果它报告范围扩展，
    请在 AILOG 中记录原因（mock 更新、生成的文件、漂移修复预先存在等）。
    在第 2 阶段发布之前，手动运行 Sentinel 的 `check-plan-drift.sh` 以获得相同效果。
-8. 提交 + 推送 + 打开 PR.
+9. 提交 + 推送 + 打开 PR.
 
 ## Charter 关闭
 

--- a/dist/.straymark/templates/i18n/es/TEMPLATE-AILOG.md
+++ b/dist/.straymark/templates/i18n/es/TEMPLATE-AILOG.md
@@ -33,6 +33,25 @@ related: []
 2. [Acción 2]
 3. [Acción 3]
 
+## Bitácora por Lote (Batch Ledger)
+
+> Usa esta sección para Charters que abarquen 3+ lotes o >1 día de ejecución.
+> Actualiza cada entrada **inmediatamente después** de que aterriza su commit,
+> usando `straymark charter batch-complete <CHARTER-ID> <N>`. Las entradas
+> que queden como `(pending)` al cierre del Charter hacen fallar
+> `straymark charter drift`.
+>
+> Omite esta sección por completo para AILOGs de un solo lote o sesión —
+> `## Acciones Realizadas` arriba es suficiente en ese caso.
+
+### Batch 1 — [nombre desde §Tasks del Charter]
+
+(pending)
+
+### Batch 2 — [nombre desde §Tasks del Charter]
+
+(pending)
+
 ## Archivos Modificados
 
 | Archivo | Líneas Cambiadas (+/-) | Descripción del Cambio |

--- a/dist/.straymark/templates/i18n/zh-CN/TEMPLATE-AILOG.md
+++ b/dist/.straymark/templates/i18n/zh-CN/TEMPLATE-AILOG.md
@@ -33,6 +33,24 @@ related: []
 2. [操作 2]
 3. [操作 3]
 
+## 批次台账 (Batch Ledger)
+
+> 对跨越 3+ 批次或 >1 天执行的 Charter 使用此章节。
+> 每个批次的 commit 落地**立即**更新对应条目，使用
+> `straymark charter batch-complete <CHARTER-ID> <N>`。Charter 关闭时
+> 仍为 `(pending)` 的条目会导致 `straymark charter drift` 失败。
+>
+> 对于单批次或单会话的 AILOG，请完全省略此章节——上方的
+> `## 执行的操作` 已足够。
+
+### Batch 1 — [来自 Charter §Tasks 的名称]
+
+(pending)
+
+### Batch 2 — [来自 Charter §Tasks 的名称]
+
+(pending)
+
 ## 修改的文件
 
 | 文件 | 变更行数 (+/-) | 变更描述 |

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.13.4"
+version: "4.14.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.13.4` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.12.3` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.14.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.13.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.4
+✔ Downloaded StrayMark fw-4.14.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.4
+✔ Framework updated to fw-4.14.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.4
+✔ Framework updated to fw-4.14.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.4                 │
+  │ Framework │ fw-4.14.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.4
+  Using version: fw-4.14.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -422,7 +422,8 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 - `straymark charter list` — enumerate Charters with optional filters
 - `straymark charter status` — show Charter detail, or the most recent 5 Charters
 - `straymark charter close` — record post-execution telemetry and bump status to `closed` *(Phase 2, fw-4.6.0+)*
-- `straymark charter drift` — detect file-vs-commit drift with AILOG-aware suppression *(Phase 2, fw-4.6.0+)*
+- `straymark charter drift` — detect file-vs-commit drift with AILOG-aware suppression and Batch Ledger gate *(Phase 2, fw-4.6.0+; Batch Ledger gate cli-3.13.0+)*
+- `straymark charter batch-complete` — mark a Charter batch as complete in the AILOG `## Batch Ledger` *(cli-3.13.0+, fw-4.14.0+)*
 - `straymark charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.9.0+)*
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
@@ -548,18 +549,21 @@ $ straymark charter close CHARTER-01
     Status updated: in-progress/declared → closed
 ```
 
-#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--no-batch-ledger-check] [--path <dir>]`
 
 Detect file-vs-commit drift at Charter close. Wraps the framework's `.straymark/scripts/check-charter-drift.sh` (zero false positives validated empirically across PLAN-05 retrospective + PLAN-06 prospective in Sentinel). The CLI value-add over the raw script is **AILOG-awareness**: paths reported as "declared but not modified" are silenced when they appear in the `## Risk` / `## Riesgos` / `## 风险` section of any AILOG referenced by the Charter's `originating_ailogs`. Use `--no-ailog-suppress` to disable.
+
+**Batch Ledger gate** *(cli-3.13.0+)*. When the Charter status is `in-progress` or `closed`, the command also checks each originating AILOG for `## Batch Ledger` entries left as `(pending)` and fails with a clear diagnostic listing the missing batches. AILOGs without a ledger contribute nothing — the section is opt-in. Use `--no-batch-ledger-check` to bypass (intended for adopters consolidating the ledger post-close).
 
 | Argument/Flag | Default | Description |
 |---|---|---|
 | `CHARTER-ID` | — | Same resolution rules as `charter status` |
 | `--range` | `HEAD~1..HEAD` | Git revision range to check |
 | `--no-ailog-suppress` *(cli-3.10.0+ always emits a confirming INFO line)* | false | Disable AILOG-aware suppression (show every declared-omitted path). When passed, the CLI always prints an `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` line — including when N=0 — so that the diagnostic mode is visible in output even on a clean run. |
+| `--no-batch-ledger-check` *(cli-3.13.0+)* | false | Disable the Batch Ledger gate. Use when the Charter's AILOG opted out of the ledger pattern at close time. |
 | `--path` | `.` | Target project directory |
 
-**Exit codes:** `0` if no drift (or only AILOG-suppressed); `1` if there's unaccounted drift; `2` for usage errors (Charter not found, bash missing, etc.).
+**Exit codes:** `0` if no drift (or only AILOG-suppressed) and no pending batches; `1` if there's unaccounted drift or any `### Batch N` is still `(pending)`; `2` for usage errors (Charter not found, bash missing, etc.).
 
 **Example:**
 
@@ -598,6 +602,56 @@ Both forms are handled in both directions: a declared wildcard suppresses both "
 Paths under `.straymark/charters/*` and `.straymark/07-ai-audit/*` are **never** reported as "modified but not declared". This is opinionated by design — those paths are always legitimate when the Charter itself or the AILOG of execution is touched. Empirically validated in Sentinel CHARTER-04: a stray `git add -A` staged unrelated user-untracked files (`.claude/skills/`, `cmd/sentinel/sentinel`); the rule correctly suppressed the governance noise without hiding the genuine project-file expansion ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
 
 If you're running a Charter whose explicit scope is governance churn (e.g., a bulk approval Charter touching only `.straymark/07-ai-audit/`), the drift check will report 0 modified files and you'll need to verify scope by reading the AILOG. A `--strict-scope` flag that disables the always-in-scope rule is on the table for a future minor if a real adopter reports the asymmetry as a friction.
+
+#### `straymark charter batch-complete <CHARTER-ID> <N> [--note <body>] [--non-interactive] [--path <dir>]`
+
+*Available since **cli-3.13.0** + **fw-4.14.0**.*
+
+Mark a Charter batch as complete in the originating AILOG's `## Batch Ledger`. The command substitutes the `(pending)` placeholder under `### Batch <N>` with the batch notes captured interactively (default) or via `--note` (one-shot / scripted). The drift gate at close time (`straymark charter drift`) rejects any `### Batch N` left as `(pending)`, making the per-batch update load-bearing rather than a discipline reminder.
+
+**When to use it.** Only for multi-batch Charters that span 3+ batches or >1 day of execution. Single-batch AILOGs document everything in `## Actions Performed` and skip the ledger entirely. The Charter template's §Tasks reminds the author to maintain the ledger when applicable.
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `CHARTER-ID` | — | Same resolution rules as `charter status` |
+| `N` | — | Batch number (1-based) — matches the `### Batch <N>` heading in the AILOG `## Batch Ledger` |
+| `--note <body>` | — | Pre-filled batch note body. With this flag, the command writes the note non-interactively and skips prompts. Designed for agents and scripts. |
+| `--non-interactive` | false | Disable prompts. Requires `--note` (a missing `--note` aborts instead of hanging). |
+| `--path` | `.` | Target project directory |
+
+The command reads `originating_ailogs[0]` from the Charter frontmatter to locate the target AILOG. It rejects with a clear error when:
+
+- the Charter has no `originating_ailogs` entry (cannot resolve a target file);
+- the AILOG file is missing from `.straymark/07-ai-audit/agent-logs/`;
+- the AILOG has no `## Batch Ledger` section (add the section first, or skip the command if the Charter is single-batch);
+- no `### Batch <N>` heading exists under `## Batch Ledger`;
+- the target batch is already completed (refuses to overwrite — edit the AILOG manually for corrections).
+
+**Interactive flow.** Three prompts: files touched (one-liner), tests added or status (one-liner), and a multiline design note (terminate with `.` on a line by itself or Ctrl-D). Empty fields are skipped in the output. The resulting body is written under the `### Batch <N>` heading; the `(pending)` placeholder is replaced.
+
+**Examples:**
+
+```bash
+# Interactive — humans pasting batch notes
+$ straymark charter batch-complete CHARTER-17 5
+✔ AILOG: .straymark/07-ai-audit/agent-logs/AILOG-2026-05-13-048-charter-17.md
+✔ ### Batch 5 — Migration 022 + handlers
+Files touched: migrations/022_dedup.sql, services/handler_x.go
+Tests added or status: handler_x_test.go +12 -0, passing
+note (multiline; finish with `.` on a line):
+> Used existing processed_events table; saw R8 (CHECK constraint missing ARCHIVED).
+> .
+
+OK `### Batch 5` written.
+Reminder: `git add .straymark/07-ai-audit/agent-logs/AILOG-2026-05-13-048-charter-17.md` before pushing.
+
+# One-shot — agents / scripts
+$ straymark charter batch-complete CHARTER-17 5 \
+    --note "Migration 022 + handlers. Files: migrations/022_dedup.sql, services/handler_x.go. Tests passing. R8 surfaced (CHECK constraint missing ARCHIVED), fixed atomically."
+OK `### Batch 5` written.
+```
+
+**Workflow integration.** Per `Charter §Tasks` template guidance, run `batch-complete` *immediately after* the batch commit lands but *before* pushing. The AILOG update and the work it documents then ride the same push. The drift gate at close (`straymark charter drift CHARTER-NN`) rejects any pending batch and prints the list — making "forgot to update the ledger" a hard failure rather than silent erosion of the audit trail.
 
 #### `straymark charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
 
@@ -1053,7 +1107,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.4
+  Framework version: fw-4.14.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -237,8 +237,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.13.4` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.12.3` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.14.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.13.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.13.4)
+# y descarga el último release fw-* (ej. fw-4.14.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.13.4` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.12.3` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.14.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.13.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.4
+✔ Downloaded StrayMark fw-4.14.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.4
+✔ Framework updated to fw-4.14.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.4
+✔ Framework updated to fw-4.14.0
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.13.4
+Framework version: fw-4.14.0
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -392,7 +392,8 @@ Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-
 - `straymark charter list` — enumera Charters con filtros opcionales
 - `straymark charter status` — muestra detalle de un Charter, o los 5 más recientes
 - `straymark charter close` *(cli-3.7.0+)* — registra la telemetría post-ejecución y mueve el Charter a `closed`
-- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware
+- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware y gate de Batch Ledger *(gate añadido en cli-3.13.0)*
+- `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — marca un batch del Charter como completado en la `## Batch Ledger` del AILOG
 - `straymark charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <titulo>] [path]`
@@ -482,18 +483,21 @@ $ straymark charter close CHARTER-01
     Status updated: in-progress/declared → closed
 ```
 
-#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--no-batch-ledger-check] [--path <dir>]`
 
 Detecta drift archivo-vs-commit al cierre del Charter. Envuelve el script del framework `.straymark/scripts/check-charter-drift.sh` (cero falsos positivos validados empíricamente en PLAN-05 retrospectivo + PLAN-06 prospectivo en Sentinel). El valor agregado del CLI sobre el script crudo es la **AILOG-awareness**: los paths reportados como "declarados pero no modificados" se silencian cuando aparecen en la sección `## Risk` / `## Riesgos` / `## 风险` de algún AILOG referenciado por `originating_ailogs` del Charter. Usa `--no-ailog-suppress` para deshabilitarlo.
+
+**Gate de Batch Ledger** *(cli-3.13.0+)*. Cuando el Charter está en estado `in-progress` o `closed`, el comando también revisa cada AILOG originante por entradas `## Batch Ledger` que sigan en `(pending)` y falla con un diagnóstico claro listando los batches faltantes. Los AILOGs sin ledger no contribuyen — la sección es opt-in. Usa `--no-batch-ledger-check` para bypass (pensado para adopters que consolidan la ledger post-close).
 
 | Argumento/Flag | Default | Descripción |
 |---|---|---|
 | `CHARTER-ID` | — | Mismas reglas de resolución que `charter status`. |
 | `--range` | `HEAD~1..HEAD` | Rango de revisiones git a chequear. |
 | `--no-ailog-suppress` *(cli-3.10.0+ siempre emite una línea INFO de confirmación)* | false | Deshabilita la supresión AILOG-aware (muestra todo path declarado-omitido). Cuando se pasa el flag, el CLI siempre imprime una línea `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` — incluso cuando N=0 — para que el modo diagnóstico sea visible en la salida aun en una corrida limpia. |
+| `--no-batch-ledger-check` *(cli-3.13.0+)* | false | Deshabilita el gate de Batch Ledger. Usar cuando el AILOG del Charter optó por no usar el patrón al momento del close. |
 | `--path` | `.` | Directorio del proyecto. |
 
-**Códigos de salida:** `0` si no hay drift (o solo AILOG-suprimido); `1` si hay drift no contabilizado; `2` para errores de uso (Charter no encontrado, bash ausente, etc.).
+**Códigos de salida:** `0` si no hay drift (o solo AILOG-suprimido) y ningún batch pendiente; `1` si hay drift no contabilizado o algún `### Batch N` sigue `(pending)`; `2` para errores de uso (Charter no encontrado, bash ausente, etc.).
 
 **Ejemplo:**
 
@@ -532,6 +536,51 @@ Ambas formas se manejan en ambas direcciones: un wildcard declarado suprime tant
 Los paths bajo `.straymark/charters/*` y `.straymark/07-ai-audit/*` **nunca** se reportan como "modificado pero no declarado". Es opinionated por diseño — esos paths son siempre legítimos cuando el Charter mismo o el AILOG de ejecución son tocados. Validado empíricamente en Sentinel CHARTER-04: un `git add -A` accidental stageó archivos no-tracked del usuario (`.claude/skills/`, `cmd/sentinel/sentinel`); la regla suprimió correctamente el ruido de gobernanza sin esconder la expansión genuina de archivos del proyecto ([issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)).
 
 Si corres un Charter cuyo scope explícito es churn de gobernanza (p.ej. un Charter de aprobación bulk que toca solo `.straymark/07-ai-audit/`), el chequeo reportará 0 archivos modificados y necesitarás verificar el scope leyendo el AILOG. Un flag `--strict-scope` que deshabilite la regla "siempre en scope" está sobre la mesa para una minor futura si un adopter real reporta la asimetría como fricción.
+
+#### `straymark charter batch-complete <CHARTER-ID> <N> [--note <body>] [--non-interactive] [--path <dir>]`
+
+*Disponible desde **cli-3.13.0** + **fw-4.14.0**.*
+
+Marca un batch del Charter como completado en la `## Batch Ledger` del AILOG originante. El comando sustituye el placeholder `(pending)` bajo `### Batch <N>` con notas del batch capturadas interactivamente (por defecto) o vía `--note` (one-shot / scripted). El gate de drift al cierre (`straymark charter drift`) rechaza cualquier `### Batch N` que quede como `(pending)`, haciendo la actualización por-batch load-bearing en vez de un recordatorio de disciplina.
+
+**Cuándo usarlo.** Solo para Charters multi-batch que abarquen 3+ lotes o >1 día de ejecución. AILOGs de un solo batch documentan todo en `## Acciones Realizadas` y saltan la ledger por completo. El template Charter en §Tasks recuerda al autor mantener la ledger cuando aplica.
+
+| Argumento/Flag | Default | Descripción |
+|---|---|---|
+| `CHARTER-ID` | — | Mismas reglas de resolución que `charter status`. |
+| `N` | — | Número de batch (1-based) — coincide con el heading `### Batch <N>` en `## Batch Ledger` del AILOG. |
+| `--note <body>` | — | Cuerpo de la nota pre-llenado. Con este flag, el comando escribe la nota no-interactivamente y salta los prompts. Diseñado para agentes y scripts. |
+| `--non-interactive` | false | Deshabilita prompts. Requiere `--note` (la ausencia de `--note` aborta en lugar de colgarse). |
+| `--path` | `.` | Directorio del proyecto. |
+
+El comando lee `originating_ailogs[0]` del frontmatter del Charter para localizar el AILOG destino. Rechaza con error claro cuando:
+
+- el Charter no tiene entrada `originating_ailogs` (no puede resolver archivo destino);
+- el archivo AILOG no existe en `.straymark/07-ai-audit/agent-logs/`;
+- el AILOG no tiene sección `## Batch Ledger` (añadir la sección primero, o saltar el comando si el Charter es de un solo batch);
+- no existe heading `### Batch <N>` bajo `## Batch Ledger`;
+- el batch destino ya está completado (rehúsa sobrescribir — editar el AILOG manualmente para correcciones).
+
+**Flujo interactivo.** Tres prompts: archivos tocados (one-liner), tests añadidos o estado (one-liner), y nota de diseño multilínea (terminar con `.` solo en una línea o Ctrl-D). Los campos vacíos se omiten en la salida. El cuerpo resultante se escribe bajo el heading `### Batch <N>`; el placeholder `(pending)` se reemplaza.
+
+**Ejemplos:**
+
+```bash
+# Interactivo — humanos pegando notas
+$ straymark charter batch-complete CHARTER-17 5
+✔ AILOG: .straymark/07-ai-audit/agent-logs/AILOG-2026-05-13-048-charter-17.md
+✔ ### Batch 5 — Migración 022 + handlers
+
+OK `### Batch 5` written.
+Reminder: `git add .straymark/07-ai-audit/agent-logs/AILOG-2026-05-13-048-charter-17.md` before pushing.
+
+# One-shot — agentes / scripts
+$ straymark charter batch-complete CHARTER-17 5 \
+    --note "Migración 022 + handlers. Archivos: migrations/022.sql, services/handler_x.go. Tests pasando. R8 surgió (CHECK constraint sin ARCHIVED), fix atómico."
+OK `### Batch 5` written.
+```
+
+**Integración con workflow.** Según la guía del template Charter en §Tasks, correr `batch-complete` *inmediatamente después* de que aterriza el commit del batch pero *antes* de pushear. La actualización del AILOG y el trabajo que documenta viajan en el mismo push. El gate de drift al cierre (`straymark charter drift CHARTER-NN`) rechaza cualquier batch pendiente e imprime la lista — convirtiendo "olvidé actualizar la ledger" en una falla dura en lugar de erosión silenciosa del audit trail.
 
 #### `straymark charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
 
@@ -859,7 +908,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.4
+  Framework version: fw-4.14.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -255,8 +255,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.4` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.12.3` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.14.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.13.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.13.4）
+# 下载最新的 fw-* 发布（例如 fw-4.14.0）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.13.4` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.12.3` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.14.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.13.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.13.4
+✔ Downloaded StrayMark fw-4.14.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.13.4
+✔ Framework updated to fw-4.14.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.13.4
+✔ Framework updated to fw-4.14.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.13.4                 │
+  │ Framework │ fw-4.14.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.13.4
+  Using version: fw-4.14.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -422,7 +422,8 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 - `straymark charter list` — 用可选过滤器枚举章程
 - `straymark charter status` — 显示章程详情，或最近的 5 个章程
 - `straymark charter close` *(cli-3.7.0+)* — 记录执行后遥测并将章程移至 `closed`
-- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制
+- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制和 Batch Ledger 门控 *(门控在 cli-3.13.0 添加)*
+- `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — 在 AILOG 的 `## Batch Ledger` 中将章程批次标记为已完成
 - `straymark charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
@@ -499,18 +500,21 @@ $ straymark charter close CHARTER-01
     Status updated: in-progress/declared → closed
 ```
 
-#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--path <dir>]`
+#### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--no-batch-ledger-check] [--path <dir>]`
 
 在章程关闭时检测文件 vs 提交漂移。封装框架的 `.straymark/scripts/check-charter-drift.sh`（在 Sentinel PLAN-05 回顾性 + PLAN-06 前瞻性中实证验证零误报）。CLI 在原始脚本之上的附加价值是 **AILOG 感知**：报告为"已声明但未修改"的路径，如果出现在被章程 `originating_ailogs` 引用的任何 AILOG 的 `## Risk` / `## Riesgos` / `## 风险` 节中，则被静默。使用 `--no-ailog-suppress` 来禁用。
+
+**Batch Ledger 门控** *(cli-3.13.0+)*。当章程状态为 `in-progress` 或 `closed` 时，该命令还检查每个 originating AILOG 中仍为 `(pending)` 的 `## Batch Ledger` 条目，并以清晰的诊断列出缺失的批次。没有 ledger 的 AILOG 不参与 — 该章节是 opt-in 的。使用 `--no-batch-ledger-check` 来绕过（用于在 close 后合并 ledger 的 adopter）。
 
 | 参数/标志 | 默认值 | 描述 |
 |---|---|---|
 | `CHARTER-ID` | — | 与 `charter status` 相同的解析规则。 |
 | `--range` | `HEAD~1..HEAD` | 要检查的 git 修订范围。 |
 | `--no-ailog-suppress` *(cli-3.10.0+ 始终输出确认 INFO 行)* | false | 禁用 AILOG 感知抑制（显示每条已声明但被遗漏的路径）。传入此标志时，CLI 始终打印 `INFO: AILOG-aware suppression bypassed (would have suppressed: N path(s)…)` 行 — 即使 N=0 — 以便诊断模式即使在干净运行时也在输出中可见。 |
+| `--no-batch-ledger-check` *(cli-3.13.0+)* | false | 禁用 Batch Ledger 门控。当章程的 AILOG 在 close 时显式选择不使用 ledger 模式时使用。 |
 | `--path` | `.` | 目标项目目录。 |
 
-**退出码：** `0` 没有漂移（或仅 AILOG 抑制）；`1` 存在未计入的漂移；`2` 用法错误（章程未找到、bash 缺失等）。
+**退出码：** `0` 没有漂移（或仅 AILOG 抑制）且无 pending 批次；`1` 存在未计入的漂移或任何 `### Batch N` 仍为 `(pending)`；`2` 用法错误（章程未找到、bash 缺失等）。
 
 **示例：**
 
@@ -549,6 +553,51 @@ OK all declared-omitted paths are documented in AILOGs — drift accepted.
 `.straymark/charters/*` 和 `.straymark/07-ai-audit/*` 下的路径**永远不会**被报告为"已修改但未声明"。这是有意的设计 — 当章程本身或执行的 AILOG 被触动时，这些路径总是合法的。在 Sentinel CHARTER-04 中实证验证：一次意外的 `git add -A` 暂存了无关的用户未跟踪文件（`.claude/skills/`、`cmd/sentinel/sentinel`）；该规则正确抑制了治理噪声而没有掩盖真正的项目文件扩展（[issue #81 W2](https://github.com/StrangeDaysTech/straymark/issues/81#issuecomment-update)）。
 
 如果你运行的章程显式 scope 是治理 churn（例如仅触动 `.straymark/07-ai-audit/` 的批量批准章程），漂移检查将报告 0 个修改文件，你需要通过阅读 AILOG 来验证 scope。一个 `--strict-scope` 标志（禁用"始终在 scope"规则）在桌面上，用于未来 minor 版本，前提是真实的 adopter 报告这种不对称为摩擦。
+
+#### `straymark charter batch-complete <CHARTER-ID> <N> [--note <body>] [--non-interactive] [--path <dir>]`
+
+*自 **cli-3.13.0** + **fw-4.14.0** 起可用。*
+
+在 originating AILOG 的 `## Batch Ledger` 中将一个章程批次标记为已完成。该命令将 `### Batch <N>` 下的 `(pending)` 占位符替换为以交互方式（默认）或通过 `--note`（一次性 / 脚本化）捕获的批次说明。关闭时的 drift 门控（`straymark charter drift`）拒绝任何仍为 `(pending)` 的 `### Batch N`，使按批次的更新变为强制性而非纪律提醒。
+
+**何时使用。** 仅用于跨越 3+ 批次或 >1 天执行的多批次章程。单批次 AILOG 在 `## 执行的操作` 中记录一切，完全跳过 ledger。Charter 模板的 §Tasks 提醒作者在适用时维护 ledger。
+
+| 参数/标志 | 默认值 | 描述 |
+|---|---|---|
+| `CHARTER-ID` | — | 与 `charter status` 相同的解析规则。 |
+| `N` | — | 批次号（从 1 开始）— 与 AILOG `## Batch Ledger` 中的 `### Batch <N>` 标题匹配。 |
+| `--note <body>` | — | 预填充的批次说明正文。使用此标志，该命令非交互式地写入说明并跳过 prompt。为 agent 和脚本设计。 |
+| `--non-interactive` | false | 禁用 prompt。需要 `--note`（缺少 `--note` 会中止而非挂起）。 |
+| `--path` | `.` | 目标项目目录。 |
+
+该命令读取章程 frontmatter 的 `originating_ailogs[0]` 来定位目标 AILOG。当出现以下情况时，以清晰错误拒绝执行：
+
+- 章程没有 `originating_ailogs` 条目（无法解析目标文件）；
+- AILOG 文件在 `.straymark/07-ai-audit/agent-logs/` 中缺失；
+- AILOG 没有 `## Batch Ledger` 章节（先添加该章节，或如果是单批次 Charter 则跳过命令）；
+- `## Batch Ledger` 下没有 `### Batch <N>` 标题；
+- 目标批次已完成（拒绝覆盖 — 如需更正请手动编辑 AILOG）。
+
+**交互流程。** 三个 prompt：touched 文件（单行）、添加的 tests 或状态（单行）、多行设计说明（用单行 `.` 或 Ctrl-D 结束）。空字段在输出中被跳过。结果正文写入 `### Batch <N>` 标题下；`(pending)` 占位符被替换。
+
+**示例：**
+
+```bash
+# 交互式 — 人类粘贴批次说明
+$ straymark charter batch-complete CHARTER-17 5
+✔ AILOG: .straymark/07-ai-audit/agent-logs/AILOG-2026-05-13-048-charter-17.md
+✔ ### Batch 5 — Migration 022 + handlers
+
+OK `### Batch 5` written.
+Reminder: `git add .straymark/07-ai-audit/agent-logs/AILOG-2026-05-13-048-charter-17.md` before pushing.
+
+# 一次性 — agent / 脚本
+$ straymark charter batch-complete CHARTER-17 5 \
+    --note "Migration 022 + handlers. 文件: migrations/022.sql, services/handler_x.go. Tests passing. R8 (CHECK constraint missing ARCHIVED), 原子修复."
+OK `### Batch 5` written.
+```
+
+**Workflow 集成。** 根据 Charter §Tasks 模板的指引，在批次的 commit 落地**之后**但推送**之前**运行 `batch-complete`。AILOG 的更新和它所记录的工作随后乘同一次 push。关闭时的 drift 门控（`straymark charter drift CHARTER-NN`）拒绝任何 pending 批次并打印列表 — 将"忘记更新 ledger"从审计轨迹的静默侵蚀变为硬失败。
 
 #### `straymark charter audit <CHARTER-ID> [--range <REV..REV>] [--prepare | --merge-reports] [--merge-into <PATH>] [--path <dir>]`
 
@@ -993,7 +1042,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.13.4
+  Framework version: fw-4.14.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

Closes three upstream issues filed by Sentinel during its CHARTER-17 cycle. All field-validated downstream, additive, zero rupture for existing artifacts. Pre-announcement hardening — pay the deuda once now so adopters who follow Sentinel inherit a clean slate.

- **closes #143** — `shellcheck` cleanup in `dist/.github/workflows/docs-validation.yml` so adopters can add `actionlint` to CI without `-shellcheck=` or per-adopter `-ignore` patterns.
- **closes #145** — regex extension `[0-9]{3}` → `[0-9]{3}[a-z]?` across the workflow + both framework JSON schemas + CLI test schema. Canonizes the same-day same-sequence collision recovery convention.
- **partially closes #146 (Proposal C)** — `## Batch Ledger` opt-in template section + new `straymark charter batch-complete` subcommand + `straymark charter drift` extended with a Batch Ledger gate. **Proposal D (cross-Charter `lessons-learned.md` index) intentionally deferred** to a post-announcement Charter — flagged in CHANGELOG.

## What's in scope

### Framework (fw-4.14.0)

- `dist/.github/workflows/docs-validation.yml`: shellcheck cleanup + regex extension.
- `dist/.straymark/schemas/charter.schema.v0.json` + `charter-telemetry.schema.v0.json`: regex extension parity.
- `dist/.straymark/templates/TEMPLATE-AILOG.md` (EN + ES + zh-CN): new opt-in `## Batch Ledger` section with guidance.
- `dist/.straymark/templates/charter/charter-template.md` (EN + ES + zh-CN): §Tasks updated to point at the batch-complete workflow.
- Governance footers + version refs bumped (`v4.14.0` / `fw-4.14.0`).

### CLI (cli-3.13.0)

- `cli/src/ailog.rs` (new): shared helpers for AILOG file discovery + Batch Ledger parsing/editing. Promoted from `drift.rs` privates so `batch_complete` can reuse.
- `cli/src/commands/charter/batch_complete.rs` (new): hybrid UX (interactive prompts by default; `--note "..."` one-shot for agents; `--non-interactive` requires `--note`).
- `cli/src/commands/charter/drift.rs`: new Batch Ledger gate (fails on `### Batch N (pending)` when Charter is `in-progress`/`closed`); `--no-batch-ledger-check` bypass.
- `cli/src/charter_schema.rs`: `TEST_SCHEMA` regex updated + 3 new tests pin the `[a-z]?` behavior (accepts single letter, rejects multi-letter, rejects uppercase).
- 9 new tests across `cli/src/ailog.rs` and `cli/src/commands/charter/drift.rs` cover the new ledger parsing/writing and the drift gate edge cases (declared/in-progress/closed gating, opt-in section absence).

### Docs

- `docs/adopters/CLI-REFERENCE.md` (EN + ES + zh-CN): new `batch-complete` section + `drift` extension + version table bump.
- `README.md` + i18n: version table bump.
- `CHANGELOG.md`: consolidated entry `## Framework 4.14.0 / CLI 3.13.0 — Sentinel feedback cycle ...`.

## Test plan

- [x] `cargo test` — full suite passes (501+ tests across lib + integration suites)
- [x] `cargo build --release` — clean build
- [x] `straymark charter batch-complete --help` — flags surface correctly
- [x] `straymark charter drift --help` — `--no-batch-ledger-check` flag surfaces
- [x] YAML syntax for `docs-validation.yml` valid (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [ ] CI runs `actionlint` on the workflow (will surface upstream once the action is added)
- [ ] End-to-end smoke against a sample repo with multi-batch Charter (post-merge, before tagging)

## Deferred / out of scope

- **Proposal D of #146** (cross-Charter `lessons-learned.md` index) — separate Charter post-announcement. Sentinel keeps its local workaround until then.
- Migration of existing AILOGs to `## Batch Ledger` — opt-in retroactive; no upstream migration script.

## Sentinel reconciliation

Once fw-4.14.0 / cli-3.13.0 land, Sentinel can revert:
- `actionlint -shellcheck=` flag in `StrangeDaysTech/sentinel#72` (now redundant — `actionlint -color` is clean upstream).
- Local regex extension in `docs-validation.yml` (now upstream).
- `CLAUDE.md` "Multi-batch Charter discipline (TRANSIENT)" subsection + agent memory entry (now load-bearing as `## Batch Ledger` + `batch-complete` upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)