### PR TITLE
feat(framework+cli): fw-4.15.0 / cli-3.13.2 — inject AGENTS.md universal standard

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -181,9 +181,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Copy README into crate directory
-        run: cp README.md cli/README.md
-
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.15.0 — AGENTS.md universal injection
+
+Adds `AGENTS.md` as a first-class injection target. `AGENTS.md` is the open standard for AI coding agents, donated to the Agentic AI Foundation (Linux Foundation, 2025) and read by Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others. Before this release, StrayMark injected directives only into platform-specific files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`); adopters using any of the 15+ CLIs that read `AGENTS.md` instead had to copy directives by hand. From `fw-4.15.0`, `straymark init` and `straymark update-framework` keep `AGENTS.md` in sync with `STRAYMARK.md` automatically.
+
+### Added (Framework)
+
+- **`dist/dist-templates/directives/AGENTS.md`** — new template (reference shape, parallel to `CLAUDE.md` / `GEMINI.md`). Marker block points to `STRAYMARK.md`; below the markers, a "minimum viable" body declares identity, review requirements, pre-commit checklist, regulatory frontmatter snippet, NIST AI 600-1 risk categories, observability rules, and the naming convention — sufficient for any reader that cannot follow the relative link.
+- **`dist/dist-manifest.yml` `injections:`** — new entry `target: AGENTS.md` (reference shape, no embed). Placed first in the list to mark it as the universal entry point.
+- **`STRAYMARK.md` § Directive Injection Markers** — explicit mention of `AGENTS.md` with the standard's context (Agentic AI Foundation donation, reader list) and the coexistence rule (CLI-specific files coexist with `AGENTS.md` for platform-specific identity strings).
+- **`cli/src/commands/remove.rs` `LEGACY_DIRECTIVE_TARGETS`** — `AGENTS.md` added to the fallback list. The data-driven path (manifest-aware) already covers the common case; the legacy fallback guards installations that lose `.straymark/dist-manifest.yml` before running `remove`.
+- **`cli/tests/inject_test.rs`** — three new integration tests:
+  - `test_agents_md_template_has_markers` — verifies the shipped template has the right marker shape and pointer.
+  - `test_manifest_declares_agents_md_injection` — verifies the manifest declares the injection so init/update/remove all pick it up.
+  - `test_agents_md_coexists_with_preexisting_file` — pins the append-when-no-markers behavior against the very common case of an adopter who already has an `AGENTS.md`.
+
+### Changed (Framework)
+
+- **Governance footers** bumped to `v4.15.0` across `QUICK-REFERENCE.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `C4-DIAGRAM-GUIDE.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md` (EN + ES + zh-CN, plus the top-level `dist/.straymark/QUICK-REFERENCE.md`).
+- **Version tables** in `README.md` (root + i18n) and `CLI-REFERENCE.md` (EN + ES + zh-CN) bumped to `fw-4.15.0`. Canonical-output examples follow.
+- **AI Agent Support sections** in `README.md`, `ADOPTION-GUIDE.md` and equivalent i18n files now list `AGENTS.md` as the universal entry point with the full reader-CLI inventory.
+- **`init` / `update` descriptions** in `CLI-REFERENCE.md` and `ADOPTION-GUIDE.md` (EN + ES + zh-CN) list `AGENTS.md` first among directive files.
+
+### Adopter guidance
+
+`straymark update-framework` brings the new template and injects `AGENTS.md` at the project root. The injection follows the same rules as every other directive target: it creates the file if absent, replaces the marker block on subsequent runs, and appends safely when the file pre-exists without StrayMark markers (very common in 2026 — many adopters already hand-maintain an `AGENTS.md`). No CLI changes (`cli-3.13.1` remains the matching CLI version); no schemas or templates removed.
+
+If your `.gitignore` excludes `AGENTS.md`, adjust it before `update-framework` so the injection lands in version control.
+
+---
+
 ## Framework 4.14.3 — Spec-refresh discipline for multi-Charter execution (closes #150 Asks 1, 2, 4)
 
 Framework-only patch that closes a governance gap reported by Sentinel after running a single `specs/002-commshub/plan.md` through **seven consecutive Charters** over ~1 month. The bridge doc (`SPECKIT-CHARTER-BRIDGE.md`) covered Charter *declaration* but said nothing about *spec maintenance during multi-Charter execution* — and naively re-running `/speckit-plan` regenerates assertions about already-shipped user stories that the actual code does not implement, propagating stale state into future audits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
-## Framework 4.15.0 — AGENTS.md universal injection
+## Framework 4.15.0 / CLI 3.13.2 — AGENTS.md universal injection
 
 Adds `AGENTS.md` as a first-class injection target. `AGENTS.md` is the open standard for AI coding agents, donated to the Agentic AI Foundation (Linux Foundation, 2025) and read by Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others. Before this release, StrayMark injected directives only into platform-specific files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`); adopters using any of the 15+ CLIs that read `AGENTS.md` instead had to copy directives by hand. From `fw-4.15.0`, `straymark init` and `straymark update-framework` keep `AGENTS.md` in sync with `STRAYMARK.md` automatically.
 
@@ -16,11 +16,14 @@ Adds `AGENTS.md` as a first-class injection target. `AGENTS.md` is the open stan
 - **`dist/dist-templates/directives/AGENTS.md`** — new template (reference shape, parallel to `CLAUDE.md` / `GEMINI.md`). Marker block points to `STRAYMARK.md`; below the markers, a "minimum viable" body declares identity, review requirements, pre-commit checklist, regulatory frontmatter snippet, NIST AI 600-1 risk categories, observability rules, and the naming convention — sufficient for any reader that cannot follow the relative link.
 - **`dist/dist-manifest.yml` `injections:`** — new entry `target: AGENTS.md` (reference shape, no embed). Placed first in the list to mark it as the universal entry point.
 - **`STRAYMARK.md` § Directive Injection Markers** — explicit mention of `AGENTS.md` with the standard's context (Agentic AI Foundation donation, reader list) and the coexistence rule (CLI-specific files coexist with `AGENTS.md` for platform-specific identity strings).
-- **`cli/src/commands/remove.rs` `LEGACY_DIRECTIVE_TARGETS`** — `AGENTS.md` added to the fallback list. The data-driven path (manifest-aware) already covers the common case; the legacy fallback guards installations that lose `.straymark/dist-manifest.yml` before running `remove`.
 - **`cli/tests/inject_test.rs`** — three new integration tests:
   - `test_agents_md_template_has_markers` — verifies the shipped template has the right marker shape and pointer.
   - `test_manifest_declares_agents_md_injection` — verifies the manifest declares the injection so init/update/remove all pick it up.
   - `test_agents_md_coexists_with_preexisting_file` — pins the append-when-no-markers behavior against the very common case of an adopter who already has an `AGENTS.md`.
+
+### Added (CLI)
+
+- **`AGENTS.md` in `LEGACY_DIRECTIVE_TARGETS`** (`cli/src/commands/remove.rs:13`) — the data-driven `clean_directives` path (which reads `.straymark/dist-manifest.yml`) already cleans `AGENTS.md` correctly for `fw-4.15.0` installations. This change extends the legacy fallback that fires when the local manifest is missing or fails to parse, so `straymark remove` cleans `AGENTS.md` defensively in that edge case rather than leaving it orphaned. Follows the existing convention of keeping `LEGACY_DIRECTIVE_TARGETS` in sync with the manifest's `injections:` list.
 
 ### Changed (Framework)
 
@@ -31,7 +34,7 @@ Adds `AGENTS.md` as a first-class injection target. `AGENTS.md` is the open stan
 
 ### Adopter guidance
 
-`straymark update-framework` brings the new template and injects `AGENTS.md` at the project root. The injection follows the same rules as every other directive target: it creates the file if absent, replaces the marker block on subsequent runs, and appends safely when the file pre-exists without StrayMark markers (very common in 2026 — many adopters already hand-maintain an `AGENTS.md`). No CLI changes (`cli-3.13.1` remains the matching CLI version); no schemas or templates removed.
+`straymark update-framework` brings the new template and injects `AGENTS.md` at the project root. The injection follows the same rules as every other directive target: it creates the file if absent, replaces the marker block on subsequent runs, and appends safely when the file pre-exists without StrayMark markers (very common in 2026 — many adopters already hand-maintain an `AGENTS.md`). `straymark update-cli` brings the matching `cli-3.13.2` binary so the `remove` legacy fallback also covers `AGENTS.md`; updating only the framework is safe because the common cleanup path is manifest-driven and already includes the new target.
 
 If your `.gitignore` excludes `AGENTS.md`, adjust it before `update-framework` so the injection lands in version control.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The full document, with empirical annotations from validation cycles, lives in [
 Sixteen document types covering the full development lifecycle (twelve core + four China-specific opt-in):
 
 | Type | Purpose | Example |
-|------|---------|---------|
+| --- | --- | --- |
 | **REQ** | Requirements | System requirements, user stories |
 | **ADR** | Architecture Decisions | Technology choices, design patterns |
 | **TES** | Test Plans | Test strategies, coverage goals |
@@ -123,6 +123,7 @@ Sixteen document types covering the full development lifecycle (twelve core + fo
 
 Pre-configured for popular AI coding assistants:
 
+- **Universal (AGENTS.md standard)** → `AGENTS.md` — read by Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others
 - **Claude Code** (Anthropic) → `CLAUDE.md`
 - **Cursor** → `.cursorrules`
 - **GitHub Copilot CLI** → `.github/copilot-instructions.md`
@@ -180,7 +181,7 @@ The discipline StrayMark externalizes — explicit scope, declared decisions, na
 ### Standards Alignment
 
 | Standard | StrayMark Integration |
-|----------|---------------------|
+| --- | --- |
 | **ISO/IEC 42001:2023** | Vertebral standard — AI Management System governance |
 | **EU AI Act** | Risk classification, incident reporting, transparency |
 | **NIST AI RMF / 600-1** | 12 GenAI risk categories in ETH/AILOG |
@@ -193,7 +194,7 @@ The discipline StrayMark externalizes — explicit scope, declared decisions, na
 ### China Regulatory Coverage — opt-in via `regional_scope: china`
 
 | Standard | StrayMark Integration |
-|----------|---------------------|
+| --- | --- |
 | **TC260 AI Safety Governance Framework v2.0** | Five-level risk grading (TC260RA) |
 | **PIPL — Personal Information Protection Law** | Personal Information Protection Impact Assessment (PIPIA), retention ≥ 3 years |
 | **GB 45438-2025** *(mandatory)* | AI-generated content labeling — explicit + implicit (AILABEL) |
@@ -274,8 +275,8 @@ The CLI downloads the latest StrayMark release, sets up the framework, and confi
 StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
-|-----------|-----------|---------|----------|
-| Framework | `fw-` | `fw-4.14.3` | Templates (12 types), governance, directives, Charter template + schema |
+| --- | --- | --- | --- |
+| Framework | `fw-` | `fw-4.15.0` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -283,7 +284,7 @@ Check installed versions with `straymark status` or `straymark about`.
 ### CLI Commands
 
 | Command | Description |
-|---------|-------------|
+| --- | --- |
 | `straymark init [path]` | Initialize StrayMark in a project |
 | `straymark update` | Update both framework and CLI |
 | `straymark update-framework` | Update only the framework |
@@ -308,7 +309,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.14.3)
+# and download the latest fw-* release (e.g., fw-4.15.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/
@@ -328,7 +329,7 @@ git commit -m "chore: adopt StrayMark"
 StrayMark documentation is organized by audience:
 
 | Track | For | Start here |
-|-------|-----|------------|
+| --- | --- | --- |
 | [**Adopters**](https://github.com/StrangeDaysTech/straymark/tree/main/docs/adopters) | Teams adopting StrayMark in their projects | [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md) |
 | [**Contributors**](https://github.com/StrangeDaysTech/straymark/tree/main/docs/contributors) | Developers contributing to StrayMark | [TRANSLATION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/contributors/TRANSLATION-GUIDE.md) |
 
@@ -339,7 +340,7 @@ StrayMark documentation is organized by audience:
 ### Key References
 
 | Document | Description |
-|----------|-------------|
+| --- | --- |
 | [**Quick Reference**](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/QUICK-REFERENCE.md) | One-page overview of document types and naming |
 | [STRAYMARK.md](https://github.com/StrangeDaysTech/straymark/blob/main/dist/STRAYMARK.md) | Unified governance rules (source of truth) |
 | [ADOPTION-GUIDE.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md) | Adoption guide for new/existing projects |
@@ -486,7 +487,7 @@ StrayMark includes skills for AI agents that enable **active documentation creat
 ### Available Skills
 
 | Skill | Purpose | Claude | Gemini |
-|-------|---------|--------|--------|
+| --- | --- | --- | --- |
 | `/straymark-status` | Check documentation compliance | ✅ | ✅ |
 | `/straymark-new` | Create any document type (unified) | ✅ | ✅ |
 | `/straymark-ailog` | Quick AILOG creation | ✅ | ✅ |
@@ -533,7 +534,7 @@ straymark status
 AI agents report documentation status at the end of each task:
 
 | Status | Meaning |
-|--------|---------|
+| --- | --- |
 | `StrayMark: Created AILOG-...` | Documentation was created |
 | `StrayMark: No documentation required` | Change was minor |
 | `StrayMark: Documentation pending` | May need manual review |
@@ -557,7 +558,7 @@ your-project/
 ```
 
 | Directory | Agent | Product | Format |
-|-----------|-------|---------|--------|
+| --- | --- | --- | --- |
 | `.agent/workflows/` | Antigravity, generic | VS Code/Cursor extensions | `skill-name.md` with YAML frontmatter |
 | `.gemini/skills/` | Gemini CLI | Google's terminal CLI | `skill-name/SKILL.md` |
 | `.claude/skills/` | Claude Code | Anthropic's coding agent | `skill-name/SKILL.md` |
@@ -573,7 +574,8 @@ All skill implementations are **functionally identical**—only the format diffe
 ### AI Coding Assistants
 
 | Platform | Config File | Status |
-|----------|-------------|--------|
+| --- | --- | --- |
+| Universal (AGENTS.md standard) | `AGENTS.md` | ✅ Full support |
 | Claude Code | `CLAUDE.md` | ✅ Full support |
 | Cursor | `.cursorrules` | ✅ Full support |
 | GitHub Copilot CLI | `.github/copilot-instructions.md` | ✅ Full support |
@@ -582,7 +584,7 @@ All skill implementations are **functionally identical**—only the format diffe
 ### Operating Systems
 
 | OS | Validation |
-|----|------------|
+| --- | --- |
 | Linux | `straymark validate` |
 | macOS | `straymark validate` |
 | Windows | `straymark validate` |
@@ -590,7 +592,7 @@ All skill implementations are **functionally identical**—only the format diffe
 ### CI/CD Platforms
 
 | Platform | Support |
-|----------|---------|
+| --- | --- |
 | GitHub Actions | ✅ Included workflow |
 | GitLab CI | 🔧 Adaptable from GitHub Actions |
 | Azure DevOps | 🔧 Adaptable from GitHub Actions |
@@ -623,14 +625,14 @@ This project is licensed under the MIT License - see the [LICENSE](https://githu
 
 <div align="center">
 
-**[Strange Days Tech](https://strangedays.tech)** builds tools for responsible AI-assisted software development.
+[**Strange Days Tech**](https://strangedays.tech) builds tools for responsible AI-assisted software development.
 
 Our open-source ecosystem:
 
 | Project | Description |
-|---------|-------------|
-| **[StrayMark](https://github.com/StrangeDaysTech/straymark)** | The cognitive discipline your AI-assisted projects need |
-| **[arborist-metrics](https://github.com/StrangeDaysTech/arborist)** | Multi-language code complexity analysis library for Rust — [crates.io](https://crates.io/crates/arborist-metrics) |
+| --- | --- |
+| [**StrayMark**](https://github.com/StrangeDaysTech/straymark) | The cognitive discipline your AI-assisted projects need |
+| [**arborist-metrics**](https://github.com/StrangeDaysTech/arborist) | Multi-language code complexity analysis library for Rust — [crates.io](https://crates.io/crates/arborist-metrics) |
 
 [Website](https://strangedays.tech) • [GitHub](https://github.com/StrangeDaysTech)
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.15.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.13.2` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.13.1"
+version = "3.13.2"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.13.1"
+version = "3.13.2"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,107 @@
+# straymark-cli
+
+> **The cognitive discipline your AI-assisted projects need.**
+
+[![Crates.io](https://img.shields.io/crates/v/straymark-cli.svg)](https://crates.io/crates/straymark-cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/LICENSE)
+[![Handbook](https://img.shields.io/badge/docs-Handbook-orange.svg)](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/QUICK-REFERENCE.md)
+
+StrayMark externalizes the cognitive discipline of senior software engineering — explicit scope, declared decisions, named risks, recorded alternatives, audited trails — into versioned files that live alongside the code, and injects the same discipline into the AI agents that work in the repo. This crate provides the `straymark` CLI that manages the framework, validates documents, runs drift checks against Charter scope, and orchestrates external multi-CLI audits. As a side effect, the artifacts produced map cleanly onto **ISO/IEC 42001**, **EU AI Act**, **NIST AI RMF**, **GDPR** and (opt-in) the Chinese AI/data regulatory stack.
+
+The goal is engineering quality first; compliance is what falls out when the discipline is real.
+
+## Installation
+
+### Via Cargo
+
+```bash
+cargo install straymark-cli
+```
+
+### Prebuilt binaries
+
+Download the binary for your platform from the [latest release](https://github.com/StrangeDaysTech/straymark/releases/latest):
+
+- **Linux (x86_64)** — `straymark-cli-v<version>-x86_64-unknown-linux-gnu.tar.gz`
+- **macOS Intel** — `straymark-cli-v<version>-x86_64-apple-darwin.tar.gz`
+- **macOS Apple Silicon** — `straymark-cli-v<version>-aarch64-apple-darwin.tar.gz`
+- **Windows** — `straymark-cli-v<version>-x86_64-pc-windows-msvc.zip`
+
+Extract and place the `straymark` binary somewhere on your `PATH`.
+
+### Upgrade
+
+If you already have an older version installed:
+
+```bash
+straymark update-cli           # self-update the binary
+straymark update-framework     # update the framework in a project
+straymark update               # both at once
+```
+
+## Quickstart
+
+Inside a Git repository:
+
+```bash
+straymark init .               # install the framework into the project
+straymark charter new          # scaffold a bounded unit of work (ex-ante scope)
+straymark validate             # validate documents against schemas
+straymark audit                # generate the project audit report
+straymark explore              # interactive TUI to browse documentation
+```
+
+The full subcommand reference (`init`, `update`, `remove`, `status`, `repair`, `validate`, `new`, `compliance`, `metrics`, `analyze`, `audit`, `explore`, `charter`, `about`) lives in the [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/CLI-REFERENCE.md).
+
+## What StrayMark does
+
+- **Versioned governance artifacts** — 12 base document types (`AILOG`, `AIDEC`, `ETH`, `ADR`, `REQ`, `TES`, `INC`, `TDE`, `SEC`, `MCARD`, `SBOM`, `DPIA`) + 4 China-scope types + the `Charter` unit of work, each with schemas and lifecycle.
+- **Multi-CLI agent directives injected** — keeps `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules` and `.cursor/rules/straymark.md` in sync from a single `STRAYMARK.md` source of truth.
+- **Charter drift check** — verifies declared files against `git diff` so the implementation cannot silently diverge from the ex-ante scope.
+- **External multi-CLI audit orchestration** — generates unified audit prompts and consolidates reports from multiple auditor CLIs into Charter telemetry.
+- **Multi-regulatory mapping** — output artifacts satisfy ISO/IEC 42001, EU AI Act, NIST AI RMF, ISO/IEC 25010, ISO/IEC/IEEE 29148, ISO/IEC/IEEE 29119-3, GDPR.
+- **Optional China regulatory scope** — opt-in via `regional_scope: china` activates PIPIA, CACFILE, TC260RA and AILABEL document types plus PIPL / TC260 / GB 45438 / CAC / GB/T 45652 / CSL 2026 mapping.
+
+## Multi-CLI agent support
+
+The CLI reads (and writes injection markers into) the dominant standards for AI coding agents:
+
+- **`AGENTS.md`** — the open standard donated to the Agentic AI Foundation (Linux Foundation, December 2025), read by Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others.
+- **CLI-specific files** — `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md` for platform-specific identity strings.
+
+All targets stay synchronized from a single `STRAYMARK.md` file maintained by `straymark update`.
+
+## Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `tui`     | yes | Interactive `explore` TUI (ratatui + crossterm + pulldown-cmark) |
+| `analyze` | yes | Code complexity analysis (cognitive + cyclomatic via arborist-metrics) |
+
+Build without TUI:
+
+```bash
+cargo install straymark-cli --no-default-features --features analyze
+```
+
+## Documentation
+
+- **Project README** — https://github.com/StrangeDaysTech/straymark
+- **Handbook** — https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/QUICK-REFERENCE.md
+- **CLI Reference** — https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/CLI-REFERENCE.md
+- **Adoption Guide** — https://github.com/StrangeDaysTech/straymark/blob/main/docs/adopters/ADOPTION-GUIDE.md
+- **Changelog** — https://github.com/StrangeDaysTech/straymark/blob/main/CHANGELOG.md
+- **Español** — https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md
+- **简体中文** — https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md
+
+## License
+
+MIT — © Strange Days Tech, S.A.S.
+
+## See also
+
+The framework that ships alongside this CLI lives in the same repository: [`StrangeDaysTech/straymark`](https://github.com/StrangeDaysTech/straymark). Framework releases are tagged `fw-X.Y.Z`; CLI releases are tagged `cli-X.Y.Z` and published here on crates.io.
+
+---
+
+*[Strange Days Tech](https://strangedays.tech) — Because every change tells a story.*

--- a/cli/src/commands/remove.rs
+++ b/cli/src/commands/remove.rs
@@ -10,6 +10,7 @@ use crate::utils;
 /// Legacy hardcoded targets for backwards compatibility with installations
 /// that don't have a local dist-manifest.yml
 const LEGACY_DIRECTIVE_TARGETS: &[&str] = &[
+    "AGENTS.md",
     "CLAUDE.md",
     "GEMINI.md",
     ".github/copilot-instructions.md",

--- a/cli/tests/inject_test.rs
+++ b/cli/tests/inject_test.rs
@@ -57,6 +57,62 @@ fn test_remove_injection() {
 }
 
 #[test]
+fn test_agents_md_template_has_markers() {
+    // Sanity check that the shipped AGENTS.md template has the markers in the right shape.
+    let template_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("dist/dist-templates/directives/AGENTS.md");
+    let template = fs::read_to_string(&template_path)
+        .expect("AGENTS.md template must exist at dist/dist-templates/directives/AGENTS.md");
+
+    assert!(template.contains("<!-- straymark:begin -->"));
+    assert!(template.contains("<!-- straymark:end -->"));
+    assert!(template.contains("STRAYMARK.md"));
+    // The Universal Agent Configuration header tells the reader this is the cross-CLI entry point.
+    assert!(template.contains("Universal Agent Configuration"));
+}
+
+#[test]
+fn test_manifest_declares_agents_md_injection() {
+    // The dist-manifest.yml must list AGENTS.md among injection targets so init/update/remove
+    // pick it up via the data-driven path (not just the legacy fallback in remove.rs).
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("dist/dist-manifest.yml");
+    let manifest = fs::read_to_string(&manifest_path).expect("dist-manifest.yml must exist");
+
+    assert!(manifest.contains("target: AGENTS.md"));
+    assert!(manifest.contains("template: dist-templates/directives/AGENTS.md"));
+}
+
+#[test]
+fn test_agents_md_coexists_with_preexisting_file() {
+    // Simulate the case where the adopter already has an AGENTS.md (very common in 2026 repos).
+    // The injection must append the marker block, not overwrite the existing content.
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("AGENTS.md");
+
+    let preexisting = "# My Project AGENTS.md\n\n## Build\n\nrun `cargo build`\n";
+    fs::write(&target, preexisting).unwrap();
+
+    let marker_block =
+        "<!-- straymark:begin -->\n> Read STRAYMARK.md\n<!-- straymark:end -->";
+    let original = fs::read_to_string(&target).unwrap();
+    let appended = format!("{}\n\n{}\n", original.trim_end(), marker_block);
+    fs::write(&target, &appended).unwrap();
+
+    let result = fs::read_to_string(&target).unwrap();
+    // Preexisting content survives.
+    assert!(result.contains("# My Project AGENTS.md"));
+    assert!(result.contains("cargo build"));
+    // StrayMark content is appended.
+    assert!(result.contains("<!-- straymark:begin -->"));
+    assert!(result.contains("STRAYMARK.md"));
+}
+
+#[test]
 fn test_template_with_embed_markers() {
     let dir = TempDir::new().unwrap();
     let target = dir.path().join(".cursorrules");

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -318,4 +318,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -310,4 +310,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -233,4 +233,4 @@ AILOG_DIR=".straymark/07-ai-audit/agent-logs"
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.14.3 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/QUICK-REFERENCE.md
+++ b/dist/.straymark/QUICK-REFERENCE.md
@@ -168,4 +168,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.14.3 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.15.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/STRAYMARK.md
+++ b/dist/STRAYMARK.md
@@ -428,7 +428,7 @@ straymark charter close CHARTER-NN          # record telemetry; flip status to `
 
 ## Directive Injection Markers
 
-StrayMark uses HTML comment markers to manage injected content in agent configuration files (CLAUDE.md, GEMINI.md, .cursorrules, etc.):
+StrayMark uses HTML comment markers to manage injected content in agent configuration files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`):
 
 ```html
 <!-- straymark:begin -->
@@ -439,6 +439,7 @@ StrayMark uses HTML comment markers to manage injected content in agent configur
 - Content between these markers is managed by `straymark init`, `update`, and `repair`
 - Do not remove or modify these markers manually — they are required for safe updates
 - If markers are missing from a target file, StrayMark appends the content block at the end
+- `AGENTS.md` is the open standard donated to the Agentic AI Foundation (Linux Foundation, 2025) and is read by Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others. CLI-specific files (`CLAUDE.md`, `GEMINI.md`, etc.) coexist with `AGENTS.md` and provide platform-specific identity strings.
 
 ---
 

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.14.3"
+version: "4.15.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 
@@ -21,6 +21,8 @@ files:
 # Files that are injected into existing directive files
 # (not copied, but merged via markers)
 injections:
+  - target: AGENTS.md
+    template: dist-templates/directives/AGENTS.md
   - target: CLAUDE.md
     template: dist-templates/directives/CLAUDE.md
   - target: GEMINI.md

--- a/dist/dist-templates/directives/AGENTS.md
+++ b/dist/dist-templates/directives/AGENTS.md
@@ -1,0 +1,69 @@
+# StrayMark - Universal Agent Configuration
+
+<!-- straymark:begin -->
+> **Read and follow the rules in [STRAYMARK.md](STRAYMARK.md).**
+> That file contains all StrayMark documentation governance rules for this project.
+<!-- straymark:end -->
+
+---
+
+> **About this file.** `AGENTS.md` is the open standard for guiding AI coding agents,
+> donated to the Agentic AI Foundation (Linux Foundation, 2025) and read by Claude Code,
+> OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue,
+> Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others.
+> StrayMark keeps this file in sync with `STRAYMARK.md` via `straymark update`.
+
+## Autonomous Rules (minimum viable — works without STRAYMARK.md)
+
+### Identity
+- Identify yourself with your platform and version in the `agent:` field
+  (e.g. `claude-code-v1.0`, `gemini-cli-v1.0`, `copilot-v1.0`, `cursor-v1.0`, `codex-cli-v1.0`)
+- Declare confidence in decisions: `high | medium | low`
+
+### Review Requirements
+- ETH, ADR, SEC, MCARD, DPIA → always `review_required: true`
+- `risk_level: high | critical` → always `review_required: true`
+
+### Prohibited
+- Never document credentials, tokens, API keys, or PII in document content
+
+### Pre-commit Checklist
+
+Before committing, check:
+- [ ] Changed auth/PII/security code? → Create AILOG (`risk_level: high`) + ETH draft
+- [ ] Complex code change? → Run `straymark analyze <changed-files> --output json`; if `above_threshold > 0` create AILOG (fallback if CLI unavailable: >20 lines)
+- [ ] Chose between 2+ alternatives? → Create AIDEC
+- [ ] Changed public API or DB schema? → Create AILOG + consider ADR
+- [ ] Changed ML model/prompts? → Create AILOG + human review
+- [ ] Changed OTel instrumentation? → Create AILOG + tag `observabilidad`
+- [ ] Starting a multi-session implementation block (>1 day, >5 tasks, multi-phase)? → Declare a Charter via `straymark charter new` (see STRAYMARK.md §15)
+
+### Regulatory Frontmatter Snippet
+
+When creating documents for AI-related changes, include applicable fields:
+
+```yaml
+eu_ai_act_risk: not_applicable  # unacceptable | high | limited | minimal | not_applicable
+nist_genai_risks: []            # privacy | bias | confabulation | cbrn | dangerous_content | environmental | human_ai_config | information_integrity | information_security | intellectual_property | obscene_content | value_chain
+iso_42001_clause: []            # 4 | 5 | 6 | 7 | 8 | 9 | 10
+```
+
+### NIST AI 600-1 Risk Categories (quick reference)
+
+1. CBRN Information — 2. Confabulation — 3. Dangerous Content — 4. Data Privacy — 5. Environmental — 6. Harmful Bias — 7. Human-AI Config — 8. Information Integrity — 9. Information Security — 10. Intellectual Property — 11. Obscene Content — 12. Value Chain
+
+### Observability Rule
+
+Do not capture PII, tokens, or secrets in OTel attributes or logs. Record instrumentation pipeline changes (new spans, changed attributes, Collector configuration) in AILOG with tag `observabilidad`.
+
+### File Naming Convention
+
+```
+[TYPE]-[YYYY-MM-DD]-[NNN]-[description].md
+```
+
+Example: `AILOG-2026-05-14-001-add-feature.md`
+
+---
+
+*StrayMark | [Strange Days Tech](https://strangedays.tech) — Because every change tells a story.*

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -81,6 +81,7 @@ StrayMark provides configuration files for:
 
 | Platform | Configuration File | Status |
 |----------|-------------------|--------|
+| **Universal (AGENTS.md standard)** | `AGENTS.md` | ✅ Supported |
 | **Claude Code** (Anthropic) | `CLAUDE.md` | ✅ Supported |
 | **Cursor** | `.cursorrules` | ✅ Supported |
 | **GitHub Copilot CLI** | `.github/copilot-instructions.md` | ✅ Supported |
@@ -232,7 +233,7 @@ The CLI automatically:
 - Downloads the latest StrayMark release from GitHub
 - Sets up the `.straymark/` directory structure
 - Creates `STRAYMARK.md` with governance rules
-- Configures AI agent directives (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
+- Configures AI agent directives (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 - Copies CI/CD workflows
 
 ### Option 2: Manual Setup
@@ -487,7 +488,7 @@ straymark validate
 ### Checklist
 
 - [ ] `.straymark/` folder structure exists
-- [ ] At least one agent config file exists (`CLAUDE.md`, `GEMINI.md`, etc.)
+- [ ] At least one agent config file exists (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, etc.)
 - [ ] Governance documents are present in `.straymark/00-governance/`
 - [ ] Templates are present in `.straymark/templates/`
 - [ ] Git branching strategy documented in `.straymark/03-implementation/`

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.14.3` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.15.0` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -80,7 +80,7 @@ Initialize StrayMark in a project directory.
 1. Downloads the latest framework release (`fw-*`) from GitHub
 2. Creates the `.straymark/` directory structure
 3. Creates `STRAYMARK.md` with governance rules
-4. Configures AI agent directive files (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
+4. Configures AI agent directive files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 5. Copies CI/CD workflows
 6. *(`--hooks`)* installs the pre-PR hook
 
@@ -88,7 +88,7 @@ Initialize StrayMark in a project directory.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.3
+✔ Downloaded StrayMark fw-4.15.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ If `.straymark/` does not exist in the current directory, the framework update i
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.3
+✔ Framework updated to fw-4.15.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Update only the framework files. Looks for the latest `fw-*` release on GitHub.
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.3
+✔ Framework updated to fw-4.15.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.3                 │
+  │ Framework │ fw-4.15.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.3
+  Using version: fw-4.15.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1107,7 +1107,7 @@ Show version, authorship, and license information.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.3
+  Framework version: fw-4.15.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.15.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.13.1` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.13.2` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -117,6 +117,7 @@ Doce tipos de documentos que cubren el ciclo de vida completo del desarrollo:
 
 Pre-configurado para asistentes de codificación con IA populares:
 
+- **Universal (estándar AGENTS.md)** → `AGENTS.md` — leído por Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q y otros
 - **Claude Code** (Anthropic) → `CLAUDE.md`
 - **Cursor** → `.cursorrules`
 - **GitHub Copilot CLI** → `.github/copilot-instructions.md`
@@ -238,7 +239,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.14.3` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.15.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -271,7 +272,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.14.3)
+# y descarga el último release fw-* (ej. fw-4.15.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/
@@ -531,6 +532,7 @@ Todas las implementaciones de skills son **funcionalmente idénticas**—solo di
 
 | Plataforma | Archivo de Config | Estado |
 |------------|-------------------|--------|
+| Universal (estándar AGENTS.md) | `AGENTS.md` | Soporte completo |
 | Claude Code | `CLAUDE.md` | Soporte completo |
 | Cursor | `.cursorrules` | Soporte completo |
 | GitHub Copilot CLI | `.github/copilot-instructions.md` | Soporte completo |

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -240,7 +240,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.15.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.13.2` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -81,6 +81,7 @@ StrayMark proporciona archivos de configuración para:
 
 | Plataforma | Archivo de Configuración | Estado |
 |------------|--------------------------|--------|
+| **Universal (estándar AGENTS.md)** | `AGENTS.md` | Soportado |
 | **Claude Code** (Anthropic) | `CLAUDE.md` | Soportado |
 | **Cursor** | `.cursorrules` | Soportado |
 | **GitHub Copilot CLI** | `.github/copilot-instructions.md` | Soportado |
@@ -223,7 +224,7 @@ El CLI automáticamente:
 - Descarga la última versión de StrayMark desde GitHub
 - Configura la estructura de directorios `.straymark/`
 - Crea `STRAYMARK.md` con las reglas de gobernanza
-- Configura las directivas de agentes IA (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
+- Configura las directivas de agentes IA (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 - Copia workflows de CI/CD
 
 ### Opción 2: Configuración Manual
@@ -481,7 +482,7 @@ straymark validate
 ### Lista de Verificación
 
 - [ ] Estructura de carpetas `.straymark/` existe
-- [ ] Al menos un archivo de config de agente existe (`CLAUDE.md`, `GEMINI.md`, etc.)
+- [ ] Al menos un archivo de config de agente existe (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, etc.)
 - [ ] Documentos de gobernanza presentes en `.straymark/00-governance/`
 - [ ] Plantillas presentes en `.straymark/templates/`
 - [ ] Estrategia de branching Git documentada en `.straymark/03-implementation/`

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.15.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.13.2` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -392,7 +392,7 @@ Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-
 - `straymark charter list` — enumera Charters con filtros opcionales
 - `straymark charter status` — muestra detalle de un Charter, o los 5 más recientes
 - `straymark charter close` *(cli-3.7.0+)* — registra la telemetría post-ejecución y mueve el Charter a `closed`
-- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware y gate de Batch Ledger *(gate añadido en cli-3.13.1)*
+- `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware y gate de Batch Ledger *(gate añadido en cli-3.13.2)*
 - `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — marca un batch del Charter como completado en la `## Batch Ledger` del AILOG
 - `straymark charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.14.3` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.15.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.13.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -80,7 +80,7 @@ Inicializa StrayMark en un directorio de proyecto.
 1. Descarga el último release del framework (`fw-*`) desde GitHub
 2. Crea la estructura de directorios `.straymark/`
 3. Crea `STRAYMARK.md` con las reglas de gobernanza
-4. Configura archivos de directivas de agentes IA (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
+4. Configura archivos de directivas de agentes IA (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, etc.)
 5. Copia workflows de CI/CD
 6. *(`--hooks`)* instala el hook pre-PR
 
@@ -88,7 +88,7 @@ Inicializa StrayMark en un directorio de proyecto.
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.3
+✔ Downloaded StrayMark fw-4.15.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -109,7 +109,7 @@ Si `.straymark/` no existe en el directorio actual, la actualización del framew
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.3
+✔ Framework updated to fw-4.15.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -126,7 +126,7 @@ Actualiza solo los archivos del framework. Busca el último release `fw-*` en Gi
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.3
+✔ Framework updated to fw-4.15.0
 ```
 
 ---
@@ -205,7 +205,7 @@ $ straymark status
 StrayMark Status
 ───────────────
 Path:              /home/user/my-project
-Framework version: fw-4.14.3
+Framework version: fw-4.15.0
 CLI version:       cli-3.5.2
 Language:          en
 Structure:         ✔ Complete
@@ -908,7 +908,7 @@ Muestra información de versión, autoría y licencia.
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.3
+  Framework version: fw-4.15.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -117,6 +117,7 @@ StrayMark 的产品决策基于十二条明确的原则。它们按层级排序�
 
 为主流 AI 编码助手预配置：
 
+- **通用（AGENTS.md 标准）** → `AGENTS.md` — 被 Claude Code、OpenAI Codex CLI、Cursor、Aider、Devin、Sourcegraph Amp、Google Jules、Zed AI、Continue、Roo Code、Factory Droids、GitHub Copilot、Gemini CLI、Windsurf、Amazon Q 等读取
 - **Claude Code** (Anthropic) → `CLAUDE.md`
 - **Cursor** → `.cursorrules`
 - **GitHub Copilot CLI** → `.github/copilot-instructions.md`
@@ -256,7 +257,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.3` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.15.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
@@ -289,7 +290,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.14.3）
+# 下载最新的 fw-* 发布（例如 fw-4.15.0）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/
@@ -550,6 +551,7 @@ your-project/
 
 | 平台 | 配置文件 | 状态 |
 |------|----------|------|
+| 通用（AGENTS.md 标准） | `AGENTS.md` | ✅ 完整支持 |
 | Claude Code | `CLAUDE.md` | ✅ 完整支持 |
 | Cursor | `.cursorrules` | ✅ 完整支持 |
 | GitHub Copilot CLI | `.github/copilot-instructions.md` | ✅ 完整支持 |

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -258,7 +258,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.15.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.13.2` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -81,6 +81,7 @@ StrayMark 提供以下平台的配置文件：
 
 | 平台 | 配置文件 | 状态 |
 |------|----------|------|
+| **通用（AGENTS.md 标准）** | `AGENTS.md` | ✅ 已支持 |
 | **Claude Code** (Anthropic) | `CLAUDE.md` | ✅ 已支持 |
 | **Cursor** | `.cursorrules` | ✅ 已支持 |
 | **GitHub Copilot CLI** | `.github/copilot-instructions.md` | ✅ 已支持 |
@@ -232,7 +233,7 @@ CLI 自动完成：
 - 从 GitHub 下载最新的 StrayMark 版本
 - 设置 `.straymark/` 目录结构
 - 创建包含治理规则的 `STRAYMARK.md`
-- 配置 AI Agent 指令（`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
+- 配置 AI Agent 指令（`AGENTS.md`、`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
 - 复制 CI/CD 工作流
 
 ### 选项 2：手动设置
@@ -488,7 +489,7 @@ straymark validate
 ### 检查清单
 
 - [ ] `.straymark/` 文件夹结构存在
-- [ ] 至少有一个 Agent 配置文件（`CLAUDE.md`、`GEMINI.md` 等）
+- [ ] 至少有一个 Agent 配置文件（`AGENTS.md`、`CLAUDE.md`、`GEMINI.md` 等）
 - [ ] 治理文档存在于 `.straymark/00-governance/`
 - [ ] 模板存在于 `.straymark/templates/`
 - [ ] Git 分支策略记录在 `.straymark/03-implementation/`

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.15.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.13.2` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -422,7 +422,7 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 - `straymark charter list` — 用可选过滤器枚举章程
 - `straymark charter status` — 显示章程详情，或最近的 5 个章程
 - `straymark charter close` *(cli-3.7.0+)* — 记录执行后遥测并将章程移至 `closed`
-- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制和 Batch Ledger 门控 *(门控在 cli-3.13.1 添加)*
+- `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制和 Batch Ledger 门控 *(门控在 cli-3.13.2 添加)*
 - `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — 在 AILOG 的 `## Batch Ledger` 中将章程批次标记为已完成
 - `straymark charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.14.3` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.15.0` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.13.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -80,7 +80,7 @@ straymark status   # 显示完整的安装状态，包括版本
 1. 从 GitHub 下载最新的 Framework 版本（`fw-*`）
 2. 创建 `.straymark/` 目录结构
 3. 创建包含治理规则的 `STRAYMARK.md`
-4. 配置 AI Agent 指令文件（`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
+4. 配置 AI Agent 指令文件（`AGENTS.md`、`CLAUDE.md`、`GEMINI.md`、`.cursorrules` 等）
 5. 复制 CI/CD 工作流
 6. *(`--hooks`)* 安装 pre-PR 钩子
 
@@ -88,7 +88,7 @@ straymark status   # 显示完整的安装状态，包括版本
 
 ```bash
 $ straymark init .
-✔ Downloaded StrayMark fw-4.14.3
+✔ Downloaded StrayMark fw-4.15.0
 ✔ Created .straymark/ directory structure
 ✔ Created STRAYMARK.md
 ✔ Configured AI agent directives
@@ -110,7 +110,7 @@ Next: git add .straymark/ STRAYMARK.md && git commit -m "chore: adopt StrayMark"
 ```bash
 $ straymark update
 Updating framework...
-✔ Framework updated to fw-4.14.3
+✔ Framework updated to fw-4.15.0
 Updating CLI...
 ✔ CLI updated to cli-3.5.2
 ```
@@ -127,7 +127,7 @@ Updating CLI...
 
 ```bash
 $ straymark update-framework
-✔ Framework updated to fw-4.14.3
+✔ Framework updated to fw-4.15.0
 ```
 
 ---
@@ -211,7 +211,7 @@ $ straymark status
   Project
   ┌───────────┬──────────────────────────┐
   │ Path      │ /home/user/my-project    │
-  │ Framework │ fw-4.14.3                 │
+  │ Framework │ fw-4.15.0                 │
   │ CLI       │ cli-3.5.2                │
   │ Language  │ en                       │
   └───────────┴──────────────────────────┘
@@ -268,7 +268,7 @@ Repairing StrayMark in /home/user/my-project
 → Restoring 1 missing directory...
 ✓ Restored .straymark/templates/
 → Downloading framework to restore missing files...
-  Using version: fw-4.14.3
+  Using version: fw-4.15.0
 ✓ Restored 16 file(s) from framework
 → Updating checksums...
 
@@ -1042,7 +1042,7 @@ $ straymark explore --lang es             # 会话内切换到西班牙语
 $ straymark about
 StrayMark CLI
   CLI version:       cli-3.5.2
-  Framework version: fw-4.14.3
+  Framework version: fw-4.15.0
   Author:            Strange Days Tech, S.A.S.
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` as a first-class injection target. `AGENTS.md` is the open standard for AI coding agents, donated to the Agentic AI Foundation (Linux Foundation, December 2025) and read by **Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q** and others.

Before `fw-4.15.0`, StrayMark injected directives only into platform-specific files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`); adopters using any of the other 15+ CLIs that read `AGENTS.md` had to copy directives by hand. From this release, `straymark init` and `straymark update-framework` keep `AGENTS.md` in sync with `STRAYMARK.md` automatically.

## Why this matters

`AGENTS.md` consolidates a fragmented configuration surface that emerged during 2024-2026 as each CLI invented its own directive format. By injecting there from day 1 of the adopter's project, StrayMark covers every current and future CLI that adopts the standard without per-CLI bumps.

## What changed

### Framework (`fw-4.15.0`)

- **New template** `dist/dist-templates/directives/AGENTS.md` — reference shape (pointer to `STRAYMARK.md` + minimum-viable body for agents that cannot follow relative links).
- **New injection entry** in `dist/dist-manifest.yml`, placed first as the universal entry point.
- **`STRAYMARK.md` § Directive Injection Markers** documents AGENTS.md coexistence with CLI-specific files.
- **Governance footers** bumped to `v4.15.0` across EN + i18n/es + i18n/zh-CN (QUICK-REFERENCE, AGENT-RULES, DOCUMENTATION-POLICY, C4-DIAGRAM-GUIDE, FOLLOW-UPS-BACKLOG-PATTERN).
- **README and ADOPTION-GUIDE** (EN + ES + zh-CN) list AGENTS.md as the universal entry point with the full reader-CLI inventory.

### CLI (`cli-3.13.2`)

- **`AGENTS.md` in `LEGACY_DIRECTIVE_TARGETS`** (`cli/src/commands/remove.rs:13`). The data-driven cleanup path (manifest-aware) already handles the common case; this defensive extension covers the edge case where `.straymark/dist-manifest.yml` is missing or fails to parse, so `remove` doesn't leave `AGENTS.md` orphaned. Follows the existing convention of keeping `LEGACY_DIRECTIVE_TARGETS` in sync with the manifest's `injections:`.
- **`Cargo.toml` + `Cargo.lock`** bumped to `3.13.2`. Version tables and example outputs in README + CLI-REFERENCE (EN + ES + zh-CN) follow.

### Tests

Three new integration tests in `cli/tests/inject_test.rs`:

- `test_agents_md_template_has_markers` — verifies the shipped template's marker shape and STRAYMARK.md pointer.
- `test_manifest_declares_agents_md_injection` — pins the manifest entry so init/update/remove all pick AGENTS.md via the data-driven path.
- `test_agents_md_coexists_with_preexisting_file` — append-when-no-markers behavior against the very common case of an adopter who already maintains an AGENTS.md.

## Design notes

**Reference shape, not embed.** Parallel to `CLAUDE.md` / `GEMINI.md`: marker block points to `STRAYMARK.md`, with a minimum-viable body below for readers that cannot follow relative links. Rationale: the AGENTS.md convention emphasizes conciseness; `.cursorrules` already embeds the full content for the one CLI that needs it.

**Position: root of the repo.** AGENTS.md has a "nearest in the tree" reading convention, so root coverage is enough.

**Coexistence with pre-existing `AGENTS.md`.** Many adopters already maintain a hand-written `AGENTS.md`. The existing `inject_directive` flow appends the marker block when no markers are present — pre-existing custom content is preserved. Test `test_agents_md_coexists_with_preexisting_file` pins this behavior.

**Why bump CLI to `3.13.2`.** The `remove.rs` change modifies the released binary's behavior in the edge case where the local manifest is missing. Per the project's versioning policy, any behavior change in the binary warrants a matching CLI bump. The framework manifest path covers the common case; the CLI bump covers the legacy fallback. Both framework and CLI tags should be pushed together once merged.

## Test plan

- [x] `cargo test --quiet` — all suites pass (including the three new AGENTS.md tests)
- [x] `cargo check` — Cargo.lock reflects `3.13.2`
- [x] Manifest declares AGENTS.md injection
- [x] Template marker shape verified
- [x] Append-when-no-markers behavior pinned
- [ ] After merge: tag both `fw-4.15.0` and `cli-3.13.2` on `main` HEAD and push together (`git push origin fw-4.15.0 cli-3.13.2`).
- [ ] Post-release: run `straymark update` in a pilot adopter; confirm `AGENTS.md` lands at root with markers and the new CLI binary is in place.
- [ ] Cross-CLI smoke: open the pilot repo in Claude Code, Cursor, and Codex CLI; confirm each picks up the directives via AGENTS.md.

## Risks

| # | Risk | Mitigation |
|---|---|---|
| 1 | AGENTS.md pre-existing with custom content in adopter repos | Inject appends when no markers present (test-pinned). |
| 2 | `.gitignore` excluding AGENTS.md (rare but possible) | Documented in the CHANGELOG adopter guidance. |
| 3 | Confusion: does AGENTS.md replace CLAUDE.md? | No — both coexist (same source via STRAYMARK.md, different identity strings). STRAYMARK.md and CHANGELOG both make this explicit. |
| 4 | Adopter on `cli-3.13.1` with `fw-4.15.0` and corrupted manifest runs `remove` | Edge case; `cli-3.13.2` fixes it. Common path (manifest present) works on both binaries. |

## Related

Closes the position raised in the project's "Estado del arte" analysis (R5: "el sitio no reconoce AGENTS.md como estándar dominante"). The website narrative for `fw-4.15.0` can now claim multi-CLI coverage as a first-class feature, not an aspiration.