### PR TITLE
feat(framework): fw-4.14.1 — docs sync for batch-complete + Batch Ledger discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.14.1 — Docs sync for batch-complete + Batch Ledger discoverability
+
+Framework-only patch that closes the documentation gap left by `fw-4.14.0` / `cli-3.13.0`. The release added the `batch-complete` subcommand and the Batch Ledger workflow but didn't surface them in three places adopters and contributors discover the project from: the root `README.md` (and i18n overlays), the project's user-facing comparison/feature lists, and **`dist/STRAYMARK.md`** — the governance file shipped to every adopter via `straymark init`.
+
+### Changed (Framework)
+
+- **`dist/STRAYMARK.md` §15 (Charter lifecycle)** — new "Batch update" stage row inserted between "In progress" and "Drift check", documenting the per-batch ledger update pattern and pointing at `straymark charter batch-complete CHARTER-NN <N>`. The "Drift check" row now mentions that pending `### Batch N` entries cause a hard fail (with `--no-batch-ledger-check` bypass).
+- **`dist/STRAYMARK.md` Quick CLI surface** — added the `batch-complete` line and annotated the `drift` line with "AILOG-aware + Batch Ledger gate".
+- **Governance footers** updated to `v4.14.1` across `QUICK-REFERENCE.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `C4-DIAGRAM-GUIDE.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md` (EN + ES + zh-CN, plus the top-level `dist/.straymark/QUICK-REFERENCE.md`).
+
+### Changed (Repo-level docs, not shipped via `straymark init`)
+
+- **`README.md`** (root, EN + i18n/es + i18n/zh-CN) — "Features → CLI Tools" bullet expanded to include `batch-complete` and the Batch Ledger gate on `drift`; the table-of-commands row for `straymark charter <subcommand>` updated likewise.
+- **`docs/adopters/CLI-REFERENCE.md`** (EN + ES + zh-CN) — version tables + canonical-output examples bumped to `fw-4.14.1`. The detailed `batch-complete` section and the extended `drift` description added in `fw-4.14.0`/`cli-3.13.0` remain unchanged; their `*(cli-3.13.0+ + fw-4.14.0+)*` minimum-version annotations are intentionally preserved (those mark when the feature was introduced, not the current release).
+
+### Why a patch release for docs only
+
+The `dist/STRAYMARK.md` change is governance content shipped to every adopter — without bumping the framework, `straymark update-framework` would not bring the new content to existing installations. The cost of a patch tag is one CI run; the value is that any new or existing adopter who runs `straymark init` or `straymark update-framework` sees the canonical Charter lifecycle table with the Batch Ledger pattern visible.
+
+### Adopter guidance
+
+`straymark update-framework` brings the updated `STRAYMARK.md` and governance footers. No behavior changes: the CLI is unchanged (`cli-3.13.0` remains the matching CLI version), and no schemas or templates moved.
+
+---
+
 ## Framework 4.14.0 / CLI 3.13.0 — Sentinel feedback cycle: shellcheck cleanup, regex extension, multi-batch AILOG ledger
 
 Closes three upstream issues filed by Sentinel during its CHARTER-17 cycle, all field-validated downstream and ready for upstream canonization. The unifying theme is **pre-announcement hardening**: each issue was discovered in real adopter usage, the fix is additive (zero ruptura para existing artifacts), and Sentinel can revert its local workaround once this release lands.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Built-in safeguards ensure humans stay in control:
 
 Built-in commands that turn the discipline into actionable feedback:
 
-- **`straymark charter <new|list|status|close|drift|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression; `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
+- **`straymark charter <new|list|status|close|drift|batch-complete|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression and (cli-3.13.0+) gates on `### Batch N (pending)` entries in the AILOG `## Batch Ledger`; `batch-complete` (cli-3.13.0+) marks a batch as complete in the ledger for multi-batch Charters (3+ batches or >1 day); `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
 - **`straymark approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
 - **`straymark validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `.straymark/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
 - **`straymark metrics`** — Governance KPIs, review rates, risk distribution, trends
@@ -274,7 +274,7 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.14.0` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.14.1` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.13.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -291,7 +291,7 @@ Check installed versions with `straymark status` or `straymark about`.
 | `straymark status [path]` | Show installation health and doc stats |
 | `straymark repair [path]` | Restore missing directories and framework files |
 | `straymark validate [path]` | Validate documents for compliance and correctness (use `--include-charters` for Charters, `--check-pending-reviews` for approval backlog) |
-| `straymark charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness), `audit` (multi-model external review, orchestration-only) |
+| `straymark charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness + Batch Ledger gate), `batch-complete` (mark a batch as complete in the AILOG `## Batch Ledger` for multi-batch Charters), `audit` (multi-model external review, orchestration-only) |
 | `straymark approve <doc-id>` | Record a formal human approval on a `review_required: true` document (frontmatter + canonical body section) |
 | `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
 | `straymark metrics [path]` | Show governance metrics and documentation statistics |
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.14.0)
+# and download the latest fw-* release (e.g., fw-4.14.1)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -313,4 +313,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -306,4 +306,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -305,4 +305,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.14.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.1 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/STRAYMARK.md
+++ b/dist/STRAYMARK.md
@@ -399,7 +399,8 @@ Trigger row in section 6 names the heuristic; expanded:
 |-------|--------------|-----|
 | **Declared** | Operator scaffolds Charter, fills scope/files/risks/tasks. Status `declared`. | `straymark charter new` |
 | **In progress** | Operator flips status to `in-progress` when execution starts. Day-to-day work continues to produce AILOGs. | (manual frontmatter edit) |
-| **Drift check** | Before closing, verify declared files vs. actual git diff. AILOG-suppressed paths are noise-filtered. | `straymark charter drift` |
+| **Batch update** *(multi-batch only, fw-4.14.0+)* | For Charters spanning 3+ batches or >1 day, the AILOG carries a `## Batch Ledger` with one `### Batch N` entry per batch starting as `(pending)`. After each batch commit lands, fill the entry **before pushing** so the AILOG update and the work ride the same push. Single-batch Charters skip this step entirely. | `straymark charter batch-complete CHARTER-NN <N>` |
+| **Drift check** | Before closing, verify declared files vs. actual git diff. AILOG-suppressed paths are noise-filtered; pending `### Batch N` entries cause a hard fail (`--no-batch-ledger-check` bypasses). | `straymark charter drift` |
 | **External audit** *(optional)* | Generate prompt → run N auditor CLIs → consolidate → merge into telemetry. | `straymark charter audit` + `/straymark-audit-prompt` + `/straymark-audit-execute` + `/straymark-audit-review` |
 | **Closed** | Telemetry yaml emitted; status flips to `closed`; charter is now an audit artifact. | `straymark charter close` |
 
@@ -412,12 +413,13 @@ Trigger row in section 6 names the heuristic; expanded:
 ### Quick CLI surface
 
 ```bash
-straymark charter new                # scaffold a Charter (interactive)
-straymark charter list               # enumerate Charters with status/effort/origin
-straymark charter status CHARTER-NN  # detailed view of one Charter
-straymark charter drift CHARTER-NN   # file-vs-commit drift, AILOG-aware
-straymark charter audit CHARTER-NN   # multi-model external audit (orchestration only)
-straymark charter close CHARTER-NN   # record telemetry; flip status to `closed`
+straymark charter new                       # scaffold a Charter (interactive)
+straymark charter list                      # enumerate Charters with status/effort/origin
+straymark charter status CHARTER-NN         # detailed view of one Charter
+straymark charter drift CHARTER-NN          # file-vs-commit drift, AILOG-aware + Batch Ledger gate
+straymark charter batch-complete CHARTER-NN <N>  # fill AILOG `## Batch Ledger` Batch <N> (multi-batch only)
+straymark charter audit CHARTER-NN          # multi-model external audit (orchestration only)
+straymark charter close CHARTER-NN          # record telemetry; flip status to `closed`
 ```
 
 > **Schema**: `.straymark/schemas/charter.schema.v0.json` (declarative) and `.straymark/schemas/charter-telemetry.schema.v0.json` (telemetry). Both are experimental v0 — patterns crystallize after validation against a second domain (Principle #12).

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.14.0"
+version: "4.14.1"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.14.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.14.1` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.13.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.0
+✔ Downloaded StrayMark fw-4.14.1
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.0
+✔ Framework updated to fw-4.14.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.0
+✔ Framework updated to fw-4.14.1
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.0                 │
+  │ Framework │ fw-4.14.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.0
+  Using version: fw-4.14.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1107,7 +1107,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.0
+  Framework version: fw-4.14.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -140,7 +140,7 @@ Salvaguardas incorporadas que aseguran que los humanos mantengan el control:
 
 Comandos integrados que convierten la disciplina en feedback accionable:
 
-- **`straymark charter <new|list|status|close|drift|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware; `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
+- **`straymark charter <new|list|status|close|drift|batch-complete|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware y (cli-3.13.0+) hace gate sobre entradas `### Batch N (pending)` en `## Batch Ledger` del AILOG; `batch-complete` (cli-3.13.0+) marca un batch como completado en la ledger para Charters multi-batch (3+ lotes o >1 día); `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
 - **`straymark approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
 - **`straymark validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `.straymark/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
 - **`straymark metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
@@ -237,7 +237,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.14.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.14.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.13.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.14.0)
+# y descarga el último release fw-* (ej. fw-4.14.1)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.14.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.14.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.13.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.0
+✔ Downloaded StrayMark fw-4.14.1
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.0
+✔ Framework updated to fw-4.14.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.0
+✔ Framework updated to fw-4.14.1
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.14.0
+Framework version: fw-4.14.1
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -908,7 +908,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.0
+  Framework version: fw-4.14.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -140,7 +140,7 @@ StrayMark 的产品决策基于十二条明确的原则。它们按层级排序�
 
 将纪律转化为可执行反馈的内置命令：
 
-- **`straymark charter <new|list|status|close|drift|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
+- **`straymark charter <new|list|status|close|drift|batch-complete|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差，并（cli-3.13.0+）对 AILOG `## Batch Ledger` 中的 `### Batch N (pending)` 条目进行门控；`batch-complete`（cli-3.13.0+）将批次标记为已在多批次章程（3+ 批次或 >1 天）的台账中完成；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
 - **`straymark approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
 - **`straymark validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `.straymark/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
 - **`straymark metrics`** — 治理 KPI、审查率、风险分布、趋势
@@ -255,7 +255,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.14.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.13.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.14.0）
+# 下载最新的 fw-* 发布（例如 fw-4.14.1）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.0` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.14.1` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.13.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.0
+✔ Downloaded StrayMark fw-4.14.1
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.0
+✔ Framework updated to fw-4.14.1
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.0
+✔ Framework updated to fw-4.14.1
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.0                 │
+  │ Framework │ fw-4.14.1                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.0
+  Using version: fw-4.14.1
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1042,7 +1042,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.0
+  Framework version: fw-4.14.1
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

Closes the documentation gap left by [#147](https://github.com/StrangeDaysTech/straymark/pull/147) (`fw-4.14.0` / `cli-3.13.0`). The release added the `batch-complete` subcommand and the Batch Ledger workflow but did NOT surface them in the three places adopters and contributors discover the project from:

1. **Root `README.md`** (EN + i18n/es + i18n/zh-CN) — the "CLI Tools" feature bullet and the table-of-commands row listed `charter <new|list|status|close|drift|audit>` without `batch-complete`.
2. **`dist/STRAYMARK.md` §15 (Charter lifecycle)** — the lifecycle stage table jumped from "In progress" to "Drift check" with no mention of the per-batch ledger update pattern. The Quick CLI surface block missed the `batch-complete` invocation.
3. **Governance footers + version tables** — still showing `v4.14.0` / `fw-4.14.0`, hiding that a newer release exists.

## Why a patch release (not just a docs PR)

`dist/STRAYMARK.md` is governance content shipped to every adopter via `straymark init`. Without bumping the framework, `straymark update-framework` would not bring the canonical Charter lifecycle update with the new Batch Ledger row. The cost of a patch tag is one CI run; the value is that any new or existing adopter who runs `straymark init` or `straymark update-framework` sees the canonical workflow surface batch-complete naturally.

## What's in scope

### Framework (shipped via `straymark init` / `update-framework`)

- `dist/STRAYMARK.md` §15: new "Batch update" row in the Charter lifecycle table + extended "Drift check" row mention + `batch-complete` line in the Quick CLI surface.
- Governance footers across `00-governance/` (EN + ES + zh-CN) bumped to `v4.14.1`.
- `dist/dist-manifest.yml` version → `4.14.1`.

### Repo-level docs (visible on GitHub, not shipped)

- `README.md` (root, EN + i18n/es + i18n/zh-CN): "CLI Tools" bullet + commands table expanded with `batch-complete` and the Batch Ledger gate description on `drift`.
- `docs/adopters/CLI-REFERENCE.md` (EN + ES + zh-CN): version tables + canonical output examples bumped to `fw-4.14.1`. The `*(cli-3.13.0+, fw-4.14.0+)*` minimum-version annotations on `batch-complete` are intentionally preserved — those mark when the feature was introduced, not the current release.

### Changelog

- New `## Framework 4.14.1` entry explaining the rationale and listing each touched file.

## What's NOT in scope

- No CLI changes. `cli-3.13.0` remains the matching CLI version; no `Cargo.toml` bump.
- No schema, template, workflow, or hook changes — pure documentation.
- No re-translations of Sentinel-derived narrative — this PR is sync-only.

## Test plan

- [x] `cat dist/dist-manifest.yml` shows `version: \"4.14.1\"`
- [x] `grep \"v4.14.1\" dist/.straymark/00-governance/QUICK-REFERENCE.md` shows the new footer
- [x] `grep \"batch-complete\" dist/STRAYMARK.md README.md docs/i18n/es/README.md docs/i18n/zh-CN/README.md` all find the new entries
- [x] `grep \"fw-4.14.0[^+]\"` in repo-level docs returns only the 3 intentional minimum-version markers
- [ ] CI release-framework workflow packages `straymark-fw-4.14.1.zip` cleanly (post-tag)
- [ ] `straymark update-framework` from a fw-4.14.0 install pulls the new STRAYMARK.md (post-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)