### PR TITLE
feat(framework+cli): fw-4.14.2 / cli-3.13.1 — TDE terminal `resolved` (closes #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.14.2 / CLI 3.13.1 — TDE terminal `resolved` (closes #149)
+
+Closes [#149](https://github.com/StrangeDaysTech/straymark/issues/149) — surfaced by Sentinel post-CHARTER-17 housekeeping. TDE adopters who keep documents on disk as audit history after the debt is paid had no canonical status to mark the closure; `accepted` / `superseded` / `deprecated` all carry the wrong semantics. The validator rejected `resolved` with `META-003`.
+
+This release ships **Option A** of the issue's proposal triplet (flat enum + `resolved`) and documents **Option B** (per-doc-type lifecycle vocabulary) as the deliberate next evolution.
+
+### Added (CLI)
+
+- **`resolved`** is now a valid value in `VALID_STATUSES` (`cli/src/validation.rs:48`). Adopter-facing effect: `straymark validate` accepts `status: resolved` on TDE documents without `META-003`. Two new tests pin the behavior:
+  - `test_validate_tde_resolved_terminal_state` — TDE with `status: resolved` passes.
+  - `test_validate_rejects_non_canonical_ailog_terminals` — `final`, `closed`, `completed` (Sentinel's invented AILOG terminals reported in #149) continue to fail with `META-003`. Adopters using these on AILOGs should migrate to `accepted` per `TEMPLATE-AILOG.md` and `DOCUMENTATION-POLICY.md §6`.
+
+### Changed (Framework)
+
+- **`dist/.straymark/00-governance/DOCUMENTATION-POLICY.md` §3 (EN + i18n/es + i18n/zh-CN)** — lifecycle diagram extended with the `resolved` terminal branch (TDE-only); new `resolved` row in the status table with the principled distinction from `accepted` / `superseded` / `deprecated`; §6 table column updated to note that TDE enters at `identified` and has its own terminal `resolved`.
+- **`dist/.straymark/templates/TEMPLATE-TDE.md` (EN + i18n/es + i18n/zh-CN)** — frontmatter `status: identified` annotated with the `→ resolved` transition; new optional `## Resolution` body section (omit while the debt is still open) with fields for Resolved by / Date / Verification / Notes.
+
+### Deliberately deferred (Option B)
+
+The principled fix to the per-doc-type lifecycle vocabulary problem is to promote the flat `VALID_STATUSES` enum to a `HashMap<DocType, Vec<&str>>` so each doc type has its own canonical state machine and the validator inspects `doc.doc_type` before deciding which set to apply. The reasons to defer:
+
+- Option A unblocks adopters today (Sentinel reports 2 TDE files with `status: resolved`); shipping it is ~30 LOC + docs.
+- Option B is ~150 LOC + a per-type test matrix expansion + non-trivial decisions about which terminals each type should have. Doing it pre-announcement risks calcifying choices we'd rather make based on a second adopter's lifecycle needs.
+- The `VALID_STATUSES` constant doc-comment in `validation.rs` and the explanatory paragraph in `DOCUMENTATION-POLICY.md §3` both name the trade-off explicitly: "TDE is the only type today with a custom terminal; the validator accepts `resolved` globally as a stop-gap. Issue #149 Option B will scope `resolved` strictly to TDE; until then, using it on non-TDE documents passes validation but is semantically incorrect."
+
+### Adopter guidance
+
+- `straymark update-framework` brings the new `TEMPLATE-TDE.md` and `DOCUMENTATION-POLICY.md`. Existing TDE files are unaffected — the template change is purely additive.
+- `straymark update-cli` brings the relaxed validator. TDE files marked `status: resolved` start passing immediately.
+- Sentinel-side AILOGs marked `final` / `closed` / `completed` continue to fail validation. The fix is to migrate those to `accepted` (the canonical AILOG terminal per `TEMPLATE-AILOG.md`) and capture the "work completed" semantics in the body or in the originating Charter's telemetry, not in the AILOG status field.
+
+---
+
 ## Framework 4.14.1 — Docs sync for batch-complete + Batch Ledger discoverability
 
 Framework-only patch that closes the documentation gap left by `fw-4.14.0` / `cli-3.13.0`. The release added the `batch-complete` subcommand and the Batch Ledger workflow but didn't surface them in three places adopters and contributors discover the project from: the root `README.md` (and i18n overlays), the project's user-facing comparison/feature lists, and **`dist/STRAYMARK.md`** — the governance file shipped to every adopter via `straymark init`.

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.14.1` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.13.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.14.2` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.14.1)
+# and download the latest fw-* release (e.g., fw-4.14.2)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -42,14 +42,33 @@ impl ValidationResult {
 }
 
 /// Valid status values per DOCUMENTATION-POLICY.md §3 lifecycle + §6 per-type defaults.
-/// `identified` is the canonical TDE entry state (agent-driven discovery, awaits
-/// human prioritization); functionally equivalent to `draft` for lifecycle gating
-/// but semantically distinct in adopter analytics.
+///
+/// - `identified` is the canonical TDE entry state (agent-driven discovery, awaits
+///   human prioritization); functionally equivalent to `draft` for lifecycle gating
+///   but semantically distinct in adopter analytics (regression #130).
+/// - `resolved` is the canonical TDE terminal state for "the debt described here
+///   was addressed; document is kept on disk as audit history". Neither `accepted`
+///   ("we accept this debt continues to exist"), `superseded` ("another TDE took
+///   its place"), nor `deprecated` ("the TDE concept itself is no longer relevant")
+///   captures this semantics correctly. Issue #149 surfaced the gap empirically
+///   in Sentinel post-CHARTER-17 housekeeping.
+///
+/// **Per-doc-type lifecycle vocabulary** (Option B in issue #149) is the principled
+/// next evolution: promote this flat enum to a `HashMap<DocType, Vec<&str>>` so each
+/// doc type has its own canonical state machine and the validator inspects
+/// `doc.doc_type` before deciding which set to apply. Deferred deliberately —
+/// shipping Option A (flat enum + `resolved`) keeps the validator's surface stable
+/// and avoids per-type branching until a second doc type needs a non-standard
+/// terminal. Adding `resolved` flat-globally is mildly permissive (an ADR with
+/// `status: resolved` would pass) but the damage is bounded: `DOCUMENTATION-POLICY`
+/// documents `resolved` as TDE-specific, and the per-type expansion in Option B
+/// will tighten the validation without breaking any existing TDE adopters.
 const VALID_STATUSES: &[&str] = &[
     "draft",
     "identified",
     "review",
     "accepted",
+    "resolved",
     "superseded",
     "deprecated",
 ];

--- a/cli/tests/validate_test.rs
+++ b/cli/tests/validate_test.rs
@@ -349,6 +349,61 @@ fn test_validate_dpia_document_valid() {
         .stdout(predicate::str::contains("passed validation"));
 }
 
+/// Regression test for issue #149: TDE documents can move to `status: resolved`
+/// when the debt described has been addressed. The document is kept on disk as
+/// audit history. `accepted` / `superseded` / `deprecated` do not capture this
+/// semantics correctly.
+#[test]
+fn test_validate_tde_resolved_terminal_state() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+
+    create_doc(
+        dir.path(),
+        "06-evolution/technical-debt",
+        "TDE-2026-05-11-001-architectural-refactor.md",
+        "id: TDE-2026-05-11-001\ntitle: Architectural Refactor Debt\nstatus: resolved\ncreated: 2026-05-11\nagent: claude-code-v1.0\nconfidence: high\nreview_required: false\nrisk_level: medium\ntype: architecture\nimpact: high\neffort: medium\ntags:\n  - architecture\nrelated: []\npriority: null\nassigned_to: null",
+    );
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("passed validation"));
+}
+
+/// Regression test for issue #149: status values reported by Sentinel as invented
+/// local terminals (`final`, `closed`, `completed`) MUST continue to fail
+/// validation. They are not canonical AILOG terminals — the canonical AILOG
+/// terminal is `accepted` per TEMPLATE-AILOG.md and DOCUMENTATION-POLICY.md §6.
+/// Documented in CHANGELOG fw-4.14.2 / cli-3.13.1 as "adopters using `final` /
+/// `closed` / `completed` should migrate to `accepted`".
+#[test]
+fn test_validate_rejects_non_canonical_ailog_terminals() {
+    for status in ["final", "closed", "completed"] {
+        let dir = TempDir::new().unwrap();
+        setup_straymark(dir.path());
+
+        create_doc(
+            dir.path(),
+            "07-ai-audit/agent-logs",
+            "AILOG-2026-05-13-001-test.md",
+            &format!(
+                "id: AILOG-2026-05-13-001\ntitle: Test\nstatus: {}\ncreated: 2026-05-13\nagent: claude-code-v1.0\nconfidence: high\nreview_required: false\nrisk_level: low\ntags: []\nrelated: []",
+                status
+            ),
+        );
+
+        let mut cmd = Command::cargo_bin("straymark").unwrap();
+        cmd.arg("validate")
+            .arg(dir.path().to_str().unwrap())
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains("META-003"));
+    }
+}
+
 /// Regression test for issue #130: TDE documents ship with `status: identified`
 /// per TEMPLATE-TDE.md and DOCUMENTATION-POLICY.md §6 — the validator must accept
 /// it as a valid lifecycle entry state.

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -156,6 +156,10 @@ identified ──┐
              │                       └──────► superseded
              │
              └──► (TDE-only entry state, see §6)
+                                      │
+                                      ▼
+                                  resolved
+                                  (TDE-only terminal — debt paid; see §6)
 ```
 
 | Status | Description |
@@ -163,10 +167,11 @@ identified ──┐
 | `identified` | Entry state for agent-driven discovery types (TDE today). Functionally equivalent to `draft` for lifecycle gating — a human reviewer is expected to prioritize and promote it. Semantically distinct so adopter analytics can distinguish "agent found this debt" from "human is drafting a deliberate doc". |
 | `draft` | In draft, pending review |
 | `accepted` | Approved and current |
+| `resolved` | **TDE-only terminal state**: the technical debt described in this document has been addressed; the file is kept on disk as audit history. Distinct from `accepted` ("we accept this debt continues to exist"), `superseded` ("another TDE replaced this one"), and `deprecated` ("the TDE concept itself is no longer relevant"). The canonical closing reference (the Charter, PR, or commit that paid the debt) goes in the `## Resolution` body section. |
 | `deprecated` | Obsolete, but kept as reference |
 | `superseded` | Replaced by another document |
 
-The per-type default status mapping lives in §6 — most types enter at `draft` or `accepted`, but TDE enters at `identified` per the agent-autonomy boundary (agent identifies, human prioritizes).
+The per-type default status mapping lives in §6 — most types enter at `draft` or `accepted`, but TDE enters at `identified` per the agent-autonomy boundary (agent identifies, human prioritizes). TDE is the only type today with a custom terminal state (`resolved`); the validator accepts `resolved` globally as a stop-gap. A future per-doc-type lifecycle vocabulary (issue #149 Option B) will scope `resolved` to TDE strictly; until then, using it on non-TDE documents is allowed by the validator but semantically incorrect.
 
 ---
 
@@ -269,7 +274,7 @@ For documents that require multiple reviewers (e.g., ETH with both legal and eng
 | `REQ` | Requirement | `01-requirements/` | `draft` | Yes |
 | `TES` | Test Plan | `04-testing/` | `draft` | Yes |
 | `INC` | Incident Post-mortem | `05-operations/incidents/` | `draft` | Yes |
-| `TDE` | Technical Debt | `06-evolution/technical-debt/` | `identified` | No |
+| `TDE` | Technical Debt | `06-evolution/technical-debt/` | `identified` (enters here; terminal `resolved` when debt paid — TDE-only) | No |
 | `SEC` | Security Assessment | `08-security/` | `draft` | Yes (always) |
 | `MCARD` | Model/System Card | `09-ai-models/` | `draft` | Yes (always) |
 | `SBOM` | Software Bill of Materials | `07-ai-audit/` | `accepted` | No |
@@ -313,4 +318,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -156,6 +156,10 @@ identified ──┐
              │                       └──────► superseded
              │
              └──► (estado de entrada TDE-only, ver §6)
+                                      │
+                                      ▼
+                                  resolved
+                                  (terminal sólo-TDE — deuda pagada; ver §6)
 ```
 
 | Estado | Descripción |
@@ -163,10 +167,11 @@ identified ──┐
 | `identified` | Estado de entrada para los tipos de descubrimiento dirigidos por agente (TDE hoy). Funcionalmente equivalente a `draft` para el lifecycle gating — se espera que un revisor humano lo priorice y lo promueva. Semánticamente distinto para que las analíticas del adopter puedan distinguir "el agente encontró esta deuda" de "un humano está redactando un documento deliberado". |
 | `draft` | En borrador, pendiente de revisión |
 | `accepted` | Aprobado y vigente |
+| `resolved` | **Estado terminal sólo-TDE**: la deuda técnica descrita en este documento fue atendida; el archivo se mantiene en disco como historia de auditoría. Distinto de `accepted` ("aceptamos que esta deuda persista"), `superseded` ("otro TDE reemplazó a este") y `deprecated` ("el concepto de TDE mismo ya no es relevante"). La referencia canónica de cierre (el Charter, PR o commit que pagó la deuda) va en la sección body `## Resolución`. |
 | `deprecated` | Obsoleto, pero se mantiene como referencia |
 | `superseded` | Reemplazado por otro documento |
 
-El mapeo de status por defecto por tipo vive en §6 — la mayoría de tipos entran en `draft` o `accepted`, pero TDE entra en `identified` por la frontera de autonomía del agente (el agente identifica, el humano prioriza).
+El mapeo de status por defecto por tipo vive en §6 — la mayoría de tipos entran en `draft` o `accepted`, pero TDE entra en `identified` por la frontera de autonomía del agente (el agente identifica, el humano prioriza). TDE es el único tipo hoy con un terminal personalizado (`resolved`); el validador acepta `resolved` globalmente como medida transitoria. Una futura tabla de vocabulario de lifecycle por-tipo (issue #149 Opción B) acotará `resolved` estrictamente a TDE; hasta entonces, usarlo en documentos no-TDE pasa la validación pero es semánticamente incorrecto.
 
 ---
 
@@ -270,7 +275,7 @@ Para documentos que requieren múltiples revisores (p. ej., ETH con sign-off de 
 | `REQ` | Requisito | `01-requirements/` | `draft` | Sí |
 | `TES` | Plan de Pruebas | `04-testing/` | `draft` | Sí |
 | `INC` | Post-mortem de Incidente | `05-operations/incidents/` | `draft` | Sí |
-| `TDE` | Deuda Técnica | `06-evolution/technical-debt/` | `identified` | No |
+| `TDE` | Deuda Técnica | `06-evolution/technical-debt/` | `identified` (entra aquí; terminal `resolved` cuando la deuda se paga — sólo-TDE) | No |
 | `SEC` | Evaluación de Seguridad | `08-security/` | `draft` | Sí (siempre) |
 | `MCARD` | Tarjeta de Modelo/Sistema | `09-ai-models/` | `draft` | Sí (siempre) |
 | `SBOM` | Lista de Materiales de Software | `07-ai-audit/` | `accepted` | No |
@@ -306,4 +311,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -156,6 +156,10 @@ identified ──┐
              │                       └──────► superseded
              │
              └──► (TDE 专用入口状态，见 §6)
+                                      │
+                                      ▼
+                                  resolved
+                                  (TDE 专用终态——债务已偿；见 §6)
 ```
 
 | 状态 | 说明 |
@@ -163,10 +167,11 @@ identified ──┐
 | `identified` | 由代理驱动发现的类型的入口状态（今日仅 TDE）。在生命周期校验上等同于 `draft`——期望人工审阅者来排定优先级并推进。语义上有所区分，以便 adopter 的分析能够区分"代理发现了此债务"与"人工正在起草一份有意识的文档"。 |
 | `draft` | 草稿中，待审核 |
 | `accepted` | 已批准且为当前有效版本 |
+| `resolved` | **TDE 专用终态**：本文档所述的技术债务已被解决；文档作为审计历史保留在磁盘上。区别于 `accepted`（"我们接受这笔债务继续存在"）、`superseded`（"另一份 TDE 取代了它"）和 `deprecated`（"TDE 这一概念本身已不再适用"）。规范的关闭引用（偿清债务的 Charter、PR 或 commit）写入 `## 解决记录` 章节。 |
 | `deprecated` | 已废弃，但保留作为参考 |
 | `superseded` | 已被其他文档替代 |
 
-按类型的默认 status 映射位于 §6——大多数类型以 `draft` 或 `accepted` 进入，但 TDE 因代理自主权边界（代理识别、人工排序）以 `identified` 进入。
+按类型的默认 status 映射位于 §6——大多数类型以 `draft` 或 `accepted` 进入，但 TDE 因代理自主权边界（代理识别、人工排序）以 `identified` 进入。TDE 是今日唯一拥有自定义终态（`resolved`）的类型；验证器全局接受 `resolved` 作为过渡安排。未来的按文档类型生命周期词汇表（issue #149 选项 B）将把 `resolved` 严格限定到 TDE；在此之前，将其用于非 TDE 文档可通过验证，但语义上不正确。
 
 ---
 
@@ -269,7 +274,7 @@ review_outcome: approved                # approved | revisions_requested | rejec
 | `REQ` | 需求 | `01-requirements/` | `draft` | 是 |
 | `TES` | 测试计划 | `04-testing/` | `draft` | 是 |
 | `INC` | 事故事后分析 | `05-operations/incidents/` | `draft` | 是 |
-| `TDE` | 技术债务 | `06-evolution/technical-debt/` | `identified` | 否 |
+| `TDE` | 技术债务 | `06-evolution/technical-debt/` | `identified`（在此进入；债务偿清时 `resolved` 为终态——仅 TDE） | 否 |
 | `SEC` | 安全评估 | `08-security/` | `draft` | 是（始终） |
 | `MCARD` | 模型/系统卡 | `09-ai-models/` | `draft` | 是（始终） |
 | `SBOM` | 软件物料清单 | `07-ai-audit/` | `accepted` | 否 |
@@ -305,4 +310,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.14.1 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.1 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.2 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/templates/TEMPLATE-TDE.md
+++ b/dist/.straymark/templates/TEMPLATE-TDE.md
@@ -1,7 +1,7 @@
 ---
 id: TDE-YYYY-MM-DD-NNN
 title: [Technical debt title]
-status: identified
+status: identified                # `identified` → `resolved` when the debt is paid (TDE-only terminal)
 created: YYYY-MM-DD
 agent: [agent-name-v1.0]
 confidence: high | medium | low
@@ -123,5 +123,24 @@ Impact   │             │             │
 | Sprint/Milestone | [If applicable] |
 | Assigned to | [Team/Person] |
 | Comments | [Notes] |
+
+---
+
+## Resolution
+
+> Fill this section AND flip `status: identified → resolved` in the frontmatter when
+> the debt described here has been addressed. Keep the document on disk — `resolved`
+> is the canonical TDE terminal state; the file becomes audit history rather than
+> being deleted. See DOCUMENTATION-POLICY.md §3 for the lifecycle semantics.
+>
+> Omit this section entirely while the debt is still `identified` / `accepted` /
+> superseded — it is meaningful only at the terminal transition.
+
+| Field | Value |
+|-------|-------|
+| Resolved by | [Charter ID / PR / commit that paid the debt] |
+| Date | [YYYY-MM-DD] |
+| Verification | [How was the resolution verified — tests, drift check, audit, etc.] |
+| Notes | [Anything future readers should know, e.g. partial-resolution scope] |
 
 <!-- Template: StrayMark | https://strangedays.tech -->

--- a/dist/.straymark/templates/i18n/es/TEMPLATE-TDE.md
+++ b/dist/.straymark/templates/i18n/es/TEMPLATE-TDE.md
@@ -1,7 +1,7 @@
 ---
 id: TDE-YYYY-MM-DD-NNN
 title: [Título de la deuda técnica]
-status: identified
+status: identified                # `identified` → `resolved` cuando la deuda se paga (terminal sólo-TDE)
 created: YYYY-MM-DD
 agent: [agent-name-v1.0]
 confidence: high | medium | low
@@ -123,5 +123,24 @@ Impacto  │               │               │
 | Sprint/Milestone | [Si aplica] |
 | Asignado a | [Equipo/Persona] |
 | Comentarios | [Notas] |
+
+---
+
+## Resolución
+
+> Llena esta sección Y cambia `status: identified → resolved` en el frontmatter cuando
+> la deuda descrita aquí haya sido atendida. Mantén el documento en disco — `resolved`
+> es el estado terminal canónico de TDE; el archivo se convierte en historia de auditoría
+> en lugar de eliminarse. Ver DOCUMENTATION-POLICY.md §3 para la semántica del ciclo.
+>
+> Omite esta sección completamente mientras la deuda sigue `identified` / `accepted` /
+> superseded — solo tiene sentido en la transición terminal.
+
+| Campo | Valor |
+|-------|-------|
+| Resuelto por | [ID del Charter / PR / commit que pagó la deuda] |
+| Fecha | [YYYY-MM-DD] |
+| Verificación | [Cómo se verificó la resolución — tests, drift check, audit, etc.] |
+| Notas | [Cualquier cosa que los lectores futuros deban saber, p.ej. scope de resolución parcial] |
 
 <!-- Template: StrayMark | https://strangedays.tech -->

--- a/dist/.straymark/templates/i18n/zh-CN/TEMPLATE-TDE.md
+++ b/dist/.straymark/templates/i18n/zh-CN/TEMPLATE-TDE.md
@@ -1,7 +1,7 @@
 ---
 id: TDE-YYYY-MM-DD-NNN
 title: [技术债务标题]
-status: identified
+status: identified                # `identified` → `resolved` 当债务偿清时（仅 TDE 的终态）
 created: YYYY-MM-DD
 agent: [agent-name-v1.0]
 confidence: high | medium | low
@@ -123,5 +123,23 @@ promoted_from_followup: null    # FU-NNN，如果从 .straymark/follow-ups-backl
 | 迭代/里程碑 | [如适用] |
 | 分配给 | [团队/个人] |
 | 备注 | [说明] |
+
+---
+
+## 解决记录 (Resolution)
+
+> 当此处所述的债务被解决时，填写此章节**并**将 frontmatter 的 `status: identified` 翻转为 `resolved`。
+> 保留磁盘上的文档——`resolved` 是 TDE 的规范终态；文件成为审计历史而非被删除。
+> 关于生命周期语义，请见 DOCUMENTATION-POLICY.md §3。
+>
+> 当债务仍为 `identified` / `accepted` / superseded 时，请完全省略此章节——
+> 它仅在终态转换时有意义。
+
+| 字段 | 值 |
+|------|-----|
+| 解决者 | [偿清债务的 Charter ID / PR / commit] |
+| 日期 | [YYYY-MM-DD] |
+| 验证方式 | [如何验证已解决——测试、drift 检查、审计等] |
+| 备注 | [未来读者应当知晓的事项，例如部分解决的范围] |
 
 <!-- Template: StrayMark | https://strangedays.tech -->

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.14.1"
+version: "4.14.2"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.14.1` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.13.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.14.2` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.1
+✔ Downloaded StrayMark fw-4.14.2
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.1
+✔ Framework updated to fw-4.14.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.1
+✔ Framework updated to fw-4.14.2
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.1                 │
+  │ Framework │ fw-4.14.2                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.1
+  Using version: fw-4.14.2
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1107,7 +1107,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.1
+  Framework version: fw-4.14.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -237,8 +237,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.14.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.13.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.14.2` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.14.1)
+# y descarga el último release fw-* (ej. fw-4.14.2)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.14.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.13.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.14.2` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.1
+✔ Downloaded StrayMark fw-4.14.2
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.1
+✔ Framework updated to fw-4.14.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.1
+✔ Framework updated to fw-4.14.2
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.14.1
+Framework version: fw-4.14.2
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -392,7 +392,7 @@ Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-
 - `straymark charter list` — enumera Charters con filtros opcionales
 - `straymark charter status` — muestra detalle de un Charter, o los 5 más recientes
 - `straymark charter close` *(cli-3.7.0+)* — registra la telemetría post-ejecución y mueve el Charter a `closed`
-- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware y gate de Batch Ledger *(gate añadido en cli-3.13.0)*
+- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware y gate de Batch Ledger *(gate añadido en cli-3.13.1)*
 - `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — marca un batch del Charter como completado en la `## Batch Ledger` del AILOG
 - `straymark charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
 
@@ -908,7 +908,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.1
+  Framework version: fw-4.14.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -255,8 +255,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.13.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.14.2` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.14.1）
+# 下载最新的 fw-* 发布（例如 fw-4.14.2）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.1` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.13.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.14.2` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.1
+✔ Downloaded StrayMark fw-4.14.2
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.1
+✔ Framework updated to fw-4.14.2
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.1
+✔ Framework updated to fw-4.14.2
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.1                 │
+  │ Framework │ fw-4.14.2                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.1
+  Using version: fw-4.14.2
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -422,7 +422,7 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 - `straymark charter list` — 用可选过滤器枚举章程
 - `straymark charter status` — 显示章程详情，或最近的 5 个章程
 - `straymark charter close` *(cli-3.7.0+)* — 记录执行后遥测并将章程移至 `closed`
-- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制和 Batch Ledger 门控 *(门控在 cli-3.13.0 添加)*
+- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制和 Batch Ledger 门控 *(门控在 cli-3.13.1 添加)*
 - `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — 在 AILOG 的 `## Batch Ledger` 中将章程批次标记为已完成
 - `straymark charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
 
@@ -1042,7 +1042,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.1
+  Framework version: fw-4.14.2
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

Closes [#149](https://github.com/StrangeDaysTech/straymark/issues/149). Surfaced by Sentinel post-CHARTER-17 housekeeping: TDE adopters who keep documents on disk as audit history after the debt is paid had no canonical status to mark the closure. `accepted` (\"we accept this debt continues to exist\"), `superseded` (\"another TDE replaced this\") and `deprecated` (\"the TDE concept is no longer relevant\") all carry the wrong semantics. The validator rejected `resolved` with `META-003`.

This PR ships **Option A** of the issue's proposal triplet (flat enum + `resolved`) and documents **Option B** (per-doc-type lifecycle vocabulary) as the deliberate next evolution.

## Why A now, not B

| | LOC | Trade-off |
|---|---|---|
| **A — add `resolved` flat** (shipping) | ~30 LOC + docs | Unblocks adopters today (Sentinel reports 2 TDE files with `status: resolved`). Mildly permissive — non-TDE docs with `status: resolved` pass validation but are semantically incorrect. The doc-comment in `validation.rs` and `DOCUMENTATION-POLICY.md §3` both name this gap explicitly. |
| **B — per-doc-type lifecycle lookup** (deferred) | ~150 LOC + per-type test matrix | The principled fix. Aligns with #130's framing (\"No `doc.doc_type` inspection, no branching\"). Best done after a second adopter exercises a non-standard terminal, so we don't calcify choices pre-announcement. |
| **C — lifecycle declarations in `DOCUMENTATION-POLICY.md`** (parked) | ~250 LOC + parsing | Governance-as-data; aligns with the `DOC_TYPE_PREFIXES` workflow pattern. Likely the right end-state once B exists and the per-type matrices have stabilized in real adopters. |

Issue body itself recommended A as the minimum viable fix.

## Scope

### CLI (cli-3.13.1)

- **`cli/src/validation.rs:48`** — `resolved` added to `VALID_STATUSES`. The constant doc-comment now explains the TDE semantics, the alternatives that don't fit, and the explicit deferral of Option B with the trade-off named.
- **`cli/tests/validate_test.rs`** — two new regression tests:
  - `test_validate_tde_resolved_terminal_state` (positive): TDE with `status: resolved` passes validation.
  - `test_validate_rejects_non_canonical_ailog_terminals` (negative): `final` / `closed` / `completed` continue to fail with `META-003`. Adopters using these on AILOGs (Sentinel reported 4 such files in #149) should migrate to `accepted` — the canonical AILOG terminal per `TEMPLATE-AILOG.md` and `DOCUMENTATION-POLICY.md §6`.

### Framework (fw-4.14.2)

- **`dist/.straymark/00-governance/DOCUMENTATION-POLICY.md`** (EN + i18n/es + i18n/zh-CN):
  - §3 lifecycle diagram extended with the `resolved` terminal branch (TDE-only).
  - §3 status table: new row with the principled distinction (`resolved` vs `accepted` vs `superseded` vs `deprecated`).
  - §6 TDE row annotated with the entry/terminal lifecycle.
  - Closing paragraph names Option B explicitly so adopters reading the policy know the per-doc-type tightening is coming.
- **`dist/.straymark/templates/TEMPLATE-TDE.md`** (EN + i18n/es + i18n/zh-CN):
  - Frontmatter `status: identified` annotated with the `→ resolved` transition.
  - New optional `## Resolution` body section (Resolved by / Date / Verification / Notes). Section is explicitly opt-in — meaningful only at the terminal transition.

### Docs sync

- README.md (root + i18n/es + i18n/zh-CN), CLI-REFERENCE.md (EN + ES + zh-CN): version tables + canonical output examples bumped to `fw-4.14.2` / `cli-3.13.1`. Minimum-version markers (`*(cli-3.13.0+, fw-4.14.0+)*`) are intentionally preserved.

## Test plan

- [x] `cargo test` — full suite passes (29 validate_test cases, +2 vs. previous baseline of 27)
- [x] New tests verified to fail with the previous `VALID_STATUSES` (`resolved` was rejected) and pass with the new one
- [x] `test_validate_rejects_non_canonical_ailog_terminals` exercises all three Sentinel-invented terminals (`final`, `closed`, `completed`) — all still rejected as expected
- [ ] Post-merge: Sentinel runs `straymark update-cli` + `straymark update-framework` and confirms 2 TDE files now pass + 4 AILOG files still fail (proving the targeted scope)

## Sentinel reconciliation

After this release:
- **TDE-2026-05-11-001** (CommsHub RequireScope architectural gap) and **TDE-2026-05-11-004** (charter-docs-layout drift) — can set `status: resolved` and fill the `## Resolution` body section pointing at CHARTER-15 / PR #64 respectively. Validates cleanly.
- **AILOG-2026-05-07-041 / -042 / -043 / -048** — should migrate the invented `final` / `closed` / `completed` to `accepted`. The \"work completed\" semantics belong in the originating Charter's telemetry (`closed_at`, drift outcome), not in the AILOG status field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)