### PR TITLE
feat(framework+cli): fw-4.16.0 / cli-3.14.0 — Charter-chain evolution patterns (closes #156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.16.0 / CLI 3.14.0 — Charter-chain evolution patterns (Issue #156)
+
+Codifies two patterns surfaced by the Sentinel adopter after seven consecutive CommsHub Charters (Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)): a **pre-declare SpecKit refresh** that absorbs accumulated chain-level learnings before the next Charter is declared, and a **post-close audit-driven Batch N.4 amendment** that handles bounded external-audit findings on the same execute branch without opening a new Charter. Both are operator-driven; the framework ships canonical guidance in `00-governance/CHARTER-CHAIN-EVOLUTION.md` (EN/ES/zh-CN), opt-in telemetry slots in the schema, and two new read-only/scaffolding CLI helpers. Also fixes the `straymark charter audit --merge-into` bug where the v0 re-audit guard rejected the empty-array placeholder `external_audit: []`, breaking the post-close audit-cycle round-trip.
+
+### Added (Framework)
+
+- **`dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md`** (EN, ES, zh-CN) — new canonical doc covering both patterns (Pattern 1 = pre-declare SpecKit refresh; Pattern 2 = post-close audit-driven amendment), each with when-it-applies + mechanics + telemetry + empirical anchor from Sentinel CHARTER-18. Establishes `06-evolution/<name>-rfc.md` as the canonical adopter-local home for in-flight RFCs and `00-governance/<NAME>.md` as the upstream-accepted home.
+- **`dist/.straymark/schemas/charter-telemetry.schema.v0.json`** — two new optional sub-objects under `charter_telemetry`:
+  - `pre_declare_refresh` (enabled, refresh_pr, refresh_aidec, plus integer counts for reusable_patterns / code_gaps / discipline_patterns / empirical_corrections / operator_decisions).
+  - `post_close_amendment` (applied, trigger ∈ {external_audit, production_incident, deferred_implementation}, ailog_id, findings_closed, files_modified, effort_hours).
+  - Schema stays v0 — the N=1-domain caveat from the existing $comment carries forward; the addendum is documented inline.
+- **`dist/.straymark/templates/charter/charter-telemetry-template.yaml`** — commented stubs for the two new blocks with guidance on when to populate them.
+- **`dist/STRAYMARK.md` §15.A and §15.B** — two new subsections inside the Charter chapter describing each pattern at a glance and citing the helper commands. Quick CLI surface listing extended with `refresh-suggest` and `amend`.
+- **`dist/.straymark/templates/charter/charter-template.md`** — Batch Ledger task note pointing readers to §15.B + `straymark charter amend` when audit findings arrive after `status: closed`.
+- **`dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md`** — short cross-reference at the top of "Spec maintenance during multi-Charter execution" pointing to CHARTER-CHAIN-EVOLUTION.md Pattern 1 as the canonical extension.
+
+### Added (CLI)
+
+- **`straymark charter refresh-suggest <module> [--threshold N]`** *(new)* — read-only. Reads the last 3 closed Charters whose `charter_id` contains the module (case-insensitive substring), computes the rolling mean of `agent_quality.r_n_plus_one_emergent_count`, and prints a recommendation (refresh-now / not-needed / insufficient-data). Default threshold 6. Always exits 0 — informational, never a CI gate. Located at `cli/src/commands/charter/refresh_suggest.rs`.
+- **`straymark charter amend <CHARTER-ID> --trigger <kind> --ailog-title <title> [--findings-closed N] [--merge-into <PATH>]`** *(new)* — scaffolds the three artifacts of a post-close Batch N.4 amendment: creates a new AILOG stub under `agent-logs/` with `risk_level: high` + `amends:` pointing back to the most-recent prior AILOG; appends a `## Historical correction (YYYY-MM-DD)` subsection to that prior AILOG; renders the `post_close_amendment:` YAML block (printed to stdout or merged via `--merge-into`). Does NOT touch git — the operator decides when to commit. Located at `cli/src/commands/charter/amend.rs`.
+- **`cli/tests/charter_refresh_suggest_test.rs`** and **`cli/tests/charter_amend_test.rs`** — 9 new integration tests covering: trigger / no-trigger / insufficient-data / zero-match / threshold override (refresh-suggest); AILOG creation + historical correction append + merge-into round-trip + closed-status guard + invalid-trigger rejection (amend).
+
+### Fixed (CLI)
+
+- **`straymark charter audit --merge-reports --merge-into <PATH>` placeholder support** (`cli/src/commands/charter/audit.rs:370-432`) — the v0 anti-duplicate guard rejected any presence of `external_audit:`, including the empty placeholder `external_audit: []`. The new implementation parses the YAML semantically and distinguishes three cases: missing → append (original behavior), empty placeholder `[]` → **replace in place** (new — fixes Issue #156 sub-issue), populated array → still rejected with a clearer error message (anti-duplicate guard intact). `straymark charter close` now writes the `external_audit: []` placeholder by default so the post-close audit cycle round-trips cleanly without manual YAML editing. New regression test `audit_merge_into_replaces_empty_external_audit_placeholder` pins the fix.
+
+### Changed (Framework)
+
+- **Governance footers** bumped to `v4.16.0` across `QUICK-REFERENCE.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `C4-DIAGRAM-GUIDE.md` (EN + ES + zh-CN).
+- **Version tables** in `README.md` (root + ES + zh-CN) and `CLI-REFERENCE.md` (EN + ES + zh-CN) bumped to `fw-4.16.0` / `cli-3.14.0`. CLI command listings extended with the two new subcommands.
+
+### Adopter guidance
+
+- `straymark update-framework` brings the new template fields, the canonical doc in three languages, and the schema additions. Both new schema sub-objects are **optional** — existing telemetry files validate unchanged.
+- `straymark update-cli` brings `cli-3.14.0` with the bug fix for `--merge-into` and the two new subcommands. The `external_audit: []` placeholder now emitted by `charter close` is harmless for v0.1 adopters whose tooling treats the schema as v0 — the schema permits the empty array.
+- After update, run `straymark charter refresh-suggest <module>` on any module with 3+ closed Charters to check whether the heuristic suggests a refresh; the command is read-only and side-effect-free.
+
+---
+
 ## Framework 4.15.0 / CLI 3.13.2 — AGENTS.md universal injection
 
 Adds `AGENTS.md` as a first-class injection target. `AGENTS.md` is the open standard for AI coding agents, donated to the Agentic AI Foundation (Linux Foundation, 2025) and read by Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others. Before this release, StrayMark injected directives only into platform-specific files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`); adopters using any of the 15+ CLIs that read `AGENTS.md` instead had to copy directives by hand. From `fw-4.15.0`, `straymark init` and `straymark update-framework` keep `AGENTS.md` in sync with `STRAYMARK.md` automatically.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Built-in safeguards ensure humans stay in control:
 
 Built-in commands that turn the discipline into actionable feedback:
 
-- **`straymark charter <new|list|status|close|drift|batch-complete|audit>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression and (cli-3.13.0+) gates on `### Batch N (pending)` entries in the AILOG `## Batch Ledger`; `batch-complete` (cli-3.13.0+) marks a batch as complete in the ledger for multi-batch Charters (3+ batches or >1 day); `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls). For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
+- **`straymark charter <new|list|status|close|drift|batch-complete|audit|refresh-suggest|amend>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression and (cli-3.13.0+) gates on `### Batch N (pending)` entries in the AILOG `## Batch Ledger`; `batch-complete` (cli-3.13.0+) marks a batch as complete in the ledger for multi-batch Charters (3+ batches or >1 day); `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls); `refresh-suggest` (cli-3.14.0+) prints a heuristic recommendation for a pre-declare SpecKit refresh when a multi-Charter module's rolling `r_n_plus_one_emergent_count` mean exceeds a threshold; `amend` (cli-3.14.0+) scaffolds a post-close Batch N.4 amendment (audit-driven remediation) on the same execute branch without opening a new Charter. For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
 - **`straymark approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
 - **`straymark validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `.straymark/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
 - **`straymark metrics`** — Governance KPIs, review rates, risk distribution, trends
@@ -276,8 +276,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
-| Framework | `fw-` | `fw-4.15.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.13.2` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.16.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.14.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -293,7 +293,7 @@ Check installed versions with `straymark status` or `straymark about`.
 | `straymark status [path]` | Show installation health and doc stats |
 | `straymark repair [path]` | Restore missing directories and framework files |
 | `straymark validate [path]` | Validate documents for compliance and correctness (use `--include-charters` for Charters, `--check-pending-reviews` for approval backlog) |
-| `straymark charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness + Batch Ledger gate), `batch-complete` (mark a batch as complete in the AILOG `## Batch Ledger` for multi-batch Charters), `audit` (multi-model external review, orchestration-only) |
+| `straymark charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness + Batch Ledger gate), `batch-complete` (mark a batch as complete in the AILOG `## Batch Ledger` for multi-batch Charters), `audit` (multi-model external review, orchestration-only), `refresh-suggest` (pre-declare SpecKit refresh heuristic for multi-Charter modules, fw-4.16.0+), `amend` (scaffold a post-close Batch N.4 amendment, fw-4.16.0+) |
 | `straymark approve <doc-id>` | Record a formal human approval on a `review_required: true` document (frontmatter + canonical body section) |
 | `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
 | `straymark metrics [path]` | Show governance metrics and documentation statistics |
@@ -309,7 +309,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.15.0)
+# and download the latest fw-* release (e.g., fw-4.16.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.13.2"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.13.2"
+version = "3.14.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/commands/charter/amend.rs
+++ b/cli/src/commands/charter/amend.rs
@@ -1,0 +1,527 @@
+//! `straymark charter amend <id>` — scaffold a post-close Batch N.4 amendment.
+//!
+//! Pattern 2 in `dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md`:
+//! external audit findings (or other bounded triggers) arrive after the
+//! Charter has been marked `status: closed`, the fix surface is small enough
+//! that a new Charter would be overkill, and the operator wants the
+//! remediation to ride on the original execute branch.
+//!
+//! This command does NOT touch git. It prepares three artifacts so the
+//! operator can commit at their leisure:
+//!
+//! 1. A new AILOG stub in `.straymark/07-ai-audit/agent-logs/` with the
+//!    convention `risk_level: high`, `review_required: true`, and an
+//!    `amends:` field linking back to the most-recent originating AILOG of
+//!    the Charter.
+//! 2. A `## Historical correction (YYYY-MM-DD)` subsection appended to the
+//!    located previous AILOG, pointing forward to the new id.
+//! 3. A rendered `post_close_amendment:` YAML block, either printed to
+//!    stdout for manual paste or merged into the Charter's `.telemetry.yaml`
+//!    via `--merge-into`.
+//!
+//! fw-4.16.0+ (Issue #156).
+
+use anyhow::{bail, Context, Result};
+use chrono::Utc;
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+
+use crate::ailog::agent_logs_dir;
+use crate::charter::{discover_and_parse, find_by_id, CharterStatus};
+
+pub fn run(
+    project_path: &str,
+    charter_id_input: &str,
+    trigger: &str,
+    findings_closed: u32,
+    ailog_title: &str,
+    merge_into: Option<&str>,
+) -> Result<()> {
+    let project_root = Path::new(project_path);
+    let ailog_title = ailog_title.trim();
+    if ailog_title.is_empty() {
+        bail!("--ailog-title must be non-empty");
+    }
+    validate_trigger(trigger)?;
+
+    // ── Charter lookup ───────────────────────────────────────────────────
+    let (charters, errors) = discover_and_parse(project_root);
+    for (path, err) in &errors {
+        eprintln!(
+            "  {} could not parse {} — {}",
+            "⚠".yellow().bold(),
+            path.display(),
+            err
+        );
+    }
+    let charter = find_by_id(&charters, charter_id_input).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No Charter matches `{}` (tried full id, CHARTER-NN prefix, and bare NN).",
+            charter_id_input
+        )
+    })?;
+    if !matches!(charter.frontmatter.status, CharterStatus::Closed) {
+        bail!(
+            "Charter {} is not closed (status: {:?}). The amendment pattern \
+             applies only AFTER `status: closed` — see STRAYMARK.md §15.B.",
+            charter.frontmatter.charter_id,
+            charter.frontmatter.status
+        );
+    }
+
+    // ── Locate previous AILOG (optional — warn if absent) ────────────────
+    let agent_logs = agent_logs_dir(project_root);
+    let previous_ailog = locate_previous_ailog(&agent_logs, &charter.frontmatter.charter_id)?;
+    let previous_ailog_id = previous_ailog
+        .as_ref()
+        .and_then(|p| extract_ailog_id_from_filename(p));
+
+    // ── Mint new AILOG ───────────────────────────────────────────────────
+    let today = Utc::now().date_naive().format("%Y-%m-%d").to_string();
+    let nnn = next_ailog_nnn(&agent_logs, &today)?;
+    let slug = slugify(ailog_title);
+    if slug.is_empty() {
+        bail!("--ailog-title slugifies to empty — pass a title with alphanumerics");
+    }
+    let new_ailog_id = format!("AILOG-{today}-{nnn:03}");
+    let new_ailog_filename = format!("{new_ailog_id}-{slug}.md");
+    let new_ailog_path = agent_logs.join(&new_ailog_filename);
+    if new_ailog_path.exists() {
+        bail!(
+            "Refusing to overwrite existing AILOG at {}",
+            new_ailog_path.display()
+        );
+    }
+    if !agent_logs.exists() {
+        std::fs::create_dir_all(&agent_logs).with_context(|| {
+            format!("Failed to create {}", agent_logs.display())
+        })?;
+    }
+    let new_ailog_body = render_new_ailog(
+        &new_ailog_id,
+        ailog_title,
+        &charter.frontmatter.charter_id,
+        trigger,
+        findings_closed,
+        previous_ailog_id.as_deref(),
+    );
+    std::fs::write(&new_ailog_path, &new_ailog_body)
+        .with_context(|| format!("Failed to write {}", new_ailog_path.display()))?;
+
+    // ── Append Historical correction to previous AILOG (if found) ────────
+    if let (Some(prev_path), Some(prev_id)) = (previous_ailog.as_ref(), previous_ailog_id.as_deref())
+    {
+        append_historical_correction(prev_path, &new_ailog_id, &today, trigger)?;
+        println!(
+            "  {} Appended `## Historical correction ({})` to {}",
+            "✔".green().bold(),
+            today,
+            prev_path.display()
+        );
+        let _ = prev_id; // already in the appended block
+    } else {
+        println!(
+            "  {} No prior AILOG mentioning {} found — skipped historical-correction step.",
+            "⚠".yellow().bold(),
+            charter.frontmatter.charter_id
+        );
+        println!(
+            "  {}",
+            "  Edit the new AILOG manually if you want to link back to a specific prior AILOG."
+                .dimmed()
+        );
+    }
+    println!(
+        "  {} Created new AILOG at {}",
+        "✔".green().bold(),
+        new_ailog_path.display()
+    );
+
+    // ── Render post_close_amendment YAML block ───────────────────────────
+    let yaml_block = render_post_close_amendment_yaml(
+        trigger,
+        &new_ailog_id,
+        findings_closed,
+    );
+
+    if let Some(target) = merge_into {
+        let telemetry_path = PathBuf::from(target);
+        merge_post_close_amendment_into(&telemetry_path, &yaml_block)?;
+        println!(
+            "  {} Merged `post_close_amendment:` block into {}",
+            "✔".green().bold(),
+            telemetry_path.display()
+        );
+    } else {
+        println!();
+        println!(
+            "  {}",
+            "post_close_amendment YAML — paste under `charter_telemetry:`:".bold()
+        );
+        println!();
+        println!("{yaml_block}");
+        println!();
+    }
+
+    println!();
+    println!(
+        "  {}",
+        "Next: review the new AILOG, edit it with concrete details, then commit \
+         on the original execute branch (do NOT branch off main)."
+            .dimmed()
+    );
+
+    Ok(())
+}
+
+fn validate_trigger(trigger: &str) -> Result<()> {
+    match trigger {
+        "external_audit" | "production_incident" | "deferred_implementation" => Ok(()),
+        other => bail!(
+            "Invalid --trigger `{}` (allowed: external_audit | production_incident | deferred_implementation)",
+            other
+        ),
+    }
+}
+
+/// Search recursively under `agent-logs/` for an AILOG file whose content
+/// mentions the canonical charter_id (full form, e.g. `CHARTER-18-commshub-...`).
+/// Returns the most-recently-modified match — a reasonable proxy for "the
+/// AILOG that documented the original execute work".
+fn locate_previous_ailog(
+    agent_logs: &Path,
+    canonical_charter_id: &str,
+) -> Result<Option<PathBuf>> {
+    if !agent_logs.exists() {
+        return Ok(None);
+    }
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    walk_files(agent_logs, &mut |path| {
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            return;
+        }
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return;
+        };
+        if !content.contains(canonical_charter_id) {
+            return;
+        }
+        let Ok(meta) = std::fs::metadata(path) else {
+            return;
+        };
+        let Ok(mtime) = meta.modified() else { return };
+        match &best {
+            Some((b_mtime, _)) if *b_mtime >= mtime => {}
+            _ => best = Some((mtime, path.to_path_buf())),
+        }
+    });
+    Ok(best.map(|(_, p)| p))
+}
+
+fn walk_files(dir: &Path, visit: &mut dyn FnMut(&Path)) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_files(&path, visit);
+        } else {
+            visit(&path);
+        }
+    }
+}
+
+fn extract_ailog_id_from_filename(path: &Path) -> Option<String> {
+    let name = path.file_name().and_then(|n| n.to_str())?;
+    let stem = name.strip_suffix(".md")?;
+    // Take the first 5 dash-separated components: AILOG-YYYY-MM-DD-NNN[a-z]?
+    let parts: Vec<&str> = stem.split('-').take(5).collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    if parts[0] != "AILOG" {
+        return None;
+    }
+    Some(parts.join("-"))
+}
+
+fn next_ailog_nnn(agent_logs: &Path, today: &str) -> Result<u32> {
+    let prefix = format!("AILOG-{today}-");
+    let mut max_seen: Option<u32> = None;
+    if agent_logs.exists() {
+        let mut paths: Vec<PathBuf> = Vec::new();
+        walk_files(agent_logs, &mut |p| paths.push(p.to_path_buf()));
+        for path in paths {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Some(rest) = name.strip_prefix(&prefix) else {
+                continue;
+            };
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(n) = digits.parse::<u32>() {
+                max_seen = Some(max_seen.map_or(n, |m| m.max(n)));
+            }
+        }
+    }
+    Ok(max_seen.map_or(1, |n| n + 1))
+}
+
+/// Lightweight slugifier — lowercased ascii alphanumerics + dashes, collapsed.
+/// Mirrors `commands::charter::new::slugify` semantics (kebab, no truncation
+/// beyond 60 chars).
+fn slugify(title: &str) -> String {
+    let mut out = String::with_capacity(title.len());
+    let mut last_dash = true;
+    for c in title.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.chars().count() > 60 {
+        trimmed.chars().take(60).collect()
+    } else {
+        trimmed
+    }
+}
+
+fn render_new_ailog(
+    new_ailog_id: &str,
+    title: &str,
+    charter_id: &str,
+    trigger: &str,
+    findings_closed: u32,
+    amends: Option<&str>,
+) -> String {
+    let amends_line = amends
+        .map(|a| format!("amends: {a}\n"))
+        .unwrap_or_default();
+    format!(
+        "---\n\
+id: {new_ailog_id}\n\
+type: ailog\n\
+title: \"{title}\"\n\
+charter_id: {charter_id}\n\
+risk_level: high\n\
+review_required: true\n\
+{amends_line}\
+trigger: {trigger}\n\
+findings_closed: {findings_closed}\n\
+---\n\
+\n\
+# {title}\n\
+\n\
+> Post-close Batch N.4 amendment for {charter_id}. See [STRAYMARK.md §15.B](../../../STRAYMARK.md) and [CHARTER-CHAIN-EVOLUTION.md Pattern 2](../../00-governance/CHARTER-CHAIN-EVOLUTION.md).\n\
+\n\
+## Context\n\
+\n\
+- **Trigger**: `{trigger}`\n\
+- **Charter**: `{charter_id}` (closed)\n\
+- **Findings closed**: {findings_closed}\n\
+{}\
+\n\
+*(Describe what surfaced after `status: closed` — Critical/High audit findings, production incident details, or the deferred-implementation gap being closed. Cite F1...Fn ids from the audit `review.md` where applicable.)*\n\
+\n\
+## Decision\n\
+\n\
+*(What you are changing now, scoped to the bounded fix surface. The amendment must remain in one cohesive PR (~< 25 files, no architectural reopen) — if scope grows, abandon this AILOG and open a new Charter instead.)*\n\
+\n\
+## Change list\n\
+\n\
+- *(Per-file or per-component description of the amendment commit.)*\n\
+\n\
+## Risks\n\
+\n\
+- *(R1: …)*\n\
+\n\
+## Validation\n\
+\n\
+- *(Tests, manual smoke, audit-finding-by-id closure evidence.)*\n\
+\n\
+## Telemetry\n\
+\n\
+This amendment populates `charter_telemetry.post_close_amendment:` in the Charter's `.telemetry.yaml`. Run `straymark charter amend {charter_id} --trigger {trigger} --merge-into .straymark/charters/<NN-slug>.telemetry.yaml` (this command) with the appropriate path to auto-merge, or paste the YAML block printed by the CLI.\n\
+",
+        amends
+            .map(|a| format!("- **Amends**: [{a}]({a}.md) (forward pointer; the original gets a `## Historical correction` subsection)\n"))
+            .unwrap_or_default()
+    )
+}
+
+fn append_historical_correction(
+    prev_path: &Path,
+    new_ailog_id: &str,
+    today: &str,
+    trigger: &str,
+) -> Result<()> {
+    let mut content = std::fs::read_to_string(prev_path)
+        .with_context(|| format!("Failed to read {}", prev_path.display()))?;
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    if !content.ends_with("\n\n") {
+        content.push('\n');
+    }
+    content.push_str(&format!(
+        "## Historical correction ({today})\n\
+\n\
+This decision was amended by [{new_ailog_id}]({new_ailog_id}.md) after \
+`status: closed`. Trigger: `{trigger}`. See Pattern 2 in \
+`.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md`.\n"
+    ));
+    std::fs::write(prev_path, content)
+        .with_context(|| format!("Failed to write {}", prev_path.display()))?;
+    Ok(())
+}
+
+fn render_post_close_amendment_yaml(
+    trigger: &str,
+    new_ailog_id: &str,
+    findings_closed: u32,
+) -> String {
+    format!(
+        "  post_close_amendment:\n    \
+applied: true\n    \
+trigger: \"{trigger}\"\n    \
+ailog_id: \"{new_ailog_id}\"\n    \
+findings_closed: {findings_closed}\n    \
+files_modified: 0\n    \
+effort_hours: 0.0\n"
+    )
+}
+
+/// Merge a rendered `post_close_amendment:` block into an existing telemetry
+/// YAML. Refuses to overwrite an existing populated block.
+fn merge_post_close_amendment_into(telemetry_path: &Path, rendered: &str) -> Result<()> {
+    if !telemetry_path.exists() {
+        bail!(
+            "Telemetry file not found: {}\n  \
+             Run `straymark charter close <CHARTER-ID>` first.",
+            telemetry_path.display()
+        );
+    }
+    let mut content = std::fs::read_to_string(telemetry_path)
+        .with_context(|| format!("Failed to read {}", telemetry_path.display()))?;
+
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("{} is not valid YAML", telemetry_path.display()))?;
+    let charter_telemetry = parsed
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml::Value::String("charter_telemetry".into())))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} does not have a top-level `charter_telemetry:` key.",
+                telemetry_path.display()
+            )
+        })?;
+    if charter_telemetry
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml::Value::String("post_close_amendment".into())))
+        .is_some()
+    {
+        bail!(
+            "{} already has a `post_close_amendment:` block. Refusing to\n  \
+             overwrite. Edit the YAML by hand if you genuinely intend to\n  \
+             update an existing amendment record.",
+            telemetry_path.display()
+        );
+    }
+
+    while content.ends_with("\n\n") {
+        content.pop();
+    }
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push('\n');
+    content.push_str(rendered);
+
+    std::fs::write(telemetry_path, &content)
+        .with_context(|| format!("Failed to write {}", telemetry_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_kebab_and_clamp() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+        assert_eq!(slugify("  --weird/--TITLE--  "), "weird-title");
+        let long = slugify(&"a-b-".repeat(40));
+        assert!(long.chars().count() <= 60);
+    }
+
+    #[test]
+    fn next_ailog_nnn_increments_correctly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("AILOG-2026-05-15-001-foo.md"), "x").unwrap();
+        std::fs::write(dir.join("AILOG-2026-05-15-003-bar.md"), "x").unwrap();
+        std::fs::write(dir.join("AILOG-2026-05-14-007-baz.md"), "x").unwrap();
+        assert_eq!(next_ailog_nnn(dir, "2026-05-15").unwrap(), 4);
+        assert_eq!(next_ailog_nnn(dir, "2026-05-16").unwrap(), 1);
+    }
+
+    #[test]
+    fn validate_trigger_accepts_canonical_values() {
+        assert!(validate_trigger("external_audit").is_ok());
+        assert!(validate_trigger("production_incident").is_ok());
+        assert!(validate_trigger("deferred_implementation").is_ok());
+        assert!(validate_trigger("misc").is_err());
+    }
+
+    #[test]
+    fn append_historical_correction_appends_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("AILOG-2026-05-14-049-x.md");
+        std::fs::write(&path, "---\nid: AILOG-2026-05-14-049\n---\n\nBody.\n").unwrap();
+        append_historical_correction(&path, "AILOG-2026-05-15-050", "2026-05-15", "external_audit")
+            .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("## Historical correction (2026-05-15)"));
+        assert!(content.contains("AILOG-2026-05-15-050"));
+        assert!(content.contains("external_audit"));
+    }
+
+    #[test]
+    fn merge_post_close_refuses_existing_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("t.yaml");
+        std::fs::write(
+            &path,
+            "charter_telemetry:\n  charter_id: x\n  post_close_amendment:\n    applied: true\n",
+        )
+        .unwrap();
+        let err = merge_post_close_amendment_into(&path, "  post_close_amendment:\n    applied: true\n").unwrap_err();
+        assert!(err.to_string().contains("already has"));
+    }
+
+    #[test]
+    fn merge_post_close_appends_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("t.yaml");
+        std::fs::write(
+            &path,
+            "charter_telemetry:\n  charter_id: x\n  outcome:\n    completed_as_planned: true\n",
+        )
+        .unwrap();
+        merge_post_close_amendment_into(
+            &path,
+            "  post_close_amendment:\n    applied: true\n    trigger: \"external_audit\"\n    ailog_id: \"AILOG-2026-05-15-050\"\n    findings_closed: 0\n    files_modified: 0\n    effort_hours: 0.0\n",
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("post_close_amendment:"));
+        assert!(content.contains("AILOG-2026-05-15-050"));
+        // Must still be valid YAML after the merge.
+        let _: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+    }
+}

--- a/cli/src/commands/charter/audit.rs
+++ b/cli/src/commands/charter/audit.rs
@@ -364,9 +364,16 @@ fn run_merge_reports(
 }
 
 /// Append a freshly-rendered `external_audit:` block to an existing Charter
-/// telemetry YAML. v0 deliberately rejects re-audit (file already has the
-/// key) so the operator can reconcile manually rather than silently
-/// duplicating findings.
+/// telemetry YAML.
+///
+/// v0.2 (fw-4.16.0, Issue #156) — placeholder-aware merge:
+/// - missing `external_audit:` key → append the new block (original behavior)
+/// - empty placeholder `external_audit: []` → REPLACE it in place (so the
+///   post-close audit cycle round-trips when close (or any tool) writes the
+///   placeholder)
+/// - populated `external_audit:` array with one or more entries → bail with
+///   guidance (re-audit/append is still unsupported; operator reconciles
+///   manually rather than silently duplicating findings)
 fn merge_external_audit_into(
     telemetry_path: &Path,
     auditor_summaries: &[AuditorSummary],
@@ -385,50 +392,143 @@ fn merge_external_audit_into(
     let mut content = std::fs::read_to_string(telemetry_path)
         .with_context(|| format!("Failed to read {}", telemetry_path.display()))?;
 
-    // Sanity: must parse as YAML.
-    let _: serde_yaml::Value = serde_yaml::from_str(&content)
+    // Parse the full document so we can inspect `charter_telemetry.external_audit`
+    // semantically rather than via fragile string matching (fw-4.16.0).
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&content)
         .with_context(|| format!("{} is not valid YAML", telemetry_path.display()))?;
 
-    if !content.contains("charter_telemetry:") {
+    let charter_telemetry = parsed
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml::Value::String("charter_telemetry".into())))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} does not have a top-level `charter_telemetry:` key — \
+                 expected the standard charter close output shape.",
+                telemetry_path.display()
+            )
+        })?;
+
+    let existing_external_audit = charter_telemetry
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml::Value::String("external_audit".into())));
+
+    let placeholder = match existing_external_audit {
+        None => ExternalAuditState::Missing,
+        Some(serde_yaml::Value::Sequence(seq)) if seq.is_empty() => {
+            ExternalAuditState::EmptyPlaceholder
+        }
+        Some(serde_yaml::Value::Sequence(_)) => ExternalAuditState::Populated,
+        Some(_) => {
+            bail!(
+                "{} has `charter_telemetry.external_audit` set to a non-array \
+                 value — refusing to overwrite. Fix the YAML by hand or remove \
+                 the key before re-running.",
+                telemetry_path.display()
+            );
+        }
+    };
+
+    if matches!(placeholder, ExternalAuditState::Populated) {
         bail!(
-            "{} does not have a top-level `charter_telemetry:` key — \
-             expected the standard charter close output shape.",
+            "{} already has a populated `external_audit:` block. Re-audit\n  \
+             (appending to an existing array) is not supported in v0. Re-run\n  \
+             `straymark charter audit <id> --merge-reports` (without --merge-into)\n  \
+             to print the new YAML, then merge manually if you want to append.",
             telemetry_path.display()
         );
     }
 
-    // v0: re-audit (appending to existing array) is not supported. Detect
-    // the key at indent 0 or 2 and bail with guidance.
-    if content.contains("\n  external_audit:")
-        || content.contains("\nexternal_audit:")
-        || content.starts_with("  external_audit:")
-        || content.starts_with("external_audit:")
-    {
-        bail!(
-            "{} already has an `external_audit:` block. Re-audit (appending\n  \
-             to an existing array) is not supported in v0. Re-run\n  \
-             `straymark charter audit <id> --finalize` (without --merge-into) to\n  \
-             print the new YAML, then merge manually if you want to append.",
-            telemetry_path.display()
-        );
-    }
+    let rendered = render_external_audit_yaml(auditor_summaries, canonical_charter_id);
 
-    while content.ends_with("\n\n") {
-        content.pop();
+    match placeholder {
+        ExternalAuditState::Missing => {
+            while content.ends_with("\n\n") {
+                content.pop();
+            }
+            if !content.ends_with('\n') {
+                content.push('\n');
+            }
+            content.push_str("\n  external_audit:\n");
+            content.push_str(&rendered);
+        }
+        ExternalAuditState::EmptyPlaceholder => {
+            content = replace_empty_external_audit_placeholder(&content, &rendered)?;
+        }
+        ExternalAuditState::Populated => unreachable!("guarded above"),
     }
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-
-    content.push_str("\n  external_audit:\n");
-    content.push_str(&render_external_audit_yaml(
-        auditor_summaries,
-        canonical_charter_id,
-    ));
 
     std::fs::write(telemetry_path, &content)
         .with_context(|| format!("Failed to write {}", telemetry_path.display()))?;
     Ok(())
+}
+
+enum ExternalAuditState {
+    Missing,
+    EmptyPlaceholder,
+    Populated,
+}
+
+/// Replace a `  external_audit: []` placeholder line (at indent 2 inside
+/// `charter_telemetry:`) with a fully-rendered block. Tolerates whitespace
+/// variations (`[]`, `[ ]`) and trailing comments. Bails if the placeholder
+/// line cannot be located — that means the YAML parsed an empty array but
+/// the source uses flow/block syntax we cannot rewrite safely.
+fn replace_empty_external_audit_placeholder(content: &str, rendered: &str) -> Result<String> {
+    let mut out = String::with_capacity(content.len() + rendered.len());
+    let mut replaced = false;
+
+    for line in content.split_inclusive('\n') {
+        if !replaced && is_empty_external_audit_placeholder_line(line) {
+            // Capture the original indentation so we preserve the file's
+            // existing style (charter_telemetry sub-keys are indented by 2
+            // spaces by close.rs, but we don't want to hardcode that).
+            let indent: String = line.chars().take_while(|c| *c == ' ' || *c == '\t').collect();
+            out.push_str(&indent);
+            out.push_str("external_audit:\n");
+            out.push_str(rendered);
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            replaced = true;
+        } else {
+            out.push_str(line);
+        }
+    }
+
+    if !replaced {
+        bail!(
+            "Could not locate `external_audit: []` placeholder line in the\n  \
+             telemetry YAML to replace. The YAML parses as an empty array but\n  \
+             the source uses a block/multi-line form this CLI does not yet\n  \
+             rewrite. Remove the `external_audit:` key by hand and re-run, or\n  \
+             omit --merge-into to print the YAML for manual merge."
+        );
+    }
+
+    Ok(out)
+}
+
+/// Returns true for lines like `  external_audit: []`, `external_audit:[]`,
+/// `  external_audit: [ ]  # comment`, etc. Stays strictly on the empty-array
+/// placeholder form — any inline element (e.g. `[ {auditor: ...} ]`) returns
+/// false and falls back to the populated-array bail path.
+fn is_empty_external_audit_placeholder_line(line: &str) -> bool {
+    let trimmed = line.trim_end_matches(['\n', '\r']);
+    let after_indent = trimmed.trim_start_matches([' ', '\t']);
+    let Some(rest) = after_indent.strip_prefix("external_audit:") else {
+        return false;
+    };
+    let mut rest = rest.trim_start_matches([' ', '\t']);
+    if let Some(after_open) = rest.strip_prefix('[') {
+        rest = after_open.trim_start_matches([' ', '\t']);
+    } else {
+        return false;
+    }
+    let Some(after_close) = rest.strip_prefix(']') else {
+        return false;
+    };
+    let tail = after_close.trim_start_matches([' ', '\t']);
+    tail.is_empty() || tail.starts_with('#')
 }
 
 // ── Audit context + template resolution ────────────────────────────────────

--- a/cli/src/commands/charter/close.rs
+++ b/cli/src/commands/charter/close.rs
@@ -447,6 +447,13 @@ fn render_yaml(d: TelemetryDraft) -> String {
         d.agent_r_n_plus_one
     ));
 
+    // fw-4.16.0 (Issue #156): emit the external_audit placeholder so the
+    // post-close audit cycle can replace it via `charter audit --merge-into`
+    // without requiring the operator to pre-edit the YAML. The audit merge
+    // distinguishes empty `[]` (replace in place) from a populated array
+    // (bail, anti-duplicate guard).
+    out.push_str("\n  external_audit: []\n");
+
     out.push_str("\n  outcome:\n");
     out.push_str(&format!("    completed_as_planned: {}\n", d.outcome_completed));
     out.push_str(&format!(

--- a/cli/src/commands/charter/mod.rs
+++ b/cli/src/commands/charter/mod.rs
@@ -6,10 +6,12 @@
 //! drift check, in PR 3).
 //! Phase 3 will add `audit` (multi-model external audit).
 
+pub mod amend;
 pub mod audit;
 pub mod batch_complete;
 pub mod close;
 pub mod drift;
 pub mod list;
 pub mod new;
+pub mod refresh_suggest;
 pub mod status;

--- a/cli/src/commands/charter/refresh_suggest.rs
+++ b/cli/src/commands/charter/refresh_suggest.rs
@@ -1,0 +1,355 @@
+//! `straymark charter refresh-suggest <module>` — read-only heuristic
+//! recommending a pre-declare SpecKit refresh when a multi-Charter module's
+//! recent telemetry shows the chain has accumulated enough emergent risk that
+//! the next Charter is likely to inherit stale spec premises.
+//!
+//! See `dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` Pattern 1
+//! for the canonical framework guidance this command operationalizes, and
+//! Issue #156 for the original RFC.
+//!
+//! v0.2 / fw-4.16.0:
+//! - Module match is a case-insensitive substring scan on `charter_id`.
+//! - Only `status: closed` Charters with a parseable
+//!   `agent_quality.r_n_plus_one_emergent_count` are eligible.
+//! - Ranking is by `closed_at` (descending), top 3 used for the rolling mean.
+//! - Default threshold is 6; override with `--threshold N`.
+//! - Detection of "has a refresh PR landed since the chain branch point" is
+//!   deferred to a future iteration — out of scope for v0 (the rolling-mean
+//!   signal carries the heuristic on its own per Sentinel telemetry).
+//!
+//! Exit code is always 0 — this is informational, never a CI gate.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+
+use crate::charter::{discover_and_parse, Charter, CharterStatus};
+
+const DEFAULT_THRESHOLD: u32 = 6;
+const ROLLING_WINDOW: usize = 3;
+
+pub fn run(project_path: &str, module: &str, threshold: Option<u32>) -> Result<()> {
+    let project_root = Path::new(project_path);
+    let module = module.trim();
+    if module.is_empty() {
+        anyhow::bail!("<module> argument must be non-empty");
+    }
+
+    let (charters, errors) = discover_and_parse(project_root);
+    if !errors.is_empty() {
+        eprintln!(
+            "  {} {} Charter file(s) could not be parsed and were skipped.",
+            "⚠".yellow().bold(),
+            errors.len()
+        );
+        for (path, err) in &errors {
+            eprintln!("    {} → {}", path.display(), err);
+        }
+        eprintln!();
+    }
+
+    let module_lower = module.to_ascii_lowercase();
+    let mut module_charters: Vec<&Charter> = charters
+        .iter()
+        .filter(|c| matches!(c.frontmatter.status, CharterStatus::Closed))
+        .filter(|c| {
+            c.frontmatter
+                .charter_id
+                .to_ascii_lowercase()
+                .contains(&module_lower)
+        })
+        .collect();
+
+    if module_charters.is_empty() {
+        println!(
+            "  {} No closed Charters match module `{}` (substring on charter_id).",
+            "ℹ".cyan().bold(),
+            module
+        );
+        println!("  {}", "Recommendation: nothing to suggest yet.".dimmed());
+        return Ok(());
+    }
+
+    let mut rows: Vec<CharterRow> = module_charters
+        .drain(..)
+        .map(|c| load_charter_row(project_root, c))
+        .collect::<Result<Vec<_>>>()?;
+
+    // Closed-at descending. Charters without a parseable closed_at sink to the
+    // bottom so they are still visible in the table but never seed the rolling
+    // mean.
+    rows.sort_by(|a, b| b.closed_at.cmp(&a.closed_at));
+
+    let threshold = threshold.unwrap_or(DEFAULT_THRESHOLD);
+    let window: Vec<&CharterRow> = rows
+        .iter()
+        .filter(|r| r.r_n_plus_one.is_some())
+        .take(ROLLING_WINDOW)
+        .collect();
+
+    print_table(&rows, &window);
+
+    let rolling_mean = if window.is_empty() {
+        None
+    } else {
+        let sum: u32 = window
+            .iter()
+            .map(|r| r.r_n_plus_one.unwrap_or(0))
+            .sum();
+        Some(sum as f64 / window.len() as f64)
+    };
+
+    print_recommendation(module, threshold, &window, rolling_mean);
+
+    Ok(())
+}
+
+struct CharterRow {
+    charter_id: String,
+    closed_at: Option<String>,
+    r_n_plus_one: Option<u32>,
+    telemetry_path: Option<PathBuf>,
+}
+
+fn load_charter_row(project_root: &Path, charter: &Charter) -> Result<CharterRow> {
+    let telemetry_path = telemetry_path_for(project_root, charter);
+    let (closed_at, r_n_plus_one) = match telemetry_path.as_ref() {
+        Some(p) if p.exists() => parse_telemetry(p)
+            .with_context(|| format!("Failed to parse telemetry at {}", p.display()))?,
+        _ => (None, None),
+    };
+
+    Ok(CharterRow {
+        charter_id: charter.frontmatter.charter_id.clone(),
+        closed_at,
+        r_n_plus_one,
+        telemetry_path,
+    })
+}
+
+/// Locate the telemetry sidecar for a Charter. Charters live at
+/// `.straymark/charters/<NN-slug>.md`; telemetry sits next to them as
+/// `<NN-slug>.telemetry.yaml` per the convention in charter.rs.
+fn telemetry_path_for(_project_root: &Path, charter: &Charter) -> Option<PathBuf> {
+    let stem = charter.path.file_stem()?.to_str()?;
+    let parent = charter.path.parent()?;
+    Some(parent.join(format!("{stem}.telemetry.yaml")))
+}
+
+fn parse_telemetry(path: &Path) -> Result<(Option<String>, Option<u32>)> {
+    let content = std::fs::read_to_string(path)?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&content)?;
+    let ct = value
+        .as_mapping()
+        .and_then(|m| m.get(serde_yaml::Value::String("charter_telemetry".into())));
+    let Some(ct) = ct else {
+        return Ok((None, None));
+    };
+    let mapping = match ct.as_mapping() {
+        Some(m) => m,
+        None => return Ok((None, None)),
+    };
+    let closed_at = mapping
+        .get(serde_yaml::Value::String("closed_at".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let r_n_plus_one = mapping
+        .get(serde_yaml::Value::String("agent_quality".into()))
+        .and_then(|aq| aq.as_mapping())
+        .and_then(|aq| aq.get(serde_yaml::Value::String("r_n_plus_one_emergent_count".into())))
+        .and_then(|v| v.as_u64())
+        .and_then(|n| u32::try_from(n).ok());
+    Ok((closed_at, r_n_plus_one))
+}
+
+fn print_table(all: &[CharterRow], window: &[&CharterRow]) {
+    println!();
+    println!(
+        "  {}",
+        format!(
+            "Closed Charters matched (window: top {} by closed_at)",
+            ROLLING_WINDOW
+        )
+        .bold()
+    );
+    println!();
+    println!(
+        "    {:<40}  {:<12}  {:>10}  {}",
+        "charter_id".dimmed(),
+        "closed_at".dimmed(),
+        "R<N+1>".dimmed(),
+        "telemetry".dimmed()
+    );
+    println!(
+        "    {:<40}  {:<12}  {:>10}  {}",
+        "----------",
+        "----------",
+        "------",
+        "---------"
+    );
+    for (idx, row) in all.iter().enumerate() {
+        let in_window = window.iter().any(|w| w.charter_id == row.charter_id);
+        let marker = if in_window { "●" } else { " " };
+        let id_cell = if in_window {
+            row.charter_id.as_str().green().bold().to_string()
+        } else {
+            row.charter_id.as_str().to_string()
+        };
+        let closed = row.closed_at.as_deref().unwrap_or("—").to_string();
+        let r = row
+            .r_n_plus_one
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "—".to_string());
+        let tel = row
+            .telemetry_path
+            .as_ref()
+            .map(|p| {
+                if p.exists() {
+                    p.file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("(present)")
+                        .to_string()
+                } else {
+                    "(missing)".to_string()
+                }
+            })
+            .unwrap_or_else(|| "(no path)".to_string());
+        let _ = idx;
+        println!(
+            "  {} {:<40}  {:<12}  {:>10}  {}",
+            marker, id_cell, closed, r, tel.dimmed()
+        );
+    }
+    println!();
+}
+
+fn print_recommendation(
+    module: &str,
+    threshold: u32,
+    window: &[&CharterRow],
+    rolling_mean: Option<f64>,
+) {
+    println!("  {}", "Heuristic".bold());
+    println!(
+        "    Chain length (closed Charters in window): {}",
+        window.len()
+    );
+    println!("    Threshold for rolling mean:               > {}", threshold);
+    match rolling_mean {
+        Some(m) => println!(
+            "    Rolling mean of agent_quality.r_n_plus_one_emergent_count: {:.2}",
+            m
+        ),
+        None => println!(
+            "    Rolling mean: {} (insufficient telemetry)",
+            "—".dimmed()
+        ),
+    }
+    println!();
+
+    let chain_ok = window.len() >= ROLLING_WINDOW;
+    let mean_exceeds = rolling_mean.map(|m| m > threshold as f64).unwrap_or(false);
+
+    if chain_ok && mean_exceeds {
+        println!(
+            "  {} {}",
+            "▶".green().bold(),
+            format!(
+                "Recommend a pre-declare SpecKit refresh for `{}` before the next Charter.",
+                module
+            )
+            .bold()
+        );
+        println!(
+            "  {}",
+            "  See .straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md Pattern 1 for mechanics."
+                .dimmed()
+        );
+        println!(
+            "  {}",
+            "  Telemetry slot: `charter_telemetry.pre_declare_refresh` in the next Charter."
+                .dimmed()
+        );
+    } else if !chain_ok {
+        println!(
+            "  {} Chain shorter than {} closed Charters with telemetry — heuristic not yet meaningful.",
+            "ℹ".cyan().bold(),
+            ROLLING_WINDOW
+        );
+        println!(
+            "  {}",
+            "  Recommendation: continue per-Charter pattern; revisit after the next close.".dimmed()
+        );
+    } else {
+        println!(
+            "  {} Rolling mean is within threshold — refresh not recommended.",
+            "✔".green().bold()
+        );
+        println!(
+            "  {}",
+            "  Per-Charter pattern alone is doing its job for this module.".dimmed()
+        );
+    }
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_telemetry(dir: &std::path::Path, name: &str, closed_at: &str, r_n: u32) {
+        let path = dir.join(format!("{name}.telemetry.yaml"));
+        let body = format!(
+            "charter_telemetry:\n  \
+             charter_id: \"{name}\"\n  \
+             charter_title: \"x\"\n  \
+             closed_at: \"{closed_at}\"\n  \
+             effort:\n    estimated_effort: \"M\"\n    actual_effort: \"M\"\n  \
+             agent_quality:\n    r_n_plus_one_emergent_count: {r_n}\n  \
+             outcome:\n    completed_as_planned: true\n    scope_changes: \"ninguno\"\n"
+        );
+        std::fs::write(&path, body).unwrap();
+    }
+
+    fn write_charter(dir: &std::path::Path, name: &str) {
+        let path = dir.join(format!("{name}.md"));
+        let body = format!(
+            "---\ncharter_id: {name}\nstatus: closed\neffort_estimate: M\ntrigger: x\n---\nbody\n"
+        );
+        std::fs::write(&path, body).unwrap();
+    }
+
+    #[test]
+    fn parse_telemetry_extracts_closed_at_and_r_n_plus_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_telemetry(tmp.path(), "10-x", "2026-05-01", 7);
+        let (closed, r_n) =
+            parse_telemetry(&tmp.path().join("10-x.telemetry.yaml")).unwrap();
+        assert_eq!(closed.as_deref(), Some("2026-05-01"));
+        assert_eq!(r_n, Some(7));
+    }
+
+    #[test]
+    fn placeholder_telemetry_returns_none_for_missing_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("11.telemetry.yaml");
+        std::fs::write(&path, "charter_telemetry:\n  charter_id: x\n").unwrap();
+        let (closed, r_n) = parse_telemetry(&path).unwrap();
+        assert_eq!(closed, None);
+        assert_eq!(r_n, None);
+    }
+
+    #[test]
+    fn module_filter_is_case_insensitive_substring_on_charter_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let charters_dir = tmp.path().join(".straymark/charters");
+        std::fs::create_dir_all(&charters_dir).unwrap();
+        write_charter(&charters_dir, "12-commshub-foo");
+        write_charter(&charters_dir, "13-other");
+        write_telemetry(&charters_dir, "12-commshub-foo", "2026-05-10", 8);
+        write_telemetry(&charters_dir, "13-other", "2026-05-12", 3);
+
+        // Just ensure the run completes; the printed table is non-fatal.
+        run(tmp.path().to_str().unwrap(), "CommsHub", Some(6)).unwrap();
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -377,6 +377,55 @@ enum CharterCommands {
         #[arg(long = "path", default_value = ".")]
         path: String,
     },
+    /// Pre-declare SpecKit refresh recommendation for a multi-Charter module.
+    /// Read-only. Computes the rolling mean of
+    /// `agent_quality.r_n_plus_one_emergent_count` across the last 3 closed
+    /// Charters matching the module and compares against a threshold (default
+    /// 6). See STRAYMARK.md §15.A and
+    /// `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` Pattern 1.
+    /// fw-4.16.0+ (Issue #156).
+    RefreshSuggest {
+        /// Module name to match (case-insensitive substring on charter_id).
+        /// Example: `commshub` matches `CHARTER-18-commshub-us5-...`.
+        module: String,
+        /// Override the rolling-mean threshold (default: 6).
+        #[arg(long)]
+        threshold: Option<u32>,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
+    /// Scaffold a post-close Batch N.4 amendment for a closed Charter
+    /// (audit-driven remediation, production incident, or deferred
+    /// implementation). Creates a NEW AILOG stub, edits the most-recent
+    /// originating AILOG with a `## Historical correction` subsection, and
+    /// prints the `post_close_amendment:` YAML block ready for paste (or
+    /// auto-merged into the telemetry with `--merge-into`). Does not touch
+    /// git — operator decides when to commit. See STRAYMARK.md §15.B and
+    /// `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` Pattern 2.
+    /// fw-4.16.0+ (Issue #156).
+    Amend {
+        /// Charter identifier (CHARTER-NN, CHARTER-NN-slug, or just NN).
+        /// Must be already closed.
+        charter_id: String,
+        /// What surfaced the need for the amendment.
+        #[arg(long, value_parser = ["external_audit", "production_incident", "deferred_implementation"])]
+        trigger: String,
+        /// Number of findings closed by the amendment (default: 0).
+        #[arg(long, default_value_t = 0)]
+        findings_closed: u32,
+        /// Short title for the new AILOG (drives filename slug).
+        #[arg(long)]
+        ailog_title: String,
+        /// Optional: merge the rendered `post_close_amendment:` block directly
+        /// into the Charter's telemetry YAML at the given path instead of
+        /// printing it.
+        #[arg(long)]
+        merge_into: Option<String>,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
     /// Detect file-vs-commit drift at Charter close (declared-but-not-modified
     /// files; scope expansion). Suppresses alerts on paths already documented
     /// as risks in the Charter's originating AILOGs.
@@ -557,6 +606,26 @@ fn main() {
                 merge_reports,
                 calibrate,
                 finalize,
+                merge_into.as_deref(),
+            ),
+            CharterCommands::RefreshSuggest {
+                module,
+                threshold,
+                path,
+            } => commands::charter::refresh_suggest::run(&path, &module, threshold),
+            CharterCommands::Amend {
+                charter_id,
+                trigger,
+                findings_closed,
+                ailog_title,
+                merge_into,
+                path,
+            } => commands::charter::amend::run(
+                &path,
+                &charter_id,
+                &trigger,
+                findings_closed,
+                &ailog_title,
                 merge_into.as_deref(),
             ),
         },

--- a/cli/tests/charter_amend_test.rs
+++ b/cli/tests/charter_amend_test.rs
@@ -1,0 +1,205 @@
+//! Integration smoke tests for `straymark charter amend` (fw-4.16.0+).
+//!
+//! See `cli/src/commands/charter/amend.rs` for unit coverage; this exercises
+//! the end-to-end CLI surface.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write_closed_charter(dir: &Path) {
+    let charters = dir.join(".straymark/charters");
+    std::fs::create_dir_all(&charters).unwrap();
+    let body = "---\n\
+charter_id: CHARTER-18-commshub-us5\n\
+status: closed\n\
+effort_estimate: L\n\
+trigger: \"x\"\n\
+---\n\
+Body.\n";
+    std::fs::write(charters.join("18-commshub-us5.md"), body).unwrap();
+}
+
+fn write_prior_ailog(dir: &Path) {
+    let logs = dir.join(".straymark/07-ai-audit/agent-logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let body = "---\n\
+id: AILOG-2026-05-14-049\n\
+type: ailog\n\
+charter_id: CHARTER-18-commshub-us5\n\
+---\n\
+\n\
+# Original CHARTER-18 AILOG\n\
+\n\
+Body referencing CHARTER-18-commshub-us5.\n";
+    std::fs::write(logs.join("AILOG-2026-05-14-049-original.md"), body).unwrap();
+}
+
+fn write_minimal_telemetry(dir: &Path) -> std::path::PathBuf {
+    let charters = dir.join(".straymark/charters");
+    std::fs::create_dir_all(&charters).unwrap();
+    let path = charters.join("18-commshub-us5.telemetry.yaml");
+    std::fs::write(
+        &path,
+        "charter_telemetry:\n  \
+         charter_id: \"CHARTER-18-commshub-us5\"\n  \
+         charter_title: \"x\"\n  \
+         closed_at: \"2026-05-15\"\n  \
+         effort:\n    estimated_effort: \"L\"\n    actual_effort: \"L\"\n  \
+         outcome:\n    completed_as_planned: true\n    scope_changes: \"ninguno\"\n",
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn amend_creates_new_ailog_and_appends_historical_correction() {
+    let dir = TempDir::new().unwrap();
+    write_closed_charter(dir.path());
+    write_prior_ailog(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "amend",
+            "CHARTER-18",
+            "--trigger",
+            "external_audit",
+            "--findings-closed",
+            "5",
+            "--ailog-title",
+            "post-close DI wiring",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("post_close_amendment YAML"))
+        .stdout(predicate::str::contains("Created new AILOG"))
+        .stdout(predicate::str::contains("Appended `## Historical correction"));
+
+    // Original AILOG must now contain the Historical correction subsection.
+    let original_path = dir
+        .path()
+        .join(".straymark/07-ai-audit/agent-logs/AILOG-2026-05-14-049-original.md");
+    let original = std::fs::read_to_string(&original_path).unwrap();
+    assert!(
+        original.contains("## Historical correction ("),
+        "original AILOG must carry Historical correction subsection:\n{original}"
+    );
+    assert!(
+        original.contains("external_audit"),
+        "trigger reason recorded in correction subsection"
+    );
+
+    // A new AILOG file must exist with today's date.
+    let logs = dir.path().join(".straymark/07-ai-audit/agent-logs");
+    let entries: Vec<String> = std::fs::read_dir(&logs)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with("AILOG-") && n != "AILOG-2026-05-14-049-original.md")
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one new AILOG must have been created: {entries:?}");
+    assert!(
+        entries[0].contains("post-close-di-wiring"),
+        "new AILOG filename must carry the slugified title: {}",
+        entries[0]
+    );
+}
+
+#[test]
+fn amend_fails_when_charter_not_closed() {
+    let dir = TempDir::new().unwrap();
+    let charters = dir.path().join(".straymark/charters");
+    std::fs::create_dir_all(&charters).unwrap();
+    std::fs::write(
+        charters.join("19-still-running.md"),
+        "---\ncharter_id: CHARTER-19-still-running\nstatus: in-progress\neffort_estimate: M\ntrigger: \"x\"\n---\nBody.\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "amend",
+            "CHARTER-19",
+            "--trigger",
+            "external_audit",
+            "--ailog-title",
+            "should fail",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is not closed"));
+}
+
+#[test]
+fn amend_rejects_invalid_trigger() {
+    let dir = TempDir::new().unwrap();
+    write_closed_charter(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "amend",
+            "CHARTER-18",
+            "--trigger",
+            "totally-bogus",
+            "--ailog-title",
+            "x",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure();
+}
+
+#[test]
+fn amend_merge_into_writes_post_close_amendment_to_telemetry() {
+    let dir = TempDir::new().unwrap();
+    write_closed_charter(dir.path());
+    write_prior_ailog(dir.path());
+    let telemetry_path = write_minimal_telemetry(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "amend",
+            "CHARTER-18",
+            "--trigger",
+            "external_audit",
+            "--findings-closed",
+            "3",
+            "--ailog-title",
+            "merge-into smoke",
+            "--merge-into",
+            telemetry_path.to_str().unwrap(),
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Merged `post_close_amendment:`"));
+
+    let merged = std::fs::read_to_string(&telemetry_path).unwrap();
+    assert!(
+        merged.contains("post_close_amendment:"),
+        "merged telemetry must carry the post_close_amendment block:\n{merged}"
+    );
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(&merged).expect("merged YAML must parse");
+    let trigger = parsed
+        .get("charter_telemetry")
+        .and_then(|v| v.get("post_close_amendment"))
+        .and_then(|v| v.get("trigger"))
+        .and_then(|v| v.as_str());
+    assert_eq!(trigger, Some("external_audit"));
+}

--- a/cli/tests/charter_audit_test.rs
+++ b/cli/tests/charter_audit_test.rs
@@ -665,7 +665,72 @@ fn audit_merge_into_rejects_existing_external_audit() {
         .arg(dir.path().to_str().unwrap())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("already has an `external_audit:`"));
+        .stderr(predicate::str::contains(
+            "already has a populated `external_audit:`",
+        ));
+}
+
+/// Regression for Issue #156: when the telemetry has `external_audit: []`
+/// (the placeholder `charter close` writes in fw-4.16.0+), the merge must
+/// REPLACE the placeholder in place rather than reject with the "already has"
+/// guard. The guard exists only to prevent silent duplication, not to block
+/// the legitimate post-close round-trip.
+#[test]
+fn audit_merge_into_replaces_empty_external_audit_placeholder() {
+    if !bash_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_finalized_audit(dir.path());
+    let telemetry_path = write_minimal_telemetry(dir.path());
+
+    // Pre-populate with the EMPTY placeholder (what charter close writes).
+    let mut existing = std::fs::read_to_string(&telemetry_path).unwrap();
+    existing.push_str("\n  external_audit: []\n");
+    std::fs::write(&telemetry_path, &existing).unwrap();
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "audit",
+            "CHARTER-01",
+            "--merge-reports",
+            "--merge-into",
+            telemetry_path.to_str().unwrap(),
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Merged external_audit"));
+
+    let merged = std::fs::read_to_string(&telemetry_path).unwrap();
+    // Placeholder line must be gone; populated block must be present.
+    assert!(
+        !merged.contains("external_audit: []"),
+        "empty placeholder must be replaced, not left in:\n{merged}"
+    );
+    assert!(
+        merged.contains("\n  external_audit:\n"),
+        "external_audit block must be at indent 2:\n{merged}"
+    );
+    assert!(
+        merged.contains("- auditor: \"copilot-v1.0.37\""),
+        "first auditor present after placeholder replacement"
+    );
+    // Resulting YAML must still parse cleanly.
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&merged)
+        .expect("merge result must be valid YAML");
+    let arr = parsed
+        .get("charter_telemetry")
+        .and_then(|v| v.get("external_audit"))
+        .and_then(|v| v.as_sequence())
+        .expect("charter_telemetry.external_audit must be an array after merge");
+    assert!(
+        !arr.is_empty(),
+        "external_audit array must be non-empty after merge"
+    );
 }
 
 #[test]

--- a/cli/tests/charter_refresh_suggest_test.rs
+++ b/cli/tests/charter_refresh_suggest_test.rs
@@ -1,0 +1,154 @@
+//! Integration smoke tests for `straymark charter refresh-suggest` (fw-4.16.0+).
+//!
+//! See `cli/src/commands/charter/refresh_suggest.rs` for unit coverage of the
+//! parsing helpers; this file exercises the assembled binary end-to-end.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write_charter(dir: &Path, charter_id: &str) {
+    let charters = dir.join(".straymark/charters");
+    std::fs::create_dir_all(&charters).unwrap();
+    let stem = charter_id.strip_prefix("CHARTER-").unwrap_or(charter_id);
+    let body = format!(
+        "---\ncharter_id: {charter_id}\nstatus: closed\neffort_estimate: M\ntrigger: \"x\"\n---\nBody.\n"
+    );
+    std::fs::write(charters.join(format!("{stem}.md")), body).unwrap();
+}
+
+fn write_telemetry(dir: &Path, charter_id: &str, closed_at: &str, r_n: u32) {
+    let charters = dir.join(".straymark/charters");
+    std::fs::create_dir_all(&charters).unwrap();
+    let stem = charter_id.strip_prefix("CHARTER-").unwrap_or(charter_id);
+    let body = format!(
+        "charter_telemetry:\n  \
+         charter_id: \"{charter_id}\"\n  \
+         charter_title: \"x\"\n  \
+         closed_at: \"{closed_at}\"\n  \
+         effort:\n    estimated_effort: \"M\"\n    actual_effort: \"M\"\n  \
+         agent_quality:\n    r_n_plus_one_emergent_count: {r_n}\n  \
+         outcome:\n    completed_as_planned: true\n    scope_changes: \"ninguno\"\n"
+    );
+    std::fs::write(
+        charters.join(format!("{stem}.telemetry.yaml")),
+        body,
+    )
+    .unwrap();
+}
+
+#[test]
+fn refresh_suggest_recommends_when_rolling_mean_exceeds_threshold() {
+    let dir = TempDir::new().unwrap();
+    write_charter(dir.path(), "CHARTER-10-commshub-us1");
+    write_charter(dir.path(), "CHARTER-11-commshub-us2");
+    write_charter(dir.path(), "CHARTER-12-commshub-us3");
+    write_telemetry(dir.path(), "CHARTER-10-commshub-us1", "2026-04-01", 7);
+    write_telemetry(dir.path(), "CHARTER-11-commshub-us2", "2026-04-15", 8);
+    write_telemetry(dir.path(), "CHARTER-12-commshub-us3", "2026-05-01", 9);
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "refresh-suggest",
+            "commshub",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Recommend a pre-declare SpecKit refresh"));
+}
+
+#[test]
+fn refresh_suggest_holds_when_rolling_mean_within_threshold() {
+    let dir = TempDir::new().unwrap();
+    write_charter(dir.path(), "CHARTER-20-commshub-us1");
+    write_charter(dir.path(), "CHARTER-21-commshub-us2");
+    write_charter(dir.path(), "CHARTER-22-commshub-us3");
+    write_telemetry(dir.path(), "CHARTER-20-commshub-us1", "2026-04-01", 2);
+    write_telemetry(dir.path(), "CHARTER-21-commshub-us2", "2026-04-15", 1);
+    write_telemetry(dir.path(), "CHARTER-22-commshub-us3", "2026-05-01", 3);
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "refresh-suggest",
+            "commshub",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("refresh not recommended"));
+}
+
+#[test]
+fn refresh_suggest_reports_insufficient_when_chain_too_short() {
+    let dir = TempDir::new().unwrap();
+    write_charter(dir.path(), "CHARTER-30-commshub-us1");
+    write_telemetry(dir.path(), "CHARTER-30-commshub-us1", "2026-05-01", 99);
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "refresh-suggest",
+            "commshub",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Chain shorter than 3 closed Charters"));
+}
+
+#[test]
+fn refresh_suggest_zero_matches_prints_nothing_to_suggest() {
+    let dir = TempDir::new().unwrap();
+    write_charter(dir.path(), "CHARTER-40-something-else");
+    write_telemetry(dir.path(), "CHARTER-40-something-else", "2026-05-01", 99);
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "refresh-suggest",
+            "commshub",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No closed Charters match module `commshub`"));
+}
+
+#[test]
+fn refresh_suggest_threshold_flag_overrides_default() {
+    let dir = TempDir::new().unwrap();
+    // r_n_plus_one = 5 each → rolling mean = 5, below default 6 but above 3.
+    write_charter(dir.path(), "CHARTER-50-commshub-us1");
+    write_charter(dir.path(), "CHARTER-51-commshub-us2");
+    write_charter(dir.path(), "CHARTER-52-commshub-us3");
+    write_telemetry(dir.path(), "CHARTER-50-commshub-us1", "2026-04-01", 5);
+    write_telemetry(dir.path(), "CHARTER-51-commshub-us2", "2026-04-15", 5);
+    write_telemetry(dir.path(), "CHARTER-52-commshub-us3", "2026-05-01", 5);
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args([
+            "charter",
+            "refresh-suggest",
+            "commshub",
+            "--threshold",
+            "3",
+            "--path",
+        ])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Recommend a pre-declare SpecKit refresh"));
+}

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -379,4 +379,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md
+++ b/dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md
@@ -1,0 +1,196 @@
+# Charter Chain Evolution — StrayMark
+
+> Two complementary patterns for keeping a multi-Charter module honest: refreshing SpecKit artifacts before a Charter is declared, and amending a closed Charter when audit findings arrive after `status: closed`.
+
+**Languages**: English | [Español](i18n/es/CHARTER-CHAIN-EVOLUTION.md) | [简体中文](i18n/zh-CN/CHARTER-CHAIN-EVOLUTION.md)
+
+---
+
+## Status
+
+**v0 — proven in N=1 domain** (`StrangeDaysTech/sentinel` CHARTER-18, 2026-05-15, Issue #156).
+
+Both patterns are conventions documented here as canonical framework guidance. The CLI ships read-only and scaffolding helpers (`straymark charter refresh-suggest`, `straymark charter amend`); the patterns themselves are operator-driven. Either pattern may evolve once a second adopter validates them — until then, the N=1-domain caveat applies (Principle #12).
+
+---
+
+## Why this document exists
+
+StrayMark's Charter pattern (`STRAYMARK.md` §15) assumes a single Charter is the bounded unit of work. That works for isolated Charters. It also works for the *first* Charter in a chain. But when a module accumulates many user-story Charters over months, two failure modes surface that the per-Charter pattern alone does not address:
+
+1. **Spec drift at the chain level** — the SpecKit artifacts (`plan.md`, `data-model.md`, `contracts/*`, `quickstart.md`, `research.md`) were authored against the framework version and reality of the module at chain start. After 3+ Charters, accumulated learnings (reusable patterns extracted, code gaps found, framework conventions evolved, operator decisions ratified) have drifted the spec away from the implementation. Going directly from Charter-N close into Charter-(N+1) declare causes systematic mid-flight scope expansions and emergent `R<N+1> (new, not in Charter)` entries.
+2. **Audit findings at the cycle level** — external audit cycles run post-close (auditors execute asynchronously after the close ceremony). Critical or High findings can arrive after the Charter has been marked `status: closed`. The framework's options are then: (a) open a new Charter for remediation (heavy — full declare + Tasks + ceremony for ~5 file edits), or (b) leave the findings in `review.md` and lose the "atomic with the Charter" property.
+
+Pattern 1 below addresses (1). Pattern 2 addresses (2). The two compose — a Charter that *received* Pattern 1 is more likely to *avoid* Pattern 2, because the refresh absorbs the pre-execution risk that the audit would surface post-close. They are complementary, not substitutable.
+
+---
+
+## Pattern 1 — Pre-declare SpecKit refresh
+
+### When this pattern applies
+
+Adopt this pattern when **all** of these hold for a SpecKit-driven module:
+
+- The module has **3 or more closed Charters** (chain length ≥ 3).
+- The rolling mean of `charter_telemetry.agent_quality.r_n_plus_one_emergent_count` across the last 3 closed Charters is **> 6**.
+- No refresh PR has landed in the SpecKit artifacts since the chain's last branch point.
+
+Run `straymark charter refresh-suggest <module>` to evaluate the heuristic against your `.telemetry.yaml` history. The CLI reads the last closed Charters of the named module and prints a recommendation; it does not mutate anything.
+
+Below the threshold, the per-Charter pattern alone is sufficient — adopting the refresh too early adds a PR's worth of overhead without payoff.
+
+### Shape
+
+A **dedicated refresh PR** lands between Charter-N close and Charter-(N+1) declare. It touches only the **non-locked sections** of the SpecKit artifacts:
+
+- `specs/<module>/plan.md` — phase plans, dependency notes, sequencing.
+- `specs/<module>/data-model.md` — entities, fields, conventions.
+- `specs/<module>/contracts/*.md` — interface contracts, request/response shapes.
+- `specs/<module>/quickstart.md` — runnable scenarios.
+- `specs/<module>/research.md` — accumulated knowledge (see "Categorized learnings table" below).
+
+`research.md` carries the load-bearing artifact: a **categorized learnings table** consolidating what the chain learned. Minimum buckets:
+
+| Bucket | What goes here |
+|---|---|
+| Reusable patterns | Idioms / utilities / wrappers that emerged across Charters and should be inherited going forward (e.g. `withRLS` wrapper, brand-cache LRU, dedup table pattern). |
+| Code gaps | Identified-but-unfixed work the chain discovered but did not close (e.g. unwired tables, stub implementations, missing columns). Each gap is a `Gn` entry with description + owning Charter (current or future). |
+| Discipline patterns | Process learnings the chain ratified (e.g. cross-family audit pair, batch-complete discipline, per-batch close cadence). |
+| Empirical corrections | Places where the spec drifted from the implementation. `EC1...ECn` entries: spec said X, reality is Y, reconciliation chosen. |
+
+Optional **operator decisions (Dn)** are ratified pre-declare with: decision, alternatives considered, chosen path, rationale. Subsequent Charters inherit Dn as contracts.
+
+### Mechanics
+
+1. **Refresh PR** before the next Charter declare. Optional AIDEC documenting the refresh decision + alternatives considered. The PR title should make the scope explicit (e.g. `spec(<module>): US<n> plan refresh — LOCKED-aware Phase 7+8 redesign`).
+2. **Categorized learnings table** in `research.md` with the four buckets above. Each entry has a stable id (Pn / Gn / DPn / ECn) so subsequent Charters can cite by id.
+3. **Operator decisions (Dn)** if applicable — listed explicitly with alternatives + chosen path + rationale.
+4. **Next Charter's `## Context` section** cites each pattern, correction, and decision by id. Charter scope is grounded in refreshed reality, not in the chain-start spec.
+
+### Telemetry
+
+Populate `charter_telemetry.pre_declare_refresh:` in the *next* Charter's telemetry (the one that consumed the refresh, not the refresh PR itself):
+
+```yaml
+pre_declare_refresh:
+  enabled: true
+  refresh_pr: "owner/repo#76"
+  refresh_aidec: "AIDEC-YYYY-MM-DD-NNN-speckit-refresh"
+  reusable_patterns_integrated: 7
+  code_gaps_integrated: 4
+  discipline_patterns_integrated: 3
+  empirical_corrections_integrated: 15
+  operator_decisions_ratified: 3
+```
+
+Omit the block entirely if no refresh occurred — absence means "pattern not used".
+
+### Why this works (empirical)
+
+Sentinel CHARTER-18 was the first Charter in a 7-Charter chain to close cleanly without a mid-flight remediation Charter. `estimation_drift_factor: 1.0`, `pre_work.items_discovered_during_planning: 0`, `overall_satisfaction: 5/5`. Operator's drift reason statement: *"the SpecKit refresh from PR #76 ... eliminated most ambiguity that drove drift in prior Charters. No mid-flight remediation Charter required — the EC1..EC15 empirical-corrections inventory in research.md absorbed what would have been pre-execution risk into in-execution awareness."*
+
+---
+
+## Pattern 2 — Post-close audit-driven amendment (Batch N.4)
+
+### When this pattern applies
+
+Adopt this pattern when **all** of these hold after a Charter has been marked `status: closed`:
+
+- One or more external audit findings emerge in the post-close `review.md` graded **Critical** or **High**.
+- The Charter's `closure_criterion` is materially unmet by the un-remediated findings (i.e. shipping as-is would invalidate the close).
+- The fix surface fits in **one cohesive PR** (~< 25 files, no architectural reopen — no new abstractions, no migrations, no API breaks).
+
+If the fix surface is larger or architectural, open a new Charter instead. The amendment pattern exists for the bounded case; it is not a Charter-evasion mechanism.
+
+### Shape
+
+The amendment rides **the same execute branch** as the original Charter (the branch is still mergeable to `main`; the amendment commit lands on top). A **new AILOG** documents the amendment — not an edit of the original AILOG.
+
+```
+charter-<N>-execute branch
+├── (original commits — Charter execute work)
+├── commit X: charter close (status: closed, telemetry.yaml written)
+└── commit Y: charter-<N>(batch-7.4): audit-driven remediation — <short summary>
+    ↑
+    AILOG-YYYY-MM-DD-MMM (NEW) documents this commit
+    AILOG-YYYY-MM-DD-NNN (ORIGINAL) gets a `## Historical correction` subsection
+                                    pointing forward to AILOG-...-MMM
+```
+
+### Mechanics
+
+1. **Same execute branch** — do not branch off `main`. The original Charter's execute branch is still the unit; the amendment commit rides along.
+2. **New AILOG** under `.straymark/07-ai-audit/agent-logs/` documents the amendment. Convention: `risk_level: high` and `review_required: true`. The new AILOG carries an `amends:` field pointing back to the original AILOG id.
+3. **Historical correction in the original AILOG** — append a `## Historical correction (YYYY-MM-DD)` subsection at the end of the original AILOG with the forward pointer to the new AILOG. Audit decisions are distinct from execute decisions; the original's body remains intact as the historical record.
+4. **PR commentary** — if the execute PR has not yet merged, add the amendment commit to it and update the PR description with a "Batch N.4 amendment" subsection listing the closed findings. If the PR already merged, open a follow-up PR that references the original PR and the AILOG.
+5. **Telemetry** — populate `charter_telemetry.post_close_amendment:` (see below). Use `straymark charter audit <id> --merge-reports --merge-into <telemetry-yaml>` to merge external audit findings into the same file; the CLI tolerates `external_audit: []` placeholder rewrites in v0.2+.
+
+`straymark charter amend <id>` scaffolds steps 2, 3, and 5 (creates the new AILOG stub, edits the original AILOG with the Historical correction subsection, prints the YAML block). It does not touch git — the operator decides when to commit.
+
+### Telemetry
+
+Populate `charter_telemetry.post_close_amendment:` in the Charter's `.telemetry.yaml`:
+
+```yaml
+post_close_amendment:
+  applied: true
+  trigger: "external_audit"           # external_audit | production_incident | deferred_implementation
+  ailog_id: "AILOG-YYYY-MM-DD-MMM"    # the NEW AILOG, not the original
+  findings_closed: 5
+  files_modified: 19
+  effort_hours: 6.0
+```
+
+Omit the block entirely if no amendment occurred.
+
+### Why this works (empirical)
+
+Sentinel CHARTER-18 closed 2026-05-15 with `external-audit-pending.yaml`. Audit reports landed 2026-05-15..05-17. Five findings (4 Critical/High from `gpt-5.3-codex`, 1 Critical from `gemini-2.5-pro`, 1 Medium found by the calibrator) were code-level fixes — DI wiring, retry header parsing, multi-tenant filter, timeout default. The Batch 7.4 amendment closed all five in one cohesive commit (19 files, +2257/-106 lines). A new Charter would have created multi-week governance overhead for ~6h of focused engineering.
+
+---
+
+## Cross-pattern composition
+
+The two patterns operate at different levels of the chain and compose:
+
+| Pattern | Level | Frequency | Absorbs |
+|---|---|---|---|
+| Pre-declare SpecKit refresh | Chain / module | Once per 3+ Charters | Spec-level drift (architectural assumptions, table naming, framework version evolution) |
+| Post-close audit-driven amendment | Cycle / Charter | Per Charter when triggered | Runtime-level drift (DI wiring, retry semantics, multi-tenant filters) |
+
+A Charter that *received* Pattern 1 is more likely to *avoid* Pattern 2 — the refresh absorbs pre-execution risk that would otherwise surface as post-close findings. But CHARTER-18 needed *both* — the refresh handled spec-level drift; the amendment handled runtime-level drift the refresh did not reach into. Encourage Pattern 1 at the chain level; tolerate Pattern 2 at the cycle level.
+
+---
+
+## Authority / acceptance flow for upstreaming new patterns
+
+This document is itself the output of the acceptance flow Sentinel walked through for these two patterns (Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)). The canonical flow for upstreaming a new Charter-chain pattern is:
+
+1. **Adopter-local RFC** lives at `.straymark/06-evolution/<name>-rfc.md` in the adopter's own tree. The adopter ships the pattern there first — N=1 evidence is necessary but not sufficient.
+2. **Upstream Issue** in `StrangeDaysTech/straymark` mirroring the local RFC body, with telemetry citations and PR links.
+3. **Upstream acceptance** lands as: (a) a doc here in `00-governance/` describing the pattern canonically, (b) telemetry schema additions (opt-in), (c) optional CLI scaffolding for the operator-facing mechanics. The N=1-domain caveat carries forward to v1 stabilization.
+4. **Second-domain validation** before the pattern's schema fields graduate from optional to recommended.
+
+`06-evolution/` is the canonical adopter-local home for in-flight RFCs. Once accepted upstream, the canonical home is `00-governance/<NAME>.md` — the convention this document instantiates.
+
+---
+
+## Open questions
+
+- **Threshold tuning** — the rolling-mean threshold of 6 for `r_n_plus_one_emergent_count` is Sentinel-derived. A second domain may move it. The `straymark charter refresh-suggest` CLI exposes `--threshold N` for adopter calibration.
+- **Module heuristic** — `refresh-suggest <module>` currently matches `<module>` against the Charter title and slug. SpecKit-conventional modules (`specs/<NNN>-<module>/`) could provide a stricter binding via the Charter's `originating_spec` field in a future fw bump.
+- **Amendment frequency cap** — Pattern 2 is bounded by "one cohesive PR". A Charter receiving two or more amendment commits over time should be re-evaluated as a sign that the original close was premature.
+
+---
+
+## Related
+
+- [STRAYMARK.md §15](../../STRAYMARK.md) — Charter lifecycle and the per-Charter pattern this document extends.
+- [SPECKIT-CHARTER-BRIDGE.md](SPECKIT-CHARTER-BRIDGE.md) — how SpecKit artifacts map to Charters; Pattern 1 lives on this seam.
+- [FOLLOW-UPS-BACKLOG-PATTERN.md](FOLLOW-UPS-BACKLOG-PATTERN.md) — sibling pattern for accumulated `§Follow-ups` across many AILOGs.
+- [`.straymark/schemas/charter-telemetry.schema.v0.json`](../schemas/charter-telemetry.schema.v0.json) — `pre_declare_refresh` and `post_close_amendment` are defined here.
+
+---
+
+*StrayMark fw-4.16.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -318,4 +318,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -241,4 +241,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md
+++ b/dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md
@@ -134,6 +134,8 @@ originating_charter: CHARTER-02-peek-mvp-foundation
 ## Spec maintenance during multi-Charter execution
 
 > **Empirical anchor**: surfaced by [issue #150](https://github.com/StrangeDaysTech/straymark/issues/150) after Sentinel ran a single `specs/002-commshub/plan.md` (committed 2026-04-21) through **seven consecutive Charters** (CHARTER-07 through CHARTER-17, ~1 month). Twelve aprendizajes empíricos that materially impact the next Charter's scope were *not* reflected in the plan. The pattern below codifies what Sentinel discovered before CHARTER-18 fill.
+>
+> **Canonical extension** *(fw-4.16.0+)*: this section's procedural guidance (when + how + gates) is the mechanical floor. The *named pattern* — including the `r_n_plus_one_emergent_count` rolling-mean trigger heuristic, the categorized-learnings table contract, telemetry slot `pre_declare_refresh:`, and the `straymark charter refresh-suggest` helper — lives in [CHARTER-CHAIN-EVOLUTION.md](CHARTER-CHAIN-EVOLUTION.md) **Pattern 1**. Read both: this doc tells you the *how*, that one names the *pattern* and feeds it back into telemetry.
 
 The lifecycle map above assumes **one-pass**: SpecKit artifacts are generated once, then Charters are declared and executed. This scales fine for features that produce a single Charter. When a single spec drives many Charters spaced weeks apart, **planning artifacts drift relative to shipped code** — and naively re-running `/speckit-plan` is *worse*, not better: regeneration asserts things about already-shipped user stories that the actual code does not implement, and future readers (auditors, agents, new operators) trust those regenerated artifacts as ground truth.
 

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -379,4 +379,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/CHARTER-CHAIN-EVOLUTION.md
+++ b/dist/.straymark/00-governance/i18n/es/CHARTER-CHAIN-EVOLUTION.md
@@ -1,0 +1,196 @@
+# Evolución de la cadena de Charters — StrayMark
+
+> Dos patrones complementarios para mantener honesto un módulo multi-Charter: refrescar los artefactos SpecKit antes de declarar un Charter, y enmendar un Charter cerrado cuando llegan hallazgos de auditoría después de `status: closed`.
+
+**Idiomas**: [English](../../CHARTER-CHAIN-EVOLUTION.md) | Español | [简体中文](../zh-CN/CHARTER-CHAIN-EVOLUTION.md)
+
+---
+
+## Estado
+
+**v0 — validado en N=1 dominio** (`StrangeDaysTech/sentinel` CHARTER-18, 2026-05-15, Issue #156).
+
+Ambos patrones son convenciones documentadas aquí como guía canónica del framework. La CLI envía helpers read-only y de scaffolding (`straymark charter refresh-suggest`, `straymark charter amend`); los patrones en sí los conduce el operador. Cualquiera de los dos patrones puede evolucionar cuando un segundo adopter los valide — hasta entonces, aplica la advertencia de dominio N=1 (Principio #12).
+
+---
+
+## Por qué existe este documento
+
+El patrón Charter de StrayMark (`STRAYMARK.md` §15) asume que un único Charter es la unidad acotada de trabajo. Eso funciona para Charters aislados. También funciona para el *primer* Charter de una cadena. Pero cuando un módulo acumula muchos user-story Charters a lo largo de meses, emergen dos modos de falla que el patrón por-Charter no aborda:
+
+1. **Deriva de spec a nivel de cadena** — los artefactos SpecKit (`plan.md`, `data-model.md`, `contracts/*`, `quickstart.md`, `research.md`) se escribieron contra la versión del framework y la realidad del módulo al inicio de la cadena. Tras 3+ Charters, los aprendizajes acumulados (patrones reusables extraídos, gaps de código encontrados, convenciones del framework evolucionadas, decisiones del operador ratificadas) han alejado la spec de la implementación. Pasar directamente del cierre del Charter-N al declare del Charter-(N+1) produce expansiones de scope sistemáticas en mid-flight y entradas emergentes `R<N+1> (new, not in Charter)`.
+2. **Hallazgos de auditoría a nivel de ciclo** — los ciclos de auditoría externa corren post-close (los auditores ejecutan asincrónicamente después de la ceremonia de cierre). Hallazgos Critical o High pueden llegar después de que el Charter está marcado `status: closed`. Las opciones del framework son entonces: (a) abrir un Charter nuevo de remediación (pesado — declare + Tasks + ceremonia completos para ~5 ediciones de archivo), o (b) dejar los hallazgos en `review.md` y perder la propiedad "atómico con el Charter".
+
+El Patrón 1 aborda (1). El Patrón 2 aborda (2). Los dos componen — un Charter que *recibió* el Patrón 1 tiene más probabilidad de *evitar* el Patrón 2, porque el refresh absorbe el riesgo pre-ejecución que la auditoría surfacearía post-close. Son complementarios, no sustituibles.
+
+---
+
+## Patrón 1 — Refresh de SpecKit pre-declare
+
+### Cuándo aplica este patrón
+
+Adopta este patrón cuando **todo** lo siguiente sostenga para un módulo dirigido por SpecKit:
+
+- El módulo tiene **3 o más Charters cerrados** (longitud de cadena ≥ 3).
+- La media móvil de `charter_telemetry.agent_quality.r_n_plus_one_emergent_count` sobre los últimos 3 Charters cerrados es **> 6**.
+- Ningún PR de refresh ha aterrizado en los artefactos SpecKit desde el último branch point de la cadena.
+
+Ejecuta `straymark charter refresh-suggest <module>` para evaluar la heurística contra tu historial `.telemetry.yaml`. La CLI lee los últimos Charters cerrados del módulo nombrado e imprime una recomendación; no muta nada.
+
+Por debajo del umbral, el patrón por-Charter solo es suficiente — adoptar el refresh demasiado pronto añade overhead de un PR sin beneficio.
+
+### Forma
+
+Un **PR dedicado de refresh** aterriza entre el cierre del Charter-N y el declare del Charter-(N+1). Toca solo las **secciones no-locked** de los artefactos SpecKit:
+
+- `specs/<module>/plan.md` — planes de fase, notas de dependencia, secuenciación.
+- `specs/<module>/data-model.md` — entidades, campos, convenciones.
+- `specs/<module>/contracts/*.md` — contratos de interfaz, formas de request/response.
+- `specs/<module>/quickstart.md` — escenarios ejecutables.
+- `specs/<module>/research.md` — conocimiento acumulado (ver "Tabla de aprendizajes categorizados" abajo).
+
+`research.md` carga el artefacto load-bearing: una **tabla de aprendizajes categorizados** que consolida lo que la cadena aprendió. Buckets mínimos:
+
+| Bucket | Qué va aquí |
+|---|---|
+| Patrones reusables | Idioms / utilities / wrappers que emergieron a través de Charters y deberían heredarse hacia adelante (p.ej. wrapper `withRLS`, LRU brand-cache, patrón de tabla de dedup). |
+| Gaps de código | Trabajo identificado-pero-no-arreglado que la cadena descubrió pero no cerró (p.ej. tablas sin wirear, implementaciones stub, columnas faltantes). Cada gap es una entrada `Gn` con descripción + Charter dueño (actual o futuro). |
+| Patrones de disciplina | Aprendizajes de proceso que la cadena ratificó (p.ej. pareja de auditoría cross-family, disciplina de batch-complete, cadencia de close per-batch). |
+| Correcciones empíricas | Lugares donde la spec derivó de la implementación. Entradas `EC1...ECn`: la spec decía X, la realidad es Y, reconciliación elegida. |
+
+Decisiones opcionales **del operador (Dn)** se ratifican pre-declare con: decisión, alternativas consideradas, camino elegido, racional. Los Charters posteriores heredan Dn como contratos.
+
+### Mecánica
+
+1. **PR de refresh** antes del próximo Charter declare. AIDEC opcional documentando la decisión del refresh + alternativas consideradas. El título del PR debería hacer explícito el scope (p.ej. `spec(<module>): US<n> plan refresh — LOCKED-aware Phase 7+8 redesign`).
+2. **Tabla de aprendizajes categorizados** en `research.md` con los cuatro buckets arriba. Cada entrada tiene un id estable (Pn / Gn / DPn / ECn) para que Charters posteriores puedan citar por id.
+3. **Decisiones del operador (Dn)** si aplican — listadas explícitamente con alternativas + camino elegido + racional.
+4. **Sección `## Context` del próximo Charter** cita cada patrón, corrección y decisión por id. El scope del Charter se ancla en realidad refrescada, no en la spec del inicio de cadena.
+
+### Telemetría
+
+Popula `charter_telemetry.pre_declare_refresh:` en la telemetría del *próximo* Charter (el que consumió el refresh, no en el PR de refresh mismo):
+
+```yaml
+pre_declare_refresh:
+  enabled: true
+  refresh_pr: "owner/repo#76"
+  refresh_aidec: "AIDEC-YYYY-MM-DD-NNN-speckit-refresh"
+  reusable_patterns_integrated: 7
+  code_gaps_integrated: 4
+  discipline_patterns_integrated: 3
+  empirical_corrections_integrated: 15
+  operator_decisions_ratified: 3
+```
+
+Omite el bloque entero si no ocurrió un refresh — la ausencia significa "patrón no usado".
+
+### Por qué funciona (empírico)
+
+Sentinel CHARTER-18 fue el primer Charter en una cadena de 7 Charters en cerrar limpiamente sin un Charter de remediación mid-flight. `estimation_drift_factor: 1.0`, `pre_work.items_discovered_during_planning: 0`, `overall_satisfaction: 5/5`. Statement de drift del operador: *"el refresh de SpecKit del PR #76 ... eliminó la mayor parte de la ambigüedad que conducía la deriva en Charters previos. No se requirió Charter de remediación mid-flight — el inventario de correcciones empíricas EC1..EC15 en research.md absorbió lo que habría sido riesgo pre-ejecución en consciencia in-ejecución."*
+
+---
+
+## Patrón 2 — Enmienda post-close dirigida por auditoría (Batch N.4)
+
+### Cuándo aplica este patrón
+
+Adopta este patrón cuando **todo** lo siguiente sostenga después de que un Charter ha sido marcado `status: closed`:
+
+- Uno o más hallazgos de auditoría externa emergen en el `review.md` post-close calificados **Critical** o **High**.
+- El `closure_criterion` del Charter está materialmente incumplido por los hallazgos no remediados (es decir, enviar tal como está invalidaría el cierre).
+- La superficie de fix cabe en **un PR cohesivo** (~< 25 archivos, sin reopen arquitectónico — sin abstracciones nuevas, sin migraciones, sin API breaks).
+
+Si la superficie de fix es mayor o arquitectónica, abre un Charter nuevo en su lugar. El patrón de enmienda existe para el caso acotado; no es un mecanismo de evasión de Charter.
+
+### Forma
+
+La enmienda viaja en **la misma rama de execute** que el Charter original (la rama sigue mergeable a `main`; el commit de enmienda aterriza encima). Un **AILOG nuevo** documenta la enmienda — no una edición del AILOG original.
+
+```
+rama charter-<N>-execute
+├── (commits originales — trabajo de execute del Charter)
+├── commit X: charter close (status: closed, telemetry.yaml escrito)
+└── commit Y: charter-<N>(batch-7.4): audit-driven remediation — <resumen corto>
+    ↑
+    AILOG-YYYY-MM-DD-MMM (NUEVO) documenta este commit
+    AILOG-YYYY-MM-DD-NNN (ORIGINAL) recibe una subsección `## Historical correction`
+                                    apuntando adelante a AILOG-...-MMM
+```
+
+### Mecánica
+
+1. **Misma rama de execute** — no bifurques desde `main`. La rama de execute del Charter original sigue siendo la unidad; el commit de enmienda viaja con ella.
+2. **AILOG nuevo** bajo `.straymark/07-ai-audit/agent-logs/` documenta la enmienda. Convención: `risk_level: high` y `review_required: true`. El AILOG nuevo carga un campo `amends:` apuntando de vuelta al id del AILOG original.
+3. **Corrección histórica en el AILOG original** — anexa una subsección `## Historical correction (YYYY-MM-DD)` al final del AILOG original con el puntero adelante al AILOG nuevo. Las decisiones de auditoría son distintas de las de execute; el cuerpo del original permanece intacto como registro histórico.
+4. **Comentario en el PR** — si el PR de execute aún no ha merged, agrega el commit de enmienda y actualiza la descripción del PR con una subsección "Batch N.4 amendment" listando los hallazgos cerrados. Si el PR ya merged, abre un PR de seguimiento referenciando el PR original y el AILOG.
+5. **Telemetría** — popula `charter_telemetry.post_close_amendment:` (ver abajo). Usa `straymark charter audit <id> --merge-reports --merge-into <telemetry-yaml>` para mergear hallazgos de auditoría externa al mismo archivo; la CLI tolera reescrituras del placeholder `external_audit: []` en v0.2+.
+
+`straymark charter amend <id>` hace scaffolding de los pasos 2, 3 y 5 (crea el stub del AILOG nuevo, edita el AILOG original con la subsección Historical correction, imprime el bloque YAML). No toca git — el operador decide cuándo committear.
+
+### Telemetría
+
+Popula `charter_telemetry.post_close_amendment:` en el `.telemetry.yaml` del Charter:
+
+```yaml
+post_close_amendment:
+  applied: true
+  trigger: "external_audit"           # external_audit | production_incident | deferred_implementation
+  ailog_id: "AILOG-YYYY-MM-DD-MMM"    # el AILOG NUEVO, no el original
+  findings_closed: 5
+  files_modified: 19
+  effort_hours: 6.0
+```
+
+Omite el bloque entero si no ocurrió enmienda.
+
+### Por qué funciona (empírico)
+
+Sentinel CHARTER-18 cerró el 2026-05-15 con `external-audit-pending.yaml`. Los reportes de auditoría aterrizaron 2026-05-15..05-17. Cinco hallazgos (4 Critical/High de `gpt-5.3-codex`, 1 Critical de `gemini-2.5-pro`, 1 Medium encontrado por el calibrador) fueron fixes a nivel de código — wiring DI, parsing de header de retry, filtro multi-tenant, default de timeout. La enmienda Batch 7.4 cerró los cinco en un commit cohesivo (19 archivos, +2257/-106 líneas). Un Charter nuevo habría creado overhead de gobernanza multi-semana para ~6h de ingeniería enfocada.
+
+---
+
+## Composición cross-pattern
+
+Los dos patrones operan en distintos niveles de la cadena y componen:
+
+| Patrón | Nivel | Frecuencia | Absorbe |
+|---|---|---|---|
+| Refresh de SpecKit pre-declare | Cadena / módulo | Una vez cada 3+ Charters | Deriva a nivel de spec (asunciones arquitectónicas, naming de tablas, evolución de versión de framework) |
+| Enmienda post-close dirigida por auditoría | Ciclo / Charter | Por Charter cuando se dispara | Deriva a nivel de runtime (wiring DI, semántica de retry, filtros multi-tenant) |
+
+Un Charter que *recibió* el Patrón 1 tiene más probabilidad de *evitar* el Patrón 2 — el refresh absorbe riesgo pre-ejecución que de otro modo surgiría como hallazgos post-close. Pero CHARTER-18 necesitó *ambos* — el refresh manejó deriva a nivel de spec; la enmienda manejó deriva a nivel de runtime que el refresh no alcanzaba. Fomenta el Patrón 1 al nivel de cadena; tolera el Patrón 2 al nivel de ciclo.
+
+---
+
+## Flujo de autoridad / aceptación para upstreaming de patrones nuevos
+
+Este documento es por sí mismo el output del flujo de aceptación que Sentinel caminó para estos dos patrones (Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)). El flujo canónico para upstreamear un patrón nuevo de cadena-Charter es:
+
+1. **RFC adopter-local** vive en `.straymark/06-evolution/<name>-rfc.md` en el árbol del adopter. El adopter envía el patrón ahí primero — la evidencia N=1 es necesaria pero no suficiente.
+2. **Issue upstream** en `StrangeDaysTech/straymark` reflejando el cuerpo del RFC local, con citas de telemetría y enlaces a PRs.
+3. **Aceptación upstream** aterriza como: (a) un doc aquí en `00-governance/` describiendo el patrón canónicamente, (b) adiciones al schema de telemetría (opt-in), (c) scaffolding CLI opcional para la mecánica orientada al operador. La advertencia de dominio N=1 se traslada a la estabilización v1.
+4. **Validación en segundo dominio** antes de que los campos de schema del patrón gradúen de opcionales a recomendados.
+
+`06-evolution/` es el hogar canónico adopter-local para RFCs en vuelo. Una vez aceptado upstream, el hogar canónico es `00-governance/<NAME>.md` — la convención que este documento instancia.
+
+---
+
+## Preguntas abiertas
+
+- **Tuneo de umbral** — el umbral de media móvil de 6 para `r_n_plus_one_emergent_count` es derivado de Sentinel. Un segundo dominio puede moverlo. La CLI `straymark charter refresh-suggest` expone `--threshold N` para calibración del adopter.
+- **Heurística de módulo** — `refresh-suggest <module>` actualmente matchea `<module>` contra el título y slug del Charter. Los módulos convencionales de SpecKit (`specs/<NNN>-<module>/`) podrían proveer un binding más estricto vía el campo `originating_spec` del Charter en un bump futuro de fw.
+- **Cap de frecuencia de enmienda** — el Patrón 2 está acotado por "un PR cohesivo". Un Charter que recibe dos o más commits de enmienda a lo largo del tiempo debería re-evaluarse como señal de que el cierre original fue prematuro.
+
+---
+
+## Relacionado
+
+- [STRAYMARK.md §15](../../../STRAYMARK.md) — Ciclo de vida del Charter y el patrón por-Charter que este documento extiende.
+- [SPECKIT-CHARTER-BRIDGE.md](SPECKIT-CHARTER-BRIDGE.md) — cómo los artefactos SpecKit mapean a Charters; el Patrón 1 vive en esta costura.
+- [FOLLOW-UPS-BACKLOG-PATTERN.md](FOLLOW-UPS-BACKLOG-PATTERN.md) — patrón hermano para `§Follow-ups` acumulados a lo largo de muchos AILOGs.
+- [`.straymark/schemas/charter-telemetry.schema.v0.json`](../../schemas/charter-telemetry.schema.v0.json) — `pre_declare_refresh` y `post_close_amendment` están definidos aquí.
+
+---
+
+*StrayMark fw-4.16.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -374,4 +374,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/CHARTER-CHAIN-EVOLUTION.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/CHARTER-CHAIN-EVOLUTION.md
@@ -1,0 +1,196 @@
+# Charter 链演化 — StrayMark
+
+> 两个互补的模式，用于保持多 Charter 模块的诚实性：在 Charter 被声明之前刷新 SpecKit 工件；以及当审计发现在 `status: closed` 之后到达时，对已关闭的 Charter 进行修订。
+
+**语言**: [English](../../CHARTER-CHAIN-EVOLUTION.md) | [Español](../es/CHARTER-CHAIN-EVOLUTION.md) | 简体中文
+
+---
+
+## 状态
+
+**v0 — 已在 N=1 领域验证**（`StrangeDaysTech/sentinel` CHARTER-18, 2026-05-15, Issue #156）。
+
+两个模式都是作为框架规范指南记录在此的约定。CLI 提供只读和脚手架辅助工具（`straymark charter refresh-suggest`、`straymark charter amend`）；模式本身由操作员驱动。一旦第二个采用者验证，任一模式都可能演化 —— 在那之前，N=1 领域警告适用（原则 #12）。
+
+---
+
+## 本文档存在的原因
+
+StrayMark 的 Charter 模式（`STRAYMARK.md` §15）假设单个 Charter 是有界的工作单元。对孤立的 Charter 而言这是有效的。对链中*第一个* Charter 也是有效的。但当一个模块在数月内累积许多用户故事 Charter 时，会浮现两种逐 Charter 模式无法解决的失败模式：
+
+1. **链级别的规范漂移** —— SpecKit 工件（`plan.md`、`data-model.md`、`contracts/*`、`quickstart.md`、`research.md`）是针对链开始时模块的框架版本和现实编写的。在 3+ Charter 之后，累积的学习成果（提取的可重用模式、发现的代码缺口、演化的框架约定、批准的操作员决策）已使规范偏离了实现。直接从 Charter-N 关闭进入 Charter-(N+1) 声明会导致系统性的执行中作用域扩张和涌现的 `R<N+1> (new, not in Charter)` 条目。
+2. **周期级别的审计发现** —— 外部审计周期在关闭后运行（审计员在关闭仪式后异步执行）。Critical 或 High 发现可在 Charter 被标记为 `status: closed` 之后到达。框架的选项是：(a) 为补救开新 Charter（重 —— 为 ~5 个文件编辑做完整声明 + Tasks + 仪式），或 (b) 将发现留在 `review.md` 中并失去"与 Charter 原子化"的属性。
+
+模式 1 解决 (1)。模式 2 解决 (2)。两者组合 —— *接受过*模式 1 的 Charter 更可能*避免*模式 2，因为刷新吸收了审计本应在关闭后浮现的执行前风险。它们是互补的，而非可替代的。
+
+---
+
+## 模式 1 —— 预声明 SpecKit 刷新
+
+### 何时适用此模式
+
+当 SpecKit 驱动的模块满足**全部**以下条件时采用此模式：
+
+- 模块有**3 个或更多已关闭的 Charter**（链长 ≥ 3）。
+- 最近 3 个已关闭 Charter 的 `charter_telemetry.agent_quality.r_n_plus_one_emergent_count` 滚动均值**大于 6**。
+- 自链最近的分支点以来，没有刷新 PR 落入 SpecKit 工件。
+
+运行 `straymark charter refresh-suggest <module>` 对你的 `.telemetry.yaml` 历史评估启发式。CLI 读取所命名模块的最近关闭的 Charter 并打印建议；不会进行任何变更。
+
+低于阈值时，仅逐 Charter 模式就足够 —— 过早采用刷新会增加一个 PR 的开销而没有回报。
+
+### 形状
+
+一个**专用的刷新 PR** 在 Charter-N 关闭和 Charter-(N+1) 声明之间落地。它只触及 SpecKit 工件的**非锁定部分**：
+
+- `specs/<module>/plan.md` —— 阶段计划、依赖说明、排序。
+- `specs/<module>/data-model.md` —— 实体、字段、约定。
+- `specs/<module>/contracts/*.md` —— 接口契约、请求/响应形状。
+- `specs/<module>/quickstart.md` —— 可运行场景。
+- `specs/<module>/research.md` —— 累积的知识（见下方的"分类学习表"）。
+
+`research.md` 承载着关键工件：一个**分类学习表**，整合链所学到的内容。最小桶：
+
+| 桶 | 此处放什么 |
+|---|---|
+| 可重用模式 | 跨 Charter 涌现的、应向前继承的惯用法 / 实用程序 / 包装器（例如 `withRLS` 包装器、品牌缓存 LRU、去重表模式）。 |
+| 代码缺口 | 链发现但未关闭的已识别但未修复的工作（例如未接线的表、桩实现、缺失的列）。每个缺口是一个带描述 + 拥有者 Charter（当前或未来）的 `Gn` 条目。 |
+| 纪律模式 | 链批准的过程学习（例如跨家族审计对、batch-complete 纪律、每批次关闭节奏）。 |
+| 经验校正 | 规范偏离实现的地方。`EC1...ECn` 条目：规范说 X，现实是 Y，选择的协调。 |
+
+可选的**操作员决策（Dn）**在预声明时被批准，包含：决策、考虑的备选方案、选择的路径、理由。后续 Charter 将 Dn 作为契约继承。
+
+### 机制
+
+1. **刷新 PR** 在下一个 Charter 声明之前。可选的 AIDEC 记录刷新决策 + 考虑的备选方案。PR 标题应明确作用域（例如 `spec(<module>): US<n> plan refresh — LOCKED-aware Phase 7+8 redesign`）。
+2. **分类学习表** 在 `research.md` 中，包含上述四个桶。每个条目有稳定的 id（Pn / Gn / DPn / ECn），以便后续 Charter 可按 id 引用。
+3. **操作员决策（Dn）** 如适用 —— 明确列出，带备选方案 + 选择的路径 + 理由。
+4. **下一个 Charter 的 `## Context` 部分** 按 id 引用每个模式、校正和决策。Charter 作用域基于刷新后的现实，而非链开始的规范。
+
+### 遥测
+
+在*下一个* Charter 的遥测中填充 `charter_telemetry.pre_declare_refresh:`（消费刷新的那个，而非刷新 PR 本身）：
+
+```yaml
+pre_declare_refresh:
+  enabled: true
+  refresh_pr: "owner/repo#76"
+  refresh_aidec: "AIDEC-YYYY-MM-DD-NNN-speckit-refresh"
+  reusable_patterns_integrated: 7
+  code_gaps_integrated: 4
+  discipline_patterns_integrated: 3
+  empirical_corrections_integrated: 15
+  operator_decisions_ratified: 3
+```
+
+若未发生刷新，则整个块省略 —— 不在场意味着"模式未使用"。
+
+### 为何有效（经验性）
+
+Sentinel CHARTER-18 是 7-Charter 链中第一个无需执行中补救 Charter 即可干净关闭的 Charter。`estimation_drift_factor: 1.0`、`pre_work.items_discovered_during_planning: 0`、`overall_satisfaction: 5/5`。操作员的漂移原因陈述：*"来自 PR #76 的 SpecKit 刷新 ... 消除了在先前 Charter 中驱动漂移的大部分歧义。无需执行中补救 Charter —— research.md 中的 EC1..EC15 经验校正清单将本会是执行前风险的东西吸收为执行中觉察。"*
+
+---
+
+## 模式 2 —— 关闭后审计驱动的修订（Batch N.4）
+
+### 何时适用此模式
+
+当 Charter 被标记 `status: closed` 之后满足**全部**以下条件时采用此模式：
+
+- 在关闭后的 `review.md` 中浮现一个或多个被评定为 **Critical** 或 **High** 的外部审计发现。
+- Charter 的 `closure_criterion` 由于未补救的发现而实质上未满足（即按现状发布将使关闭无效）。
+- 修复表面适合**一个内聚的 PR**（~< 25 个文件，无架构重新打开 —— 无新抽象、无迁移、无 API 破坏）。
+
+如果修复表面更大或属架构性，请改为开新 Charter。修订模式是为有界情形而存在的；它不是 Charter 规避机制。
+
+### 形状
+
+修订搭载在**与原 Charter 相同的 execute 分支**上（分支仍可合并到 `main`；修订提交落在其上）。一个**新 AILOG** 记录修订 —— 不是原 AILOG 的编辑。
+
+```
+charter-<N>-execute 分支
+├── （原始提交 —— Charter execute 工作）
+├── 提交 X：charter close（status: closed，写入 telemetry.yaml）
+└── 提交 Y：charter-<N>(batch-7.4): audit-driven remediation —— <简短摘要>
+    ↑
+    AILOG-YYYY-MM-DD-MMM（新）记录此提交
+    AILOG-YYYY-MM-DD-NNN（原）获得一个 `## Historical correction` 子节
+                                  向前指向 AILOG-...-MMM
+```
+
+### 机制
+
+1. **相同的 execute 分支** —— 不要从 `main` 分叉。原 Charter 的 execute 分支仍是单元；修订提交搭载在其上。
+2. **新 AILOG** 在 `.straymark/07-ai-audit/agent-logs/` 下记录修订。约定：`risk_level: high` 且 `review_required: true`。新 AILOG 携带一个 `amends:` 字段指回原 AILOG id。
+3. **原 AILOG 中的历史校正** —— 在原 AILOG 末尾追加一个 `## Historical correction (YYYY-MM-DD)` 子节，含指向新 AILOG 的前向指针。审计决策与执行决策不同；原始的主体保持完整作为历史记录。
+4. **PR 评论** —— 如果 execute PR 尚未合并，将修订提交添加到其中并以"Batch N.4 amendment"子节更新 PR 描述，列出已关闭的发现。如果 PR 已合并，开一个后续 PR 引用原 PR 和 AILOG。
+5. **遥测** —— 填充 `charter_telemetry.post_close_amendment:`（见下）。使用 `straymark charter audit <id> --merge-reports --merge-into <telemetry-yaml>` 将外部审计发现合并到同一文件；CLI 在 v0.2+ 容忍 `external_audit: []` 占位符重写。
+
+`straymark charter amend <id>` 为步骤 2、3 和 5 做脚手架（创建新 AILOG 桩，编辑原 AILOG 加上 Historical correction 子节，打印 YAML 块）。不触碰 git —— 操作员决定何时提交。
+
+### 遥测
+
+在 Charter 的 `.telemetry.yaml` 中填充 `charter_telemetry.post_close_amendment:`：
+
+```yaml
+post_close_amendment:
+  applied: true
+  trigger: "external_audit"           # external_audit | production_incident | deferred_implementation
+  ailog_id: "AILOG-YYYY-MM-DD-MMM"    # 新 AILOG，而非原始的
+  findings_closed: 5
+  files_modified: 19
+  effort_hours: 6.0
+```
+
+若未发生修订，则整个块省略。
+
+### 为何有效（经验性）
+
+Sentinel CHARTER-18 在 2026-05-15 关闭，带 `external-audit-pending.yaml`。审计报告于 2026-05-15..05-17 到达。五个发现（来自 `gpt-5.3-codex` 的 4 个 Critical/High、来自 `gemini-2.5-pro` 的 1 个 Critical、校准员发现的 1 个 Medium）是代码级修复 —— DI 接线、重试 header 解析、多租户过滤器、超时默认值。Batch 7.4 修订在一个内聚提交中关闭了所有五个（19 个文件，+2257/-106 行）。新 Charter 将为 ~6 小时的聚焦工程创建多周治理开销。
+
+---
+
+## 跨模式组合
+
+两个模式在链的不同层级运作并组合：
+
+| 模式 | 层级 | 频率 | 吸收 |
+|---|---|---|---|
+| 预声明 SpecKit 刷新 | 链 / 模块 | 每 3+ Charter 一次 | 规范级漂移（架构假设、表命名、框架版本演化） |
+| 关闭后审计驱动修订 | 周期 / Charter | 触发时按 Charter | 运行时级漂移（DI 接线、重试语义、多租户过滤器） |
+
+*接受过*模式 1 的 Charter 更可能*避免*模式 2 —— 刷新吸收了否则将作为关闭后发现浮现的执行前风险。但 CHARTER-18 *两者*都需要 —— 刷新处理规范级漂移；修订处理刷新无法触及的运行时级漂移。在链层级鼓励模式 1；在周期层级容忍模式 2。
+
+---
+
+## 用于上游新模式的权威 / 接受流程
+
+本文档本身是 Sentinel 为这两个模式走过的接受流程的输出（Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)）。上游新 Charter-链模式的标准流程是：
+
+1. **采用者本地 RFC** 位于采用者自己树中的 `.straymark/06-evolution/<name>-rfc.md`。采用者先在那里发布模式 —— N=1 证据是必要的但不充分的。
+2. **上游 Issue** 在 `StrangeDaysTech/straymark` 镜像本地 RFC 主体，带遥测引用和 PR 链接。
+3. **上游接受** 以以下形式落地：(a) 此处 `00-governance/` 中描述模式规范的文档，(b) 遥测 schema 添加（opt-in），(c) 操作员面向机制的可选 CLI 脚手架。N=1 领域警告携带至 v1 稳定化。
+4. **第二领域验证** 在模式的 schema 字段从可选毕业到推荐之前。
+
+`06-evolution/` 是飞行中 RFC 的标准采用者本地归宿。上游接受后，标准归宿是 `00-governance/<NAME>.md` —— 此文档实例化的约定。
+
+---
+
+## 开放问题
+
+- **阈值调优** —— `r_n_plus_one_emergent_count` 滚动均值 6 的阈值源于 Sentinel。第二个领域可能移动它。CLI `straymark charter refresh-suggest` 暴露 `--threshold N` 供采用者校准。
+- **模块启发式** —— `refresh-suggest <module>` 目前将 `<module>` 与 Charter 标题和 slug 匹配。SpecKit 约定模块（`specs/<NNN>-<module>/`）可在未来的 fw 升级中通过 Charter 的 `originating_spec` 字段提供更严格的绑定。
+- **修订频率上限** —— 模式 2 受限于"一个内聚的 PR"。随时间接收两个或更多修订提交的 Charter 应被重新评估为原始关闭过早的信号。
+
+---
+
+## 相关
+
+- [STRAYMARK.md §15](../../../STRAYMARK.md) —— Charter 生命周期及本文档扩展的逐 Charter 模式。
+- [SPECKIT-CHARTER-BRIDGE.md](SPECKIT-CHARTER-BRIDGE.md) —— SpecKit 工件如何映射到 Charter；模式 1 生活在此接缝上。
+- [FOLLOW-UPS-BACKLOG-PATTERN.md](FOLLOW-UPS-BACKLOG-PATTERN.md) —— 跨许多 AILOG 累积的 `§Follow-ups` 的姐妹模式。
+- [`.straymark/schemas/charter-telemetry.schema.v0.json`](../../schemas/charter-telemetry.schema.v0.json) —— `pre_declare_refresh` 和 `post_close_amendment` 在此定义。
+
+---
+
+*StrayMark fw-4.16.0 | [GitHub](https://github.com/StrangeDaysTech/straymark) | Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -310,4 +310,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -216,4 +216,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark v4.15.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark v4.16.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/schemas/charter-telemetry.schema.v0.json
+++ b/dist/.straymark/schemas/charter-telemetry.schema.v0.json
@@ -3,7 +3,7 @@
   "$id": "https://straymark.dev/schemas/charter-telemetry.schema.v0.json",
   "title": "StrayMark Charter Telemetry (experimental v0)",
   "description": "Schema for the post-execution telemetry recorded at Charter close. See Propuesta/straymark-charter-telemetry.md v0.3 for the questions this instrumentation is designed to answer and the empirical evidence behind each field.",
-  "$comment": "EXPERIMENTAL v0. Derived from 5 PLAN-NN.telemetry.yaml files in Sentinel (one project, Go backend) — same N=1-domain caveat as charter.schema.v0.json. Will not stabilize to v1.0 until validated in a second domain. The 4 fields refined by Sentinel relative to v0.1 of the doc are: external_audit as array (dual-audit calibration), outcome.scope_change_notes with F1...FN encoding, agent_quality.r_n_plus_one_emergent_count, qualitative.format_iteration. Adopters: this schema is for the YAML inside the top-level `charter_telemetry:` key in .straymark/charters/CHARTER-NN.telemetry.yaml — not for the file itself.",
+  "$comment": "EXPERIMENTAL v0. Derived from 5 PLAN-NN.telemetry.yaml files in Sentinel (one project, Go backend) — same N=1-domain caveat as charter.schema.v0.json. Will not stabilize to v1.0 until validated in a second domain. The 4 fields refined by Sentinel relative to v0.1 of the doc are: external_audit as array (dual-audit calibration), outcome.scope_change_notes with F1...FN encoding, agent_quality.r_n_plus_one_emergent_count, qualitative.format_iteration. v0.2 addendum (fw-4.16.0, 2026-05-15): added optional `pre_declare_refresh` and `post_close_amendment` sub-objects per Issue #156 (Sentinel CHARTER-18 RFC). Both validated in Sentinel only; the N=1-domain caveat still applies — fields are opt-in and absent by default. Adopters: this schema is for the YAML inside the top-level `charter_telemetry:` key in .straymark/charters/CHARTER-NN.telemetry.yaml — not for the file itself.",
   "type": "object",
   "required": ["charter_telemetry"],
   "additionalProperties": false,
@@ -193,6 +193,58 @@
             "new_charters_created": { "type": "integer", "minimum": 0 },
             "charters_invalidated": { "type": "integer", "minimum": 0 },
             "associated_stage_id": { "type": "string" }
+          }
+        },
+
+        "pre_declare_refresh": {
+          "type": "object",
+          "description": "Optional. Populate if this Charter was preceded by a SpecKit refresh PR per the Charter-chain-evolution pattern (see .straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md Pattern 1). Absence means the pattern was not applied.",
+          "additionalProperties": false,
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "True if a refresh PR landed before this Charter's declare."
+            },
+            "refresh_pr": {
+              "type": ["string", "null"],
+              "description": "URL or short ref of the refresh PR (e.g. owner/repo#76). Null if enabled but not yet linked."
+            },
+            "refresh_aidec": {
+              "type": ["string", "null"],
+              "description": "AIDEC id ratifying the refresh decision (e.g. AIDEC-YYYY-MM-DD-NNN-slug). Null if no AIDEC was filed."
+            },
+            "reusable_patterns_integrated": { "type": "integer", "minimum": 0 },
+            "code_gaps_integrated": { "type": "integer", "minimum": 0 },
+            "discipline_patterns_integrated": { "type": "integer", "minimum": 0 },
+            "empirical_corrections_integrated": { "type": "integer", "minimum": 0 },
+            "operator_decisions_ratified": { "type": "integer", "minimum": 0 }
+          }
+        },
+
+        "post_close_amendment": {
+          "type": "object",
+          "description": "Optional. Populate if this Charter received a Batch N.4 amendment after `status: closed` (see .straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md Pattern 2). Absence means no post-close amendment occurred.",
+          "additionalProperties": false,
+          "required": ["applied"],
+          "properties": {
+            "applied": {
+              "type": "boolean",
+              "description": "True if a post-close amendment commit landed on the same execute branch."
+            },
+            "trigger": {
+              "type": "string",
+              "enum": ["external_audit", "production_incident", "deferred_implementation"],
+              "description": "What surfaced the need for the amendment after close."
+            },
+            "ailog_id": {
+              "type": "string",
+              "pattern": "^AILOG-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{3}[a-z]?(-[a-z0-9-]+)?$",
+              "description": "The AILOG that documents the amendment (NEW, not amending the original — the original gets a `## Historical correction` subsection pointing forward to this id)."
+            },
+            "findings_closed": { "type": "integer", "minimum": 0 },
+            "files_modified": { "type": "integer", "minimum": 0 },
+            "effort_hours": { "type": "number", "minimum": 0 }
           }
         },
 

--- a/dist/.straymark/templates/charter/charter-telemetry-template.yaml
+++ b/dist/.straymark/templates/charter/charter-telemetry-template.yaml
@@ -112,6 +112,35 @@ charter_telemetry:
     charters_invalidated: 0
     associated_stage_id: ""
 
+  # ---------- Pre-declare SpecKit refresh (optional) ----------
+  # Populate this block ONLY if this Charter was preceded by a SpecKit refresh PR
+  # per the Charter-chain-evolution pattern (see
+  # .straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md Pattern 1). Omit the block
+  # entirely if the refresh did not apply — absence means "pattern not used".
+  # Use `straymark charter refresh-suggest <module>` to check the heuristic.
+  # pre_declare_refresh:
+  #   enabled: true
+  #   refresh_pr: "owner/repo#76"
+  #   refresh_aidec: "AIDEC-YYYY-MM-DD-NNN-slug"
+  #   reusable_patterns_integrated: 0
+  #   code_gaps_integrated: 0
+  #   discipline_patterns_integrated: 0
+  #   empirical_corrections_integrated: 0
+  #   operator_decisions_ratified: 0
+
+  # ---------- Post-close audit-driven amendment (optional) ----------
+  # Populate this block ONLY if this Charter received a Batch N.4 amendment AFTER
+  # `status: closed` (e.g. external audit findings remediated on the same execute
+  # branch). See .straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md Pattern 2.
+  # `straymark charter amend <id>` scaffolds the amendment and emits this block.
+  # post_close_amendment:
+  #   applied: true
+  #   trigger: "external_audit"           # external_audit | production_incident | deferred_implementation
+  #   ailog_id: "AILOG-YYYY-MM-DD-NNN"    # the NEW AILOG that documents the amendment
+  #   findings_closed: 0
+  #   files_modified: 0
+  #   effort_hours: 0.0
+
   # ---------- Qualitative (where insight usually lives) ----------
   # Quantitative fields tell you what happened; qualitative tells you what to change.
   # The format_iteration field is part of the self-evolving feedback loop: each

--- a/dist/.straymark/templates/charter/charter-template.md
+++ b/dist/.straymark/templates/charter/charter-template.md
@@ -126,6 +126,9 @@ follow-up insights are captured if the risk surfaces lessons for a later cycle.]
    ledger before pushing. The drift gate at close will reject any
    `### Batch N` left as `(pending)`. Skip this step for single-batch
    Charters — `## Actions Performed` in the AILOG suffices.
+   *Note*: if audit findings arrive **after** `status: closed` and warrant
+   a bounded code-level fix, see STRAYMARK.md §15.B (post-close Batch N.4
+   amendment) and `straymark charter amend` instead of opening a new Charter.
 7. Local verification passes clean.
 8. **Auto-checklist drift** (when Phase 2 of the CLI roadmap ships):
    `straymark charter drift CHARTER-NN <range>` to detect drifts between declared

--- a/dist/STRAYMARK.md
+++ b/dist/STRAYMARK.md
@@ -420,9 +420,36 @@ straymark charter drift CHARTER-NN          # file-vs-commit drift, AILOG-aware 
 straymark charter batch-complete CHARTER-NN <N>  # fill AILOG `## Batch Ledger` Batch <N> (multi-batch only)
 straymark charter audit CHARTER-NN          # multi-model external audit (orchestration only)
 straymark charter close CHARTER-NN          # record telemetry; flip status to `closed`
+straymark charter refresh-suggest <module>  # SpecKit refresh recommendation (chain-level, fw-4.16.0+) — see §15.A
+straymark charter amend CHARTER-NN          # scaffold post-close Batch N.4 amendment (fw-4.16.0+) — see §15.B
 ```
 
 > **Schema**: `.straymark/schemas/charter.schema.v0.json` (declarative) and `.straymark/schemas/charter-telemetry.schema.v0.json` (telemetry). Both are experimental v0 — patterns crystallize after validation against a second domain (Principle #12).
+
+### §15.A — Pre-declare SpecKit refresh *(fw-4.16.0+)*
+
+Multi-Charter modules accumulate spec drift over time. After 3+ Charters in a chain, SpecKit artifacts (`plan.md`, `data-model.md`, `contracts/*`, `quickstart.md`, `research.md`) authored at chain start tend to lag behind the implementation. The fix is a dedicated **refresh PR** between Charter-N close and Charter-(N+1) declare that integrates accumulated learnings into `research.md` (categorized buckets: reusable patterns, code gaps, discipline patterns, empirical corrections) and ratifies operator decisions. The next Charter's `## Context` cites each learning by id.
+
+**Trigger heuristic** — adopt when (a) chain length ≥ 3 closed Charters in the module AND (b) rolling mean of `agent_quality.r_n_plus_one_emergent_count` across last 3 > 6 AND (c) no refresh PR landed since the chain's branch point. Run:
+
+```bash
+straymark charter refresh-suggest <module>  # read-only — prints recommendation
+```
+
+**Telemetry** — `charter_telemetry.pre_declare_refresh:` (optional, opt-in). See `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` Pattern 1 for full mechanics.
+
+### §15.B — Post-close audit-driven amendment (Batch N.4) *(fw-4.16.0+)*
+
+External audit cycles run post-close. When Critical or High findings arrive after a Charter has been marked `status: closed`, the bounded remediation pattern is a **Batch N.4 amendment** that rides on the same execute branch: a new AILOG documents the amendment, the original AILOG receives a `## Historical correction` subsection pointing forward, and the telemetry gains a `post_close_amendment:` block. Apply only when (a) findings are Critical/High, (b) the Charter's closure criterion is materially unmet, AND (c) the fix surface fits in one cohesive PR (~< 25 files, no architectural reopen). Larger or architectural fixes warrant a new Charter.
+
+```bash
+straymark charter amend CHARTER-NN \         # scaffolds the new AILOG, edits the original, prints YAML
+  --trigger external_audit \
+  --findings-closed 5 \
+  --ailog-title "post-close remediation — DI wiring + retry"
+```
+
+The command does not touch git — the operator decides when to commit. The `straymark charter audit <id> --merge-reports --merge-into <telemetry-yaml>` path tolerates `external_audit: []` placeholders in v0.2+ schema so the round-trip with `post_close_amendment` is smooth. See `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` Pattern 2 for full mechanics.
 
 ---
 

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.15.0"
+version: "4.16.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -425,6 +425,8 @@ Manage **Charters**: bounded, auditable units of work declared ex-ante and valid
 - `straymark charter drift` — detect file-vs-commit drift with AILOG-aware suppression and Batch Ledger gate *(Phase 2, fw-4.6.0+; Batch Ledger gate cli-3.13.0+)*
 - `straymark charter batch-complete` — mark a Charter batch as complete in the AILOG `## Batch Ledger` *(cli-3.13.0+, fw-4.14.0+)*
 - `straymark charter audit` — orchestrate a multi-model external review (3-step prepare/calibrate/finalize) *(Phase 3, fw-4.9.0+)*
+- `straymark charter refresh-suggest` — heuristic recommendation for a pre-declare SpecKit refresh across a multi-Charter module *(cli-3.14.0+, fw-4.16.0+)*
+- `straymark charter amend` — scaffold a post-close Batch N.4 amendment (audit-driven remediation on the same execute branch) *(cli-3.14.0+, fw-4.16.0+)*
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 
@@ -763,6 +765,86 @@ $ straymark charter audit CHARTER-05 --merge-reports \
 > **Why orchestration-only?** Implementing 3 HTTP clients (OpenAI / Google / Anthropic) is 1-2 weeks + perpetual maintenance when APIs change. v1 audit-skills extend the orchestration-only stance to a second mode (CLI auditor-side with tool use enforcement) where the operator runs their own auditor CLIs and StrayMark's prompts enforce the discipline (`cite path:line of files actually opened`). StrayMark still doesn't manage API keys, doesn't invoke APIs, doesn't maintain HTTP clients.
 
 > **Skill alternative *(fw-4.9.0+, expanded in fw-4.9.0)*.** Three skills wrap the CLI for IDE-driven workflows: `/straymark-audit-prompt CHARTER-ID` (calls `--prepare`), `/straymark-audit-execute CHARTER-ID` (runs in auditor CLIs to read the prompt and write a report), and `/straymark-audit-review CHARTER-ID` (consolidates N reports into `review.md` and merges YAML). With these skills the operator never copies/pastes prompts or reports — file exchange happens via the canonical filesystem paths under `.straymark/audits/`. See the [Skills](#skills) section below. The CLI remains the single source of truth — the skills only add UX-inline.
+
+> **Placeholder-aware merge *(fw-4.16.0+, Issue #156).*** From `fw-4.16.0` `straymark charter close` writes an `external_audit: []` placeholder under `charter_telemetry:`. `--merge-into` now REPLACES that placeholder in place; only a non-empty `external_audit:` array still triggers the re-audit guard (anti-duplicate). Round-trip with the post-close audit cycle (`/straymark-audit-review`) requires no manual YAML editing.
+
+#### `straymark charter refresh-suggest <module> [--threshold N] [--path <dir>]`
+
+*Available since **cli-3.14.0** + **fw-4.16.0**. Operationalizes Pattern 1 of `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` (Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)).*
+
+Read-only heuristic recommending a pre-declare SpecKit refresh PR before the next Charter declare for a multi-Charter module. Reads the `.telemetry.yaml` files of closed Charters whose `charter_id` contains the module name (case-insensitive substring), picks the 3 most recent by `closed_at`, computes the rolling mean of `agent_quality.r_n_plus_one_emergent_count`, and compares against a threshold (default 6).
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `<module>` | — | Module name to match (e.g. `commshub` matches `CHARTER-18-commshub-us5-...`). Required. |
+| `--threshold N` | `6` | Override the rolling-mean threshold used to trigger the recommendation. |
+| `--path <dir>` | `.` | Project directory |
+
+**Exit code is always 0** — this is informational, never a CI gate. The output is a table of matched Charters (with the 3 in the rolling window highlighted) plus a recommendation: refresh-now, refresh-not-needed, or insufficient-data.
+
+**Example:**
+
+```bash
+$ straymark charter refresh-suggest commshub
+
+  Closed Charters matched (window: top 3 by closed_at)
+
+    charter_id                              closed_at      R<N+1>  telemetry
+    ----------                              ----------     ------  ---------
+  ● CHARTER-18-commshub-us5-cloud-tasks…    2026-05-15          9  18-commshub-us5-….telemetry.yaml
+  ● CHARTER-17-commshub-us4-templating      2026-05-10          8  17-commshub-us4-….telemetry.yaml
+  ● CHARTER-16-commshub-us3-routing         2026-05-04          7  16-commshub-us3-….telemetry.yaml
+    CHARTER-13-commshub-us1-foundation      2026-04-18          5  13-commshub-us1-….telemetry.yaml
+
+  Heuristic
+    Chain length (closed Charters in window): 3
+    Threshold for rolling mean:               > 6
+    Rolling mean of agent_quality.r_n_plus_one_emergent_count: 8.00
+
+  ▶ Recommend a pre-declare SpecKit refresh for `commshub` before the next Charter.
+    See .straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md Pattern 1 for mechanics.
+    Telemetry slot: `charter_telemetry.pre_declare_refresh` in the next Charter.
+```
+
+#### `straymark charter amend <CHARTER-ID> --trigger <kind> --ailog-title <title> [--findings-closed N] [--merge-into <PATH>] [--path <dir>]`
+
+*Available since **cli-3.14.0** + **fw-4.16.0**. Operationalizes Pattern 2 of `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` (Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156)).*
+
+Scaffold a post-close Batch N.4 amendment for an already-closed Charter when external audit findings, a production incident, or a deferred-implementation gap warrant a bounded code-level fix on the same execute branch (no new Charter, no branch off `main`).
+
+The command does **NOT** touch git. It prepares three artifacts so the operator can commit at their leisure:
+
+1. **A new AILOG stub** under `.straymark/07-ai-audit/agent-logs/AILOG-YYYY-MM-DD-NNN-<slug>.md` with `risk_level: high`, `review_required: true`, and an `amends:` field linking back to the most-recent prior AILOG that mentions the Charter.
+2. **A `## Historical correction (YYYY-MM-DD)` subsection** appended to the located prior AILOG, pointing forward to the new id and recording the trigger.
+3. **A rendered `post_close_amendment:` YAML block**, printed to stdout for manual paste or merged directly into the Charter's telemetry YAML via `--merge-into`.
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `<CHARTER-ID>` | — | Same resolution rules as `charter status`. The Charter MUST be `status: closed`. |
+| `--trigger <kind>` | — | Required. One of `external_audit`, `production_incident`, `deferred_implementation`. |
+| `--ailog-title <title>` | — | Required. Drives the slug of the new AILOG filename and its in-body heading. |
+| `--findings-closed N` | `0` | Number of audit findings closed by the amendment. Populates the `post_close_amendment.findings_closed` field. |
+| `--merge-into <PATH>` | — | Optional. Write the `post_close_amendment:` block directly into the telemetry YAML at `<PATH>` instead of printing it. Refuses to overwrite an already-populated block. |
+| `--path <dir>` | `.` | Project directory |
+
+**Bounded-use guard:** the amendment pattern applies only when (a) the fix surface fits in **one cohesive PR** (~< 25 files, no architectural reopen), (b) the Charter's closure criterion is materially unmet by the un-remediated trigger, and (c) the findings are Critical or High (for `external_audit`). Larger fixes warrant a new Charter — the CLI does not enforce these gates, but the doc at `.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` Pattern 2 makes them explicit.
+
+**Example:**
+
+```bash
+$ straymark charter amend CHARTER-18 \
+    --trigger external_audit \
+    --findings-closed 5 \
+    --ailog-title "post-close DI wiring + retry header" \
+    --merge-into .straymark/charters/18-commshub-us5.telemetry.yaml
+
+  ✔ Appended `## Historical correction (2026-05-15)` to .straymark/07-ai-audit/agent-logs/AILOG-2026-05-14-049-original.md
+  ✔ Created new AILOG at .straymark/07-ai-audit/agent-logs/AILOG-2026-05-15-050-post-close-di-wiring-retry-header.md
+  ✔ Merged `post_close_amendment:` block into .straymark/charters/18-commshub-us5.telemetry.yaml
+
+  Next: review the new AILOG, edit it with concrete details, then commit
+  on the original execute branch (do NOT branch off main).
+```
 
 ---
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -142,7 +142,7 @@ Salvaguardas incorporadas que aseguran que los humanos mantengan el control:
 
 Comandos integrados que convierten la disciplina en feedback accionable:
 
-- **`straymark charter <new|list|status|close|drift|batch-complete|audit>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware y (cli-3.13.0+) hace gate sobre entradas `### Batch N (pending)` en `## Batch Ledger` del AILOG; `batch-complete` (cli-3.13.0+) marca un batch como completado en la ledger para Charters multi-batch (3+ lotes o >1 día); `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM). Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
+- **`straymark charter <new|list|status|close|drift|batch-complete|audit|refresh-suggest|amend>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware y (cli-3.13.0+) hace gate sobre entradas `### Batch N (pending)` en `## Batch Ledger` del AILOG; `batch-complete` (cli-3.13.0+) marca un batch como completado en la ledger para Charters multi-batch (3+ lotes o >1 día); `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM); `refresh-suggest` (cli-3.14.0+) imprime una recomendación heurística para un refresh SpecKit pre-declare cuando la media móvil de `r_n_plus_one_emergent_count` de un módulo multi-Charter supera un umbral; `amend` (cli-3.14.0+) hace scaffolding de una enmienda post-close Batch N.4 (remediación dirigida por auditoría) sobre la misma rama de execute sin abrir un Charter nuevo. Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
 - **`straymark approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
 - **`straymark validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `.straymark/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
 - **`straymark metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
@@ -239,8 +239,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.15.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.13.2` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.16.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.14.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -272,7 +272,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.15.0)
+# y descarga el último release fw-* (ej. fw-4.16.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.15.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.13.2` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.16.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.14.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -395,6 +395,8 @@ Gestiona **Charters**: unidades acotadas y auditables de trabajo, declaradas ex-
 - `straymark charter drift` *(cli-3.7.0+)* — chequea drift archivo-vs-commit con supresión AILOG-aware y gate de Batch Ledger *(gate añadido en cli-3.13.2)*
 - `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — marca un batch del Charter como completado en la `## Batch Ledger` del AILOG
 - `straymark charter audit` *(cli-3.8.0+)* — orquesta una revisión externa multi-modelo (orchestration-only, ver más abajo)
+- `straymark charter refresh-suggest` *(cli-3.14.0+, fw-4.16.0+)* — recomendación heurística para refresh SpecKit pre-declare en módulos multi-Charter (ver [CHARTER-CHAIN-EVOLUTION.md](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/i18n/es/CHARTER-CHAIN-EVOLUTION.md) Patrón 1)
+- `straymark charter amend` *(cli-3.14.0+, fw-4.16.0+)* — scaffolding para enmienda post-close Batch N.4 (remediación dirigida por auditoría sobre la misma rama de execute, sin abrir un Charter nuevo — ver [CHARTER-CHAIN-EVOLUTION.md](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/i18n/es/CHARTER-CHAIN-EVOLUTION.md) Patrón 2)
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <titulo>] [path]`
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -142,7 +142,7 @@ StrayMark 的产品决策基于十二条明确的原则。它们按层级排序�
 
 将纪律转化为可执行反馈的内置命令：
 
-- **`straymark charter <new|list|status|close|drift|batch-complete|audit>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差，并（cli-3.13.0+）对 AILOG `## Batch Ledger` 中的 `### Batch N (pending)` 条目进行门控；`batch-complete`（cli-3.13.0+）将批次标记为已在多批次章程（3+ 批次或 >1 天）的台账中完成；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
+- **`straymark charter <new|list|status|close|drift|batch-complete|audit|refresh-suggest|amend>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差，并（cli-3.13.0+）对 AILOG `## Batch Ledger` 中的 `### Batch N (pending)` 条目进行门控；`batch-complete`（cli-3.13.0+）将批次标记为已在多批次章程（3+ 批次或 >1 天）的台账中完成；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）；`refresh-suggest`（cli-3.14.0+）当多 Charter 模块的 `r_n_plus_one_emergent_count` 滚动均值超过阈值时，输出预声明 SpecKit 刷新的启发式建议；`amend`（cli-3.14.0+）为关闭后审计驱动的 Batch N.4 修订做脚手架，在原 execute 分支上落地而不开启新 Charter。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
 - **`straymark approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
 - **`straymark validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `.straymark/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
 - **`straymark metrics`** — 治理 KPI、审查率、风险分布、趋势
@@ -257,8 +257,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.15.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.13.2` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.16.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.14.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -290,7 +290,7 @@ StrayMark 为每个组件使用独立的版本标签：
 ```bash
 # 从 GitHub 下载最新的框架发布 ZIP
 # 前往 https://github.com/StrangeDaysTech/straymark/releases
-# 下载最新的 fw-* 发布（例如 fw-4.15.0）
+# 下载最新的 fw-* 发布（例如 fw-4.16.0）
 
 # 解压并复制到你的项目
 unzip straymark-fw-*.zip -d your-project/

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,8 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.15.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.13.2` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.16.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.14.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -425,6 +425,8 @@ $ straymark validate --check-pending-reviews --max-pending-days 14
 - `straymark charter drift` *(cli-3.7.0+)* — 检查文件 vs 提交的漂移，带 AILOG 感知抑制和 Batch Ledger 门控 *(门控在 cli-3.13.2 添加)*
 - `straymark charter batch-complete` *(cli-3.13.0+, fw-4.14.0+)* — 在 AILOG 的 `## Batch Ledger` 中将章程批次标记为已完成
 - `straymark charter audit` *(cli-3.8.0+)* — 编排多模型外部审计（仅编排，详见下文）
+- `straymark charter refresh-suggest` *(cli-3.14.0+, fw-4.16.0+)* — 多 Charter 模块的预声明 SpecKit 刷新启发式建议（详见 [CHARTER-CHAIN-EVOLUTION.md](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/i18n/zh-CN/CHARTER-CHAIN-EVOLUTION.md) 模式 1）
+- `straymark charter amend` *(cli-3.14.0+, fw-4.16.0+)* — 关闭后审计驱动的 Batch N.4 修订脚手架（在原 execute 分支上落地，不开新 Charter — 详见 [CHARTER-CHAIN-EVOLUTION.md](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/i18n/zh-CN/CHARTER-CHAIN-EVOLUTION.md) 模式 2）
 
 #### `straymark charter new [-t XS|S|M|L] [--from-ailog <id> | --from-spec <path>] [--title <title>] [path]`
 


### PR DESCRIPTION
## Summary

Codifies the two patterns surfaced by the Sentinel adopter RFC in #156:

- **Pattern 1 — Pre-declare SpecKit refresh**: A dedicated refresh PR between Charter-N close and Charter-(N+1) declare integrates accumulated chain-level learnings (reusable patterns, code gaps, discipline patterns, empirical corrections) into the SpecKit `research.md`, so the next Charter grounds its scope in refreshed reality rather than chain-start spec premises.
- **Pattern 2 — Post-close audit-driven Batch N.4 amendment**: When Critical/High audit findings arrive after `status: closed` and the fix surface is bounded (~< 25 files, no architectural reopen), the remediation rides on the same execute branch via a new AILOG + `## Historical correction` on the prior AILOG + `post_close_amendment:` telemetry block — no new Charter needed.

Plus a bug fix for the sub-issue surfaced in #156: `straymark charter audit --merge-reports --merge-into` rejected even the empty placeholder `external_audit: []`, breaking the post-close audit-cycle round-trip.

### Framework (`fw-4.16.0`)

- New canonical doc `dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md` (EN + ES + zh-CN) covering both patterns: when-they-apply, mechanics, telemetry, empirical anchor from Sentinel CHARTER-18, cross-pattern composition note, authority/acceptance flow for upstreaming new patterns.
- `charter-telemetry.schema.v0.json` gains two optional sub-objects: `pre_declare_refresh` (enabled, refresh_pr, refresh_aidec, integer counts) and `post_close_amendment` (applied, trigger ∈ {external_audit, production_incident, deferred_implementation}, ailog_id, findings_closed, files_modified, effort_hours). Schema stays v0 — the N=1-domain caveat carries forward.
- `STRAYMARK.md §15` extended with §15.A and §15.B pointing to the helpers; Quick CLI surface listing updated.
- `SPECKIT-CHARTER-BRIDGE.md` + `charter-template.md` Batch Ledger note: cross-references to the canonical doc.
- Governance footers bumped to v4.16.0 across the 4 docs × 3 languages.

### CLI (`cli-3.14.0`)

- **`straymark charter refresh-suggest <module> [--threshold N]`** *(new)* — read-only. Reads the last 3 closed Charters of the module, computes the rolling mean of `agent_quality.r_n_plus_one_emergent_count`, prints a recommendation. Default threshold 6. Always exits 0; informational.
- **`straymark charter amend <CHARTER-ID> --trigger <kind> --ailog-title <title>`** *(new)* — scaffolds the new AILOG stub, appends `## Historical correction` to the most-recent prior AILOG, renders the `post_close_amendment:` YAML block (printed to stdout or merged via `--merge-into`). Does **NOT** touch git — operator decides when to commit.
- **`straymark charter audit --merge-into` placeholder fix** — semantic YAML parse distinguishes missing (append, original behavior), empty placeholder `[]` (replace in place, new), populated array (still rejected with clearer message). `charter close` now writes `external_audit: []` so the post-close audit cycle round-trips cleanly.

### Docs

- CLI-REFERENCE.md sections for both new subcommands in EN + ES + zh-CN.
- Versioning tables in README + CLI-REFERENCE bumped (EN + ES + zh-CN).
- `CHANGELOG.md` new section combining Framework + CLI bumps.

## Test plan

- [x] `cargo check` clean — no new warnings beyond pre-existing deprecation notices in tests.
- [x] `cargo test` — all 525 tests pass (303 unit + 222 integration across 21 test files), including 9 new integration tests for `refresh-suggest` and `amend` plus a regression test for the `--merge-into` placeholder fix.
- [ ] Manual smoke in a copy of `StrangeDaysTech/sentinel`:
  - [ ] `straymark update-framework` brings the new docs in 3 languages.
  - [ ] `straymark update-cli` brings the bug fix + 2 new subcommands.
  - [ ] `straymark charter refresh-suggest commshub` returns a recommendation consistent with the operator's qualitative read of the CommsHub chain.
  - [ ] `straymark charter audit CHARTER-18 --merge-reports --merge-into ...` against a fresh telemetry with `external_audit: []` placeholder now succeeds (regression for #156 sub-issue).
- [ ] Schema validation against a synthetic `.telemetry.yaml` populated with both new sub-objects.
- [ ] CI passes on the branch.

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)