### PR TITLE
feat(framework): fw-4.14.3 — spec-refresh discipline for multi-Charter execution (#150 Cubeta A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.14.3 — Spec-refresh discipline for multi-Charter execution (closes #150 Asks 1, 2, 4)
+
+Framework-only patch that closes a governance gap reported by Sentinel after running a single `specs/002-commshub/plan.md` through **seven consecutive Charters** over ~1 month. The bridge doc (`SPECKIT-CHARTER-BRIDGE.md`) covered Charter *declaration* but said nothing about *spec maintenance during multi-Charter execution* — and naively re-running `/speckit-plan` regenerates assertions about already-shipped user stories that the actual code does not implement, propagating stale state into future audits.
+
+Ships **Cubeta A** of the issue's two-bucket plan: pure governance documentation. **Cubeta B** (the `straymark spec-drift` CLI that mechanizes Gate (a), plus a cross-Charter `lessons-learned` index per [#146 Proposal D](https://github.com/StrangeDaysTech/straymark/issues/146)) is deferred to a dedicated post-announcement Charter — tracked separately so the context survives.
+
+### Added (Framework)
+
+- **`dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md`** (EN + i18n/es + i18n/zh-CN) — new section **"Spec maintenance during multi-Charter execution"** with the empirical anchor (Sentinel CHARTER-07..17 cycle, 12 unreflected learnings). Subsections:
+  - **When to refresh** — four heuristics (≥3 closed Charters, ≥4 weeks + ≥2 Charters, `R<N>(new)` count >6, target US touches refined infra). Explicit guidance to *skip* the refresh when none hold.
+  - **How to refresh: scope-limited prompt** — name the target phase, list locked sections, cite refinement AILOGs, forbid `tasks.md` regeneration.
+  - **Three mechanical gates** — (a) Validation against code reality (diff non-target-phase entities/endpoints vs migrations/handler signatures), (b) Granular hunk-by-hunk review, (c) Two-PR split (refresh PR separate from Charter-fill PR).
+  - **Why NOT re-run `/speckit-tasks`** — regenerating destroys `[X]` completion marks and `*CHARTER-NN:* <sha>*` annotations that form the historical trace. Manual edit for the target phase only.
+  - **Constitution Check re-evaluation cadence** — codifies per-Charter (recommended) + per-spec-refresh (mandatory) + NOT per-framework-bump alone, closing the implicit-cadence ambiguity reported by Sentinel.
+  - **Roadmap: `straymark spec-drift`** — names the deferred CLI explicitly so adopters reading the policy know mechanization of Gate (a) is coming post-announcement.
+- **Anti-pattern entry** — new bullet against re-running `/speckit-tasks` mid-execution, pointing to the new section for the safe path.
+
+### Changed (Repo-level docs, not shipped via `straymark init`)
+
+- **`docs/contributors/WHAT-IS-A-CHARTER.md`** §4 Mode A — cross-link inserted right after the SpecKit-driven flow diagram, surfacing the "what happens when a single spec drives many Charters?" question with a pointer to the new bridge-doc section. Contributors landing on the conceptual doc now find the operational discipline at the natural decision point.
+- **Governance footers** updated to `v4.14.3` across `QUICK-REFERENCE.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `C4-DIAGRAM-GUIDE.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md`, `SPECKIT-CHARTER-BRIDGE.md` (EN + ES + zh-CN, plus the top-level `dist/.straymark/QUICK-REFERENCE.md`).
+- **Version tables** in `README.md` (root + i18n) and `CLI-REFERENCE.md` (EN + ES + zh-CN) bumped to `fw-4.14.3`. Canonical-output examples (`Framework updated to fw-4.14.3`, etc.) follow.
+
+### Deferred — Cubeta B (post-announcement Charter)
+
+The empirical pattern around #150 reinforces the gap surfaced by [#146 Proposal D](https://github.com/StrangeDaysTech/straymark/issues/146) (cross-Charter `lessons-learned` index). Both #146 D and #150 Ask 3 are mechanics that live *above* the Charter as a unit — the missing "cross-Charter knowledge layer". A dedicated Charter post-announcement will design this layer cohesively: lessons-learned index + `straymark spec-drift` CLI + possible umbrella `straymark spec` command. A tracking issue is filed to preserve the context across the announcement cycle.
+
+### Why a patch release for docs only
+
+`dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md` is shipped to every adopter via `straymark init`. Without a framework bump, `straymark update-framework` would not bring the new section to existing installations. Sentinel needs the canonical recommendation before filling CHARTER-18 — the ~50% probability of inheriting a critical/high finding from stale-premise inheritance is real and time-sensitive.
+
+### Adopter guidance
+
+`straymark update-framework` brings the updated bridge doc and footers. No behavior changes: the CLI is unchanged (`cli-3.13.1` remains the matching CLI version), no schemas or templates moved. Adopters running multi-Charter specs should read the new section *before* declaring their next Charter against an aging spec.
+
+---
+
 ## Framework 4.14.2 / CLI 3.13.1 — TDE terminal `resolved` (closes #149)
 
 Closes [#149](https://github.com/StrangeDaysTech/straymark/issues/149) — surfaced by Sentinel post-CHARTER-17 housekeeping. TDE adopters who keep documents on disk as audit history after the debt is paid had no canonical status to mark the closure; `accepted` / `superseded` / `deprecated` all carry the wrong semantics. The validator rejected `resolved` with `META-003`.

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 |-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.14.2` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.14.3` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -307,7 +307,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.14.2)
+# and download the latest fw-* release (e.g., fw-4.14.3)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -318,4 +318,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md
+++ b/dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md
@@ -131,6 +131,75 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 | Optional external review | Multi-model audit | `straymark charter audit CHARTER-NN` + `/straymark-audit-prompt` + `/straymark-audit-execute` + `/straymark-audit-review` |
 | Cut shipped | Close Charter | `straymark charter close CHARTER-NN` (status: `closed`, telemetry yaml emitted) |
 
+## Spec maintenance during multi-Charter execution
+
+> **Empirical anchor**: surfaced by [issue #150](https://github.com/StrangeDaysTech/straymark/issues/150) after Sentinel ran a single `specs/002-commshub/plan.md` (committed 2026-04-21) through **seven consecutive Charters** (CHARTER-07 through CHARTER-17, ~1 month). Twelve aprendizajes empíricos that materially impact the next Charter's scope were *not* reflected in the plan. The pattern below codifies what Sentinel discovered before CHARTER-18 fill.
+
+The lifecycle map above assumes **one-pass**: SpecKit artifacts are generated once, then Charters are declared and executed. This scales fine for features that produce a single Charter. When a single spec drives many Charters spaced weeks apart, **planning artifacts drift relative to shipped code** — and naively re-running `/speckit-plan` is *worse*, not better: regeneration asserts things about already-shipped user stories that the actual code does not implement, and future readers (auditors, agents, new operators) trust those regenerated artifacts as ground truth.
+
+This section answers **how**, not **whether**: what discipline keeps the spec in sync with code during multi-Charter execution **without** the regeneration step lying about the parts that already shipped.
+
+### When to refresh
+
+A spec-refresh is warranted when *any* of the following hold:
+
+1. **≥3 Charters closed against the same spec** — the volume of unreflected execution detail is high enough that the next Charter's scope decisions risk inheriting stale premises.
+2. **≥4 calendar weeks** since the spec was last refreshed (or since initial generation) and ≥2 Charters closed in that window.
+3. **AILOG `## Risk: R<N>(new, not in Charter)` count on the spec exceeds ~6 across closed Charters** — the spec's anticipation of risk has measurably under-described the territory.
+4. **The next Charter's user story touches infrastructure the prior Charters refined empirically** (new tables/migrations created, helpers extracted, contracts crystallized) and the spec describes the pre-refinement state.
+
+If none hold and the next Charter targets a fresh sub-system the prior Charters didn't touch, **skip the refresh**. Spec stability has value; refreshing on every Charter creates churn without proportional clarity gain.
+
+### How to refresh: scope-limited prompt
+
+Do **not** re-run `/speckit-plan` with a blank slate. The regenerated `plan.md` + `research.md` + `data-model.md` + `contracts/` + `quickstart.md` will assert things about already-shipped user stories that the actual code does not implement.
+
+Instead, invoke `/speckit-plan` with a **scope-limited prompt** that:
+
+1. **Names the target phase explicitly** (e.g., "refresh planning for US5 only — failover + tracking").
+2. **Lists locked sections that must not change** (e.g., "Foundation, US1, US2, US3, US4 sections are immutable — the code shipped against them is the ground truth, not the plan").
+3. **Cites the AILOGs that document refinements** (e.g., "see AILOG-2026-05-11-043 §R5 for the `processed_events` reuse pattern; reflect this in the refreshed data model").
+4. **Forbids regenerating `tasks.md`** — see next subsection.
+
+The output is a `plan.md` (and possibly `research.md` / `data-model.md` / `contracts/`) where the target-phase content is fresh and the locked sections carry forward the actually-shipped state, not the original aspirational state.
+
+### Three mechanical gates post-refresh
+
+Before merging the spec-refresh PR, three gates run sequentially:
+
+**Gate (a) — Validation against code reality.**
+For each non-target-phase entity in `data-model.md`, diff against the actual `db/migrations/*.sql` (or equivalent schema source). For each non-target-phase endpoint in `contracts/*.md`, diff against actual handler signatures. Any divergence in a *locked* section blocks merge — that's the regeneration lying. Adopters may script this against their stack; a CLI helper (`straymark spec-drift`) is on the roadmap (see #150 Ask 3).
+
+**Gate (b) — Granular diff hunk-by-hunk review.**
+Run `git diff specs/NNN-feature/` and review file-by-file, hunk-by-hunk. No changes to locked sections accepted without an explicit justification comment in the PR. The diff is small enough when scope-limited that this is feasible in one sitting.
+
+**Gate (c) — Two-PR split.**
+Land the spec-refresh as its own PR. Review it against the *code*, not against the plan-only output. Then fill the target Charter against the refreshed spec in a *separate* PR. Mixing the two collapses review surfaces: reviewers can no longer tell whether a hunk reflects new shipped state or new planned state.
+
+### Why NOT re-run `/speckit-tasks` mid-spec-execution
+
+The `tasks.md` file accumulates implementation trace state during execution: `[X]` checkboxes on completed tasks, `*CHARTER-NN: <commit-sha>*` annotations citing which Charter shipped which task, possibly `^skipped` markers with rationale. **Regenerating `tasks.md` destroys this state.** The file becomes a fresh task list with no record of what already shipped.
+
+Discipline: **never** re-run `/speckit-tasks` while a spec is in the middle of multi-Charter execution. Instead, **manually edit `tasks.md`** for the target phase only — append new tasks for the refreshed scope, leave the already-shipped sections (`[X]` + `*CHARTER-NN:*` annotations) untouched.
+
+If you discover that the original `tasks.md` had errors in shipped sections (e.g., a task was incorrectly marked `[X]` when its work was actually split across two Charters), correct it manually with a Git commit. Treat `tasks.md` as a historical record from the point of first execution onward; it is no longer a regeneratable artifact.
+
+### Constitution Check re-evaluation cadence
+
+SpecKit's Constitution Check is typically run once at `/speckit-plan` time. In multi-Charter execution against a single spec, the question of *when* to re-evaluate is left implicit. To make this explicit:
+
+- **Per-Charter (recommended)** — re-evaluate Constitution Check at the start of each new Charter declared against the spec. The check is cheap (read the constitution; compare against the Charter's declared scope) and catches drift early, before execution commits.
+- **Per-spec-refresh (mandatory when the refresh happens)** — when a scope-limited `/speckit-plan` refresh lands, the refresh PR must re-run Constitution Check against the refreshed plan. If the framework version moved (e.g., `fw-4.10.x → fw-4.14.x`), Constitution Check may yield different results because new gates exist.
+- **NOT per-framework-bump alone** — a `straymark update-framework` between Charters does *not* require an immediate Constitution Check re-run on the open spec. The check applies at the next natural boundary (next Charter declaration or spec-refresh).
+
+Codifying this as explicit cadence (rather than "whoever decides") closes a recurring ambiguity reported by Sentinel post-CHARTER-17.
+
+### Roadmap: `straymark spec-drift`
+
+A CLI command analogous to `straymark charter drift`, but operating at spec granularity — parse `data-model.md` → entities → diff against `db/migrations/*.sql`; parse `contracts/*.md` → endpoints → diff against handler signatures. It would mechanize Gate (a) above.
+
+Deferred deliberately to a post-announcement Charter (tracked separately). The CLI surface is meaningful only for adopters whose spec format follows SpecKit conventions; the language-detection layer (Go vs Rust vs TypeScript vs Python handlers; SQL vs ORM-defined schemas) is non-trivial and warrants its own design cycle informed by real adopter stacks. The discipline above (Gates a/b/c executed manually) is the v0; the CLI is the v1 that mechanizes the most expensive gate.
+
 ## Anti-patterns
 
 **Don't open a Charter "to be safe".** A Charter without a clear shippable cut becomes a wishlist. Operators end up closing it as `closed: aborted` and the telemetry is meaningless.
@@ -142,6 +211,8 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 **Don't run `straymark charter audit` without the auditor CLIs available.** The audit is orchestration-only — `straymark` does not call LLM APIs. If you don't have N auditor CLIs ready, skip the step; close the Charter without external audit.
 
 **Don't flip status to `closed` before drift check + telemetry yaml.** `straymark charter close` does both atomically; manual closure skips invariants.
+
+**Don't re-run `/speckit-tasks` mid-spec-execution.** Regenerating `tasks.md` destroys the `[X]` completion marks and `*CHARTER-NN:* …` annotations that form the historical trace. See "Spec maintenance during multi-Charter execution" above for the safe path (manual edit for the target phase only).
 
 ## When this pattern doesn't fit
 

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/SPECKIT-CHARTER-BRIDGE.md
+++ b/dist/.straymark/00-governance/i18n/es/SPECKIT-CHARTER-BRIDGE.md
@@ -131,6 +131,75 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 | Revisión externa opcional | Auditoría multi-modelo | `straymark charter audit CHARTER-NN` + `/straymark-audit-prompt` + `/straymark-audit-execute` + `/straymark-audit-review` |
 | Corte enviado | Cerrar Charter | `straymark charter close CHARTER-NN` (status: `closed`, telemetry yaml emitido) |
 
+## Mantención del spec durante ejecución multi-Charter
+
+> **Anclaje empírico**: surfaceado por [issue #150](https://github.com/StrangeDaysTech/straymark/issues/150) después de que Sentinel corriera un único `specs/002-commshub/plan.md` (committed 2026-04-21) a través de **siete Charters consecutivos** (CHARTER-07 a CHARTER-17, ~1 mes). Doce aprendizajes empíricos que impactan materialmente el scope del siguiente Charter **no** quedaron reflejados en el plan. El patrón siguiente codifica lo que Sentinel descubrió antes de llenar CHARTER-18.
+
+El mapa de ciclo de vida arriba asume **una sola pasada**: los artefactos de SpecKit se generan una vez, luego los Charters se declaran y ejecutan. Esto escala bien para features que producen un solo Charter. Cuando un solo spec conduce varios Charters espaciados por semanas, **los artefactos de planeación driftean respecto al código shippeado** — y re-correr `/speckit-plan` ingenuamente es *peor*, no mejor: la regeneración afirma cosas sobre user stories ya shippeadas que el código real no implementa, y los lectores futuros (auditores, agentes, nuevos operadores) confían en esos artefactos regenerados como ground truth.
+
+Esta sección responde **cómo**, no **si**: qué disciplina mantiene al spec sincronizado con el código durante ejecución multi-Charter **sin** que el paso de regeneración mienta sobre las partes que ya shippearon.
+
+### Cuándo refrescar
+
+Un spec-refresh está justificado cuando *cualquiera* de las siguientes condiciones se cumple:
+
+1. **≥3 Charters cerrados contra el mismo spec** — el volumen de detalle de ejecución no reflejado es lo suficientemente alto para que las decisiones de scope del siguiente Charter arriesguen heredar premisas obsoletas.
+2. **≥4 semanas calendario** desde el último refresh del spec (o desde la generación inicial) y ≥2 Charters cerrados en esa ventana.
+3. **Conteo de AILOG `## Risk: R<N>(new, not in Charter)` sobre el spec excede ~6 a través de los Charters cerrados** — la anticipación de riesgo del spec subdescribe medibly el territorio.
+4. **La user story del siguiente Charter toca infraestructura que los Charters previos refinaron empíricamente** (nuevas tablas/migraciones creadas, helpers extraídos, contratos cristalizados) y el spec describe el estado pre-refinamiento.
+
+Si ninguna se cumple y el siguiente Charter apunta a un sub-sistema fresco que los Charters previos no tocaron, **omite el refresh**. La estabilidad del spec tiene valor; refrescar en cada Charter genera churn sin ganancia proporcional de claridad.
+
+### Cómo refrescar: prompt scope-limited
+
+**No** re-corras `/speckit-plan` con pizarra en blanco. El `plan.md` + `research.md` + `data-model.md` + `contracts/` + `quickstart.md` regenerados afirmarán cosas sobre user stories ya shippeadas que el código real no implementa.
+
+En su lugar, invoca `/speckit-plan` con un **prompt scope-limited** que:
+
+1. **Nombre la fase target explícitamente** (p.ej., "refresca planeación sólo para US5 — failover + tracking").
+2. **Liste secciones bloqueadas que no deben cambiar** (p.ej., "las secciones Foundation, US1, US2, US3, US4 son inmutables — el código shippeado contra ellas es la ground truth, no el plan").
+3. **Cite los AILOGs que documentan refinamientos** (p.ej., "ver AILOG-2026-05-11-043 §R5 para el patrón de reuso de `processed_events`; reflejar esto en el data model refrescado").
+4. **Prohíba regenerar `tasks.md`** — ver subsección siguiente.
+
+El output es un `plan.md` (y posiblemente `research.md` / `data-model.md` / `contracts/`) donde el contenido de la fase target es fresco y las secciones bloqueadas cargan hacia adelante el estado realmente shippeado, no el estado aspiracional original.
+
+### Tres gates mecánicos post-refresh
+
+Antes de mergear el PR del spec-refresh, tres gates corren secuencialmente:
+
+**Gate (a) — Validación contra realidad del código.**
+Para cada entidad no-target-phase en `data-model.md`, diff contra los `db/migrations/*.sql` reales (o fuente equivalente de schema). Para cada endpoint no-target-phase en `contracts/*.md`, diff contra signatures de handlers reales. Cualquier divergencia en una sección *bloqueada* bloquea el merge — eso es la regeneración mintiendo. Los adopters pueden scriptarlo contra su stack; un helper CLI (`straymark spec-drift`) está en el roadmap (ver #150 Ask 3).
+
+**Gate (b) — Revisión granular hunk-por-hunk del diff.**
+Corre `git diff specs/NNN-feature/` y revisa archivo-por-archivo, hunk-por-hunk. Ningún cambio a secciones bloqueadas se acepta sin un comentario de justificación explícito en el PR. El diff es lo suficientemente pequeño cuando es scope-limited para que esto sea factible en una sentada.
+
+**Gate (c) — Split en dos PRs.**
+Aterriza el spec-refresh como su propio PR. Revísalo contra el *código*, no contra el output plan-only. Luego llena el Charter target contra el spec refrescado en un PR *separado*. Mezclar los dos colapsa superficies de review: los reviewers ya no pueden distinguir si un hunk refleja nuevo estado shippeado o nuevo estado planeado.
+
+### Por qué NO re-correr `/speckit-tasks` mid-ejecución
+
+El archivo `tasks.md` acumula estado de trace de implementación durante ejecución: checkboxes `[X]` en tareas completadas, anotaciones `*CHARTER-NN: <commit-sha>*` citando qué Charter shippeó qué tarea, posiblemente marcadores `^skipped` con rationale. **Regenerar `tasks.md` destruye este estado.** El archivo se vuelve una lista fresca de tareas sin registro de lo que ya shippeó.
+
+Disciplina: **nunca** re-corras `/speckit-tasks` mientras un spec está en medio de ejecución multi-Charter. En su lugar, **edita manualmente `tasks.md`** sólo para la fase target — añade tareas nuevas para el scope refrescado, deja las secciones ya-shippeadas (`[X]` + anotaciones `*CHARTER-NN:*`) intactas.
+
+Si descubres que el `tasks.md` original tenía errores en secciones shippeadas (p.ej., una tarea fue incorrectamente marcada `[X]` cuando su trabajo se partió en dos Charters), corrígelo manualmente con un commit Git. Trata `tasks.md` como un registro histórico desde el punto de primera ejecución en adelante; ya no es un artefacto regenerable.
+
+### Cadencia de re-evaluación de Constitution Check
+
+El Constitution Check de SpecKit típicamente se corre una vez en tiempo `/speckit-plan`. En ejecución multi-Charter contra un solo spec, la pregunta de *cuándo* re-evaluar queda implícita. Para hacerla explícita:
+
+- **Por-Charter (recomendado)** — re-evalúa Constitution Check al inicio de cada Charter nuevo declarado contra el spec. El check es barato (leer la constitución; comparar contra el scope declarado del Charter) y atrapa drift temprano, antes de que la ejecución se commitee.
+- **Por-spec-refresh (obligatorio cuando el refresh sucede)** — cuando un refresh de `/speckit-plan` scope-limited aterriza, el PR de refresh debe re-correr Constitution Check contra el plan refrescado. Si la versión del framework se movió (p.ej., `fw-4.10.x → fw-4.14.x`), Constitution Check puede arrojar resultados distintos porque existen gates nuevos.
+- **NO por-framework-bump aislado** — un `straymark update-framework` entre Charters *no* requiere un re-run inmediato de Constitution Check sobre el spec abierto. El check aplica en el siguiente boundary natural (siguiente declaración de Charter o spec-refresh).
+
+Codificar esto como cadencia explícita (en lugar de "lo decide quien quiera") cierra una ambigüedad recurrente reportada por Sentinel post-CHARTER-17.
+
+### Roadmap: `straymark spec-drift`
+
+Un comando CLI análogo a `straymark charter drift`, pero operando a granularidad de spec — parsear `data-model.md` → entidades → diff contra `db/migrations/*.sql`; parsear `contracts/*.md` → endpoints → diff contra signatures de handlers. Mecanizaría el Gate (a) arriba.
+
+Diferido deliberadamente a un Charter post-anuncio (tracked por separado). La superficie de CLI es significativa sólo para adopters cuyo formato de spec sigue las convenciones de SpecKit; la capa de detección de lenguaje (handlers Go vs Rust vs TypeScript vs Python; schemas SQL vs ORM-defined) es no-trivial y amerita su propio ciclo de diseño informado por stacks reales de adopters. La disciplina arriba (Gates a/b/c ejecutados manualmente) es el v0; el CLI es el v1 que mecaniza el gate más costoso.
+
 ## Anti-patrones
 
 **No abras un Charter "por si acaso".** Un Charter sin un corte enviable claro se convierte en una wishlist. El operador termina cerrándolo como `closed: aborted` y la telemetría no significa nada.
@@ -142,6 +211,8 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 **No corras `straymark charter audit` sin las CLIs auditoras disponibles.** La auditoría es orchestration-only — `straymark` no llama a APIs de LLM. Si no tienes N CLIs auditoras listas, salta el paso; cierra el Charter sin auditoría externa.
 
 **No cambies status a `closed` antes del drift check + yaml de telemetría.** `straymark charter close` hace ambos atómicamente; el cierre manual salta invariantes.
+
+**No re-corras `/speckit-tasks` mid-ejecución del spec.** Regenerar `tasks.md` destruye los marcadores `[X]` de completitud y las anotaciones `*CHARTER-NN:* …` que forman el rastro histórico. Ver "Mantención del spec durante ejecución multi-Charter" arriba para la ruta segura (edición manual sólo para la fase target).
 
 ## Cuándo este patrón no aplica
 

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -310,4 +310,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.14.2 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/SPECKIT-CHARTER-BRIDGE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/SPECKIT-CHARTER-BRIDGE.md
@@ -131,6 +131,75 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 | 可选外部审查 | 多模型审计 | `straymark charter audit CHARTER-NN` + `/straymark-audit-prompt` + `/straymark-audit-execute` + `/straymark-audit-review` |
 | 切片已发布 | 关闭 Charter | `straymark charter close CHARTER-NN`（状态：`closed`，发出 telemetry yaml） |
 
+## 多 Charter 执行期间的 spec 维护
+
+> **经验锚点**：由 [issue #150](https://github.com/StrangeDaysTech/straymark/issues/150) 浮现——Sentinel 让单个 `specs/002-commshub/plan.md`（2026-04-21 提交）连续驱动了**七个 Charter**（CHARTER-07 至 CHARTER-17，约 1 个月）。十二条经验性发现实质上影响着下一个 Charter 的 scope，但 plan 中**并未**反映这些。下面的模式编纂了 Sentinel 在填写 CHARTER-18 之前发现的内容。
+
+上方的生命周期映射假设**一次性**：SpecKit 工件生成一次，然后声明并执行 Charter。这种方式对于产出单个 Charter 的 feature 是 OK 的。当单个 spec 在几周时间内驱动多个 Charter 时，**规划工件相对于已发布代码会发生漂移**——而盲目重新运行 `/speckit-plan` 更糟：再生会断言已发布 user story 的事项，而真实代码并不实现这些；未来的读者（审计员、agents、新操作者）会信任这些再生工件为 ground truth。
+
+本节回答**如何**，而非**是否**：什么样的纪律能够使 spec 在多 Charter 执行期间与代码保持同步，**而不让**再生步骤对已经发布的部分撒谎。
+
+### 何时刷新
+
+下述条件**任一**满足时，spec 刷新是合理的：
+
+1. **同一 spec 下已关闭 ≥3 个 Charter**——未反映的执行细节量已经足够大，下一个 Charter 的 scope 决策有继承陈旧前提的风险。
+2. **距离上次刷新（或初次生成）≥4 个日历周**，且窗口内已关闭 ≥2 个 Charter。
+3. **跨已关闭 Charter 累计的 AILOG `## Risk: R<N>(new, not in Charter)` 数量超过 ~6**——spec 对风险的预期可量化地低估了实际领域。
+4. **下一个 Charter 的 user story 涉及前序 Charter 已经凭经验细化的基础设施**（新建表/migrations、抽出的 helper、固化的契约），而 spec 描述的是细化前状态。
+
+如果都不满足，且下一个 Charter 指向前序 Charter 未触及的新子系统，**跳过刷新**。Spec 的稳定性本身有价值；每个 Charter 都刷新会产生 churn，却缺乏对应的清晰度收益。
+
+### 如何刷新：scope-limited prompt
+
+**不要**以空白板的方式重新运行 `/speckit-plan`。再生的 `plan.md` + `research.md` + `data-model.md` + `contracts/` + `quickstart.md` 会断言已发布 user story 的事项，而真实代码并不实现这些。
+
+相反，使用 **scope-limited prompt** 调用 `/speckit-plan`：
+
+1. **显式命名目标阶段**（例如，"只刷新 US5 的规划——failover + tracking"）。
+2. **列出不可改动的锁定 sections**（例如，"Foundation、US1、US2、US3、US4 sections 不可变——已发布的代码是 ground truth，而非 plan"）。
+3. **引用记录精化过程的 AILOG**（例如，"参考 AILOG-2026-05-11-043 §R5 中的 `processed_events` 复用模式；在刷新的 data model 中反映这一点"）。
+4. **禁止再生 `tasks.md`**——见下一小节。
+
+输出是 `plan.md`（可能还有 `research.md` / `data-model.md` / `contracts/`），其中目标阶段内容是新鲜的，锁定 sections 承载向前的是真正发布的状态，而非原本的愿景状态。
+
+### 刷新后的三个机械门
+
+在合并 spec-refresh PR 之前，依序执行三个 gate：
+
+**Gate (a) ——对照代码现实的验证。**
+对 `data-model.md` 中每个非目标阶段实体，与实际 `db/migrations/*.sql`（或等价的 schema 来源）对 diff。对 `contracts/*.md` 中每个非目标阶段端点，与实际 handler 签名对 diff。锁定 section 中的任何分歧都会阻塞合并——那是再生在撒谎。Adopter 可以针对自己的 stack 编写脚本；CLI helper（`straymark spec-drift`）在路线图上（见 #150 Ask 3）。
+
+**Gate (b) ——按 hunk 粒度审阅 diff。**
+运行 `git diff specs/NNN-feature/`，按文件按 hunk 审阅。锁定 sections 的任何变更未经 PR 中显式的理由注释不可接受。在 scope-limited 时 diff 足够小，一坐就能完成。
+
+**Gate (c) ——两 PR 拆分。**
+将 spec-refresh 作为独立的 PR 落地。**对照代码**而非对照 plan-only 输出来审阅它。然后在*单独*的 PR 中针对刷新后的 spec 填写目标 Charter。把两者混在一起会折叠审阅表面：审阅者再也无法分辨某个 hunk 反映的是新发布的状态还是新规划的状态。
+
+### 为什么**不要**在 spec 执行中途重新运行 `/speckit-tasks`
+
+`tasks.md` 文件在执行期间积累了实现追溯状态：已完成任务的 `[X]` 复选框、引用某个 Charter 发布了某个任务的 `*CHARTER-NN: <commit-sha>*` 标注，可能还有带理由的 `^skipped` 标记。**再生 `tasks.md` 会摧毁这一状态。** 文件会变成一份没有任何已发布记录的新鲜任务清单。
+
+纪律：在 spec 处于多 Charter 执行中途时，**绝不**重新运行 `/speckit-tasks`。相反，**只针对目标阶段手工编辑 `tasks.md`**——为刷新后的 scope 追加新任务，让已发布的 sections（`[X]` + `*CHARTER-NN:*` 注释）保持不动。
+
+如果你发现原本的 `tasks.md` 在已发布 sections 中存在错误（例如，某个任务被错误标为 `[X]`，但其工作实际上跨两个 Charter），用 Git commit 手工修正。把 `tasks.md` 当作从首次执行起的历史记录；它不再是可再生的工件。
+
+### Constitution Check 再评估的节奏
+
+SpecKit 的 Constitution Check 通常在 `/speckit-plan` 时只运行一次。在针对同一 spec 的多 Charter 执行中，*何时*再评估的问题是隐式的。为了把这一点显式化：
+
+- **每 Charter（推荐）**——在针对该 spec 声明的每个新 Charter 起始时再评估 Constitution Check。该 check 成本低（读取宪法；对照 Charter 声明的 scope），在执行 commit 之前就能尽早抓住 drift。
+- **每次 spec 刷新（刷新发生时强制）**——当 scope-limited 的 `/speckit-plan` 刷新落地时，refresh PR 必须针对刷新后的 plan 重新运行 Constitution Check。如果框架版本已经移动（例如 `fw-4.10.x → fw-4.14.x`），Constitution Check 可能由于存在新的 gate 而给出不同结果。
+- **单独的 framework 升级不触发**——Charters 之间的 `straymark update-framework` **不**要求在 spec 未关闭的情况下立即再运行 Constitution Check。该 check 应用于下一次自然边界（下一个 Charter 声明或 spec 刷新）。
+
+将此编码为显式节奏（而非"谁想就谁决定"）闭合了 Sentinel 在 CHARTER-17 后报告的一处反复出现的模糊性。
+
+### 路线图：`straymark spec-drift`
+
+与 `straymark charter drift` 类似的 CLI 命令，但在 spec 粒度上工作——解析 `data-model.md` → 实体 → 与 `db/migrations/*.sql` 对 diff；解析 `contracts/*.md` → 端点 → 与 handler 签名对 diff。它会机械化上方的 Gate (a)。
+
+刻意推迟到发布后的一个 Charter（独立跟踪）。CLI 表面只对其 spec 格式遵循 SpecKit 约定的 adopter 有意义；语言检测层（Go vs Rust vs TypeScript vs Python handler；SQL vs ORM 定义的 schema）非平凡，且应当由真实 adopter stack 提供信息后再走自己的设计周期。上方的纪律（手工执行 Gates a/b/c）是 v0；CLI 是机械化最昂贵 gate 的 v1。
+
 ## 反模式
 
 **不要"以防万一"开 Charter。** 没有清晰可发布切片的 Charter 会变成愿望清单。操作者最终会把它关为 `closed: aborted`，遥测毫无意义。
@@ -142,6 +211,8 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 **没有就绪的审计员 CLI 时，不要运行 `straymark charter audit`。** 审计仅为编排——`straymark` 不调用 LLM API。如果没有 N 个审计员 CLI 就绪，跳过该步骤；不进行外部审计直接关闭 Charter。
 
 **不要在 drift 检查 + telemetry yaml 之前把状态改为 `closed`。** `straymark charter close` 原子化地完成两者；手动关闭跳过了不变量。
+
+**不要在 spec 执行中途重新运行 `/speckit-tasks`。** 再生 `tasks.md` 会摧毁形成历史轨迹的 `[X]` 完成标记与 `*CHARTER-NN:* …` 标注。安全路径见上方"多 Charter 执行期间的 spec 维护"章节（仅针对目标阶段手工编辑）。
 
 ## 此模式不适用的场景
 

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.2 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.14.3 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.14.2"
+version: "4.14.3"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.14.2` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.14.3` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.2
+✔ Downloaded StrayMark fw-4.14.3
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.2
+✔ Framework updated to fw-4.14.3
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.2
+✔ Framework updated to fw-4.14.3
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.2                 │
+  │ Framework │ fw-4.14.3                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.2
+  Using version: fw-4.14.3
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1107,7 +1107,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.2
+  Framework version: fw-4.14.3
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/contributors/WHAT-IS-A-CHARTER.md
+++ b/docs/contributors/WHAT-IS-A-CHARTER.md
@@ -93,6 +93,8 @@ spec.md  →  plan.md  →  tasks.md  →  ┐
 
 Each StrayMark Charter takes a subset of tasks (typically a user story or a phase) and adds the three layers SpecKit doesn't provide: executable verification, file declaration to measure drift against, and AILOG/audit hookup.
 
+> **What happens when a single spec drives many Charters over weeks?** The SpecKit artifacts (`plan.md`, `data-model.md`, `contracts/`, `tasks.md`) drift relative to the code shipped by intermediate Charters. Naively re-running `/speckit-plan` is *worse* — it regenerates assertions about already-shipped user stories that the actual code does not implement. See `dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md` → **"Spec maintenance during multi-Charter execution"** for the canonical discipline: when to refresh, scope-limited prompt, three mechanical gates (validation against code reality, hunk-by-hunk review, two-PR split), and the explicit warning against re-running `/speckit-tasks` mid-execution.
+
 ### Mode B — Maintenance / post-MVP (Sentinel's actual case)
 
 No SpecKit running. Sentinel's Plans 01–06 are born from AILOGs and post-MVP backlog, not from specs. The Charter's `Origen:` field points to an AILOG, not to a `specs/###-feature/`. Here the StrayMark Charter is freestanding.

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -237,7 +237,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.14.2` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.14.3` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -270,7 +270,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.14.2)
+# y descarga el último release fw-* (ej. fw-4.14.3)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.14.2` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.14.3` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.2
+✔ Downloaded StrayMark fw-4.14.3
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.2
+✔ Framework updated to fw-4.14.3
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.2
+✔ Framework updated to fw-4.14.3
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.14.2
+Framework version: fw-4.14.3
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -908,7 +908,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.2
+  Framework version: fw-4.14.3
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -255,7 +255,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.2` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.14.3` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
@@ -288,7 +288,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.14.2）
+# 下载最新的 fw-* 发布（例如 fw-4.14.3）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.2` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.14.3` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.2
+✔ Downloaded StrayMark fw-4.14.3
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.2
+✔ Framework updated to fw-4.14.3
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.2
+✔ Framework updated to fw-4.14.3
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.2                 │
+  │ Framework │ fw-4.14.3                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.2
+  Using version: fw-4.14.3
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1042,7 +1042,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.2
+  Framework version: fw-4.14.3
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

Closes **Cubeta A** of [#150](https://github.com/StrangeDaysTech/straymark/issues/150). Surfaced by Sentinel after running a single `specs/002-commshub/plan.md` through seven consecutive Charters (CHARTER-07..17, ~1 month). The bridge doc covered Charter *declaration* but said nothing about *spec maintenance during multi-Charter execution*.

The empirical case: 12 unreflected learnings (infrastructure patterns refined during execution, code gaps the plan didn't anticipate, Charter/audit patterns crystallized over the cycle) accumulated to the point that the next Charter (CHARTER-18, US5) carries ~50% probability of inheriting a critical/high audit finding from stale-premise inheritance. But naively re-running `/speckit-plan` is *worse* — regeneration asserts things about already-shipped user stories that the actual code does not implement.

This PR ships the canonical discipline as governance documentation. **Cubeta B** (the `straymark spec-drift` CLI that mechanizes Gate (a), plus the cross-Charter `lessons-learned` index from [#146 Proposal D](https://github.com/StrangeDaysTech/straymark/issues/146)) is deferred to a dedicated post-announcement Charter — tracking issue to be filed in the next commit on `main`.

## What's in scope

### `dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md` (EN + i18n/es + i18n/zh-CN)

New section **"Spec maintenance during multi-Charter execution"** with:

- **Empirical anchor**: cites #150 + Sentinel CHARTER-07..17 cycle as the discovery source.
- **When to refresh** — four heuristics: ≥3 closed Charters / ≥4 weeks + ≥2 Charters / `R<N>(new)` count >6 / target US touches refined infra. Explicit guidance to *skip* when none hold.
- **How to refresh: scope-limited prompt** — name target phase, list locked sections, cite refinement AILOGs, forbid `tasks.md` regeneration.
- **Three mechanical gates** — (a) Validation against code reality (diff non-target entities/endpoints vs migrations/handler signatures); (b) Granular hunk-by-hunk review; (c) Two-PR split (refresh PR separate from Charter-fill PR).
- **Why NOT re-run `/speckit-tasks`** — regenerating destroys `[X]` completion marks and `*CHARTER-NN:* <sha>*` annotations. Manual edit for the target phase only.
- **Constitution Check re-evaluation cadence** — per-Charter (recommended) + per-spec-refresh (mandatory) + NOT per-framework-bump alone. Closes the implicit-cadence ambiguity.
- **Roadmap: `straymark spec-drift`** — explicitly names the deferred CLI so adopters know the mechanization is coming.

Plus a new **anti-pattern entry** pointing at the safe path.

### `docs/contributors/WHAT-IS-A-CHARTER.md`

§4 Mode A: cross-link inserted right after the SpecKit-driven flow diagram, surfacing "what happens when a single spec drives many Charters?" with a pointer to the new bridge-doc section. Contributors landing on the conceptual doc find the operational discipline at the natural decision point.

### Versioning

- `dist/dist-manifest.yml` → `4.14.3`.
- Governance footers (`QUICK-REFERENCE.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `C4-DIAGRAM-GUIDE.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md`, `SPECKIT-CHARTER-BRIDGE.md`) bumped to `v4.14.3` across EN + ES + zh-CN.
- Version tables in `README.md` + i18n + `CLI-REFERENCE.md` + i18n updated.
- `CHANGELOG.md` entry explaining the Cubeta A/B split and the rationale.

## What's NOT in scope

- **No CLI changes.** `cli-3.13.1` remains the matching CLI version. No `cli/` files touched, no `Cargo.toml` bump.
- **No `straymark spec-drift` implementation.** Cubeta B; deferred to post-announcement Charter.
- **No new schema or template.** The discipline lives in governance docs, not in code.
- **No template-level changes to `charter-template.md`.** The pattern applies *across* Charters; the per-Charter template is unchanged.

## Why a patch release (not just a docs PR)

`SPECKIT-CHARTER-BRIDGE.md` is shipped to every adopter via `straymark init`. Without bumping the framework, `straymark update-framework` would not bring the new section to existing installations. Sentinel reads the section before filling CHARTER-18 — time-sensitive.

## Test plan

- [x] `cat dist/dist-manifest.yml` shows `version: \"4.14.3\"`
- [x] `grep \"Spec maintenance during multi-Charter\" dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md` finds the new section
- [x] Same grep against `i18n/es/` and `i18n/zh-CN/` overlays — paridad
- [x] `grep \"v4.14.3\" dist/.straymark/00-governance/QUICK-REFERENCE.md` shows the new footer
- [x] `grep \"fw-4.14.2[^+]\"` returns 0 results across docs (no stale footers)
- [ ] CI release-framework workflow packages `straymark-fw-4.14.3.zip` cleanly (post-tag)
- [ ] Sentinel applies the discipline on CHARTER-18 fill; reports outcome (post-merge, async)

## Follow-up — Cubeta B tracking

A separate tracking issue will be filed on `main` post-merge consolidating:
- #150 Ask 3 (the `straymark spec-drift` CLI command)
- #146 Proposal D (cross-Charter `lessons-learned.md` index)

Both are mechanics living *above* the Charter as a unit — the missing "cross-Charter knowledge layer". A post-announcement Charter will design them cohesively. Linking that issue here once filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)