### PR TITLE
docs(readme): add CLA assistant badge across en/es/zh-CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md)
+[![CLA assistant](https://cla-assistant.io/readme/badge/StrangeDaysTech/straymark)](https://cla-assistant.io/StrangeDaysTech/straymark)
 [![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/QUICK-REFERENCE.md)
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -9,6 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../../LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![CLA assistant](https://cla-assistant.io/readme/badge/StrangeDaysTech/straymark)](https://cla-assistant.io/StrangeDaysTech/straymark)
 [![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](../../../dist/.straymark/QUICK-REFERENCE.md)
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -9,6 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../../LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![CLA assistant](https://cla-assistant.io/readme/badge/StrangeDaysTech/straymark)](https://cla-assistant.io/StrangeDaysTech/straymark)
 [![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](../../../dist/.straymark/QUICK-REFERENCE.md)
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 


### PR DESCRIPTION
## Summary

Adds the CLA assistant badge to the project's three READMEs (root EN + i18n/es + i18n/zh-CN), placed right after the `PRs Welcome` badge as requested.

The placement is intentional: `PRs Welcome` + `CLA assistant` cluster naturally as contribution-readiness signals, before the `Handbook` badge which addresses a different surface (documentation entry point). Identical position across the three locales preserves visual parity for readers landing on any language overlay.

## Changes

```diff
 [![PRs Welcome](...PRs-welcome-brightgreen...)](CONTRIBUTING.md)
+[![CLA assistant](https://cla-assistant.io/readme/badge/StrangeDaysTech/straymark)](https://cla-assistant.io/StrangeDaysTech/straymark)
 [![Handbook](...docs-Handbook-orange...)](.../QUICK-REFERENCE.md)
```

Three files touched, one line added per file.

## Scope

- **Repo-level docs only** — README.md (root) + docs/i18n/es/README.md + docs/i18n/zh-CN/README.md. Not shipped via `straymark init`, so no framework bump required.
- No CHANGELOG entry — pure cosmetic addition; trivial and self-evident from git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)