### PR TITLE
feat(website): migrate blog from Aparador (14 posts EN+ES) (PR2)

### DIFF
--- a/website/blog/2026-04-05-four-names-in-four-months.md
+++ b/website/blog/2026-04-05-four-names-in-four-months.md
@@ -1,0 +1,177 @@
+---
+slug: four-names-in-four-months
+title: Four names in four months
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - prehistory
+  - identity
+  - governance
+date: 2026-04-05T00:00:00.000Z
+description: Looking for the concept by trying out names
+---
+> **Editorial note**: this is the first post published retroactively on the blog. The `date` in the frontmatter corresponds to a point inside the arc the post narrates, not the day it was written. The entire blog is being built this way, backwards, starting from the episode that triggered me to write it at all (`emergent-observation-design`, 2026-05-16). Pretending otherwise wouldn't help anyone.
+
+---
+
+## 1. The day after
+
+On 28 January 2026, at 17:29 Central Time, this commit landed in the repo:
+
+> `chore: rebrand Chronicle to Monimen`
+
+One day. Twenty-nine hours, to be exact, after the project's *initial commit*. The framework barely existed, and it was already changing its name.
+
+I'm telling this in the past tense, but it happened three months ago. And three months ago, two more renames later, it still wasn't called StrayMark. The project that today bills itself as *Documentation Governance for AI-Assisted Software Development* carries a short, disorderly prehistory that's worth naming before moving on.
+
+---
+
+## 2. Five events, four months
+
+| Date (UTC-6) | Time | Event | Anchor |
+|---|---|---|---|
+| 2026-01-27 | 12:14 | *Initial commit*: **Enigmora Chronicle Framework v1.0.0** | [`7c58b6d`](https://github.com/StrangeDaysTech/straymark/commit/7c58b6d) |
+| 2026-01-28 | 17:29 | Rebrand: Chronicle → **Monimen** | [`0b772bc`](https://github.com/StrangeDaysTech/straymark/commit/0b772bc) |
+| 2026-01-29 | 19:30 | Rebrand: Monimen → **DevTrail** (`BREAKING CHANGE`) | [`25ab7a4`](https://github.com/StrangeDaysTech/straymark/commit/25ab7a4) |
+| 2026-03-01 | 19:05 | Org rebrand: Enigmora → **Strange Days Tech** + the Rust CLI is born | [`c7e9026`](https://github.com/StrangeDaysTech/straymark/commit/c7e9026) |
+| 2026-05-08/09 | — | DevTrail → **StrayMark** (ADR + arc of 5 PRs) | ADR `2026-05-08-001`, PRs #114-#118 |
+
+Three renames in three days. Then a month-long pause. Then the org rebrand with the Rust CLI bundled in. Then another two-month pause. Then StrayMark, this time with a public ADR anchoring the decision.
+
+A small detail worth flagging: the 28 January commit (Chronicle → Monimen) was not marked `BREAKING CHANGE`. The 29 January one (Monimen → DevTrail) was. *"BREAKING CHANGE: Complete rebrand from Monimen to DevTrail"*, the commit body reads. The difference is small but telling: the second rename felt more definitive. It was, for two months.
+
+---
+
+## 3. What doesn't move
+
+This is the section that interests me most. The project changes names four times in four months. The idea doesn't.
+
+The README of the *initial commit* — the one that lived in the repo when it was called *Enigmora Chronicle Framework* — opens with this line:
+
+> **Documentation Governance for AI-Assisted Software Development**
+
+It's the same line that opens the StrayMark README today. Four names, one tagline.
+
+A bit further down, that same v1.0.0 README states the project's thesis in an explicit block quote:
+
+> *"No significant change without a documented trace."*
+
+That sentence is, today, Principle #1 of the framework. It lives in `PRINCIPLES.md §1 — Total Traceability`. The wording shifted slightly when translated into Spanish, but the weight of the claim stayed intact: no significant change without a documented trace.
+
+The eight document types listed in the v1.0.0 README — REQ, ADR, TES, INC, TDE, AILOG, AIDEC, ETH — are all still alive. Others were added later (MCARD, SBOM, SEC, DPIA), but none displaced the originals. The January taxonomy held.
+
+**The name moves four times; the idea doesn't.** What changed across those four months wasn't the *what* — it was the label that fit on it.
+
+---
+
+## 4. The AIDEC with a typo'd year
+
+There's a small anecdote I keep coming back to.
+
+The project's first structured document — the first AIDEC, the document that, in the framework's own taxonomy, records a decision made with an agent's assistance — is `AIDEC-2025-01-27-001-i18n-strategy.md`. It lives in commit [`7b7193e`](https://github.com/StrangeDaysTech/straymark/commit/7b7193e), added at 18:01 on 27 January 2026, six hours after the *initial commit*.
+
+The ID says **2025**. The commit is from **2026**.
+
+The very document that established the `[TYPE]-[YYYY-MM-DD]-[NNN]` identifier convention has a typo in its own year. The framework started imperfect, and nobody fixed it in time. Anyone who clones the repo and looks at the ID closely will notice it — and will also see that the commit which introduced it is dated correctly. That's the best evidence I have that audit discipline is something that arrives later; it doesn't ship with the repo.
+
+But more interesting than the typo is what that AIDEC decides. The question José posed in January, with help from Claude Opus 4.5, was: how do you internationalize a framework that exists for humans but whose configuration is read by agents? The answer, from the justification section of the AIDEC itself:
+
+> *"AI agents (Claude, Gemini, Copilot, Cursor) process instructions equally well in any language, so translating their config files provides no functional benefit."*
+
+The decision that document made — translate what humans read (documentation, templates); keep what agents read (CLAUDE.md, GEMINI.md, .cursorrules) in English — was an early intuition that the framework has two distinct audiences. The blog itself ratifies that intuition today: bilingual Spanish/English for the humans who'll read it, while the skills and prompts that orchestrate agents stay in English only. Three months later, it's still the right call.
+
+---
+
+## 5. The birth of the CLI — and the missing number
+
+### 5a. The day the project became software
+
+On 1 March 2026, at 19:05, commit [`c7e9026`](https://github.com/StrangeDaysTech/straymark/commit/c7e9026) landed:
+
+> *"feat: rebrand to Strange Days Tech, add CLI scaffolder, restructure repo"*
+
+Until that day, the project was prose. It was templates, skills, governance rules, and a pile of Markdown that depended on the operator (me) copying it by hand into the repos where I wanted to use it. There was a bash script called `copy-devtrail.sh`. It was a toy.
+
+That 1 March commit introduced `cli/Cargo.toml` and `cli/src/main.rs`. The first CLI was called `devtrail-cli`, version `2.0.0`, and had three commands:
+
+```rust
+enum Commands {
+    Init { path: String },
+    Update,
+    Remove { full: bool },
+}
+```
+
+`init`, `update`, `remove`. Three operations. Everything else came later: `status`, `repair`, `validate`, `new`, `compliance`, `metrics`, `analyze`, `audit`, `explore`. But the original three are still there, almost untouched.
+
+The important thing about that commit isn't the three commands: it's that, on that day, the project stopped being a body of documentation living in its own repo and started being an executable tool that gets installed into other repos. The boundary between *"documentation governance project"* and *"framework with tooling"* was crossed that Sunday in March. It matters more than any of the renames that came before.
+
+It was also, incidentally, the day the project moved GitHub accounts: from `enigmora/devtrail` to `StrangeDaysTech/devtrail`. The organization renamed itself from Enigmora to Strange Days Tech, S.A.S., in the same commit that shipped the CLI. Simultaneous renames: the product's (Monimen to DevTrail) had happened in January; the company's, in March. Two distinct layers of identity moving on different clocks.
+
+(A side note, important for archival accuracy: agent co-authorship — the `Co-Authored-By: Claude Opus X.Y` line that appears in commits — does not start in March. The *initial commit* of 27 January is already signed by Claude Opus 4.5. Transparency about AI co-authorship was a rule from the first line of code. What changes on 1 March isn't the practice, it's the scale: the CLI is the first artifact where co-authorship produces *executable code*, not documentation.)
+
+### 5b. The missing number
+
+There's a detail about framework versioning that makes more sense if you just look at `git tag`:
+
+```
+fw-2.0.0
+fw-2.1.0
+fw-4.0.0
+fw-4.1.0
+...
+```
+
+There is no `fw-3.x.x`. The project deliberately jumped from 2 to 4.
+
+The jump syncs with commit [`21e03b2`](https://github.com/StrangeDaysTech/straymark/commit/21e03b2), dated 27 March 2026, whose body describes the change like this:
+
+> *"Reposition DevTrail from 'documentation helper' to 'ISO 42001-aligned AI governance platform' across all user-facing docs. Lead with regulatory urgency (EU AI Act Aug 2026) and compliance value proposition."*
+
+Until March, DevTrail presented itself as a *documentation helper*. From that commit onward, it presented itself as an *ISO 42001-aligned AI governance platform*. The version-number jump (2 → 4, skipping 3) marked the magnitude of the thesis shift. It was a conscious call: one major bump wasn't enough to signal the difference.
+
+And this is where the prehistory starts to make retrospective sense. The intuition that had been in the repo since January — the idea of a robust, normative, standards-alignable record-keeping system — was only named explicitly in March. We'll see this more clearly in the next section, when we talk about the second name.
+
+---
+
+## 6. About the names
+
+Three of the four renames have no ADR. The justification lives only in commit messages, and sometimes not even there: the commit `chore: rebrand Chronicle to Monimen` doesn't say why Monimen. The next one, `chore: rebrand Monimen to DevTrail`, doesn't say why DevTrail either. The practice of the ADR as a disciplined artifact came later; in January the name would change with a commit and the justification would evaporate into the conversation that produced it.
+
+But some etymology is rescuable.
+
+- **Chronicle** *(27 Jan)*. Historical record. Logbook. The name speaks for itself: what you do with a *chronicle* is write down what happened, in order, so it can be reviewed later. No ADR, but the word carries its own meaning.
+
+- **Monimen** *(28 Jan)*. This is the only name whose intuition I do remember and that's worth telling. *Monimen* came from a wordplay on *Monumento* (Monument in English). The analogy that motivated the suggestion: the norms already being intuited at that point — AIDEC, AILOG, alignable with the emerging ISO 42001 governance regime — represented something solid and durable. A *monument* is something erected to last; an immovable reference point for a community. That's what the framework wanted to be. The clipped suffix — *Monimen* instead of *Monument* — was an attempt to give the term a more agile, software-like feel, less marble. It lasted twenty-five hours. But the intuition didn't die: what would, in March, get named explicitly as *ISO 42001-aligned AI governance platform* is the mature version of that same impulse. Monimen was a name with the right thesis and the wrong tongue.
+
+- **DevTrail** *(29 Jan)*. The developer's trail. Less solemn than Monimen, more concrete. The commit marked it `BREAKING CHANGE` — which, viewed from May, carries some irony: the most definitive of the first three rebrands was precisely the one that lasted three and a half months before being replaced.
+
+- **StrayMark** *(8-9 May)*. The mark, the trace that's left behind. But this rebrand deserves its own post: there's already a public ADR (`2026-05-08-001`), an arc of five core PRs (#114-#118), and a *"Why StrayMark?"* manifesto in the README that earns separate treatment. Here, I just close it as the rebrand that finally came with documentary discipline behind it.
+
+The point isn't the etymology itself. It's that each name ratified a distinct intuition about what the product was: **logbook** (Chronicle), **normative pillar** (Monimen), **developer's trail** (DevTrail), **residual mark** (StrayMark). Four names are four hypotheses about the concept. The search ends when the concept stabilizes — and only then can the name sit still.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **We weren't looking for a name. We were looking for the concept.** The four renames are evidence of searching, not of indecision. The concept got sharper as it cycled through names.
+
+2. **Three of four renames without an ADR.** The practice of the ADR as a disciplined artifact came later. In January there was no habit yet. That isn't debt — it's honesty about pace. Governance habits are the result of wanting to record what was already happening, not the precondition for starting.
+
+3. **The project became software on 1 March 2026. Before that, it was prose.** The Rust CLI is the boundary. Any conversation about StrayMark *as a framework* has to acknowledge there's a before and an after that commit.
+
+4. **There probably won't be another rebranding.** But the blog isn't promising it. The project is honest about its own mutability, and promising otherwise would betray the first claim of the first post.
+
+When I started writing this blog, two weeks ago, I didn't intend to cover the prehistory. The idea was to talk about Charters, about emergent observation, about the things the framework actually does today. But the blog itself is a retroactive act — it exists because something surprised me enough to make me start writing. And once I decided to write backwards, getting to January was inevitable. To the three renames in three days. To the AIDEC with the typo'd year. To *Monimen*.
+
+Next, in the following post: the framework's first real methodological experiment — Sentinel's six Plans, and the day *Plan* got renamed to *Charter*. That's where the story the blog came to tell actually begins.
+
+---
+
+*Anchors: commits [`7c58b6d`](https://github.com/StrangeDaysTech/straymark/commit/7c58b6d) · [`0b772bc`](https://github.com/StrangeDaysTech/straymark/commit/0b772bc) · [`25ab7a4`](https://github.com/StrangeDaysTech/straymark/commit/25ab7a4) · [`7b7193e`](https://github.com/StrangeDaysTech/straymark/commit/7b7193e) · [`c7e9026`](https://github.com/StrangeDaysTech/straymark/commit/c7e9026) · [`21e03b2`](https://github.com/StrangeDaysTech/straymark/commit/21e03b2). Original README: `git show v1.0.0:README.md`.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-04-27-exploring-the-framework.md
+++ b/website/blog/2026-04-27-exploring-the-framework.md
@@ -1,0 +1,117 @@
+---
+slug: exploring-the-framework
+title: Exploring the framework
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - tui
+  - cli
+  - i18n
+  - structural-visibility
+date: 2026-04-27T00:00:00.000Z
+description: The TUI that produced visibility without meaning to
+---
+## 1. The tool that two weeks later revealed the outlier
+
+Post 8 of this blog covered a very specific episode: the discovery of the only framework file whose canonical language was Spanish. The operator didn't find it through systematic inspection; they found it by running `straymark explore --lang es` during an audit preparation and noticing, visually, that one template was written backwards relative to the rest. The line from that post:
+
+> *"A new surface of the framework (the TUI) put all the files into simultaneous view, and the inconsistency became obvious — like tidying the bookshelf and noticing one book is shelved spine-backwards."*
+
+This post covers the tool. The TUI `straymark explore` was born almost three weeks before the discovery it enabled — on 25 April 2026 in `cli-3.4.0` — and matured across four more releases, all closed in under 48 hours. This isn't a post about code. It's a post about a specific piece of tooling that ratifies a thesis the blog already named: new tools produce visibility without meaning to.
+
+---
+
+## 2. Why a TUI in a Markdown framework
+
+By late April 2026, the framework had something like fifty governed Markdown files — `PRINCIPLES.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `QUICK-REFERENCE.md`, `SPECKIT-CHARTER-BRIDGE.md`, plus templates in `dist/.straymark/templates/`, plus audit prompts, plus the versions in three languages of each one (`i18n/es/`, `i18n/zh-CN/`). All on disk, all browsable with `find` and `cat`, all perfectly accessible.
+
+And, at the same time, all invisible. For an adopter cloning the framework for the first time, the first question wasn't *"where is rule N?"*. It was *"what's here?"*. And a recursive `ls` doesn't answer that question — it overwhelms it. A `grep` requires knowing what to search for. An editor opens one file at a time. The framework had reached the size where its own surface had become opaque.
+
+`straymark explore` was born precisely to fix that: a navigable surface that answered *"what's here?"* in three seconds. Not an IDE; not a Read-the-Docs-style system; not a static site. A TUI — terminal user interface — that runs on the adopter's repo, indexes the framework's canonical files, shows them grouped by category, and lets you read them with a colored Markdown viewer inside the terminal.
+
+The decision to build a TUI and not a web app is aligned with two things the blog already argued. First, Post 4's principle #10 — *"StrayMark is not an LLM gateway"* — generalizes to *"StrayMark is not whatever already does something else"*. We don't compete with MkDocs or Material for MkDocs. Second, the A1 decision of the same Post 4: orchestration-only. The TUI doesn't require a server, doesn't require a build step, doesn't require a connection: it runs on the adopter's repo, where the framework already lives. It's the humblest piece that could solve the problem.
+
+---
+
+## 3. What landed in `cli-3.4.0`
+
+[PR #57](https://github.com/StrangeDaysTech/straymark/pull/57) from 25 April, merged as `cli-3.4.0`, did three concrete things:
+
+- Introduced the `straymark explore` command. Two-panel layout when the terminal has 100 columns or more: navigation on the left (30%), document on the right (70%). Narrower terminals collapse to a single panel. Status bar at the foot with relevant shortcuts.
+- Indexed the framework's canonical files into a navigable hierarchy: governance docs (`AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, ...), templates (`dist/.straymark/templates/`), audit prompts, and the adopter's directories (`docs/charters/`, `.straymark/07-ai-audit/`, ...). Each node expandable with `Enter`.
+- Wired in the i18n resolver. The `--lang <code>` option lets you run `straymark explore --lang es` and get all governance docs in Spanish *if* a translation is available. If not, silent fallback to canonical EN. The commit's literal description:
+
+> *"Wire `language` config and a new `--lang` flag through the explore TUI so framework governance docs are served from `i18n/<lang>/` when a translation exists, falling back silently to English otherwise."*
+
+The i18n resolver part matters more than the TUI itself. Until `cli-3.4.0`, the helper `resolve_localized_path` was used only by `straymark new` (to resolve which template to inject into the adopter in the right language). PR #57 extracted it into `cli/src/utils.rs:146` as a shared helper, so that **a single definition of how `i18n/<lang>/` overlays resolve** backs both the `new` command and the `explore` command. The behavior stays predictable for the adopter: if you translate a template into `i18n/es/`, the TUI will show it the same way generation will use it. No surprises.
+
+Markdown rendering uses `pulldown-cmark` for the parser and `ratatui` widgets to paint. Color-coded syntax, code blocks with borders, tables with rounded borders, headings indented by level. It isn't flashy; it's readable.
+
+---
+
+## 4. Four refinements in thirty-six hours
+
+What happened between 25 and 27 April is what Post 9 named months later as a property of the process: when the proposal is well-written, implementation is execution. Four more PRs, closed in under 36 hours, took the TUI from "works" to "done":
+
+| PR | Tag | Time | What it added |
+|---|---|---|---|
+| [#60](https://github.com/StrangeDaysTech/straymark/pull/60) | cli-3.5.0 | 25 Apr 22:36 | **Live language switcher.** `L` key cycles the display language without leaving the TUI: `en → es → zh-CN → en`. The index rebuilds in-place. |
+| [#61](https://github.com/StrangeDaysTech/straymark/pull/61) | cli-3.5.0 (same release) | 25 Apr 23:41 | **OS locale auto-detect.** If the adopter has no `config.yml`, the TUI reads `$LC_ALL` / `$LANG` and maps the POSIX locale (e.g. `es_MX.UTF-8` → `es`) onto the closest supported language. |
+| [#62](https://github.com/StrangeDaysTech/straymark/pull/62) | cli-3.5.1 | 26 Apr 00:07 | **Metadata panel translated.** 25 new i18n entries for labels and titles, with visual padding to keep cross-language alignment. |
+| [#63](https://github.com/StrangeDaysTech/straymark/pull/63) | cli-3.5.2 | 26 Apr 00:13 | **Keybinding cleanup.** Removed undocumented vim aliases `l` and `h` (the lowercase `l` clashed with the `L` language switcher). Kept documented `j/k/g/G/n/N`. |
+
+The arc's speed repeats the pattern. The five PRs of fw-4.11.0 covered in Post 6 (rebrand to StrayMark) closed in forty-three minutes. The three audit-cycle releases covered in Post 4 closed in one day. The TUI curve is similar: the design was clear in PR #57, and refinements came as the operator started using the command frequently and noticed the frictions.
+
+The anecdote worth recording is `cli-3.5.2`: the `l` and `h` keys it removed were vim aliases — the operator uses them out of muscle memory in their editor. But when the uppercase-`L` language switcher landed hours earlier, the lowercase `l` and the uppercase `L` shared the same physical key, and the visual transition was confusing. The fix was to remove the undocumented aliases: the full-letter spelling (`j/k/g/G`) stays; the abbreviations that duplicated functions go away. It's a small UX detail that illustrates how TUI decisions tune against real use, not UX theory.
+
+---
+
+## 5. What the TUI revealed two weeks later
+
+Here the post picks up Post 8's thread from the other end. What `cli-3.4.0` added to the framework wasn't just a navigation command; it was a **surface of simultaneous visualization**. That is: before the TUI, the framework's files existed but were read one by one. After the TUI, they could be seen all at once, grouped, tagged, in the same presentation mode.
+
+That changes what the operator can notice.
+
+On 12 May, two and a half weeks after the `cli-3.4.0` merge, the operator ran `straymark explore --lang es` before an external audit cycle. They got to the "audit prompts" group. Opened it. And noticed something that had been there for a year: the root `audit-prompt.md` was written *in Spanish*, while every other canonical framework file had English in root and `i18n/es/` overlays. One file, backwards relative to the convention.
+
+The detail wasn't found by systematic review. It was found by visual contrast. It's exactly what Post 8 §3 codified as thesis:
+
+> *"New tools produce visibility."*
+
+The TUI didn't cause the outlier — the outlier had existed since the first commit that ported the Sentinel skill `plan-audit` into the canonical framework (Post 3 records this). The TUI didn't look for the outlier either; it isn't an inconsistency-detection tool. All it did was put every file on the same screen, in the same presentation mode, and let the human eye notice what had been there from the start. The conclusion worth recording is structural: any framework that crosses fifty canonical files needs a surface of simultaneous visualization, not because the surface is pedagogically important in itself, but because without it certain regularities of the repo become unobservable.
+
+---
+
+## 6. Small technical decisions that matter
+
+Three TUI design details worth recording, all coherent with framework principles the blog has already named:
+
+**Feature flag `tui`.** The CLI's `Cargo.toml` declares the TUI as an optional dependency (`ratatui` + `crossterm` + `pulldown-cmark` live behind the `tui` flag, enabled by default). An adopter who only wants `init`, `update`, `validate` can build a binary without the TUI via `cargo build --no-default-features`. It closes a sub-architectural decision that recurs in the framework: give the adopter value by default, but let them choose a lighter binary when the TUI adds nothing to the flow.
+
+**Lazy document loading.** The `DocIndex` keeps a `HashMap<PathBuf, Document>` that fills up as each node is opened, not at startup. For a repo with a hundred governance files, this means `straymark explore` boots in under 200ms and only reads disk when the operator hits `Enter`. The decision is technically trivial; what isn't trivial is that it was made consciously. The TUI doesn't compete with an IDE; it competes with `cat`. It has to feel just as immediate.
+
+**History stack for hyperlinks.** When one framework document mentions another (e.g., `AGENT-RULES.md §3` refers to `DOCUMENTATION-POLICY.md §6`), the TUI lets you jump to the referenced one with a click — and back with `Esc`. Internally there's a navigation stack that restores the previous document's scroll position. It's the piece that turns reading the framework from *"I open a file, close it, open another"* into *"I follow a conversation between documents without losing the thread"*. The number of cross-references the framework has today — between principles, agent rules, schemas, templates — makes this navigation structurally important, not cosmetic.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **A framework that crosses a certain size needs a surface of simultaneous visualization.** It isn't ergonomics; it's the condition for certain regularities of the repo to be observable. Post 8 documented the consequence; this post documents the tool.
+
+2. **The TUI doesn't cause the discoveries; it enables them.** The audit-prompt outlier had existed since May of the previous year. All that changed in April was that a screen appeared where it could be seen next to its peers. The tool doesn't have opinions about content; it changes the conditions under which the human eye can notice regularities.
+
+3. **When the design is clear, implementation is hours, not sprints.** Five PRs in thirty-six hours — language-aware, live switcher, OS detection, panel i18n, keybinding cleanup — are only possible because the design was closed in PR #57. It's the same pattern as Posts 4, 6 and 9.
+
+4. **The most interesting technical decision can be a compile-time flag.** The `tui` feature flag explicitly declares that the TUI is optional, that the framework still works without it, that the adopter decides. That architectural humility is the difference between a CLI that assumes how the adopter works and a CLI that offers itself where it can be useful.
+
+With this post the blog covers the `H-14` milestone the first batch left as explicit debt. The remaining candidate milestones that `PLAN-INVESTIGACION.md §1.43-55` recorded — `AGENTS.md` universal inject, full EN/ES/zh-CN i18n coverage, `straymark validate` as a formal layer, CLA assistant — stay available for future batches. No promised cadence, but recorded.
+
+---
+
+*Anchors: PR [#57](https://github.com/StrangeDaysTech/straymark/pull/57) — `cli-3.4.0` (language-aware explore, 25 Apr 2026). PRs [#60](https://github.com/StrangeDaysTech/straymark/pull/60) · [#61](https://github.com/StrangeDaysTech/straymark/pull/61) · [#62](https://github.com/StrangeDaysTech/straymark/pull/62) · [#63](https://github.com/StrangeDaysTech/straymark/pull/63) — refinements `cli-3.5.0` to `cli-3.5.2` (25-26 Apr 2026). Code: `cli/src/tui/` (15 files). Adopter doc: `docs/adopters/CLI-REFERENCE.md` §`straymark explore`.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-04-30-six-plans-and-the-rename-to-charter.md
+++ b/website/blog/2026-04-30-six-plans-and-the-rename-to-charter.md
@@ -1,0 +1,151 @@
+---
+slug: six-plans-and-the-rename-to-charter
+title: Six Plans for one thesis (and the rename to Charter)
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - sentinel
+  - charters
+  - methodology
+  - governance
+date: 2026-04-30T00:00:00.000Z
+description: 'The first systematic experiment, and the day Plan became Charter'
+---
+## 1. A footnote that says a lot
+
+In the `charter-telemetry.md` proposal, written on 30 April 2026, there's a terminological note at the top:
+
+> *"What this document calls 'Charter' was called 'Plan' in the Sentinel experiment (PLAN-01..06). The empirical data cited below refers to those historical Plans by their original name; the schema shape and prospective examples use the going-forward name 'Charter'."*
+
+It's a footnote, technical, drama-free. But it records the exact moment the artifact changed names — and, more interestingly, it records an archival decision the blog also respects: what was called *Plan* at the time keeps being called *Plan* in the original records. Rewriting the name backwards would falsify the trace.
+
+This post covers two things that happened in five days: the framework's first systematic experiment — Sentinel's six Plans, run between 25 and 28 April — and the rename that came right after, on the 30th. They aren't two separate events. One led to the other.
+
+---
+
+## 2. Six Plans on paper, five in practice
+
+The experiment was designed with six Plans (`PLAN-01` through `PLAN-06`) and executed with five. PLAN-04 never ran: it stayed as a catalog of seven *deferred features*, a list of things we wanted to do but the test cycle couldn't cover. It's only honest to say so, because the very document that validates the thesis (`thesis-validation.md`) records it openly in its summary table:
+
+| Plan | Size | What it did | Format |
+|---|---|---|---|
+| PLAN-01 | XS | Governance docs deploy | v1 |
+| PLAN-02 | S | Admin endpoint (`gcp-resource`) | v1 |
+| PLAN-03 | XS | Contract bumps | v1 |
+| PLAN-05 | M | Per-service anomaly thresholds | **v2** |
+| PLAN-06 | XS | Manual baseline recompute | **v3** |
+| *(PLAN-04 catalog)* | — | Roadmap of 7 deferred features, not executed | — |
+
+Five Plans, four distinct sizes: three XS, one S, one M. Deliberately heterogeneous domains — an operations deploy, two admin endpoints, a contract bump, a backend feature with configuration logic. It wasn't a synthetic benchmark. It was Sentinel's real code between 25 and 28 April, partitioned into bounded units and audited piece by piece with three models (Copilot, Gemini, Claude) acting as external auditors.
+
+That the sixth Plan didn't run matters for two reasons. The obvious one: the experiment ran out of time. The more interesting one: PLAN-04 was the only large Plan in the batch — seven accumulated features, no natural boundary. That precisely *that* Plan was the one that didn't make it through was already saying something about the size the format could tolerate. Small Plans, yes; roadmap-Plans, no. That lesson was canonized later without anyone having to write it: StrayMark's Charters today are *"bounded units, hours to days, one branch"*, not quarterly roadmaps.
+
+---
+
+## 3. The experiment iterated on itself
+
+Five executed Plans produced three different formats. It wasn't on a whim; it was because each cycle exposed something the previous format didn't capture.
+
+- **v1** — the first three Plans (`01`, `02`, `03`) ran on an original format. Five recurring patterns were identified in the audit AILOGs, but none was formalized into a template. They existed as habit, not as contract.
+
+- **v2** — for PLAN-05, those five patterns were materialized into `TEMPLATE.md`, plus a *"Format conventions"* section in the README. Doc-only: nothing executable yet. The hypothesis: if the format is explicit, external auditors converge better. AILOG-020 says it plainly: *"Internal patterns that have been applied for a while but have no name remain invisible to external auditors. Naming them formally turns practice into a public signal."*
+
+- **v3** — for PLAN-06, a new pattern was added (auto-checklist drift) and, this time, *executable tooling*: `scripts/check-plan-drift.sh`, ~145 lines of bash that validate whether the actual delivery matches what the Plan declared. For the first time, the format stopped being prose only and started having a verifier.
+
+What I want to point out here is the shape of the curve. v1 captured latent practice. v2 named it. v3 wrote a program that checks it. That's the full arc of any useful standardization — only compressed into five Plans, not five years.
+
+It's also the first concrete evidence of something that, two months later, would be named explicitly as Pattern 1 (*pre-declare refresh*) and Pattern 2 (*amend-on-emergence*) in `CHARTER-CHAIN-EVOLUTION.md`. What got canonized there as a meta-pattern started here, in April, as habit-without-a-name.
+
+---
+
+## 4. The hardest evidence: external auditors converging
+
+The most loaded assumption of the thesis was: *"structured notes reduce failure modes, and the reduction is visible when external auditors look"*. The way to prove it: send the output of each Plan — the modified files, the AILOG, the Plan-doc under TEMPLATE — to three auditors who hadn't participated in development (Copilot, Gemini, and a critical analysis from Claude) and compare the aggregate scores.
+
+The number `thesis-validation.md` reports for PLAN-05 (the first Plan under v2, and the only M-size one) is clear:
+
+> *"Best combined auditor calibration across 5 cycles (Copilot 9.25, Gemini 9.5). Accumulated hypothesis confirmed: TEMPLATE v2 + rich AILOGs reduce the ambiguity surface for external audit."*
+
+Two heterogeneous models, different instructions, converging around 9.3 out of 10 — on the largest Plan in the batch, no less, not the smallest. That's signal, not noise. And it replicated when v3's `check-plan-drift.sh` was exercised:
+
+> *"PLAN-05 (with known drifts): script reports 3 omitted files: `evaluator_test.go` (F4), `repository.go` (F1/R6), `statuscenter/service.go` (F5) — exactly the 3 drifts that Copilot+Gemini captured in their audits. Zero false positives."*
+
+The automated script and the two external auditors agreed exactly on which Plan files had been left undone. This isn't an argument that the script is smart — it's bash and *grep*; it couldn't be dumber. It's an argument that the Plan format, once formalized, makes *any inspector* (human, agent, script) see the same things. Structured discipline doesn't require intelligence to be audited: it requires clarity.
+
+---
+
+## 5. What the experiment *didn't* prove
+
+This is the section I most want on the record, because it's where it gets tested whether the blog is willing to be honest.
+
+`thesis-validation.md` was explicitly designed to break the thesis, not to defend it. The first line of the document reads:
+
+> *"This document confronts that thesis with data. It does not defend it; it tries to break it. The goal is that a reader who didn't buy the thesis can, reading only this text, decide whether the available evidence supports it, qualifies it, or refutes it."*
+
+The final verdict, with the thesis's six assumptions faced against the evidence, is this:
+
+| # | Assumption | Verdict |
+|---|---|---|
+| 1 | Vibe coding doesn't scale | Partially validated *(no control arm)* |
+| 2 | Structured notes reduce failure modes | Validated |
+| 3 | Regulatory byproduct with no extra work | Validated *(pending real human auditor test)* |
+| 4 | Approvals are rarely binary | No evidence — pending multi-actor project |
+| 5 | Stage > commit as traceability unit | Validated |
+| 6 | In-situ signing > later reconstruction | Partially validated *(no cryptographic signing tested)* |
+
+Three assumptions fully validated, two partial, one *without evidence*, zero refuted. The assumption about non-binary approvals went untested because Sentinel is a single-owner project; ruling on it would require a real team with multiple signers. And cryptographic signing — Sigstore, hash-chaining, the technical guarantees of an append-only log — wasn't exercised because no Plan touched that part of the flow. That stays in the document as an explicit *gap*, not as a hand-waved claim.
+
+What the experiment didn't prove matters more than what it did. If we'd published six greens instead of five honest verdicts, the blog would be marketing. The way to avoid it is to say, without softening: here are assumptions we don't have evidence for, and a one-operator project can't generate it. Others will; the framework will mature with that data.
+
+---
+
+## 6. Why Plan became Charter
+
+The 30 April rename wasn't marketing. The reason is written literally in `WHAT-IS-A-CHARTER.md`:
+
+> *"GitHub SpecKit already uses the word 'plan' (`/speckit.plan`, `plan.md`) for a different artifact, and the nominal collision generated friction in adopter docs that combine both flows."*
+
+SpecKit already had a `plan.md`. StrayMark had one too. In the documentation of an adopter using both, *plan* meant different things in adjacent paragraphs. The rename existed to fix that collision.
+
+But behind the pragmatism there's a nuance worth naming. The two artifacts *are* distinct, and the distinction is structural:
+
+| | **SpecKit `plan.md`** | **StrayMark Charter** |
+|---|---|---|
+| Granularity | Complete feature (weeks, several stories) | Bounded unit (hours to days, one branch) |
+| Dominant content | Stack, dependencies, project structure, constitution gates | Concrete files to touch, verification commands, `R<N>` risks |
+| Validation | Constitution Check (*ex-ante* gate) | Drift-check + external audit (*ex-post* gates) |
+| Optimization | *Upfront clarity* | *Ex-post traceability* |
+
+What SpecKit calls *plan* looks more like an ADR with an architectural skeleton. What StrayMark calls *Charter* looks more like a task-card with contractual verification and an audit anchor. They're complementary artifacts, not competitors; `SPECKIT-CHARTER-BRIDGE.md` makes that explicit later, in May. But the nomenclature had to stop colliding before complementarity could even be discussed.
+
+The part I find important to highlight is the adjacent decision: Sentinel's historical records — the AILOGs, the telemetry, the `check-plan-drift.sh`, the `sentinel/docs/plans/` folders — preserve the name *Plan*. `WHAT-IS-A-CHARTER.md` itself argues it this way:
+
+> *"Sentinel's historical records (Plans 01–06, `sentinel/docs/plans/`, `sentinel/scripts/check-plan-drift.sh`, AILOGs and YAML telemetries `PLAN-NN.telemetry.yaml`) preserve the original name — they are empirical evidence of a specific moment in time, and rewriting history would falsify the record."*
+
+*Rewriting history would falsify the record.* For me, that sentence is the true heart of the rename. The framework exists to preserve a trace, not to rewrite one. When the artifact changed names, the change was prospective: from 30 April onward, new ones are Charters. The old ones, the experiment ones, are still Plans. The inconsistency is deliberate, and the inconsistency *is* the evidence.
+
+The 30 April rename's other companion — the telemetry proposal — came the same day for reasons that look obvious in hindsight: if the emergent pattern deserved a new name, it also deserved structured measurement. The `charter-telemetry.schema.v0.json` schema, with its fields for invested time, detected drifts, size, domain, is the machinery that runs today what Sentinel was still measuring by hand in YAML. Plan got renamed to Charter on the same day we decided to start counting Charters.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **The experiment was designed to break, not to confirm.** *"It does not defend it; it tries to break it"* — that was, literally, the brief of the document that validated the thesis. Any technical blog worth respecting has to tolerate that framing.
+
+2. **Five Plans executed, of six designed, in four days.** The one that didn't run (the largest, a seven-feature roadmap) was, accidentally, the first evidence of what size the unit can tolerate. Today Charters are bounded by contract. In April, they were bounded by accident.
+
+3. **The format evolved inside the experiment itself: from habit, to template, to script.** Five Plans produced three versions of the format. The v1 → v2 → v3 curve is the curve of any useful standardization — just compressed.
+
+4. **The rename came from pragmatism, not marketing. And historical preservation came from principle.** *Plan* keeps being called *Plan* in Sentinel, where that's what it was called. *Charter* started being used from April onward. The framework doesn't rewrite its own archive: that's why it's worth tracing.
+
+Next, in the following post: two close-by milestones that codify qualitatively new capabilities — *Charters as a first-class entity* (PR #65, fw-4.4.0) and *the external multi-model audit cycle* (`audit-skills-design`, `audit-cli-flow`, releases fw-4.7 → fw-4.9). That's where the Sentinel experiment became CLI functionality.
+
+---
+
+*Anchors: proposals [`thesis-validation.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-04-30-thesis-validation.md) and [`charter-telemetry.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-04-30-charter-telemetry.md) (both 2026-04-30). Canonical Charter definition: [`WHAT-IS-A-CHARTER.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/contributors/WHAT-IS-A-CHARTER.md). Operational schema: `dist/.straymark/schemas/charter-telemetry.schema.v0.json`.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-06-charters-and-the-external-audit-cycle.md
+++ b/website/blog/2026-05-06-charters-and-the-external-audit-cycle.md
@@ -1,0 +1,146 @@
+---
+slug: charters-and-the-external-audit-cycle
+title: 'Charters as a first-class entity, and the external audit cycle'
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - audit
+  - cli
+  - governance
+date: 2026-05-06T00:00:00.000Z
+description: From manual ritual in Sentinel to canonized CLI command
+---
+## 1. When discipline starts to feel like ceremony
+
+By late April, Sentinel closed its fourth Charter of the month with a feeling that, in writing, sounds slightly pathetic: external audit was working — Copilot 9.25, Gemini 9.5, the drift script with zero false positives — but every close had me opening three files by hand, copying three prompts into three different windows, waiting for replies, pasting three calibration YAMLs back into the telemetry file, and eyeballing the hashes to make sure they matched. Forty minutes of copy-paste per Charter on top of work that took two hours. Discipline was working; the ritual was becoming a problem.
+
+The `audit-skills-design.md` proposal, written on 3 May, named it without softening:
+
+> *"If at every close the operator had to manually move data between files, throughput would collapse and discipline would stop being virtuous friction and turn into ceremony. Whatever can be automated reversibly should be automated; the documents are kept for ex-post human audit."*
+
+This post covers three days — from 2 to 6 May 2026 — during which two parallel arcs finished at the same time. One: the Charter stopped being artisanal practice and became a first-class entity of the CLI. Two: the external audit cycle stopped being a manual ritual with ad-hoc prompts and became a canonical command (with a counterintuitive architectural decision behind it that deserves its own section).
+
+---
+
+## 2. What Sentinel was already doing, and what StrayMark didn't have
+
+The 3 May proposal puts it in a sentence that's barely elegant but precisely accurate about what was happening:
+
+> *"Sentinel has the skills, StrayMark doesn't."*
+
+What Sentinel had: `sentinel/.claude/skills/plan-audit/` and `plan-audit-review/` — local skills that generated a prompt, calibrated the response on return, and merged it into telemetry. They worked. They had been validated across six cycles. But they were coupled to Sentinel-specific paths (`docs/plans/`, `internal/modules/`, `go vet`) and to the *"Plan"* vocabulary, which had already been renamed to Charter a week earlier.
+
+What StrayMark didn't have: nothing equivalent. The framework, up to April, was documentation + skills + a CLI with `init`, `update`, `remove`. The unit that in Sentinel was called *Plan* — the bounded unit, declared *ex-ante*, audited *ex-post* — didn't exist as a CLI artifact. It existed as practice.
+
+The arc of fw-4.4.0 (2 May) and of fw-4.7 → 4.9 (3-5 May) consists, almost verbatim, of porting what Sentinel did by hand into generic commands that any framework adopter can invoke. The migration table, copied from `cli-roadmap.md`, is honest about the origin:
+
+| Sentinel artifact *(April 2026)* | StrayMark equivalent *(May 2026)* |
+|---|---|
+| `TEMPLATE.md` (v3) in `docs/plans/` | `dist/.straymark/templates/charter-template.md` |
+| `scripts/check-plan-drift.sh` (145 bash lines) | `straymark charter drift` (Rust subcommand) |
+| Local skill `plan-audit` | Generic skill `straymark-audit-prepare` |
+| Dual reports in `audit/plans/05,06/{copilot,gemini,claude}.md` | Canonical output of `straymark charter audit` |
+| Hand-edited telemetry YAML | `dist/.straymark/schemas/charter-telemetry.schema.v0.json` |
+
+The fw-4.4.0 CHANGELOG frames it without metaphor: *"Crystallizes the Charter pattern — bounded, auditable units of work declared ex-ante and validated ex-post — that emerged from the 6-cycle Sentinel /plan-audit experiment."* The crystallization is the point. What in April was custom-with-a-bash-script, in May is a command with a validatable schema.
+
+---
+
+## 3. What happens when something becomes "first-class"
+
+PR #65 (fw-4.4.0 / cli-3.6.0, 2 May) does three concrete things:
+
+- It creates the `straymark charter new` command. Auto-increments the number (`NN-slug.md`), pre-populates the origin (`originating_ailogs` if it's born from a prior AILOG; `originating_spec` if it's born from a SpecKit `plan.md`), and supports the `--type X|S|M|L` flag to fix the size from the first moment.
+- It introduces `charter-template.md`, ported from Sentinel's `TEMPLATE.md` v3. It carries embedded the six conventions that the April experiment was crystallizing cycle by cycle: Local/Production checks separation, effort in time (not story points), structured sub-sections, `R<N>` risk documentation, closure with post-merge reconciliation via AILOG, and auto-checklist drift.
+- It ships `dist/.straymark/schemas/charter.schema.v0.json` — the schema marked `v0` on purpose, not `v1`, because the framework's principle #12 says no schema crystallizes without a second domain validating it. Sentinel is one domain. The second is missing.
+
+PR #68 (3 May) does something that looks small but matters: the *atomic Charter closure pattern*, format v4. In Sentinel, the step *"update the Plan-doc post-merge if the AILOG documents divergences"* existed as a note in the TEMPLATE but had no systematic trigger. In practice, that meant when there was divergence between what was declared and what was delivered, the operator (me) relied on memory to reconcile the document — and memory failed. The drift stayed in the repo for days, sometimes weeks, until the next cycle caught it. Format v4 makes the reconciliation a mandatory step of closure, not a marginal note.
+
+PR #69 (same day) closes one friction detail: manual numbering. Before, you had to decide whether the next Charter was 11 or 12; now `straymark charter new` reads the directory and proposes the next number. Pure UX. But it's the class of friction that, summed across twenty Charters, decides whether the framework gets used or abandoned.
+
+The three PRs shipped in the same commit storm of a Sunday and a Monday. That cadence is deliberate: once the pattern crystallizes, UX details have to close *together*, not in separate bumps that leave the adopter with half the flow.
+
+---
+
+## 4. Three releases in a day
+
+What came next — fw-4.7.0, fw-4.8.0, fw-4.9.0 — are consecutive releases of the external audit cycle. The `audit-skills-rollout.md` proposal records the pace without disguise:
+
+> *"Phase 1 executed in 1 calendar day (5 sequential PRs on 3 May 2026), substantially faster than the 1.5-2 weeks focused estimate. The throughput is due to the design in `audit-skills-design.md` already having the decisions crystallized (D1/D2/D3) and the arborist heuristic with explicit graceful-degradation — there were no pending decisions during implementation. It serves as additional operational evidence for principle #6 (when the proposal is well-written, implementation is execution, not design)."*
+
+The concrete external audit cycle consists of three chained commands:
+
+1. `straymark charter audit prepare <CHARTER-NN>` — generates canonical prompts for external auditors from the closed Charter, its associated AILOG, and the diff of touched files. Output: three `.prompt.md` files in `audit/<CHARTER-NN>/{copilot,gemini,claude}.prompt.md`.
+2. *(The human carries those prompts to their auditor of choice, receives replies, pastes them back.)*
+3. `straymark charter audit collect <CHARTER-NN>` — takes the responses, validates each one against the audit schema, merges calibrations into the Charter's telemetry, and produces a summary with the convergence (or divergence) between auditors.
+
+Decision D1 in the proposal is what holds everything else up:
+
+> *"Skills delegate via `Bash(straymark charter audit *)` to the canonical implementation. Templates live only in `dist/.straymark/audit-prompts/`. Zero drift possible between skill and CLI."*
+
+There's only one place where the prompts live, one single implementation of the flow, and skills (Claude, Cursor) invoke it via Bash. It's a humble pattern — the CLI is the single source — but it avoids what in any framework with two surfaces (skill + CLI) ends up being the chronic problem: that the skill and the CLI say different things depending on who updated which last.
+
+---
+
+## 5. Why the CLI orchestrates but doesn't invoke APIs
+
+This is the strangest decision of May, and the one that took me the most work to make. It's documented literally in `cli-roadmap.md` §0 as *"architectural decision A1"*:
+
+> *"A1 (Phase 3): orchestration-only, no HTTP API clients in v0. Roadmap §5.4 originally suggested 'support OpenAI/Google/Anthropic in v0' with API key handling. The implemented reality is that the CLI prepares prompts, validates outputs against schema, and integrates with telemetry — but does NOT invoke APIs. The operator pastes the prompts into their auditor of choice manually."*
+
+The reasoning, also literal:
+
+> *"Implementing 3 HTTP clients is 1-2 weeks + perpetual maintenance when the APIs change (premature for an experimental v0); the human-in-the-loop pattern matches Sentinel's `/plan-audit`; complies with principle #10 ('it is not an LLM gateway'); closes RFC #82 by design. HTTP clients reopen in v1 when a real adopter justifies it with data."*
+
+Three arguments, each with its own weight.
+
+**The first is pragmatic.** Three HTTP clients — OpenAI, Anthropic, Google — are between one and two weeks of implementation, plus permanent maintenance every time any of the three changes something. For a command whose manual form was already working empirically in Sentinel, that's an absurd cost. It's engineering to solve a problem no adopter had asked to solve.
+
+**The second is about continuity.** What Sentinel validated in April was precisely the human-in-the-loop pattern: the operator pastes the prompt into Copilot/Gemini/Claude *by hand*, reads the response, pastes it back. The six-Plan experiment that gave rise to this whole arc *never* invoked APIs. If the CLI now invoked APIs on its own, it would be replacing a validated pattern with an unvalidated one, with no empirical reason.
+
+**The third is about identity.** StrayMark is not an *LLM gateway*. Framework principle #10 says it explicitly. There are dozens of products that *are* — LangChain, LiteLLM, LiteLLM Proxy, OpenRouter, every wrapper — and they're useful for what they do. StrayMark does something else: it structures discipline around the work done *with* those models, whichever model that is. Whether the CLI invokes or doesn't invoke APIs changes what the framework *is*; keeping it *orchestration-only* keeps the identity clean.
+
+The part of the paragraph I care about most: *"HTTP clients reopen in v1 when a real adopter justifies it with data."* The decision wasn't closed by dogma; it was deferred behind an evidence threshold. If in six months an adopter shows that the human-in-the-loop flow breaks their throughput, the HTTP clients land. Until then, the forty seconds of manual friction it takes to paste the prompt into another window is trivial compared to the cost of maintaining three live SDKs.
+
+---
+
+## 6. What the framework decided *not* to automate
+
+It's worth closing with the other face of the same decision. The `audit-skills-design.md` proposal says:
+
+> *"Whatever can be automated reversibly should be automated; the documents are kept for ex-post human audit."*
+
+The first half explains May's three releases: prompts generated automatically, calibrations merged automatically, drift detected automatically. The second half — *"the documents are kept for ex-post human audit"* — explains what was chosen to stay manual on purpose.
+
+What the framework does *not* automate:
+
+- **The operator's reading of the AILOG before closing the Charter.** The `straymark charter audit prepare` command generates the prompts, but the operator *has* to open the AILOG and read it. If we automated that — an agent that reads, summarizes, decides — we'd lose the moment of human judgment that justifies the Charter existing at all.
+- **The decision to accept or reject the external audit.** The CLI merges calibrations into the telemetry, but doesn't act on them. If an auditor scores the Charter a 4, the Charter doesn't auto-reopen: the operator decides whether to reopen, to argue, or to declare it *acceptable-with-known-debt*. That decision is the discipline; automating it would destroy it.
+- **The invocation of the models.** As argued above: the pause where the operator copies the prompt is exactly where they decide which model to use, which prompt to tweak, whether the question as phrased seems fair. That pause is feature, not bug.
+
+The criterion running through all three is one: *automate what's reversible and mechanical; preserve as manual what's judgment*. Forty seconds of copy-paste aren't too many if they buy keeping the judgment human.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **A practice that works empirically doesn't need to be reinvented to be canonized.** Sentinel did the validation work in April; May only ported it into the framework. The crystallization is transfer, not design-from-scratch.
+
+2. **When the proposal is well-written, implementation is execution.** Three releases in a day are only possible when all the decisions were closed before code was touched. Principle #6 says it more prosaically, but this is what it means.
+
+3. **Not everything automatable should be automated.** Decision A1 — the CLI orchestrates but doesn't invoke APIs — is the technical version of a philosophical decision: human-in-the-loop isn't legacy to get rid of, it's a feature that holds the discipline up.
+
+4. **A framework's identity is defined as much by what it does as by what it doesn't.** *"It is not an LLM gateway"* is one of the few principle #10 sentences worth remembering verbatim. What StrayMark does, it does well because there are many things it refuses to do.
+
+Next, in the following post: the methodological episode that connects with the very start of this blog — *Issue #113: Charters invisible to the agents* — where the framework discovers that creating commands and schemas isn't enough if the repo's *surface* doesn't speak to the agent. It's the natural counterweight to this post: here we talk about what got canonized; there we talk about what didn't get seen.
+
+---
+
+*Anchors: PRs [#65](https://github.com/StrangeDaysTech/straymark/pull/65) · [#68](https://github.com/StrangeDaysTech/straymark/pull/68) · [#69](https://github.com/StrangeDaysTech/straymark/pull/69) (Charters first-class). Proposals [`audit-skills-design.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-03-audit-skills-design.md) · [`audit-skills-rollout.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-03-audit-skills-rollout.md) · [`audit-cli-flow.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-04-audit-cli-flow.md) · [`cli-roadmap.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-03-cli-roadmap.md) (decision A1 §0). Releases fw-4.4.0 → fw-4.9.0.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-09-charters-invisible-to-agents.md
+++ b/website/blog/2026-05-09-charters-invisible-to-agents.md
@@ -1,0 +1,129 @@
+---
+slug: charters-invisible-to-agents
+title: Charters invisible to the agents
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - agents
+  - observability
+  - governance
+date: 2026-05-09T00:00:00.000Z
+description: 'Issue #113 — the gap between having an artifact and the agent seeing it'
+---
+## 1. Six hours not to see it, five minutes to see it
+
+Issue [#113](https://github.com/StrangeDaysTech/straymark/issues/113) opens with one of those sentences that, read back months later, sounds obvious and at the same time cost a lot to reach:
+
+> *"Time to detect: ~6 hours of session work; never autonomously surfaced. Time to resolve once user prompted: ~5 minutes."*
+
+Six hours working with a capable, attentive agent, with the framework's whole canonical onboarding apparatus loaded — `STRAYMARK.md`, the project constitution, the `CLAUDE.md` checklist, the `/straymark-*` skills available, `/straymark-status` run at the start — and not once, over six hours, did the agent suggest using a Charter. When I asked for it directly, the flow was incorporated in five minutes. The asymmetry isn't about capability. It's about visibility.
+
+This post covers a short, specific episode: Issue #113, opened on 7 May 2026, three days after Charters crystallized as a first-class entity in the framework (fw-4.4.0, 2 May). It's the natural counterweight to this blog's first post. That post named a property that appeared when everything was in place. This post documents what happens when a structural piece exists but *isn't on the surface the agent reads first*.
+
+---
+
+## 2. The accidental experiment
+
+The setup wasn't designed as an experiment. It was a real project: a *greenfield* in Rust, CLI+TUI suite, on its first `v0.1` version. The agent was Claude Opus 4.7 with a 1M-token window, enough to keep the whole repo in context without paging. The flow was the canonical SpecKit one: `/speckit-specify`, `/speckit-plan`, `/speckit-tasks`, and between tasks and implement the idea of splitting into Charters should have surfaced — *in theory*.
+
+The Issue formulates it with almost cold precision:
+
+> *"A capable, attentive agent following the canonical project onboarding (`DEVTRAIL.md`, the project constitution, `CLAUDE.md` checklist, available `/devtrail-*` skills, `/devtrail-status`) did not autonomously identify Charters as a workflow concept during plan/tasks generation, even though the project clearly fit their use case (multi-session implementation, multi-phase tasks, audit value)."*
+
+*(The Issue still uses `DEVTRAIL.md` because, given the chronology, the rebrand to StrayMark was being merged almost in parallel. The mixed nomenclature is calendar residue, not oversight.)*
+
+The project met each condition where a Charter is the right unit: multi-session implementation, multiple phases, audit value. The agent did everything right — read the constitution, ran status, identified available skills, generated a reasonable SpecKit plan — and never connected to Charters. As if the concept didn't exist. To the agent, in its model of the repo, it didn't.
+
+The most uncomfortable thing about the Issue, in hindsight, is that the agent didn't fail from incapacity. It failed because the framework, without meaning to, had built a map where Charters weren't marked.
+
+---
+
+## 3. Nine gaps converging on one
+
+When the operator (me) opened the Issue and sat down to audit why it had happened, the problem wasn't one thing. It was nine. And all of them were versions of the same defect:
+
+| # | Gap | Where |
+|---|---|---|
+| 1 | The framework's canonical document didn't list Charter as a concept | `STRAYMARK.md` (then `DEVTRAIL.md`) §6/9/10/11/13/15 |
+| 2 | The `CLAUDE.md` checklist had no trigger to suggest Charter | `dist/dist-templates/directives/CLAUDE.md` (also `GEMINI.md`, `copilot-instructions.md`) |
+| 3 | Project constitutions inherited the framework's gap | Any `*-constitution.md` installed via `straymark init` |
+| 4 | No `/straymark-charter-new` skill existed | Skills directory |
+| 5 | `/straymark-status` didn't list Charters in its output | Skill + CLI subcommand `straymark status` |
+| 6 | The audit skills framed the Charter as an *external* artifact, not as a surface to generate | `/straymark-audit-*` skills |
+| 7 | Charter templates lived indistinguishable from other templates | `dist/.straymark/templates/` (root) |
+| 8 | No conceptual bridge between SpecKit (`plan.md`) and Charter | No explicit document |
+| 9 | The mental model the agent ended up building was binary: either SpecKit, or nothing | Compounded effect |
+
+Nine failures and one single defect: the Charter existed as a technical artifact (valid schema, working command, template ported from Sentinel), but wasn't named in any of the places where the agent builds its mental model of the project on entry.
+
+The agent reads `STRAYMARK.md` and the constitution to understand what the project is about. If Charter doesn't appear, it isn't there. The agent reviews which skills are available to use. If there's no `/straymark-charter-new`, it isn't there. The agent runs `/straymark-status` to understand what kinds of files live in the repo. If the output doesn't mention Charters, they aren't there. Each surface the agent passes through on onboarding repeats the same silence. And the sum of silences convinces the agent the concept isn't part of this project.
+
+---
+
+## 4. Why this episode matters beyond the Issue
+
+It's worth pausing here, because this is exactly the episode the fw-4.17.0 meta-pattern — the pattern of *emergent observation* — needed to have happened *first* in order to be formulated at all.
+
+A week after #113, in `EMERGENT-OBSERVATION-DESIGN.md`, the framework named two properties whose composition produces an agent surfacing things nobody asked it to surface: formal links between artifacts (`originating_charter`, `originating_ailog`, `originating_spec` in frontmatter), and cultural permission to flag dissonances between sources. Those two properties, *composed*, produce the agent reading the AILOG, counting the `R<N>(new, not in Charter)` entries, and flagging the delta without being asked.
+
+But there's a precondition that formulation takes for granted: that the agent *sees* the Charters on entering the repo. If the Charters aren't on the visible surface, no formal link between artifacts can compose into emergent observation — because one of the composition's terms doesn't exist for the agent.
+
+Issue #113 is the episode that documented that precondition from the reverse. Fw-4.17.0 named the pattern when it was present; fw-4.12.0 (five days earlier) closed the gap that prevented it from being present at all. Without Issue #113 and its correction, the meta-pattern wouldn't have anywhere to stand. The framework doesn't surface what it can't see, and it can't see what the surface doesn't name.
+
+---
+
+## 5. The response: multiplying surfaces
+
+PR [#122](https://github.com/StrangeDaysTech/straymark/pull/122) (`fw-4.12.0`, 9 May) closed the nine gaps with a single operational strategy: *name Charter in every place where the agent builds its model of the project*. The PR's numbers are honest: +1211 lines, −92 lines, 36 files modified, almost entirely documentation and templates. There was no code refactor. There was a redistribution of visibility.
+
+Main changes, grouped:
+
+- **In the canonical document** (`STRAYMARK.md`): a new section dedicated to Charter as a concept (§15), plus rows in the §6/9/10/11/13 tables that listed document types without Charter.
+- **In agent directives** (`CLAUDE.md`, `GEMINI.md`, `copilot-instructions.md`): an explicit trigger teaching the agent when to *suggest* a Charter, not only when to create one if asked.
+- **In skills**: new `/straymark-charter-new` (Claude, Gemini, agnostic versions). `/straymark-status` updated to list active Charters.
+- **In the CLI**: a `Charters` block added to `straymark status` output, so the agent running the command sees it among the initial signals.
+- **In templates**: moved to a dedicated subdirectory `dist/.straymark/templates/charter/`, no longer mixed with other templates.
+- **New document**: `SPECKIT-CHARTER-BRIDGE.md` (171 lines, EN/ES/zh-CN). Makes the bridge between SpecKit's `plan.md` and StrayMark's Charter explicit — the four criteria for a SpecKit feature to produce one or more Charters, the three cases where it doesn't apply, the four granularity heuristics, the `originating_spec ↔ originating_charter ↔ originating_ailog` frontmatter linkage.
+
+The epilogue of `SPECKIT-CHARTER-BRIDGE.md` records the case that originated the entire change without metaphor:
+
+> *"Cited the empirical context (issue #113): Greenfield Rust CLI/TUI suite, Claude Opus 4.7 onboarding via canonical entry points. Charters were eventually adopted (2 Charters: foundation + MVP) only after explicit user prompt — confirming the gap was systemic, not session-specific. This document removes the gap."*
+
+*The gap was systemic, not session-specific.* That sentence is the Issue's operational lesson. It wasn't a distracted agent one day; it was the framework that didn't speak to the agent about Charters in any of the places the agent was looking.
+
+---
+
+## 6. What I learned about structural visibility
+
+The lesson, written in prose and not in a table:
+
+Creating an artifact in a framework is not the same as making it visible to the agents that work in repos of that framework. They're two steps. The first — schema, command, template, examples — is the visible step: it shows up in the CHANGELOG, ships in the release, appears in `git log`. The second — anchoring the artifact on every surface where the agent enters the repo — is invisible: nothing about the second step appears as a *feature* in itself; it's cross-references, lines in checklists, items in outputs, sections in docs. But the second step is what decides whether the first one exists for the agent.
+
+The framework governs agents that read the repo from outside the session where the artifact was created. Each agent entering the repo builds its mental model from scratch, reading the canonical documents, the available skills, the status outputs. If the artifact isn't named there, it doesn't exist in the model. And a model without the artifact doesn't propose using it, doesn't audit its absence, doesn't flag related dissonances. The agent's technical capability is irrelevant if the repo's surface doesn't give it the right noun on entry.
+
+That's what I now call, internally, *structural visibility*. It isn't a property of the agent. It's a property of the repo, and by extension, a responsibility of the framework: every time it crystallizes a new concept, it has to multiply the surfaces where that concept is named. One single surface — the schema, the command, the template — isn't enough. There are nine, minimum, and they're the nine in Issue #113.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **Existing as an artifact isn't the same as being visible to the agent.** Charters had schema, command, template, examples — and were still invisible. The difference between the two states is the nine surfaces of Issue #113.
+
+2. **Six hours vs. five minutes.** A capable agent can spend hours not detecting what, once named, takes minutes to integrate. The asymmetry doesn't diagnose the agent; it diagnoses the repo.
+
+3. **Structural visibility is the framework's responsibility.** When it crystallizes a concept, it doesn't end with the command that creates it. It ends when the concept is named on every surface where the agent builds its model of the repo: canonical document, directive, skill, status, template, bridge to other frameworks.
+
+4. **Without structural visibility there is no emergent observation.** The properties that later made it possible for an agent to surface dissonances between sources — formal links + cultural permission — need, as a precondition, the artifacts to be visible from the first moment of onboarding. Issue #113 documents what happens when that precondition is missing.
+
+Next, in the following post: an episode adjacent to this one — *the rebranding to StrayMark* (`H-08`). Issue #113 was resolved in the same temporal arc as the rename from DevTrail to StrayMark, and they share something worth naming — the responsibility of a framework to declare its identity with clarity, both to its agents and to its adopters.
+
+---
+
+*Anchors: [Issue #113](https://github.com/StrangeDaysTech/straymark/issues/113) (opened 2026-05-07). [PR #122](https://github.com/StrangeDaysTech/straymark/pull/122) — `fw-4.12.0` (merged 2026-05-09). Document generated by the PR: [`SPECKIT-CHARTER-BRIDGE.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md).*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-09-the-rebrand-to-straymark.md
+++ b/website/blog/2026-05-09-the-rebrand-to-straymark.md
@@ -1,0 +1,145 @@
+---
+slug: the-rebrand-to-straymark
+title: The rebrand to StrayMark
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - rebranding
+  - governance
+  - identity
+date: 2026-05-09T00:00:00.000Z
+description: The fourth rename — this time with a public ADR and a disciplined arc
+---
+## 1. The rename that wasn't looking for the concept
+
+ADR `2026-05-08-001` opens with a sentence that, for anyone who read Post 2 of this blog, sounds out of place:
+
+> *"The decision is motivated by legal certainty over the trademark rather than by product strategy or user feedback."*
+
+The three renames of January (Chronicle → Monimen → DevTrail) were rushed searches for the concept. Each one ratified a distinct intuition about what the product was. None had an ADR; commit messages were all the documentary justification that existed.
+
+The fourth rename, the May one, is of a different nature. It doesn't come from looking for the concept. It comes from a trademark conflict investigation — commissioned via a Claude.ai web session in early May — which surfaced *"legal uncertainty about trademark ownership as the project gained adopters."* In January the project had zero adopters and renames could be improvised. In May the project had one adopter (Sentinel), 286 *crate* downloads, two open issues, and a public manifesto promising structured governance. The threshold for improvising another rebrand had already been crossed.
+
+This post covers three things: the disciplined decision made on 8 May, the operational arc of five PRs in forty-three minutes the following day, and the residuals that surfaced two days later. And, underneath all that, a subtler distinction: when a rebrand is purely surface, and when — without quite meaning to — it also changes identity.
+
+---
+
+## 2. The first disciplined rename
+
+What's new on 8 May is the form. This time there was:
+
+- **A prior investigation.** It wasn't decide-rebrand-then-justify; first a conflict was detected, then the decision followed from it.
+- **A public ADR.** Three alternatives explicitly considered (keep "DevTrail" and accept the trademark risk; hybrid branding with legacy + new in parallel; reset to v0.1.0 under StrayMark as "new project"). All three dismissed with literal argument.
+- **A temporal calculation.** The ADR itself frames the cost this way: *"The rename window narrows over time — every new adopter increases the cost of changing later... The legal risk dominates. Acting now, with one self-owned adopter, is materially cheaper than acting later under pressure."*
+
+The reason the calculation matters is structural. If the rebrand had waited two more months — until the second adopter showed up, or the third — the migration cost would have multiplied. Each adopter repo would have had to run `mv .devtrail .straymark`, update its `CLAUDE.md`/`AGENT.md`, regenerate its pipelines. With a single adopter (the operator himself), the cost was contained and reversible. What the ADR calls *"acting now is materially cheaper"* is exactly that: the rebrand was an exercise in minimizing future debt, not a marketing decision.
+
+There's an unintended echo with Post 2. That one closed with the line *"there probably won't be another rebranding."* This post, written from May, knows there was. The difference between promising and ratifying is that the fourth rename, unlike the first three, was forced by external circumstances no operator can foresee — a trademark conflict — and was faced with the discipline January didn't have.
+
+---
+
+## 3. *In scope*, *out of scope* — the ADR's masterpiece
+
+The ADR section that shapes the rest of this post is the one that distinguishes what gets renamed from what gets preserved. Cited literally:
+
+> *"In scope (the 'live state' of the project): all identifiers in source code, Cargo metadata, source-of-truth path, 30 skill/workflow files, public documentation, CI workflows, GitHub repository name."*
+
+> *"Out of scope (immutable history, preserved verbatim): all commits, commit messages, and git history; all tags published before this ADR; all release titles and bodies of releases published before; all prior CHANGELOG.md sections."*
+
+That distinction is the rebrand's armature. The *live* — paths, commands, URLs, release assets, README — is renamed in one stroke. The *historic* — git log, `devtrail-cli@3.10.0` tags, prior CHANGELOG sections, closed issues — is preserved literally. The project doesn't rewrite itself backwards.
+
+It's the same archival discipline that Post 3 documented for the Plan → Charter rename, now applied to the framework-wide operational rebrand. I lay it out as a table because it helps to see it:
+
+| Layer | Gets renamed | Gets preserved |
+|---|---|---|
+| Filesystem paths | `.devtrail/` → `.straymark/` | — |
+| Rust source | `devtrail-cli` → `straymark-cli` | — |
+| Skills/workflows | 30 files `devtrail-*` → `straymark-*` | — |
+| Public docs | README, CLAUDE.md, ADOPTION-GUIDE | — |
+| CI/CD | asset names, binary paths | Tag prefixes (`fw-`, `cli-`) untouched |
+| GitHub repo | `StrangeDaysTech/devtrail` → `StrangeDaysTech/straymark` | — |
+| CHANGELOG | New `fw-4.11.0` entry on top | Prior sections literal |
+| Published tags | — | `fw-4.10.0`, `cli-3.10.0`, etc. preserved |
+| Whole git log | — | Messages with "DevTrail" intact |
+| Legacy *crate* | — | `devtrail-cli@3.10.0` on crates.io, not *yanked* |
+
+Version continuity is the most visible proof. The next release wasn't `0.1.0` or `1.0.0`; it was `fw-4.11.0` and `cli-3.11.0`. The numbering declares, without metaphor, that the project is the same project.
+
+---
+
+## 4. Five PRs, forty-three minutes
+
+On 9 May, between 06:05 and 06:48 UTC, five PRs merged in a chain:
+
+| PR | UTC time | What it did |
+|---|---|---|
+| [#114](https://github.com/StrangeDaysTech/straymark/pull/114) | 06:05 | Merge of the ADR itself. Zero code changes — first you fix the decision. |
+| [#115](https://github.com/StrangeDaysTech/straymark/pull/115) | 06:42 | 174 *renames* + 74 modifications. Rust source (38 files), tests (18), `dist/.devtrail/` → `dist/.straymark/` (122 files via `git mv`), 30 skills × 3 platforms. |
+| [#116](https://github.com/StrangeDaysTech/straymark/pull/116) | 06:44 | Public docs in three languages (EN/ES/zh-CN). CHANGELOG preamble updated: *"StrayMark (formerly DevTrail; rebranded 2026-05-08)"*. |
+| [#117](https://github.com/StrangeDaysTech/straymark/pull/117) | 06:45 | Release workflows. Asset names (`straymark-cli-*`), release titles. Tag prefixes untouched. |
+| [#118](https://github.com/StrangeDaysTech/straymark/pull/118) | 06:48 | Bump `fw-4.11.0` / `cli-3.11.0`. New CHANGELOG section. |
+
+The order is deliberate and goes from outside in: first the law (ADR), then internal code, then what adopters see (docs), then distribution (CI), finally the consummated fact (release). This sequence has an archival reading: when someone six months out reviews `git log` chronologically, they'll first see the decision, then the implementation. Causality lives in the repo.
+
+It's worth naming a piece of the arc that broke the original plan. The ADR had contemplated nine distinct PRs (one per logical layer). In practice, the CLI tests depended on *hardcoded* paths — `include_str!("../../dist/.devtrail/...")` — and breaking the path without updating the tests at the same time left CI red. The plan compacted to five because the layers were technically coupled, not because the conceptual discipline failed. The PR #115 note records it without softening: *"The consolidation was forced by tight coupling: tests use `include_str!` on `dist/.devtrail/` paths."*
+
+Forty-three minutes for a rebrand that touched around two hundred sixty files. The pace is only possible because the ADR had closed every decision before code was touched. Framework principle #6 — *"when the proposal is well-written, implementation is execution, not design"* — found another validation case, similar to the external audit cycle one in Post 4.
+
+---
+
+## 5. Why StrayMark does change more than the name
+
+Up to here the ADR is clear: the rebrand is on the surface, the conceptual identity is preserved. But there's a nuance worth naming.
+
+PR [#120](https://github.com/StrangeDaysTech/straymark/pull/120) — merged hours after the main arc, the same 9 May — added the *"Why StrayMark?"* section to the README. It isn't code; it's a manifesto. And it says things no prior document of the project had articulated:
+
+> *"Code is just the fossil trace of a mental battle. Real engineering happens in the chaos of decisions, calculated risks, and the paths you chose not to take. Traditionally, all that human trail is discarded as stray marks (accidental smudges) in a project's history. At Strange Days Tech, we believe those marks are the signal, not the noise."*
+
+The name choice, viewed from the manifesto, isn't arbitrary. The *stray marks* — the erratic traces, the accidental tracks most projects discard — are exactly what the framework drags to the foreground: AIDECs, AILOGs, TDEs, Charters. What in any conventional project would be discardable noise is, in this project, the raw material of audit. The name embodies the product's thesis in a way *DevTrail* never did. *DevTrail* was a neutral path; *StrayMark* is a claim.
+
+The manifesto closes with three lines that later became what an editor would call an operational *tagline*:
+
+> *"Capture the noise. Weave the signal. Humanize the machine."*
+
+Here's the small interesting tension of the rebrand. The ADR says only the surface changed; the manifesto from the same day suggests the identity was also articulated — perhaps for the first time with clarity. It's not a contradiction: the moment of the operational rebrand was used to write down what was already in the project but hadn't been named yet. The identity didn't change. It became legible.
+
+---
+
+## 6. What was left undone
+
+Even with a public ADR and a disciplined arc, *"complete"* remains an approximation.
+
+Two days after the rebrand, while Sentinel was preparing its next external audit cycle, the agent surfaced three classes of residuals. The chronology — captured honestly in `CHANGELOG.md` as inline errata — is worth keeping visible:
+
+- **PR [#137](https://github.com/StrangeDaysTech/straymark/pull/137)** (11 May, 22:55) — *Orphaned skill directories*. The rebrand rewrote the `name:` field inside each `SKILL.md`, but didn't rename the directories of the three platforms (`.gemini/skills/devtrail-*`, `.claude/skills/devtrail-*`, `.agent/workflows/devtrail-*.md`). Thirty orphaned artifacts: new name, old path. Gemini CLI reported it as ten conflict warnings at startup.
+- **PR [#138](https://github.com/StrangeDaysTech/straymark/pull/138)** (11 May, 23:32) — *Legacy Charter paths*. Three framework artifacts still referenced `docs/charters/` after `fw-4.12.0` had migrated the canonical path to `.straymark/charters/`. Worst of all: the `pre-pr.sh` hook was gated on `[ ! -d docs/charters ]`, which made for a silent *exit 0* for any post-4.12.0 adopter. The drift check had been installed for seven months but was no-op.
+- **PR [#139](https://github.com/StrangeDaysTech/straymark/pull/139)** (12 May, 12:02) — *Broken installers*. `install.sh` and `install.ps1` still pointed to `REPO=StrangeDaysTech/devtrail`, `BINARY=devtrail`, asset name `devtrail-cli-v*`. The README — already rebranded — pointed to the new URL. Result: any user copying the README command from 9 May onward got a GitHub 404 running the installer. *The product was broken in production for seventy-two hours.*
+- **PR [#140](https://github.com/StrangeDaysTech/straymark/pull/140)** (12 May, 16:49) — *Micro-residual*. Line one of `.gitignore` still read `# DevTrail - .gitignore`. Plus a new entry for `Aparador/` in internal-dev patterns.
+
+The lesson isn't that the discipline was insufficient. It's that discipline *does not prevent* residuals — it makes them findable, documentable, and repairable in a public inline errata. The first three renames (January) probably had equivalent residuals; we never cataloged them because there was no documentary habit. The fourth rebrand cataloged them. It's the first project rebrand that admits, in the public repo and in the CHANGELOG itself, that the operator didn't catch everything on the first pass.
+
+The most uncomfortable detail — broken installers for seventy-two hours — is the one I most care to record. If instead of one solo adopter (the operator) there had been a team, that window would have hit real users. *Acting now, with one self-owned adopter, was materially cheaper*, says the ADR. That's exactly what the sentence was buying: the right to be wrong for seventy-two hours without hurting anyone.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **Not all renames are the same type.** The three of January were looking for the concept; the May one was defending the project against future legal debt. Only the May one could be done with a public ADR, because only the May one was born of external evidence and not internal intuition.
+
+2. **The surface vs. identity distinction belongs to the document, not to rhetoric.** The ADR itself declares what gets renamed and what gets preserved. That list — paths yes, git log no; release titles yes, prior tags no — is the rebrand's armature. Without that explicit list, *"rebrand"* means anything you want.
+
+3. **Identity can be made legible without changing.** The *"Why StrayMark?"* manifesto didn't invent what the project was; it articulated it clearly for the first time. The operational rebrand was used to write down what was already in the code but hadn't made it to the README. Identity wasn't rewritten — it was published.
+
+4. **Discipline does not prevent residuals; it makes them findable.** Four *errata* PRs two days later aren't a failure of the rebrand; they're evidence that the rebrand was honest enough to admit what slipped through. The three January renames probably had equivalents; they were never documented.
+
+Next, in the following post, an episode that connects directly with the last point: *TDE as a mechanism for naming transversal debt* (`H-09`). The first real case the framework used to articulate how to surface debt — and which left a hard lesson about stacked-PRs that deserves its own paragraph when we get there.
+
+---
+
+*Anchors: ADR [`2026-05-08-001`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-05-08-rebranding-straymark.md). Core arc: PRs [#114](https://github.com/StrangeDaysTech/straymark/pull/114) · [#115](https://github.com/StrangeDaysTech/straymark/pull/115) · [#116](https://github.com/StrangeDaysTech/straymark/pull/116) · [#117](https://github.com/StrangeDaysTech/straymark/pull/117) · [#118](https://github.com/StrangeDaysTech/straymark/pull/118). Manifesto: PR [#120](https://github.com/StrangeDaysTech/straymark/pull/120). Residuals: PRs [#137](https://github.com/StrangeDaysTech/straymark/pull/137) · [#138](https://github.com/StrangeDaysTech/straymark/pull/138) · [#139](https://github.com/StrangeDaysTech/straymark/pull/139) · [#140](https://github.com/StrangeDaysTech/straymark/pull/140). Release: `fw-4.11.0` / `cli-3.11.0`.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
+++ b/website/blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
@@ -1,0 +1,136 @@
+---
+slug: validate-and-schemas-as-a-formal-layer
+title: Validate and the schemas as a formal layer
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - validate
+  - schemas
+  - governance
+  - phase-2
+date: 2026-05-11T00:00:00.000Z
+description: 'Phase 2: when the framework starts to verify what it had been promising'
+---
+## 1. Having schemas is not the same as validating against schemas
+
+`straymark validate` had existed since 25 March 2026 — PR #27, part of the first arc of CLI Phase 1. What it did back then was small: verify that documents in `.straymark/` had valid Markdown syntax, parseable frontmatter, and the minimum fields of the correct type. It was useful. It was not *enforcement*.
+
+What changed on 11 May 2026, with the `fw-4.6.0 / cli-3.7.0` release, was something else: Phase 2 of the CLI roadmap closed a full arc of seven PRs (#73 to #79) and consolidated them into one (#80). The CHANGELOG says it without metaphor:
+
+> *"The first feature-bearing release since the repositioning... Phase 2 of `Propuesta/devtrail-cli-roadmap.md` lands as 7 bisect-safe PRs (#73–#79), grouped here for reviewers. The release closes the empirical loop the Sentinel experiment opened: telemetry at Charter close, drift detection at Charter close, and a canonical approval signal for `review_required: true` documents."*
+
+What matters for this post isn't the seven PRs as individual milestones; it's the three that touched the `validate` command and the schemas. What in March was *"I check that this looks like a document"* in May became *"I check that this satisfies the canonical schema of the type, in the mode you ask for, with concrete operational consequences"*.
+
+---
+
+## 2. From artisanal bash to a command flag
+
+One of the most visible pieces of the change is small: the `--staged` flag.
+
+Until Phase 2, the recommended pattern for adopters to validate their documents before a commit was a bash script called `pre-commit-docs.sh`. It lived in `dist/.straymark/scripts/` and had 464 lines. It did the reasonable thing: read `git diff --cached --name-only`, filter files in `.straymark/`, parse their frontmatter with `awk`, check fields. It worked. And it was 464 lines of bash each adopter had to trust executed the right thing, in the right version, with the right YAML parser.
+
+A PR on 28 March (commit `d9ea874`) replaced the 464 lines with a flag:
+
+```bash
+straymark validate --staged
+```
+
+Reads staged files the same, filters by `.straymark/` the same, validates the same. The difference: today all of that lives in Rust inside the binary, not in bash on disk. The adopter doesn't have to maintain the script; the script can't diverge between versions; the behavior is the same on Linux, macOS and Windows. The framework stopped asking the adopter to trust a loose script and started giving them a command with the implicit promise of a versioned binary.
+
+It's the same pattern Post 6 documented for archival discipline (preserve git history instead of rewriting) or Post 4 documented with decision A1 (orchestrate without invoking APIs): move from *"the operator does X manually with risk of divergence"* to *"the framework canonizes X in a declarative command"*. `--staged` isn't an exotic feature; it's manual debt swept away.
+
+---
+
+## 3. The three v0 schemas
+
+Phase 2 also consolidated the three schemas that live in `dist/.straymark/schemas/`:
+
+| Schema | What it describes | Origin |
+| --- | --- | --- |
+| `charter.schema.v0.json` | Structure of the Charter as a first-class entity (Post 4) | Sentinel `/plan-audit` (6 cycles, format v1 → v2 → v3) |
+| `charter-telemetry.schema.v0.json` | Charter telemetry (Post 3, extended in Post 10) | 5 `PLAN-NN.telemetry.yaml` files from Sentinel |
+| `audit-output.schema.v0.json` | Canonical output of external audit (Post 4 + Post 10) | Sentinel dual-audit (Copilot + Gemini + critical Claude) |
+
+Each schema carries a `$comment` field in its root. The one in `charter.schema.v0.json` says literally:
+
+> *"EXPERIMENTAL v0. Crystallized from Sentinel /plan-audit (6 cycles, format v1 → v2 → v3). Will not stabilize to v1.0 until validated in a second domain (frontend, ML pipeline, or infra-as-code)."*
+
+The one in `charter-telemetry.schema.v0.json`, similar:
+
+> *"EXPERIMENTAL v0. Derived from 5 PLAN-NN.telemetry.yaml files in Sentinel (one project, Go backend) — same N=1-domain caveat as charter.schema.v0.json. Will not stabilize to v1.0 until validated in a second domain."*
+
+The one in `audit-output.schema.v0.json`, idem:
+
+> *"EXPERIMENTAL v0.x. Phase 3 of the CLI roadmap. Crystallized from the dual-audit pattern validated empirically in Sentinel."*
+
+All three share an explicit declaration: *no crystallizes without a second domain*. It's framework principle #12, not as a separate paragraph in governance documentation, but **inside the JSON Schema itself, in a field any standard validator reads and any schema-explorer tool renders to the user**. The framework doesn't hide the provisional nature of its schemas; it puts it where nobody can miss it.
+
+This matters more than it seems. The usual practice in schema ecosystems (JSON Schema, OpenAPI, Avro) is to publish `v1` and then bump as things change. Marking `v0` with a `$comment` saying *"this is experimental until a second domain validates it"* is admitting, from the start, that the first crystallization isn't definitive. The schema itself is honest.
+
+---
+
+## 4. Three modes of the command
+
+`straymark validate` is no longer a command with one flow. After Phase 2 it has three operational modes, each coupled to a moment in the life cycle:
+
+- **`all` mode (default)** — `straymark validate` with no flags. Walks `.straymark/` recursively, parses each `.md` file, tries to resolve its type (AILOG, AIDEC, ADR, ETH, REQ, TES, INC, TDE, MCARD, SBOM, SEC, DPIA, Charter), applies the corresponding schema, and reports per-file violations. This is the *full audit* mode. Useful for CI, useful for reviewing a fresh repo, useful when an adopter wants to measure how much formal debt accumulated.
+
+- **`--staged` mode** — `straymark validate --staged`. The one that replaced bash. Only validates files `git diff --cached --name-only` reports as staged within `.straymark/`. Its natural home is `.git/hooks/pre-commit`, and since fw-4.6.0 there's a `straymark init --hooks` that installs it automatically. This is the *operational gate* mode — the one that prevents broken documents from reaching `main`.
+
+- **`--check-pending-reviews` mode** — `straymark validate --check-pending-reviews`. The subtlest of the three, and the one that justifies more paragraphs.
+
+Until Phase 2, a document the agent marked `review_required: true` in the frontmatter (an AIDEC with low confidence, an AILOG with high risk, etc.) sat waiting for *human approval*. But there was no canonical way to *signal* that approval. The operator read the document, mentally approved it, moved on. No structural trace of the approval. This was exactly Issue [#67](https://github.com/StrangeDaysTech/straymark/issues/67).
+
+`--check-pending-reviews` closes that hole. The command walks all documents with `review_required: true` and lists them with their `confidence`, their `risk_level`, their author (human or agent), and their date. Approval is a commit that changes `review_required: true` → `review_required: false` with human co-authorship in the commit message — and `validate --check-pending-reviews` stops listing the document. Approval is a *canonical signal*, not a verbal agreement with oneself.
+
+This is the piece that closes the agent's loop. The framework lets the agent create documents without prior human approval (Post 1, property #2: *"cultural permission without blocking control"*); but marks them for review when appropriate; and now has a command to list what's pending, with no escape hatch. No audit document gets lost silently.
+
+---
+
+## 5. Phase 2 closes the empirical loop
+
+The full CHANGELOG sentence is worth keeping because it condenses what the release means:
+
+> *"The release closes the empirical loop the Sentinel experiment opened: telemetry at Charter close, drift detection at Charter close, and a canonical approval signal for `review_required: true` documents (resolving issue #67)."*
+
+Three pieces that close an arc that started with the six-Plan experiment (Post 3):
+
+1. **Telemetry at Charter close** — the YAML block Sentinel filled by hand during the experiment became the validatable `charter-telemetry.schema.v0.json`.
+2. **Drift detection at Charter close** — the 145-line bash script (`check-plan-drift.sh`) became the `straymark charter drift` subcommand, integrated into the validate flow.
+3. **Canonical approval signal** — what the operator did mentally became a command with structural consequences: `--check-pending-reviews`.
+
+It's the pattern the blog has seen recur: every time the framework crystallizes a practice Sentinel was doing manually, it does it after empirically validating that the practice works. The difference this time is that **the command that verifies the crystallization is part of the package**. Before Phase 2, Sentinel had templates, declared schemas, and the implicit promise that documents followed the schemas. After Phase 2, there is a command that **checks**. It isn't a capability change; it's a guarantee change.
+
+---
+
+## 6. Principle #12, turned into a schema
+
+The philosophical piece of the post — and the one I most want on record — is this:
+
+The `$comment` of the three v0 schemas encodes a principle the framework had been declaring in prose since April. Post 4 named it like this: *"schema marked `v0` on purpose, not `v1`, because the framework's principle #12 says no schema crystallizes without a second domain validating it"*. Post 7 applied it to the TDE design: *"the framework validated principle #12 again: no schema crystallizes without a second domain"*. Post 10 applied it to Pattern 1 and Pattern 2: *"the document says so without shortcuts: the pattern is empirically validated in Sentinel. Wait for the second domain before crystallizing it higher"*.
+
+Phase 2 does something different. **It doesn't declare the principle; it writes it inside the schema itself, in a place any schema consumer is going to read.** The `$comment` isn't marketing; it's protocol. Any JSON Schema 2020-12 validator exposes it; any IDE that parses the schema shows it. It's the first time the framework formalizes the provisional nature of its formalizations.
+
+If I had to sum it up in one sentence: the framework validates what it has, knowing that what it has is provisional, and puts that in writing *in the place where validation happens*. Validating the provisional is discipline. Crystallizing prematurely and validating the crystallized is theology.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **Having schemas is not the same as validating against schemas.** The first step is declarative; the second is operational. Phase 2 did the second, not the first. The difference between the two framework modes — *"I have the promise"* vs. *"I have the command that checks it"* — determines whether the adopter can trust what's declared.
+
+2. **The "artisanal bash → command flag" pattern is structural.** `--staged` isn't an isolated feature. It's Phase 2's version of the same pattern Post 4 documented for the external audit cycle, that Post 10 documented for the chain-evolution CLI helpers: verbose imperative → readable declarative → versioned. Every time the framework sweeps a bash script for a flag, it raises a layer of guarantees.
+
+3. **`--check-pending-reviews` closes the agent's loop.** What Post 1 named as cultural permission without pre-approval completes here: the agent can create, but documents marked for review don't get lost — the command lists them until a human approves them with an explicit commit. Without that signal, the cultural permission of Post 1 would be negligence.
+
+4. **Declared provisionality > premature formalization.** The `$comment` of v0 schemas makes principle #12 protocol, not doctrine. Any tool that consumes the schema knows the formalization is provisional. It's the strongest structural honesty a young framework can have: validate what you have, without pretending what you have is definitive.
+
+---
+
+*Anchors: PR [#27](https://github.com/StrangeDaysTech/straymark/pull/27) — original `validate` version (March 2026). Phase 2: PRs #73 to #79 + PR [#80](https://github.com/StrangeDaysTech/straymark/pull/80) — `fw-4.6.0 / cli-3.7.0` (merged 2026-05-11). Schemas: `dist/.straymark/schemas/{charter,charter-telemetry,audit-output}.schema.v0.json`. [Issue #67](https://github.com/StrangeDaysTech/straymark/issues/67) — origin of `--check-pending-reviews`.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-12-tde-and-transversal-debt.md
+++ b/website/blog/2026-05-12-tde-and-transversal-debt.md
@@ -1,0 +1,160 @@
+---
+slug: tde-and-transversal-debt
+title: TDE and transversal debt
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - tde
+  - technical-debt
+  - governance
+  - git-workflow
+date: 2026-05-12T00:00:00.000Z
+description: >-
+  The type existed. The trigger didn't. And the stacked-PR lesson that came
+  along for the ride.
+---
+## 1. Zero TDEs across thirteen Charters
+
+Issue [#128](https://github.com/StrangeDaysTech/straymark/issues/128) opens with a disquieting asymmetry:
+
+> *"Sentinel adopter (primary, fw-4.12.0) created zero TDEs across 13 closed Charters despite ≥7 instances of transversal debt routed through parallel mechanisms."*
+
+Thirteen closed Charters. At least seven recognizable pieces of transversal debt — inherited from prior Charters, crossing modules, persisting between sessions. Zero TDEs. If the operator had been discussing quotas, the data wouldn't mean anything. But the operator was me and the adopter was the same project that empirically validates the framework. If Sentinel — the repo where the full framework was being used most aggressively — wasn't producing TDEs even once in thirteen tries, something was broken.
+
+What was broken wasn't the debt, which was being captured by other channels (`R<N> (new, not in Charter)` inside the AILOGs, entries in `follow-ups-backlog.md`). What was broken was that no criterion in the framework said *"this specific piece deserves TDE, not R<N>"*. The document type existed. The operational trigger didn't.
+
+This post covers the 11-12 May 2026 episode: how the missing trigger was diagnosed, how it was closed with four canonical criteria (`fw-4.13.0`), and how the PR chain that fixed the problem left behind, in passing, an operational lesson about stacked-PRs that ended up codified in the project's `CLAUDE.md`. It's the first blog episode where the framework fixes *two different things* in the same arc, and where the second is accidental.
+
+---
+
+## 2. The type existed. The trigger didn't.
+
+`TDE` — *Technical Debt Entry* — has existed in the framework since the January initial commit (Post 2 recorded it: it was on the list of eight original types in the v1.0.0 README). The template was there. The taxonomy field was there. The `06-evolution/technical-debt/` folder was there.
+
+What wasn't there was a sentence, somewhere in the canonical apparatus, that said *"create a TDE now"*. Issue #128 put it without softening:
+
+> *"Reading the adopter-facing docs (`AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `QUICK-REFERENCE.md`, `CLAUDE.md` autonomous rules), there is no clear trigger that says 'create a TDE now'. The trigger language exists for AILOG (creation freely), AIDEC (when alternatives considered), ETH (high risk PII), ADR (architectural decisions), but TDE is just listed as 'agent can Identify'."*
+
+*"Agent can identify."* Identify if you feel like it. An agent entering the repo reads that line, shrugs, and moves on to AILOG and AIDEC, which do tell it *when*. The defect is the same one from Issue #113 (Post 5): the artifact technically exists, but the canonical *surface* doesn't give the agent the verb needed to activate it. What makes this case different from #113 is the consequence. For Charters, not seeing them meant not using the new flow. For TDE, not seeing them meant something worse: transversal debt *was* being captured — but fragmented, with no consolidated view, no prioritization across artifacts, no `assigned_to` or `priority` field for a human reviewer to order it.
+
+The Issue cites that consequence with embarrassing detail, because it enumerates everything that wasn't happening:
+
+> *"No queryable 'all open technical debts' view at the document level. No `impact × effort` prioritization matrix per item. No `assigned_to` / `priority` fields surfaced to the human reviewer. Architectural debt that legitimately spans multiple charters (e.g., scope authorization gap heritage across modules) gets fragmented into per-charter R-numbers instead of consolidated into a single TDE."*
+
+Thirteen Charters' worth of debt fragmented into per-Charter `R<N>`. From the repo operator's point of view: no consolidated list, none explicitly named as inherited, no piece of debt prioritizable at project level. Everything was in the repo. None of it was in the place the repo builds for the humans coming in from outside to read it.
+
+---
+
+## 3. Four criteria for a piece of debt
+
+PR [#129](https://github.com/StrangeDaysTech/straymark/pull/129) (`fw-4.13.0`, merged 11 May at 19:38 UTC, exactly thirteen hours after the Issue was opened) closed the gap with a new section in `AGENT-RULES.md §3` titled *"TDE vs `R<N> (new, not in Charter)"*. The four criteria, literal:
+
+| Criterion | When it applies |
+|---|---|
+| **1. Heritage from a prior Charter** | The debt is literally inherited from the previous Charter (*strict heritage*) or reappears when following the previous Charter's pattern (*pattern propagation*). |
+| **2. Applies to multiple modules or Charter execution boundaries** | The debt crosses code modules *or* crosses execution boundaries between Charters (governance-trail debt). |
+| **3. Requires a dedicated Charter outside current scope** | Resolving it requires opening its own Charter, outside the current Charter's envelope. |
+| **4. Requires human prioritization/assignment** | Deciding priority or assignment is beyond the agent's range. |
+
+The operational rule: if a piece of debt satisfies *at least one* of the four criteria, it's a TDE. If it satisfies none, it stays as `R<N>` inside the Charter where it appeared.
+
+The four each have their logic. Heritage (1) captures debt that persists across time, which a reviewer would want grouped by origin, not by Charter. Multi-module or multi-Charter (2) captures debt that lives *between* artifacts, not *inside* one. Dedicated Charter (3) acknowledges that some pieces of debt are large enough to deserve their own cycle and therefore don't fit as risk declared *ex-ante*. Human prioritization (4) acknowledges the autonomy limit: there are decisions the agent can flag but can't resolve, and those decisions deserve a document where a human can queue up.
+
+The same PR added a new field to the TDE template's frontmatter — `promoted_from_followup: FU-NNN | null` — and a section in `FOLLOW-UPS-BACKLOG-PATTERN.md` documenting how to promote a follow-ups entry to a TDE. The promotion has two shapes, both recorded literally: promotion of an existing entry (a follow-up that had been on the list for weeks matures into a TDE) and *retropromotion at creation* (when the TDE is created, it's acknowledged it originated in a prior follow-up and noted). The frontmatter field closes the trail: any TDE can now point back to the follow-up that originated it, if one existed.
+
+---
+
+## 4. Three TDEs in Sentinel — the empirical loop closed
+
+Issue #128 didn't close by argument; it closed by evidence. The same day, Sentinel — the same adopter that had been through thirteen Charters without a single TDE — created three:
+
+- A TDE for a **RequireScope architectural gap**, heritage crossing modules. Criteria 1 + 2 + 3.
+- A TDE about **missing test coverage in the HTTP layer**, debt persisting across feature Charters. Criteria 1 + 4.
+- A TDE for **review of legacy AILOGs** predating Charter format v3, a piece needing its own cycle. Criteria 1 + 3.
+
+Three documents in hours. The speed matters less than the fact that each one applied *at least one* of the criteria and none landed in gray territory. The criteria worked as an unambiguous heuristic — the operator didn't have to negotiate with himself about whether a piece was TDE or `R<N>`. The empirical loop the Issue had opened in the morning closed with three documents that same afternoon.
+
+PR [#136](https://github.com/StrangeDaysTech/straymark/pull/136) (`fw-4.13.1`, merged the next day) refined two criteria based on that same experience. *Heritage* (1) was explicitly split into *strict heritage* vs *pattern propagation* because one of Sentinel's three TDEs showed the second case clearly: the debt wasn't literally inherited; it was the same pattern reappearing when the same procedure was followed. *Multi-module* (2) was reformulated as *"multiple modules **or Charter execution boundaries**"* because another of the three TDEs was governance-trail (crossing session boundaries without crossing code modules). The criteria grew one single refinement-pass after being exercised on three real cases. The framework validated principle #12 again: no schema crystallizes without a second domain.
+
+---
+
+## 5. The stacked-PR lesson
+
+This is where the post deliberately veers off. The PR chain #129 → #131 → #133 that closed Issue #128 left behind an adjacent operational lesson — not about TDE but about how *not* to stack branches. The lesson is documented literally in `CLAUDE.md` (lines 181-220) of the public repo under the section **"Stacked PRs — avoid, or use merge commits"**.
+
+### How it broke
+
+PR #131 (`cli-3.12.1`, validator fix that was rejecting `status: identified` on TDEs) was opened with `base = #129` because `#131` needed `#129`'s code to compile its tests. Then `#129` was merged to `main` with *squash*. The current `CLAUDE.md` describes it with a precision worth quoting in full:
+
+> *"When you stack PR B on top of PR A's branch (base of B is A's head, not `main`), and A is squash-merged to `main`, B's content gets stranded:*
+>
+> *— The squash merge of A creates a new commit on `main` with content equivalent to A but a different SHA than A's original commits.*
+>
+> *— B's branch still points at A's original commits, which now have no descendant on `main`.*
+>
+> *— When B is merged, GitHub merges it into A's branch (its declared base), not `main`. The 'merge to main' never happens — even though GitHub UI shows B as MERGED."*
+
+The practical result in the #129/#131 cycle: GitHub's UI showed `#131` as *MERGED*, the validator tests were ostensibly on main, but the content never arrived. PR #133 was the procedural sync that had to be opened later to carry the content to its destination. Time lost in diagnosis: about three hours. Time of the recovery operation once understood: five minutes.
+
+### How to prevent it
+
+The `CLAUDE.md` documents two strategies, one conservative and one pragmatic:
+
+> *"1. Sequential, not stacked. Wait for PR A to merge to `main`, then rebase B onto `main` and open B as a standalone PR with `base = main`. Slower but bulletproof.*
+>
+> *2. If you must stack, use merge commits (not squash) for the parent. A merge commit preserves shared history, so subsequent merges of stacked PRs into `main` resolve cleanly. Pay the cost of a noisier `git log` for the stacked-PR safety."*
+
+Sentinel and StrayMark default to squash. That choice is good for keeping `git log` clean, one decision per feature, one commit per PR. But it costs exactly this: incompatibility with stacked-PRs. The rule `CLAUDE.md` now codifies is honest: either don't stack, or pay in commit history to be able to stack. There's no third option that doesn't break something.
+
+### How to recover (if it already happened)
+
+The recovery section of the `CLAUDE.md` is the most operational piece of the document. Four steps:
+
+> *"1. `git checkout -b chore/sync-<B-content>-to-main main`*
+>
+> *2. `git cherry-pick <B's merge commit SHA>` — should be clean because B touches files outside A's conflict zone (which is why it could be stacked in the first place).*
+>
+> *3. Push, open PR with `base = main, head = chore/sync-...`. Cherry-pick produces a fresh commit on top of `main`, so no conflicts.*
+>
+> *4. The branch protection may require `--admin` merge if the content was already reviewed in B (the original PR) — sync PRs are purely procedural."*
+
+The last step is editorially important: explicit note that an `--admin` merge is authorized *only* for procedural PRs like this — where the content was already reviewed in the original PR. It's the only exception to the *"content goes through human review"* rule of the project.
+
+The reason it's worth registering the lesson as a sub-section of the TDE post — and not as a separate post — is that they share a trait: both are pieces of **transversal process debt** the framework now explicitly names. One is code debt (TDE as a new type); the other is workflow debt (stacked-PR as a documented anti-pattern). They share an origin: real operational friction was what triggered the document.
+
+---
+
+## 6. What the episode left in the repo
+
+Four PRs in under twenty-four hours, three recorded lessons:
+
+- **PR [#129](https://github.com/StrangeDaysTech/straymark/pull/129)** (`fw-4.13.0`, 11 May 19:38 UTC) — TDE activation trigger. Four criteria + new section in `AGENT-RULES.md §3` + FU → TDE path.
+- **PR [#131](https://github.com/StrangeDaysTech/straymark/pull/131)** (`cli-3.12.1`, 11 May 19:39 UTC) — validator accepts `status: identified` on TDEs. Without the fix, the first TDE created under the new trigger failed validation.
+- **PR [#134](https://github.com/StrangeDaysTech/straymark/pull/134)** (12 May 04:54 UTC) — the stacked-PR lesson documented in `CLAUDE.md`. It didn't change framework code; it changed the repo's operational rules.
+- **PR [#136](https://github.com/StrangeDaysTech/straymark/pull/136)** (`fw-4.13.1`, 12 May 04:54 UTC) — TDE trigger refinements based on Sentinel's three real cases.
+
+What I most want to flag about the chronology: `CLAUDE.md` (PR #134) was updated in the same arc that closed Issue #128. The stacked-PR lesson didn't wait to be forgotten. If the framework's discipline is *"every significant change leaves a documented trace"*, that applies to operational friction too, not only to design. The framework exists, in part, so expensive learnings don't evaporate.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **A document type without a trigger is an invisible type.** Same as in Issue #113, what the agent doesn't see on entering the repo doesn't exist for it. TDE existed technically from January, but only started being used when the four criteria appeared in `AGENT-RULES.md §3`. Structure without an activating verb is decoration.
+
+2. **Transversal debt deserves its own type.** Fragmenting debt into per-Charter `R<N>` destroys the most important property of a governance system: the consolidated view. Four criteria, any one is enough, holds the line between *this is risk of the Charter* and *this is debt of the project*.
+
+3. **Operational learnings get documented too.** PR #134 updated the project's `CLAUDE.md` the same day the lesson surfaced. It isn't archival paranoia; it's the same rule applied to process: if the friction cost you three hours today, write the lesson today.
+
+4. **The framework grows from features as well as from anti-patterns.** This episode left behind a new type (TDE as operational entity) *and* a documented anti-pattern (stacked-PRs incompatible with squash). Both are framework material, even if only one shows up as a version bump.
+
+Next, in the following post, a brief but structural episode: *"The Spanish audit-prompt was the outlier"* (`H-10`). An i18n convention detail that revealed which language had been the canonical one — and why fixing it changed, without meaning to, how the framework thinks about translation.
+
+---
+
+*Anchors: [Issue #128](https://github.com/StrangeDaysTech/straymark/issues/128). PRs [#129](https://github.com/StrangeDaysTech/straymark/pull/129) · [#131](https://github.com/StrangeDaysTech/straymark/pull/131) · [#134](https://github.com/StrangeDaysTech/straymark/pull/134) · [#136](https://github.com/StrangeDaysTech/straymark/pull/136). Releases: `fw-4.13.0` / `cli-3.12.1` / `fw-4.13.1`. Stacked-PR lesson codified in [`CLAUDE.md` lines 181-220](https://github.com/StrangeDaysTech/straymark/blob/main/CLAUDE.md) of the repo.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-13-the-audit-prompt-was-the-outlier.md
+++ b/website/blog/2026-05-13-the-audit-prompt-was-the-outlier.md
@@ -1,0 +1,87 @@
+---
+slug: the-audit-prompt-was-the-outlier
+title: The audit-prompt was the outlier
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - i18n
+  - audit
+  - governance
+date: 2026-05-13T00:00:00.000Z
+description: The only file in the framework that lived in another language
+---
+## 1. One line from the commit
+
+This is the post's operational opening. Commit `a8a1ac5` from 12 May 2026 carries a body that begins with this sentence:
+
+> *"The unified audit-prompt template at `dist/.straymark/audit-prompts/` was the only framework artifact whose canonical content lived in Spanish — every other template, skill, workflow, and governance doc follows the EN-canonical + `i18n/<lang>/` overlay pattern resolved by `cli/src/utils.rs:146`."*
+
+One single file. Among dozens. It lived backwards. And it had been living that way since May of the previous year, without anyone noticing.
+
+This post is deliberately short. The fix it covers — PR [#142](https://github.com/StrangeDaysTech/straymark/pull/142), `fw-4.13.3` and `cli-3.12.3`, merged on 13 May — is not a major narrative milestone. It's a maintenance piece. But it records one of the regularities I keep running into in this craft: outliers are useful. They teach you the convention by contrast.
+
+---
+
+## 2. Where the outlier came from
+
+The audit-prompt wasn't born in the framework. It was born as a local *skill* of Sentinel's — `sentinel/.claude/skills/plan-audit/` — during the six-Plan experiment Post 3 covered, in April. It was a *context-specific* skill, written by the operator (me) in Spanish for reasons that can now be enumerated honestly: it was a private experiment, the operator speaks Spanish, and nobody was going to read the skill ever again. I improvised it in my language because it was for me.
+
+When the experiment crystallized into the framework — the fw-4.4.0 to fw-4.9.0 arc Post 4 covered — the skill was ported to the canonical path `dist/.straymark/audit-prompts/audit-prompt.md`. The port was mechanical: copy the file, generalize it enough that it didn't mention Sentinel-specific components, adjust the *Plan* → *Charter* nomenclature. What wasn't done: translate it to English. The file entered the framework *in the language it had been written in*. Without anyone deciding it, Spanish became the canonical version of that one artifact.
+
+The rest of the framework — every other template, every skill, the canonical governance docs — had been written in English since January, with Spanish and zh-CN as overlays under `i18n/<lang>/`. The audit-prompt was the silent exception, for six weeks, until 12 May.
+
+---
+
+## 3. How it was found: by visual inspection
+
+It wasn't emergent observation from the agent. The operator noticed it, visually. The CHANGELOG entry records it without metaphor:
+
+> *"Surfaced empirically when Sentinel audited the `straymark explore` rendering and the user noted that audit-cycle templates were ES while all other templates and skills were EN."*
+
+`straymark explore` is the framework's TUI — the interactive documentation browser Post 14 will cover. Its value is rendering all templates side by side, in the same view. And when all templates are side by side, one in another language is obvious. That's the observation.
+
+It's worth leaving the data because it matters for the blog's honesty. Post 1 articulated the pattern of *emergent observation* — an agent flagging something nobody asked it to flag — and Post 5 documented what happens when that pattern is missing because of *structural visibility*. This episode is neither. It's a more pedestrian observation: a new surface of the framework (the TUI) put all the files in simultaneous view, and the inconsistency became as obvious as when you tidy the bookshelf and notice one book is shelved with the spine backwards. Tools also produce visibility.
+
+---
+
+## 4. The fix: three moves in one commit
+
+PR #142 did three things in the same commit:
+
+- **`dist/.straymark/audit-prompts/audit-prompt.md`** rewritten in English as the canonical version. 312 lines. The translation took care to preserve the severity structure and calibration examples of the original.
+- **`dist/.straymark/audit-prompts/i18n/es/audit-prompt.md`** created as an overlay. 318 lines. It's the Spanish content that used to live in root, now in its correct place.
+- **`cli/src/commands/charter/audit.rs`** wired to the i18n resolver. Until then, the subcommand hardcoded the `dist/.straymark/audit-prompts/audit-prompt.md` path without consulting the adopter's `language` field in `.straymark/config.yml`. After the PR, it reads the project config and resolves the localized path — if the adopter has `language: es`, they get the Spanish overlay; if they have `language: zh-CN`, it falls back to EN canonical (there's no zh-CN translation of the audit-prompt yet); if they have `language: en` or don't specify, they get the canonical.
+
+Three new tests cover the three paths. Zero functional change for English users (who are the majority). For Spanish users, an improvement: before, they received the prompt in Spanish by accident (because the canonical path pointed to ES); now they receive it in Spanish by convention (because the resolver decides it).
+
+---
+
+## 5. The lateral move
+
+While doing the language switch, the operator took the chance to extract a specificity that had carried over from the Sentinel origin. The §Step 5 section of the prompt — about severity calibration of findings — cited a literal case from the April experiment: *"Etapa 12 Pub/Sub stub vs gochannel"*. A perfectly didactic example, but specific to a Sentinel component no other adopter would recognize.
+
+The English translation replaced that example with a vendor-neutral formulation: *"declared deferral, not a defect — a charter that introduces a thin adapter slated for replacement in a future Charter"*. The idea — a *stub* that is declared debt, not a defect — is preserved. What goes is the component's name.
+
+The move is small but coherent with the blog's principle. When there's an opportunity to detach the framework from a specific adopter without losing pedagogy, take it. It's the same generalization operation Post 3 documented for the six Plans and Post 4 for the first Charter: empirical content stays *in* Sentinel; what enters the framework is the vendor-neutral abstraction. The audit-prompt, almost a year later, finally finished honoring that rule.
+
+---
+
+## 6. Closing
+
+Three short claims:
+
+1. **In a framework with a convention, a single file violating it is a sign of legacy, not of design.** The audit-prompt was the outlier because it was born earlier, and nobody migrated it when the other artifacts aligned. Outliers accumulate provenance.
+
+2. **New tools produce visibility.** The ES → EN switch wasn't decided by systematic repo review. It was decided because a new TUI put all the templates on the same screen and the inconsistency became obvious. The same applies to `grep`, to aggregate views, to `status` outputs: every new surface exposes what was misaligned.
+
+3. **Small rebrands are opportunities to de-identify.** When you touch a file to change the language, the marginal cost of also extracting the adopter specificity left from origin is zero. The blog has recorded this pattern before (Plan → Charter, DevTrail → StrayMark); this is the miniature version. The framework becomes more vendor-neutral one file at a time.
+
+Next, in the following post, an episode that already brushed Post 1 but deserves its own treatment: *"Manual discipline before the pattern"* (`H-11`). How Sentinel handled `CHARTER-18` before the `Pattern 1` of chain evolution existed — the empirical learning that Post 1 later named as meta-pattern.
+
+---
+
+*Anchors: PR [#142](https://github.com/StrangeDaysTech/straymark/pull/142). Releases: `fw-4.13.3` / `cli-3.12.3`. Key commit: `a8a1ac5`. Files: `dist/.straymark/audit-prompts/audit-prompt.md` (EN canonical) + `dist/.straymark/audit-prompts/i18n/es/audit-prompt.md` (overlay). CLI: `cli/src/commands/charter/audit.rs` wired to the i18n resolver.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-14-manual-discipline-before-the-pattern.md
+++ b/website/blog/2026-05-14-manual-discipline-before-the-pattern.md
@@ -1,0 +1,144 @@
+---
+slug: manual-discipline-before-the-pattern
+title: Manual discipline before the pattern
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - speckit
+  - discipline
+  - governance
+date: 2026-05-14T00:00:00.000Z
+description: >-
+  Twelve learnings in an Issue, three gates in a PR, and a Charter that closed
+  cleanly before the name existed
+---
+## 1. The right question
+
+[Issue #150](https://github.com/StrangeDaysTech/straymark/issues/150), opened on 14 May at 16:59 UTC, wasn't looking for a *yes/no*. What the operator was asking was for the question to be reframed:
+
+> *"The real question the bridge doc should address is how, not whether: what discipline ensures spec stays in sync with code during multi-Charter execution without the regeneration step lying about the parts that already shipped."*
+
+The discipline already existed. It was being applied in Sentinel at that very moment, on `CHARTER-18`, by hand, with the feeling that any false step would bury the work of six previous Charters. What was missing — what the Issue documented with uncomfortable precision — was the name. The *when*. The rules a future adopter could follow without going through the pain of inventing them.
+
+This post covers the five hours between that Issue and the PR that canonized the discipline as upstream governance, the 12 empirical learnings that justified the canonization, and the concrete operational episode — Sentinel's `CHARTER-18` — that exercised the pattern before the pattern existed. The next post will cover what came 27 hours later: the name.
+
+---
+
+## 2. Seven Charters on the same plan
+
+Context, in one line: Sentinel executed `specs/002-commshub/plan.md` — written in commit `be29421` on 21 April 2026 — through **seven consecutive Charters** (`CHARTER-07` through `CHARTER-17`), one calendar month, without refreshing the plan once.
+
+The original plan was good. It was carefully written, with four user stories (US1-US4) detailed, the data-model declared, the contracts sketched. But the plan was a snapshot of how the operator imagined, back in April, the code would behave. Execution discovered things the plan couldn't have anticipated:
+
+- Infrastructure patterns that appeared *during* execution and turned out to be reusable (a namespace in `core.processed_events`, a `withRLS` helper, PL/pgSQL triggers for invariants).
+- Code gaps the plan assumed resolved (`AnomalyDetector` *half-built*, missing idempotency dedup, `Recipient.TenantID` schema gap).
+- Charter/audit patterns that crystallized over the month (cross-family audit cycle, HTTP layer test coverage gap, cursor pagination with strict-greater-than).
+
+When the time came to plan `CHARTER-18` for US5, the plan was a month old and the code had a month of empirical learning on top. The two weren't in sync. And `SPECKIT-CHARTER-BRIDGE.md` — the framework document that would normally answer *"what do I do here?"* — was silent on the case. The rule *"how spec stays in sync with code during multi-Charter execution"* didn't exist yet.
+
+---
+
+## 3. The twelve empirical learnings
+
+Issue #150 enumerates the twelve learnings that had accumulated without reflection in the plan. The literal table, grouped by type, is worth keeping in view:
+
+| # | Type | Learning |
+|---|---|---|
+| 1 | Infra pattern | `core.processed_events` with namespace `module='commshub'` is reusable — plan describes its own table. |
+| 2 | Infra pattern | `EnvSecretLoader` + Secret Manager projection (PRs #70/71) — plan describes direct access. |
+| 3 | Infra pattern | `withRLS` helper as single-source-of-truth for tenant isolation — plan doesn't anchor it. |
+| 4 | Infra pattern | FR-005 PL/pgSQL triggers as invariant enforcement — plan describes app-level checks. |
+| 5 | Code gap | `AnomalyDetector` *half-built* — plan implies functional. |
+| 6 | Code gap | Idempotency dedup at `delivery_log` layer missing — plan implies coordinated. |
+| 7 | Code gap | `Recipient.TenantID` schema gap — plan references `tenant_id` as if it existed. |
+| 8 | Code gap | Per-tier rate limit overrides absent — plan says *"3-tier hierarchy"* without mentioning US1 implemented a uniform tier. |
+| 9 | Charter pattern | Cross-family external audit cycle mandatory (6 consecutive) — plan silent. |
+| 10 | Charter pattern | HTTP layer test coverage gap — plan silent on test layering. |
+| 11 | Charter pattern | Cursor pagination tuple with strict-greater-than — plan silent. |
+| 12 | Charter pattern | Dispatcher interface-stable swap pattern — plan silent. |
+
+Four infrastructure patterns discovered or refined during execution. Four code gaps the plan didn't anticipate. Four Charter/audit patterns crystallized on the fly. Twelve pieces, in a single month, all real. The plan didn't have them. And the next Charter — `CHARTER-18` — was going to read the plan as if they didn't exist.
+
+The estimate the operator documented in the Issue is honest:
+
+> *"Estimated probability of ≥1 critical/high finding from stale-premise inheritance: ~50%."*
+
+Coin flip, in one word. Half of Charters started on a stale plan end with a critical finding a later audit cycle has to remediate atomically pre-close. And the other half escape only by luck.
+
+---
+
+## 4. Alternative 4: the discipline applied by hand
+
+What happened inside Sentinel, that same day, before the discipline had a name: the operator evaluated five concrete alternatives and chose the fourth. Sentinel's private AIDEC — `AIDEC-2026-05-14-001-speckit-plan-scope-limited-us5-refresh.md` — records the analysis without softening. I paraphrase it here because the detailed content lives in the private repo, but the structure of the reasoning is what matters:
+
+- **Alternative 1 — *"Read it as before"*.** Keep the plan stale and read it as the previous six times. Cost: pay the debt in a later audit cycle, ~50% probability of critical finding.
+- **Alternative 2 — Regenerate everything with `/speckit-plan`.** Risk: overwriting assertions about US1-US4 that the real code *doesn't* satisfy; the regenerator doesn't know the current state.
+- **Alternative 3 — Refresh in another PR without restrictions.** Same risk as Alt 2 plus review friction.
+- **Alternative 4 — Scope-limited refresh + 3 gates.** The chosen one.
+- **Alternative 5 — Defer CHARTER-18, do a refactor Charter first.** High calendar cost, marginal benefit over Alt 4.
+
+The fourth consisted of three concrete mechanisms:
+
+**First mechanism — *scope-limited prompt*.** Run `/speckit-plan` with an explicitly restrictive *prompt*: regenerate only Phase 7+8 corresponding to US5; leave US1-US4 byte for byte as they are, marked with `<!-- LOCKED: prior US shipped -->` comments the agent must respect. Without that explicit restriction, SpecKit's regeneration is destructive: it rewrites the whole plan, overwriting descriptions the real code already contradicts.
+
+**Second mechanism — *Gate (a): validation against code reality*.** An ad-hoc script, ~30 lines of bash + grep, that diffs each non-US5 entity in `data-model.md` against the real schema in `db/migrations/*.sql`, and each non-US5 endpoint in `contracts/*.md` against the actual handler signatures in `internal/modules/commshub/handler_*.go`. Any divergence blocks merge. The script exists in Sentinel's repo; it isn't elegant, it's operational. What the framework would canonize later as gate (a) was already there, as artisanal bash.
+
+**Third mechanism — *Gate (b): granular hunk-by-hunk review*.** Review `git diff` file by file, hunk by hunk, accepting no changes to *locked* sections without justification. The operator explicitly notes the expected friction in R1 of the AIDEC: if the agent regenerates more hunks than necessary, the human reviewer tires and the discipline collapses. Mitigation: hunks over 50 lines trigger P1 review.
+
+**Fourth mechanism — *Gate (c): two-PR split*.** The refresh is an independent PR, reviewed against **current code**. The Charter-fill that follows is another PR, reviewed against the already-refreshed plan. Don't mix the two reviews — because if they're mixed, the refresh's debt hides behind the new work.
+
+Four mechanisms. Applied manually, with no upstream documentation backing them. A single adopter (me), a single session, and the feeling the whole time of solving a case no one had solved before.
+
+---
+
+## 5. The result
+
+`CHARTER-18` closed the same day. The Charter Telemetry metrics, recorded literally in the closure YAML:
+
+- `estimation_drift_factor: 1.0` — the Charter finished exactly in the estimated hour range.
+- `pre_work.items_discovered_during_planning: 0` — no unexpected items appeared during planning.
+- `overall_satisfaction: 5/5` — the operator's best subjective calibration in the entire chain.
+
+More important than the metrics: `CHARTER-18` was the **first Charter in the chain of seven to close without a mid-flight remediation Charter**. The previous six had each needed, at least one, an atomic pre-close remediation to cover divergences between what was declared and what was delivered. CHARTER-18 didn't. The operator's closing statement, cited literally from the later `CHARTER-CHAIN-EVOLUTION.md`:
+
+> *"The SpecKit refresh from PR #76 eliminated most ambiguity that drove drift in prior Charters. No mid-flight remediation Charter required — the EC1..EC15 empirical-corrections inventory in research.md absorbed what would have been pre-execution risk into in-execution awareness."*
+
+The manual discipline worked. It didn't just close the Charter cleanly; it changed the nature of the risk. What used to be pre-execution risk (discovering divergences during Charter execution, remediating atomically) became pre-planning awareness (the `EC1..EC15` inventory enumerates the empirical corrections before declaring the Charter). The risk isn't eliminated; it's moved to a moment where it's manageable.
+
+---
+
+## 6. Four hours and forty minutes
+
+The chronology is worth keeping precise, because it's what the blog comes to record:
+
+- **14 May, 16:59 UTC** — Issue #150 opened. Twelve learnings enumerated, three gates proposed, probability analysis published.
+- **14 May, 21:39 UTC** — PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152) merged. `fw-4.14.3` shipped. *"Spec maintenance during multi-Charter execution"* added as a new section of `SPECKIT-CHARTER-BRIDGE.md` with the three gates canonized literally as framework governance. **Four hours and forty minutes** between the question and the upstream answer.
+
+What PR #152 documented as governance is exactly what the private AIDEC had applied by hand hours earlier. The three gates with the same names: validation against code reality (gate a), granular hunk-by-hunk review (gate b), two-PR split (gate c). Plus four heuristics of *when to refresh*: ≥3 closed Charters on the same plan, ≥4 weeks + ≥2 Charters, `R<N>(new)` count > 6, target US touches refined infra. Plus an explicit note on why NOT to re-run `/speckit-tasks` (because it destroys the `[X]` markers and the `*CHARTER-NN:* <sha>` annotations that form the historical trace). Plus a roadmap note mentioning a future `straymark spec-drift` CLI that would mechanize gate (a).
+
+Four hours. It's no exaggeration to say the framework wrote the guidance while the operator still had `git diff` open in another window. The discipline and its canonization were practically simultaneous. And that's worth recording because it's the reverse of the order the academic governance apparatus usually assumes: theory first, then practice. Here it went the other way. Practice first, while it hurt. Theory after, while the pain was still fresh.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **The pattern is born of the discipline, not the other way around.** The three gates of `fw-4.14.3` weren't designed in the abstract; they were *extracted* from a concrete operational episode, hours after being applied by hand. Governance is post-empirical when the framework respects the order.
+
+2. **Explicit probability is discipline.** *"~50% probability of critical finding from stale-premise inheritance"* isn't Bayesian precision; it's a public claim that forces the decision to be justified. Without that number, the question *"should we refresh?"* gets decided by intuition. With it, it gets decided by risk arithmetic.
+
+3. **Twelve learnings in thirty days is the actual cadence.** It's not noise capturable with *"let me read it later"*. It's empirical density the original plan couldn't have anticipated, and that destroys any long-range planning assumption. The cadence of agent-assisted development is this.
+
+4. **Four hours is not a record; it's a property of the process.** When the discipline is already being applied in one domain, canonizing it upstream is execution, not design. Same as we saw in Post 4 about the external audit cycle (*"five PRs in a day"*), same in Post 6 about the rebrand (*"forty-three minutes"*). The framework didn't invent the discipline; it extracted it and gave it a name.
+
+Next, in the following post, the last episode of the arc this blog came to tell: *"Pattern 1 + Pattern 2 — chain evolution"* (`H-12`). Twenty-seven hours after PR #152, the three governance gates crystallized as two named meta-patterns — *pre-declare refresh* and *amend-on-emergence* — with a telemetry schema and CLI helpers. It's the closing of the arc Post 1 opened from ahead.
+
+---
+
+*Anchors: [Issue #150](https://github.com/StrangeDaysTech/straymark/issues/150) (14 May 16:59 UTC). PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152) — `fw-4.14.3` (14 May 21:39 UTC). Canonized section: `SPECKIT-CHARTER-BRIDGE.md §"Spec maintenance during multi-Charter execution"`. CHARTER-18 metrics reported in `CHARTER-CHAIN-EVOLUTION.md` (fw-4.16.0). Private source paraphrased per `GUIA-EDITORIAL.md §7`: `AIDEC-2026-05-14-001-speckit-plan-scope-limited-us5-refresh.md` in Sentinel's repo.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-15-agents-md-as-a-universal-standard.md
+++ b/website/blog/2026-05-15-agents-md-as-a-universal-standard.md
@@ -1,0 +1,132 @@
+---
+slug: agents-md-as-a-universal-standard
+title: AGENTS.md as a universal standard
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - agents-md
+  - governance
+  - open-standards
+  - i18n
+date: 2026-05-15T00:00:00.000Z
+description: Four months between the intuition and the open standard
+---
+## 1. Four months between intuition and standard
+
+On 15 May 2026, at 19:05 UTC, PR [#155](https://github.com/StrangeDaysTech/straymark/pull/155) closed the framework as `fw-4.15.0 / cli-3.13.2`. What it brought is a single new file in the list of directives the CLI injects: `AGENTS.md`, at the adopter's repo root, parallel to the ones already there (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`).
+
+This would be trivial if it weren't for the fact that exactly four months earlier, on 27 January 2026, the project's first AIDEC — the one Post 2 covered with the typo'd-year anecdote — had declared:
+
+> *"AI agents (Claude, Gemini, Copilot, Cursor) process instructions equally well in any language, so translating their config files provides no functional benefit."*
+
+That sentence, written six hours after the project's *initial commit*, contained an intuition the framework had been operationalizing ever since: agents are a single technical audience. Config files (`CLAUDE.md`, etc.) stayed in English (while human documentation got translated into three languages) because the "AI agents" audience didn't benefit from translation. What was missing to close that intuition was giving it a single place to point at, without having to clone the file four or five times for each different vendor.
+
+This post covers exactly that: how `AGENTS.md` — an open standard donated to the Agentic AI Foundation in December 2025 — completed four months later the decision the first AIDEC had opened in January.
+
+---
+
+## 2. The fragmentation `AGENTS.md` resolves
+
+Between 2024 and 2026, while AI agent CLIs proliferated, each one invented its own instruction-file format:
+
+- Anthropic published `CLAUDE.md` with the first version of Claude Code.
+- Google adopted `GEMINI.md` for Gemini CLI.
+- GitHub established `.github/copilot-instructions.md` for Copilot CLI.
+- Cursor started with `.cursorrules` and later migrated to `.cursor/rules/*.md`.
+- OpenAI used another path for Codex CLI; Aider, Devin, Continue, Roo Code, Factory Droids, Sourcegraph Amp, Zed AI, Windsurf, Amazon Q each had their own.
+
+A StrayMark adopter using two or three of those CLIs had to maintain two or three copies of the same content, hand-synced, hoping none diverged. Up to `fw-4.14.x`, the framework acknowledged that fragmentation in its `straymark init` command: it injected into the five most common vendor-specific files. But the other ten or fifteen CLIs were left out. The adopter handled them by copying content by hand.
+
+In late 2025, the community of open-source projects producing agent CLIs did what gets done when a fragmentation becomes costly: they agreed on a standard. `AGENTS.md` at the repo root, read by everyone. The donation to the Agentic AI Foundation (Linux Foundation, December 2025) gave it institutional governance. The specification is deliberately minimal: a Markdown file, no imposed schema, in a predictable location. What each CLI does with that file is its own business; the canonical question — *"where is the agent configuration for this repo?"* — now has a single answer.
+
+By May 2026, the list of CLIs that read `AGENTS.md` includes (cited literally from the PR #155 body):
+
+> *"Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others."*
+
+Fifteen CLIs. Some still read *also* their vendor-specific files for historical compatibility. But all fifteen know to look for `AGENTS.md` first.
+
+---
+
+## 3. Adopt without killing your own
+
+The most interesting decision of `fw-4.15.0` isn't adopting `AGENTS.md`; that was inevitable once the standard had critical mass. What's interesting is *how*. The PR body articulates it without softening:
+
+> *"Parallel to CLAUDE.md / GEMINI.md: marker block points to STRAYMARK.md, with a minimum-viable body below for readers that cannot follow relative links."*
+
+Three key words: **parallel**, **marker block**, **minimum-viable body**.
+
+*Parallel* means `AGENTS.md` doesn't replace vendor-specific files. It coexists. The framework still injects `CLAUDE.md`, `GEMINI.md`, `.cursorrules` and the others. The reason is pragmatic: some CLIs (notably Cursor in its legacy version) require the full content to be embedded, not behind a relative link. Keeping the sibling files preserves that compatibility without each adopter having to wrestle with their specific CLI.
+
+*Marker block* is the convention the framework already used in the other vendor-specific files: an HTML-commented block between `<!-- straymark:begin -->` and `<!-- straymark:end -->` pointing to `STRAYMARK.md` as source-of-truth. Any `straymark update-framework` replaces only what's between those markers. Whatever the adopter wrote *outside* them — for instance, project-specific instructions — stays intact. The framework respects the adopter's file; it only governs its own section.
+
+*Minimum-viable body* is the concession to CLIs that don't follow relative links. Below the marker block, `AGENTS.md` carries a short body with the essentials: agent identity, review requirements, pre-commit checklist, regulatory frontmatter snippet, NIST AI 600-1 risk categories, observability rules, naming convention. It's enough for an agent that can't read `STRAYMARK.md` to operate correctly; it's insufficient to replace the canonical document. The asymmetry is deliberate: we want the agent to *want* to open `STRAYMARK.md`.
+
+The defensive CLI detail (`cli/src/commands/remove.rs:13`) closes the operational flank: `AGENTS.md` was added to `LEGACY_DIRECTIVE_TARGETS`. If an adopter loses their `.straymark/dist-manifest.yml` and runs `straymark remove`, the legacy fallback cleans `AGENTS.md` too instead of leaving it orphaned. It's boring housekeeping, but it's the difference between a framework that uninstalls completely and one that leaves debris.
+
+---
+
+## 4. No ADR
+
+It's worth naming an absence. The decision to adopt `AGENTS.md` did not get its own ADR.
+
+It's a deliberate contrast with Post 6's StrayMark rebrand, which did have a public `ADR-2026-05-08-001` with three evaluated alternatives and enumerated consequences. It's also a contrast with Post 12's Phase 2, which had a dense CHANGELOG entry with architectural justification. `fw-4.15.0` had only the PR body as documentary justification — a good body, with a clear argument, but not an ADR.
+
+Why? The operational answer: the decision was perceived as **additive**, not structural. Adopting an open standard that coexists with existing formats doesn't change the framework's model; it only extends it. There's no alternative whose dismissal would require formal justification: not adopting `AGENTS.md` would mean leaving fifteen CLIs out for aesthetic preference, and nobody had that argument to make.
+
+But there's a recordable lesson here. The blog has seen the pattern before — Phase 2 closes an empirical loop, the rebrand changes identity, Post 10's meta-patterns name what was already there — and in each case the question *"does this deserve an ADR?"* has a different answer. The operational rule the framework seems to have adopted, without naming it, is this: **an ADR is justified when the decision closes costly alternatives and leaves a record of those not chosen**. `fw-4.15.0` didn't close costly alternatives — it only added a layer. So the PR was enough.
+
+I leave it on the record here because it's worth acknowledging that not every change deserves an ADR, nor is every PR a historical document. Archival discipline has its own criteria.
+
+---
+
+## 5. Visibility for agents, two layers
+
+Ten days before `fw-4.15.0`, on 9 May, Issue [#113](https://github.com/StrangeDaysTech/straymark/issues/113) was closed — the episode Post 5 documented as *"Charters invisible to the agents"*. The operator had worked six hours with a capable, attentive agent, with the canonical onboarding apparatus loaded, and the agent had never proposed using a Charter. The conclusion that post canonized: *structural visibility* is the framework's responsibility, not the agent's property.
+
+`fw-4.15.0` covers the other face of the same problem.
+
+Post 5 was about **internal structural visibility**: how we ensure an agent already reading our repo discovers the framework's core concepts. PR #122's answer (Post 5) was to multiply the internal surfaces where Charter appears as a concept: `STRAYMARK.md §15`, `CLAUDE.md`/`GEMINI.md` directives, `/straymark-*` skills, `status` output, templates, the bridge to SpecKit. Nine internal surfaces.
+
+This post is about **external structural visibility**: how we ensure any agent entering the repo, whatever its vendor, finds the framework's apparatus. `fw-4.15.0`'s answer is to adopt the canonical meeting point the community chose. One external surface, read by fifteen vendors.
+
+Both layers share the same conceptual axis — *a technical artifact only exists for the agent if the surface names it* — but a different scope. Internal visibility guarantees the agent sees the Charters while reading `STRAYMARK.md`. External visibility guarantees the agent sees `STRAYMARK.md` when entering the repo. One layer without the other is incomplete.
+
+---
+
+## 6. What the adopter does when running `update-framework`
+
+The operational part of the release, cited literally from the CHANGELOG:
+
+> *"straymark update-framework brings the new template and injects AGENTS.md at the project root. The injection follows the same rules as every other directive target: it creates the file if absent, replaces the marker block on subsequent runs, and appends safely when the file pre-exists without StrayMark markers (very common in 2026 — many adopters already hand-maintain an AGENTS.md)."*
+
+Three important behaviors:
+
+1. **If it doesn't exist**, the CLI creates it with the canonical template.
+2. **If it already exists with StrayMark markers**, the CLI replaces only the content between markers.
+3. **If it already exists without markers** — very common in 2026, because many adopters were already writing their own `AGENTS.md` by hand — the CLI **appends its markers at the end of the file**, without touching what the adopter had written.
+
+It's the same archival respect the blog already documented in Posts 3 and 6: the framework governs *its section*, not the whole file. If the adopter wants to write project-specific instructions in their `AGENTS.md` — internal policies, naming conventions, instructions specific to a particular codebase — those instructions stay intact at every `update`. The StrayMark block lives within its small marked boundary, and updates within that boundary.
+
+The CHANGELOG note closes with a small operational warning worth recording: *"If your .gitignore excludes AGENTS.md, adjust it before update-framework so the injection lands in version control."* It's honest about edge cases the framework can't resolve on its own — the adopter's choice to ignore the file is sovereignty, not error.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **Four months between intuition and materialization is what it takes to close a loop well.** January's AIDEC carried the intuition — *"agents are a single audience"*. `fw-4.15.0` closed it with an open standard. Between the two, the framework iterated on vendor-specific archetypes until the universal substitute appeared. The early intuition was right; the timeline was what the ecosystem's maturation required.
+
+2. **Adopting an open standard doesn't require renouncing your own format.** `AGENTS.md` coexists with `CLAUDE.md`, `GEMINI.md`, `.cursorrules`. The decision isn't "one replaces the others" but "one joins the others when it contributes". The framework gains external visibility without losing compatibility with CLIs that require specific formats.
+
+3. **Not every change deserves an ADR.** The StrayMark rebrand closed costly alternatives and left a formal record of the discarded ones. `fw-4.15.0` only added a universal layer: no ADR would have enriched the decision. Archival discipline has operational criteria, not doctrines.
+
+4. **Visibility for agents operates in two layers.** The internal layer (Post 5, `fw-4.12.0`) ensures the agent sees the framework's concepts while reading the repo. The external layer (`fw-4.15.0`) ensures the agent enters the repo through the right door regardless of which CLI orchestrates it. One without the other leaves either capable agents reading in silence or disoriented agents with no entry point.
+
+---
+
+*Anchors: PR [#155](https://github.com/StrangeDaysTech/straymark/pull/155) — `fw-4.15.0 / cli-3.13.2` (merged 2026-05-15 19:05 UTC). Original AIDEC (Post 2): `.chronicle/07-ai-audit/decisions/AIDEC-2025-01-27-001-i18n-strategy.md` (commit `7b7193e`, ID with typo'd year). Injected template: `dist/dist-templates/directives/AGENTS.md`. Standard specification: [agents.md](https://agents.md) — donated to the Agentic AI Foundation (Linux Foundation), December 2025.*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-15-opening-the-framework.md
+++ b/website/blog/2026-05-15-opening-the-framework.md
@@ -1,0 +1,132 @@
+---
+slug: opening-the-framework
+title: Opening the framework
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - i18n
+  - cla
+  - governance
+  - opening
+date: 2026-05-15T00:00:00.000Z
+description: Seventy-two hours of gestures that only make sense together
+---
+## 1. Two gestures in seventy-two hours
+
+On 13 May 2026, at 06:20 UTC, `fw-4.13.4` merged. It closed two small i18n coverage gaps — the ISO-25010 reference document that was only in English, and the Charter template that was missing in Simplified Chinese. Twenty-two canonical framework files reached structural EN/ES/zh-CN parity.
+
+On 15 May, at 00:14 UTC, sixty-five hours later, PR [#154](https://github.com/StrangeDaysTech/straymark/pull/154) merged. It added a badge to the README — the CLA Assistant one, that small visible square that tells the visitor the repo accepts contributions under a Contributor License Agreement. The CLA policy had existed for months already in `CONTRIBUTING.md`; the only thing that changed was that it now appears in the README at first glance.
+
+This post covers the two gestures. Seen separately, they're small — one completes the last 5% of a technical job, the other publishes something that was already there. Seen together, they're the moment the framework decides to present itself to the outside. The piece an open-source project does when it stops talking to itself and starts talking to whoever wants to read it.
+
+---
+
+## 2. The last 5% of i18n coverage
+
+`fw-4.13.4` isn't a big release. PR [#144](https://github.com/StrangeDaysTech/straymark/pull/144) has 511 addition lines and almost all are translations. But the PR summary says something worth recording:
+
+> *"Brings governance docs to full 20/20/20 parity across EN + ES + zh-CN."*
+
+Twenty over twenty over twenty. Twenty-two canonical files in `dist/.straymark/00-governance/` (the count grew later; in May it was twenty), all with their counterpart in `i18n/es/` and `i18n/zh-CN/`. Full parity, not approximate.
+
+The two files that closed parity are specific:
+
+- `ISO-25010-2023-REFERENCE.md` — the normative reference to the international software quality standard, cited from framework principles. Up to `fw-4.13.4` it existed only in English. The release added `i18n/es/ISO-25010-2023-REFERENCE.md` and `i18n/zh-CN/ISO-25010-2023-REFERENCE.md`, 150 lines each.
+- `charter-template.md` in zh-CN. The Charter template was already translated into Spanish; Simplified Chinese was missing, 211 lines.
+
+It's not glamorous work. It's the piece that closes a frame. But it matters for two things. First: until that release, a Chinese adopter cloning the framework was going to find essential templates in English only, which contradicts the promise that the framework is available in three languages. Second: the blog already documented in Post 8 that the framework's i18n coverage was nearly complete, with two minor gaps remaining as recorded debt. `fw-4.13.4` closed that debt. What looked like a side note in a post about the audit-prompt outlier turned out to be a release of its own, with its own CHANGELOG entry.
+
+---
+
+## 3. What gets translated and what doesn't
+
+There's an operational rule that PR #144 codifies explicitly and that's worth recording, because it's the framework's clearest rule on i18n:
+
+> *"LLM-processed assets (skills, workflows, schemas) stay EN-only; human-primary artifacts get translated."*
+
+That is: what AI agents read — skills, workflows in `.claude/`, `.gemini/`, `.agent/`, schemas in `dist/.straymark/schemas/`, prompts in `dist/.straymark/audit-prompts/` — lives in English only. What humans read — documentation, principles, contribution guides, templates with human-facing copy — gets translated into the three languages.
+
+It's the same principle Post 13 documented as the intellectual ancestor of the universal `AGENTS.md`: agents are a single technical audience that doesn't benefit from translation. What's recordable here is that the rule, in May, is written into a PR as an operational criterion, not as an intuition. Technical proposals cite it; reviewers use it to decide whether a new file goes into `i18n/` or not.
+
+One additional detail from PR #144 is worth recording literally:
+
+> *"docs/contributors/TRANSLATION-GUIDE.md gap was left intentional — its target audience already reads English to read the guide."*
+
+The translation guide stayed intentionally in English because its audience — contributors translating the framework into other languages — necessarily already reads English. It's operational honesty: 20/20/20 parity isn't 22/22/22 for every repo file. It's 20/20/20 for files whose translation adds user value. The difference between total coverage and applicable coverage.
+
+---
+
+## 4. The badge that introduced nothing new
+
+PR #154 is the pedagogical opposite of `fw-4.13.4`. Where `fw-4.13.4` closes technical work, PR #154 publishes something that was already there. Its 12 lines of change add exactly this to the README (in English, Spanish, and Chinese):
+
+```markdown
+[![CLA assistant](https://cla-assistant.io/readme/badge/StrangeDaysTech/straymark)](https://cla-assistant.io/StrangeDaysTech/straymark)
+```
+
+A badge. A small image that appears above the README, next to the other project badges (license, version, downloads). Visually unremarkable.
+
+But the badge isn't decoration. It's a signal. And the signal says something concrete: *"this repo accepts external contributions, and here are the rules"*. Any visitor who opens the README can click the badge and land at CLA Assistant — the service that automatically comments on any contributor's first pull request, asking them to sign the Contributor License Agreement. One signature covers all future contributions to the project.
+
+What matters is that the CLA, the `CONTRIBUTING.md`, the full review policy, all of that existed before PR #154. It was coded, alive, operational. The framework already accepted external contributions — it's just that the casual repo visitor had to open `CONTRIBUTING.md` to find out how it worked.
+
+PR #154 makes a distinction worth naming: **having the policy** and **publishing the policy** are two different things. The first is internal discipline; the second is a public invitation. Until 15 May, the framework had the policy. From 15 May, it publishes it.
+
+It's an editorial change, not an architectural one. But the day an open-source project decides to put the CLA Assistant badge above the README is the day it decides to formally present itself as adoptable by third parties. It's the moment the framework stops being a one-developer-and-its-adopter (Sentinel) project and becomes a project that *accepts* having more adopters, more contributors, more hands.
+
+---
+
+## 5. When a framework feels ready to be seen
+
+These two milestones, read together, record a specific moment in a young framework's life: the moment it feels ready to be seen by people who didn't write it.
+
+`fw-4.13.4` closes the technical promise. If the framework says it's bilingual Spanish-English with experimental Simplified Chinese support, the twenty-two canonical files must be in all three languages. Not nineteen out of twenty. Not twenty out of twenty-one with two pending. Twenty over twenty over twenty. Full parity is what makes the promise credible when the visitor checks.
+
+PR #154 closes the social promise. If the framework says it accepts external contributions, the CLA badge in the README is the industry-standard way of saying so. Without the badge, the openness exists but you have to discover it; with the badge, it's signposted. The visitor's first click finds the path.
+
+It's worth naming the asymmetry of the two gestures. Closing the last 5% of technical work costs exactly that — a dedicated release, two translated files, a CHANGELOG entry. Publishing a preexisting policy costs twelve lines of Markdown. The cheap one is sometimes the operationally most significant gesture, because it changes how the outside world perceives the project without changing anything about the project itself.
+
+It's the "opening the framework" version of the pattern Post 5 documented as *structural visibility*: what exists but isn't named, doesn't exist for the agent. Here: what exists but isn't published, doesn't exist for the external adopter. Seventy-two hours in May, two small milestones — one technical, one editorial — and the framework crosses the line between *"it works but whoever wrote it knows it"* and *"it works and anyone can see it"*.
+
+---
+
+## 6. Symbolic closing of the arc
+
+With this post, the blog covers the last pending milestones from the second batch that `RETOMAR-AQUI.md §5` listed after the closing of the main H-01 → H-13 arc. The four identified candidates — `H-?-C` (validate + schemas), `H-?-A` (universal AGENTS.md), `H-?-B` (full i18n coverage), `H-?-E` (CLA badge) — are all covered: three in their own posts (Posts 12, 13, this one) and one combined.
+
+What I learned writing the second batch, looking at the four milestones together:
+
+- **Phase 2 / validate** (Post 12) is structural: the framework starts to verify what it had been promising.
+- **TUI explore** (Post 11) is about visibility: the framework becomes navigable.
+- **Universal AGENTS.md** (Post 13) is about reach: the framework becomes discoverable by any CLI.
+- **Full i18n coverage + CLA badge** (this post) is about opening: the framework becomes visible to the external visitor.
+
+Each one covers a distinct dimension of the same idea, which the blog already encoded in earlier posts: what a framework says it is isn't enough for it to be; it has to be present on every surface where someone — agent, external adopter, visitor — can build a model of the project. The second batch's milestones are the mature version of the *structural visibility* Post 5 named with a governance Issue.
+
+Now, after Post 14, there are no more candidates in the queue. If new framework milestones emerge between today and when the blog's next session activates, RETOMAR-AQUI will be used again as the resumption point. If none emerge, this post is the real closing — the closing that completes the inventory the blog set out to cover.
+
+---
+
+## 7. Closing
+
+What I took from the process, in four claims:
+
+1. **Total coverage costs little at the end of the work and a lot at the beginning.** The last 5% — those two files in Chinese — is a dedicated release. But it's only trivially closable because the other 95% was already done. 20/20/20 parity isn't born at the start; it's pursued for months and closed at the end with a small PR.
+
+2. **Having a policy and publishing it are two different things.** The framework's CLA existed months before the badge. Twelve lines of Markdown turned an internal policy into a public invitation. The day you put the badge you invent nothing; you declare you're ready to be found.
+
+3. **The operational rule of what gets translated is archival.** What humans read gets translated; what agents read lives in English. That distinction, intuited from January's first AIDEC, became an explicit review criterion in May. Every new framework file passes through that question before choosing its destination.
+
+4. **When a framework becomes adoptable by third parties is a decision, not a state.** There's a day when the operator decides the framework can be seen without embarrassment by people who didn't write it. That day materializes in small gestures — completing translations, publishing the badge — that don't change functionality but change posture. The framework stops talking to itself.
+
+With this the blog closes the second batch. The arc that started retroactively with the project's prehistory (Post 2, January) and completed with the meta-patterns (Post 10, May) now also has its corollary: the milestones that made the framework adoptable. Fourteen posts, twenty-eight files (fourteen ES + fourteen EN), between twenty-five and twenty-six thousand words per language. As the closing of Post 10 said: *the blog finishes telling the story. The framework goes on*.
+
+---
+
+*Anchors: PR [#144](https://github.com/StrangeDaysTech/straymark/pull/144) — `fw-4.13.4` (merged 2026-05-13 06:20 UTC, full i18n coverage). PR [#154](https://github.com/StrangeDaysTech/straymark/pull/154) — CLA Assistant badge in READMEs (merged 2026-05-15 00:14 UTC). Full policy: `CONTRIBUTING.md` (repo root + translations in `docs/i18n/{es,zh-CN}/CONTRIBUTING.md`).*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*
+
+*— End of the second batch of the StrayMark blog.*

--- a/website/blog/2026-05-16-emergent-observation-design.md
+++ b/website/blog/2026-05-16-emergent-observation-design.md
@@ -1,0 +1,123 @@
+---
+slug: emergent-observation-design
+title: The day the agent saw something nobody asked it to see
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - ai-agents
+  - governance
+  - emergent-design
+  - charter
+  - sentinel
+date: 2026-05-16T00:00:00.000Z
+description: Naming a design property that was already silently doing its job
+---
+> *"Hi, did we already deal with Issue #153?"*
+
+That's how the conversation started, today, May 16th, in the morning. A short, almost-housekeeping question, before getting into something else. The answer was no — Issue #153 was open on purpose, waiting for a second domain to exercise the mechanic before crystallizing it (StrayMark's Principle #12: validation against a second domain before canonization). But the question opened another door, and by the end of that conversation I had codified a design property of the framework that had been doing its job in silence for months, surfaced by an episode from just two days ago.
+
+This post is the reconstruction of that arc, because it's worth keeping. Not for the outcome — a new canonical doc, a Principle #8, a PR already merged — but for the mechanism it revealed. StrayMark has a human project behind it: making sure that agent-assisted development doesn't slip through the fingers of the engineers who are responsible for the software being produced. And this episode exposed a concrete design property pushing in that direction.
+
+A note on craft: StrayMark gets tested first on my own projects. Sentinel is one of them — private, but its interaction with StrayMark is documented in the public Issues of the StrayMark repo, so the context is linkable. I'm the author and first adopter of the framework. Principle #12 obliges me to wait for a second domain before declaring any new mechanic canonical; but the first domain is me, and this post acknowledges that without disguise.
+
+## The incident: an agent that flagged what nobody asked it to flag
+
+On **May 14, two days ago**, in Sentinel, an agent brought to my attention an observation I hadn't requested. It was about to help me fill out CHARTER-18 — a concrete piece of work inside an already-long chain — and before writing a single line of code it said, in essence:
+
+> *(translated from the original in Spanish)* There's a problem. The `specs/002-commshub/plan.md` was frozen on April 21. Since then seven consecutive Charters have passed, and across the AILOGs of that chain there are twelve empirical learnings unreflected in the plan that materially affect the scope of US5. If we fill out CHARTER-18 reading the stale plan, the next audit cycle is going to remediate divergences atomically pre-close — with approximately 50% probability of at least one critical or high finding from stale-premise inheritance.
+
+And it cited the specific AILOGs by ID. And the concrete code references.
+
+Nobody asked for that analysis. There was no trigger configured. There was no CLI command whose purpose was to produce that output. The agent was there to help me with the next task, not to audit the project's state. But while positioning itself for that next task, it saw a divergence between two sources that StrayMark's documentation explicitly connects, and it chose to flag it before proceeding.
+
+I filed Issue [#150](https://github.com/StrangeDaysTech/straymark/issues/150) that same afternoon as an RFC, and between 5pm and the night the manual spec-refresh discipline got discussed and landed in `fw-4.14.3`. The next day, **May 15**, I raised Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156) to upstream the two patterns the exercise had revealed: a *pre-declare SpecKit refresh* and a *post-close Batch N.4 amendment*. By the early hours of **May 16** they were canonized in `fw-4.16.0` as `CHARTER-CHAIN-EVOLUTION.md`, with dedicated telemetry and a CLI helper (`straymark charter refresh-suggest`). The behavior reproduced, the patterns crystallized, cycle closed.
+
+But when I sat down that same morning of the 16th to open the conversation with Issue #153 — *"did we deal with this?"* — and then bounced back the inverse question — *"hold on, what made that observation possible in the first place?"* — I realized the cycle had only half closed. What got codified in `fw-4.16.0` was the **application** of the pattern. What remained to be codified was the **mechanism** that produced it.
+
+## The human question, said with technical words
+
+I phrased it like this, in the conversation with the agent that generated this post:
+
+> *(translated from the original in Spanish)* I was somewhat surprised by the agent's behavior — that it noticed the accumulated knowledge that, if not applied, would cause problems with the implementation of Charter 18. That is, it wasn't a task I asked it to analyze, nor was it the result of a prompt trigger being activated, and it seems to me that it was thanks to the StrayMark documentation. I'd like to dig deeper into how this happened, which I think is positive, so that we can take advantage of the experience and hook it into StrayMark's habitual behavior — this emergent pattern that came from the agent and its relationship to the generated documentation was very interesting.
+
+What I'm asking there isn't to implement a feature. It's to understand a mechanism in order to reproduce it. The difference matters. When you ask to implement something, the path is clear: spec → tasks → code. When you ask to understand why something worked, the path is rarer: you have to diagnose a working system, identify which pieces made it work, and separate the accidental from the structural.
+
+There's a particular urgency to this kind of question when you're building tools to collaborate with AI agents. Because if what worked was an accident, the next agent — or the next version of the same agent — may not reproduce it. If what worked was structure, then it can be preserved deliberately. The difference between those two things, for a project that intends to give engineers control over AI-assisted development, is the difference between luck and design.
+
+## The audit: which pieces of StrayMark made the observation possible?
+
+I asked an agent to systematically map StrayMark's documentation with three concrete questions:
+
+1. Which documentary mechanisms connect sources explicitly to each other? (Frontmatter, canonical sections, stable IDs, CLI commands that cross sources.)
+2. Where does the documentation give the agent *explicit permission* to flag things beyond the task asked?
+3. What pairs of sources exist, beyond the one that originated this case, that could produce similar emergent observations if the infrastructure is present?
+
+The report came back structured, with file:line for each finding. What mattered wasn't the individual details (frontmatter with `originating_charter:`, sections `§Risk: R<N>`, conventions of stable IDs, commands like `charter drift`) but the pattern that emerged when seeing them together. Two properties consistently coexisted:
+
+**Property 1: mandatory structural cross-referencing.** Each document type has *required fields* and *canonical sections* that declare, in the document's own structure, which other documents it points to. When an agent reads an AILOG, it doesn't have to guess which Charter it belongs to — the `originating_charter:` tells it. When it sees a risk, it isn't an observation in free prose — it's an `R<N>` entry in a canonical, countable section. When the spec points to Charters, it does so formally; when Charters point to AILOGs, the same. It's an explicit linkage graph the agent can triangulate without creative work.
+
+**Property 2: cultural permission without blocking gatekeeping.** AGENT-RULES §6 tells the agent: *"Be Proactive — Identify potential risks, Suggest improvements when evident, Alert about technical debt"*. PRINCIPLES §2 tells it: *"Not hide relevant information"*. And critically, AGENT-RULES §3 gives it autonomy to *create* documents (AILOG, AIDEC, TDE) without operator pre-approval. The operator retains prioritization, not creation. The agent doesn't have to ask permission to flag something: flagging it is rule execution, not a value judgment.
+
+What's interesting is that neither property alone produces the behavior. If you only had formal linkage (Property 1) without cultural permission, you'd have a queryable corpus no agent dares to query proactively. If you only had cultural permission (Property 2) without structure, you'd have vague flags — *"I think something might be wrong somewhere"* — that operators can't act on.
+
+Combined, they produce something that deserves its own name: the agent externalized *"should I say something?"* as *"is there a canonical section where this fits?"*. If the answer is yes, flagging stops being an emotional decision and becomes mechanical execution. The cost of flagging drops because the destination — the canonical section — already exists.
+
+## Why this matters beyond StrayMark
+
+We're in a moment where AI agents can write code as fast as we think, and the question of how *not to lose control* of the process is genuinely urgent. It's not an apocalyptic question — it's an operational, craft-level question, asked by people who are building software right now and have to ship. The very pace of this episode is evidence: from the agent's diagnosis to the canonized meta-pattern less than **72 hours** passed. That speed is a gain, but it's also why visibility mechanisms matter so much.
+
+The dominant response in the industry today is some variant of *stricter prompts, more rules in context, more gates in CI*. Those approaches are valid but have one characteristic worth naming: they turn the agent into something closer to a worker executing orders in verifiable pipelines. That solves reliability but at the cost of emergent observation. An agent that only does what it's ordered to do isn't going to flag something nobody asked it to flag, no matter how good its reasoning.
+
+What the Sentinel episode showed is a different, complementary response: **build the documentary apparatus such that important divergences are structurally visible, and give the agent cultural permission to flag them without asking approval.** That preserves emergent observation as a property of the system, not as luck depending on how good the agent is or how long the prompt is.
+
+There's something almost Taoist about this stance: we don't tell the agent what to look for; we build an environment where what needs to be seen is visible. The pair "visible structure + permission to name" does the work. The agent becomes, paraphrasing some colleagues, an *honest broker* between living documentation and the state of the code.
+
+And this is what the human project behind StrayMark pursues, even if it's rarely said in those words: that the dizzying change of AI-assisted development doesn't throw us into a world where engineers lose visibility over what's being built. Visibility isn't preserved with more bureaucratic controls; it's preserved by designing the environment the agent works in so that what matters is naturally visible. The engineer doesn't become a reviewer of endless Pull Requests — they become a prioritizer of observations the agent brings structured and named.
+
+## What we did about it
+
+With the diagnosis clear, the question was how to hook it into StrayMark's habitual behavior without killing the emergent quality. This tension is real: every time you turn a spontaneous behavior into an obligation, you turn it into something else. A hard rule can be robust, but it can also generate agent resistance or false signal when triggered out of context.
+
+The decision was conservative: **name the meta-pattern, don't mandate its use.**
+
+Concretely, in PR [#160](https://github.com/StrangeDaysTech/straymark/pull/160) released as `fw-4.17.0`:
+
+- A new canonical doc — `EMERGENT-OBSERVATION-DESIGN.md` — articulates the design property with its two components, presents the Sentinel empirical case as anchor, and builds a *pyramid of instances*: the meta-pattern at the top, and underneath all the applications already canonized (Pattern 1 and Pattern 2 of chain evolution; charter drift; follow-ups backlog drift; TDE-vs-`R<N>` escalation; external audit checkpoint). What previously seemed like ad hoc patterns reveal themselves as applications of the same underlying principle. This visualization alone is worth it: when you see seven things that seemed different and suddenly recognize they share a shape, the framework gains internal coherence without having added anything.
+
+- A new Principle #8 — *Cross-Source Dissonance Surfacing* — in `PRINCIPLES.md`. It's the cultural rule condensed in five lines. The agent reads it when onboarding into the project and applies it recursively.
+
+- An expansion of `AGENT-RULES.md §6 "Be Proactive"` with concrete examples of divergence to watch for: stale spec, accumulated `R<N>` not escalated to TDE, ADR contradicted by implementation, follow-ups crossing the backlog-pattern threshold, audit findings emerging post-close. They're not obligations; they're *examples of what a proactive agent would notice*. The difference matters for preserving the emergent quality.
+
+- Four open axes identified as gaps — places where the cross-referencing infrastructure exists partially but the pattern isn't named: MCARD ↔ deployed model code, SBOM ↔ lockfiles, ADR vigente ↔ contradicting implementation, Constitution Check ↔ framework version bump. Each one needs N=1 empirical validation before crystallizing — Principle #12 applies. They got recorded in Issue [#161](https://github.com/StrangeDaysTech/straymark/issues/161) as a tracking RFC, waiting for a second domain to push one of them.
+
+- Explicit anti-patterns: how the meta breaks. If a new document type ships with optional frontmatter linkage, cross-referencing develops blind spots. If a canonical section is replaced by free prose, queryability evaporates. If blocking gatekeeping is introduced into AILOG/AIDEC/TDE creation, the cultural permission breaks. If telemetry evolves without preserving signals like `r_n_plus_one_emergent_count`, the feedback loop breaks. These anti-patterns are cheap but effective protection against accidental erosion: any future change proposal can be checked against the list to detect whether it's regressing the meta-pattern.
+
+All of this, from diagnosis to merge and the published `fw-4.17.0` release, took place between 9am and 4am the same day. Fifteen hours. Which is exactly the kind of pace the blog admits: you have to learn to operate under this clock, or control slips away.
+
+## What I learned from the process
+
+Three things I didn't expect to learn when I started by answering *"no, Issue #153 is still open"*:
+
+**First, that codifying a meta-pattern is different from codifying a pattern.** The meta-pattern doesn't add obligations; it adds *vocabulary* and *visibility of the underlying property*. That property was already doing its job; what was missing was giving it a name to protect it under future framework evolution. Whoever reads `EMERGENT-OBSERVATION-DESIGN.md` doesn't learn to do something new — they learn to *recognize* something that was already there. That's what allows preserving it deliberately.
+
+**Second, that the emergent property disappears if over-regulated.** There was a moment in the conversation where I chose not to turn Pattern 1 into a hard obligation (*"the agent MUST run `refresh-suggest` before declaring Charter-(N+1)"*) and instead keep it as recommendation plus the naming of the meta. That decision is counterintuitive if you come from the world of *"more controls = more reliability"*, but it's the right call for this kind of property. Agent proactivity is fragile: the moment it becomes a mandate, it stops being proactivity. What scales is the cultural engine ("Be Proactive") plus the structural linkage, not the list of specific obligations.
+
+**Third, that the documentary apparatus we build for agents is also educating us humans.** When I saw the seven patterns scattered across various governance docs and recognized them as instances of the same meta, I understood something about StrayMark I hadn't understood before — and StrayMark is me building it over months. The framework is revealing things to its own author. That property — that structured documentation produces *insights about itself* when audited — is a domestic variant of what the agent does when it flags a divergence. It's the same mechanism, applied at a different scale.
+
+## The human project behind it
+
+I mean it when I say StrayMark has a human project. I'm not building a documentation governance framework because frontmatter fields obsess me. I'm building it because I have the suspicion — increasingly less speculative — that the next five years of software engineering are going to be a constant negotiation between the speed agents offer and the visibility engineers need to keep being responsible for the product. If that negotiation tilts to the agents' side, we end up in a world where code gets written and nobody knows why. If it tilts to bureaucratic control, we end up without the productivity gains that justified the experiment.
+
+The balance isn't theoretical. It's built with concrete decisions: where to put a frontmatter field, which section should be canonical versus free, when to give the agent autonomy and when to retain prioritization. Each of those decisions tilts the balance one way or the other. And the only way to know if the balance is right is to test it — and to name what works when it works, so it survives the next change in the framework.
+
+The CHARTER-18 episode, two days ago, was a test. It worked. What I wrote today was giving it a name. The next test already has candidates: MCARD, SBOM, ADR vigente vs implementation, Constitution Check ↔ framework bump. Four axes where the meta-pattern could reproduce if we close the infrastructure gaps. I'll wait for a second domain to push one empirically before codifying it. Principle #12 — validation against a second domain before crystallizing — remains the guardrail.
+
+If you're reading this and you work with agents to develop software, I invite you to look at your own documentary apparatus with these two questions: *which sources are formally connected, with explicit linkage an agent can triangulate without creative work?* and *how cheap is it for the agent to flag something not asked when it detects a divergence?* If the answer to the first question is "few" and to the second is "expensive", you're probably leaving emergent observations on the table. Which isn't the end of the world — but it's exactly what separates an AI-assisted development process *under human control* from one that slips away.
+
+---
+
+*StrayMark fw-4.17.0 — Issue [#150](https://github.com/StrangeDaysTech/straymark/issues/150) · [#156](https://github.com/StrangeDaysTech/straymark/issues/156) · [#161](https://github.com/StrangeDaysTech/straymark/issues/161) · PR [#160](https://github.com/StrangeDaysTech/straymark/pull/160) · tag [`fw-4.17.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.17.0)*
+
+*Co-authored by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*

--- a/website/blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
+++ b/website/blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
@@ -1,0 +1,191 @@
+---
+slug: pattern-1-and-pattern-2-chain-evolution
+title: Pattern 1 and Pattern 2 — chain evolution
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - chain-evolution
+  - governance
+date: 2026-05-16T00:00:00.000Z
+description: When discipline stops being habit and becomes name
+---
+## 1. Twenty-seven hours to name them
+
+PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152), which closed the Post 9 episode, merged on 14 May at 21:39 UTC. It brought `fw-4.14.3` and the three canonized gates of the manual refresh.
+
+PR [#157](https://github.com/StrangeDaysTech/straymark/pull/157) — the one this post comes to tell — merged on 16 May at 00:31 UTC. Twenty-seven hours later. It brought `fw-4.16.0 / cli-3.14.0` and, with that, two named meta-patterns:
+
+- **Pattern 1 — *pre-declare SpecKit refresh***. Refresh the spec before declaring the next Charter in a chain.
+- **Pattern 2 — *post-close audit-driven Batch N.4***. Amend an already-closed Charter when external audit surfaces findings post-close, without opening a new Charter.
+
+Post 9 covered the manually applied discipline on CHARTER-18. This post covers what came after: the two named patterns, the canonical document that names them (`CHARTER-CHAIN-EVOLUTION.md`), the telemetry schema that measures them, the two *CLI helpers* that scaffold them — and, as the closing of the entire editorial arc, one hour and seventeen minutes later, a philosophical meta-pattern that reabsorbs both upward.
+
+It's the last post of the arc. The blog Post 1 opened from ahead closes here from behind.
+
+---
+
+## 2. Pattern 1 — Pre-declare refresh
+
+The literal definition, copied from the canonical document:
+
+> *"A dedicated refresh PR lands between Charter-N close and Charter-(N+1) declare. It touches only the non-locked sections of the SpecKit artifacts (plan.md, data-model.md, contracts, quickstart.md, research.md)."*
+
+This is exactly what Sentinel did manually for CHARTER-18 in Post 9. The difference between Post 9 and Post 10 is one of kind: Post 9 documents the procedure; Post 10 documents its *conditional activation* — when the framework recommends to the adopter that Pattern 1 should be applied.
+
+The activation criteria are quantifiable, and the document names them without softening:
+
+- The module has **≥ 3 closed Charters** on the same spec.
+- The rolling mean (last 3 Charters) of the `agent_quality.r_n_plus_one_emergent_count` field in telemetry is **greater than 6**.
+- No *refresh PR* has landed since the last *branch point*.
+
+The `> 6` threshold isn't arbitrary. It's Sentinel CHARTER-18 turned into a rule: the average of emergent findings (risks discovered during the Charter that weren't declared in the original plan) during CHARTER-15, 16, 17 was exactly what triggered the feeling that the spec was accumulating too much debt. The framework, instead of asking the adopter to trust intuition, gives them a number their telemetry can compare against.
+
+What Pattern 1 produces, when applied:
+
+- A categorized table in `research.md` that enumerates what was discovered in prior Charters into four types: *reusable patterns*, *code gaps*, *discipline patterns*, *empirical corrections*.
+- Explicit operational decisions (`D1`, `D2`, etc.) if categorization shows trade-offs.
+- Citations in the next Charter's `§Context`, by `id`, pointing to the integrated items.
+- An opt-in `pre_declare_refresh:` telemetry block in the `charter-telemetry.yaml` of the Charter receiving the refresh.
+
+The metric that holds the pattern up comes from Sentinel CHARTER-18 itself, cited literally in `CHARTER-CHAIN-EVOLUTION.md`:
+
+> *"Sentinel CHARTER-18 was the first Charter in a 7-Charter chain to close cleanly without a mid-flight remediation Charter. `estimation_drift_factor: 1.0`, `pre_work.items_discovered_during_planning: 0`, `overall_satisfaction: 5/5`."*
+
+One single domain. `N=1`. The document says so without shortcuts: the pattern is empirically validated *in Sentinel*. Wait for the second domain before crystallizing it higher.
+
+---
+
+## 3. Pattern 2 — Amend-on-emergence
+
+The literal definition:
+
+> *"The amendment rides the same execute branch as the original Charter (the branch is still mergeable to main; the amendment commit lands on top)."*
+
+The idea: when a closed Charter receives post-close external audit findings — *critical* or *high* — the framework doesn't force opening a new Charter. The operator can *amend* the closed Charter while the `execute` branch is still mergeable to `main`.
+
+The justification, also literal from the document:
+
+> *"A new Charter would have created multi-week governance overhead for ~6h of focused engineering."*
+
+That asymmetry — weeks of governance vs. six hours of engineering — is what the pattern resolves. Opening a new Charter to fix five post-close findings means: declare new context, repeat external audit, generate new AILOG, register telemetry from scratch. For a correction that in code takes an afternoon. Pattern 2 says: no.
+
+The activation criteria, also quantifiable:
+
+- Critical/High *findings* appear post-close, after external audit.
+- The Charter's closure criterion was materially unmet by those findings.
+- The fix surface is under 25 files.
+- It doesn't require architectural reopening (design decisions the original Charter assumed closed).
+
+If all four criteria hold, Pattern 2 applies. If any fails, you have to open a new Charter.
+
+What it produces, when applied:
+
+- An *amendment* commit on the same `execute` branch as the original Charter.
+- A new AILOG (don't edit the original) with `risk_level: high`, `review_required: true`, and an `amends:` field pointing to the original AILOG.
+- A `## Historical correction (YYYY-MM-DD)` section in the original AILOG pointing *forward* to the new one. It's archival: the original AILOG isn't rewritten; it's linked.
+- A `post_close_amendment:` telemetry block in the `charter-telemetry.yaml`.
+
+The empirical metric backing Pattern 2, cited literally:
+
+> *"Sentinel CHARTER-18 closed 2026-05-15 with audit reports landing 2026-05-15..05-17. Five findings (4 from gpt-5.3-codex, 1 from gemini-2.5-pro) were code-level fixes — DI wiring, retry header parsing, multi-tenant filter, timeout default. The Batch 7.4 amendment closed all five in one cohesive commit (19 files, +2257/-106 lines)."*
+
+One commit, 19 files, two auditor models converging on similar findings, five fixes. If it had been a new Charter: minimum two weeks between declare, external audit, and close. Instead: an *amendment* on the same branch, six hours.
+
+---
+
+## 4. Composition, not exclusion
+
+The most interesting piece of the document — and, I think, the one that best closes the arc — is the section on how the two patterns relate. Cited literally:
+
+> *"A Charter that received Pattern 1 is more likely to avoid Pattern 2, because the refresh absorbs pre-execution risk that would otherwise surface as post-close findings. But CHARTER-18 needed both — the refresh handled spec-level drift; the amendment handled runtime-level drift the refresh did not reach into."*
+
+They aren't rival patterns. They're applications of the same principle at different moments of the cycle. Pattern 1 absorbs *spec-level* drift — what the original plan no longer describes correctly. Pattern 2 absorbs *runtime-level* drift — what only shows up once the code runs, external auditors look at it fresh, and it emerges from the code itself.
+
+Sentinel CHARTER-18 needed both. The refreshed spec eliminated emergent findings a later audit cycle would have had to remediate atomically; the later *amendment* absorbed what the refresh couldn't have predicted — DI wiring, retry header parsing, a multi-tenant filter, a timeout default. Things the plan couldn't know and that only emerged when the code existed.
+
+The framework, by naming the two patterns and explicitly declaring their composition, does something I want to underline: it puts on record that discipline isn't linear. There isn't a single inspection point before each Charter; there's one before (Pattern 1) and one after (Pattern 2), and both may be necessary in the same Charter. The chain evolves; the patterns evolve too.
+
+---
+
+## 5. The schema and the helpers
+
+What `fw-4.16.0` added to the telemetry schema are two optional sub-objects in `charter-telemetry.schema.v0.json` v0.2:
+
+```yaml
+pre_declare_refresh:
+  enabled: boolean
+  refresh_pr: string | null
+  refresh_aidec: string | null
+  reusable_patterns_integrated: integer  # ≥ 0
+  code_gaps_integrated: integer
+  discipline_patterns_integrated: integer
+  empirical_corrections_integrated: integer
+  operator_decisions_ratified: integer
+
+post_close_amendment:
+  applied: boolean
+  trigger: external_audit | production_incident | deferred_implementation
+  ailog_id: string
+  findings_closed: integer
+  files_modified: integer
+  effort_hours: number
+```
+
+Integer counters, not narratives. The decision is deliberate: what the telemetry schema captures is what the agent or operator can count mechanically. What can't be counted — *how deep the problem was, how clever the fix was* — lives in the AILOG, not in telemetry. The schema measures the *shape* of work; the documents carry the *content*.
+
+And `cli-3.14.0` added two helpers, neither mutator:
+
+- **`straymark charter refresh-suggest <module> [--threshold N]`** — *read-only*. It reads the telemetry of the last three closed Charters of the module, computes the rolling mean of `r_n_plus_one_emergent_count`, and emits a recommendation: *refresh-now*, *not-needed*, or *insufficient-data*. *Exit 0* always. It's informational, never a CI gate.
+
+- **`straymark charter amend <CHARTER-ID> --trigger <kind> --ailog-title <title> [--findings-closed N] [--merge-into <PATH>]`** — scaffolding. It creates an AILOG stub with the correct fields (`risk_level: high`, `review_required: true`, `amends:` pointing to the original), adds the `## Historical correction` section to the original AILOG, and renders the `post_close_amendment:` YAML block. **Doesn't touch git.**
+
+Keeping the two helpers humble — one only recommends, the other only prepares — is consistent with the A1 decision of Post 4: *"the CLI orchestrates but doesn't invoke APIs"*. Here: the CLI suggests but doesn't decide; scaffolds but doesn't mutate. The human remains the point where discipline happens. The framework only puts the tools within reach.
+
+---
+
+## 6. Seventy-seven minutes later
+
+There's one more piece worth recording before the arc's closing. PR #157 merged at 00:31 UTC on 16 May. PR #160 — the one from Post 1, `EMERGENT-OBSERVATION-DESIGN.md`, fw-4.17.0 — merged at 01:48 UTC the same day. Seventy-seven minutes later.
+
+What happened in those seventy-seven minutes is the inverted closing of the arc. The philosophical meta-pattern Post 1 named — *emergent observation composed of formal links plus cultural permission to flag* — crystallized **one hour and seventeen minutes** after the two operational meta-patterns of this post. The philosophical meta-pattern doesn't precede the discipline; it succeeds it. It's the ascending reading of the same evidence.
+
+`CHARTER-CHAIN-EVOLUTION.md` records it explicitly in its `§Related` section:
+
+> *"EMERGENT-OBSERVATION-DESIGN.md — the meta-pattern of which Pattern 1 and Pattern 2 are applications (formal cross-referencing + cultural permission to surface)."*
+
+Pattern 1 is composition of formal links (the `r_n_plus_one_emergent_count` telemetry, the citations by `id` in `§Context`, the categorized AILOGs) with cultural permission (the rule that an agent should flag drift between spec and code when it finds it). Pattern 2 is similar composition (the AILOGs with `amends:`, the `Historical correction` section linking *forward*) with permission to flag post-close findings instead of absorbing them in silence. The two patterns are applications of the same cultural+structural principle that Post 1 named from above.
+
+It's an ending I keep liking: the blog that opened saying *"the agent saw something nobody asked it to see"* closes saying, in the chronologically preceding episode, *"here are the two things the agent can see well because the framework names them"*.
+
+---
+
+## 7. Closing the arc
+
+Ten posts. Eleven episodes covered (`H-01` through `H-13`, with several bundled). One editorial decision — retroactive publication — that Post 2 introduced and the nine following posts honored without violating it. A bilingual commitment that held at every close.
+
+Some things I learned writing the blog and that are worth recording before closing it:
+
+1. **The pattern is born of the discipline.** The phrase already appeared in Post 9, but the entire arc holds it. The meta-patterns of this post weren't designed; they were extracted. Each documented milestone had its operational episode first and its name after.
+
+2. **The cadence isn't uniform.** Nineteen days between the first commit (Post 2, 27 January) and the first bounded unit with external audit (Post 3, 25 April). Five hours between applied discipline and canonized discipline (Post 9, 14 May). Seventy-seven minutes between two meta-patterns and their philosophical reading (Posts 10 and 1, 16 May). The project went through every speed, and the blog records them all.
+
+3. **The framework isn't neutral with respect to its adopter.** Sentinel made it possible for each pattern to be empirically validated before being crystallized. The blog doesn't hide that provenance; it underlines it as a methodological precondition.
+
+4. **What isn't named, isn't seen.** Post 5 formulated it as *structural visibility*; Post 7 applied it to transversal debt; Post 8 pointed it out about the language outlier. It's the most persistent regularity of the arc. Existing as a technical artifact isn't enough. The name activates the artifact.
+
+The arc the blog came to tell — milestones `H-01` to `H-13`, the four names of the project, the six Plans, the first-class Charters, the external audit cycle, Issue #113, the rebrand to StrayMark, the TDE, the audit-prompt outlier, the manual discipline, and the two meta-patterns — closes here. What's left as explicit debt: `H-14`, the `straymark explore` TUI (which appeared laterally in Post 8 as a visibility tool), and the candidate milestones `H-?-A` to `H-?-E` that `PLAN-INVESTIGACION.md §1.43-55` listed as pending. Possible future second batch. No promise.
+
+One last observation, symmetric to Post 1. That post opened saying: *"the agent saw something nobody asked it to see"*. What the blog closes by recording, after ten episodes, is the other half of the sentence: the agent saw because the framework had put it in conditions to see. The emergent observation of Post 1 is the proof; the named patterns of this post are the preconditions. Every thing the agent surfaced during the four months the arc covers was possible because some prior episode had put an artifact, a trigger, a formal link, a visible surface where there was nothing before.
+
+The blog finishes telling the story. The framework goes on.
+
+---
+
+*Anchors: [Issue #156](https://github.com/StrangeDaysTech/straymark/issues/156). PR [#157](https://github.com/StrangeDaysTech/straymark/pull/157) — `fw-4.16.0 / cli-3.14.0` (merged 2026-05-16 00:31 UTC). Canonical document: [`CHARTER-CHAIN-EVOLUTION.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md). Schema: `dist/.straymark/schemas/charter-telemetry.schema.v0.json` v0.2. Successor meta-pattern: [`EMERGENT-OBSERVATION-DESIGN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/EMERGENT-OBSERVATION-DESIGN.md), `fw-4.17.0` (merged 2026-05-16 01:48 UTC, 77 minutes later).*
+
+*Co-written by José Villaseñor Montfort (Strange Days Tech) and Claude Opus 4.7 (1M context).*
+
+*— End of the H-01 → H-13 arc of the StrayMark blog.*

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,0 +1,13 @@
+jose:
+  name: José Villaseñor Montfort
+  title: Strange Days Tech
+  url: https://github.com/montfort
+  page: true
+  socials:
+    github: montfort
+
+claude-opus-47:
+  name: Claude Opus 4.7 (1M context)
+  title: Anthropic
+  url: https://www.anthropic.com/claude
+  page: false

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -54,7 +54,25 @@ const config: Config = {
             return `${GITHUB_EDIT_BASE}/docs/${docPath}`;
           },
         },
-        blog: false,
+        blog: {
+          path: 'blog',
+          routeBasePath: 'blog',
+          blogTitle: 'Blog',
+          blogDescription: 'The StrayMark chronicle — how the framework emerged, decision by decision.',
+          showReadingTime: true,
+          feedOptions: {
+            type: ['rss', 'atom'],
+            title: 'StrayMark Blog',
+            description: 'The StrayMark chronicle.',
+            copyright: `Copyright © ${new Date().getFullYear()} Strange Days Tech.`,
+          },
+          editUrl: ({locale, blogDirPath, blogPath}) => {
+            if (locale && locale !== 'en') {
+              return `${GITHUB_EDIT_BASE}/website/i18n/${locale}/docusaurus-plugin-content-blog/${blogPath}`;
+            }
+            return `${GITHUB_EDIT_BASE}/website/${blogDirPath}/${blogPath}`;
+          },
+        },
         theme: {
           customCss: './src/css/custom.css',
         },
@@ -80,6 +98,7 @@ const config: Config = {
           position: 'left',
           label: 'Docs',
         },
+        {to: '/blog', label: 'Blog', position: 'left'},
         {
           type: 'localeDropdown',
           position: 'right',
@@ -105,6 +124,7 @@ const config: Config = {
         {
           title: 'Project',
           items: [
+            {label: 'Blog', to: '/blog'},
             {label: 'GitHub', href: GITHUB_REPO},
             {label: 'Releases', href: `${GITHUB_REPO}/releases`},
             {label: 'Issues', href: `${GITHUB_REPO}/issues`},

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-04-05-four-names-in-four-months.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-04-05-four-names-in-four-months.md
@@ -1,0 +1,177 @@
+---
+slug: cuatro-nombres-en-cuatro-meses
+title: Cuatro nombres en cuatro meses
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - prehistoria
+  - identidad
+  - governance
+date: 2026-04-05T00:00:00.000Z
+description: Buscar el concepto buscando el nombre
+---
+> **Nota editorial**: este es el primer post publicado de forma retroactiva en el blog. La `date` del frontmatter corresponde a un momento dentro del arco que el post narra, no al día en que se escribió. El blog completo se está construyendo así, hacia atrás, desde el episodio que motivó empezar a escribirlo (`emergent-observation-design`, 2026-05-16). No tiene sentido fingir lo contrario.
+
+---
+
+## 1. El día siguiente
+
+El 28 de enero de 2026, a las 17:29 hora del centro, este commit entró al repo:
+
+> `chore: rebrand Chronicle to Monimen`
+
+Un día. Veintinueve horas, para ser exacto, después del *initial commit* del proyecto. El framework apenas existía y ya estaba cambiando de nombre.
+
+Lo cuento en pasado, pero esto pasó hace tres meses. Y hace tres meses, dos cambios de nombre después, todavía no se llamaba StrayMark. El proyecto que hoy se vende como *Documentation Governance for AI-Assisted Software Development* arrastra una prehistoria corta y desordenada que vale la pena nombrar antes de seguir adelante.
+
+---
+
+## 2. Cinco eventos, cuatro meses
+
+| Fecha (UTC-6) | Hora | Evento | Ancla |
+|---|---|---|---|
+| 2026-01-27 | 12:14 | *Initial commit*: **Enigmora Chronicle Framework v1.0.0** | [`7c58b6d`](https://github.com/StrangeDaysTech/straymark/commit/7c58b6d) |
+| 2026-01-28 | 17:29 | Rebrand: Chronicle → **Monimen** | [`0b772bc`](https://github.com/StrangeDaysTech/straymark/commit/0b772bc) |
+| 2026-01-29 | 19:30 | Rebrand: Monimen → **DevTrail** (`BREAKING CHANGE`) | [`25ab7a4`](https://github.com/StrangeDaysTech/straymark/commit/25ab7a4) |
+| 2026-03-01 | 19:05 | Rebrand de la organización: Enigmora → **Strange Days Tech** + nace el CLI Rust | [`c7e9026`](https://github.com/StrangeDaysTech/straymark/commit/c7e9026) |
+| 2026-05-08/09 | — | DevTrail → **StrayMark** (ADR + arco de 5 PRs) | ADR `2026-05-08-001`, PRs #114-#118 |
+
+Tres renames en tres días. Después una pausa de un mes entero. Después el rebrand de la organización con CLI Rust incluido. Después otra pausa de dos meses. Después StrayMark, esta vez con ADR público anclando la decisión.
+
+Detalle que me parece honesto subrayar: el commit del 28 de enero (Chronicle → Monimen) no se marcó como `BREAKING CHANGE`. El del 29 de enero (Monimen → DevTrail) sí. *"BREAKING CHANGE: Complete rebrand from Monimen to DevTrail"*, dice el body del commit. La diferencia es pequeña pero reveladora: el segundo rename se sintió más definitivo. Lo fue por dos meses.
+
+---
+
+## 3. Lo que no se mueve
+
+Esta es la sección que me interesa más. El proyecto cambia cuatro veces de nombre en cuatro meses. La idea, no.
+
+El README del *initial commit* — el que vivía en el repo cuando se llamaba *Enigmora Chronicle Framework* — abre con esta línea:
+
+> **Documentation Governance for AI-Assisted Software Development**
+
+Es la misma línea que abre el README de StrayMark hoy. Cuatro nombres, un slogan.
+
+Más adentro, el mismo README v1.0.0 enuncia la tesis del proyecto en un bloque de cita explícito:
+
+> *"No significant change without a documented trace."*
+
+Esa frase, hoy, es el Principio #1 del framework. Está en `PRINCIPLES.md §1 — Total Traceability`. La redacción cambió ligeramente al traducirse al español, pero el peso de la afirmación quedó intacto: ningún cambio significativo sin rastro documentado.
+
+Los ocho tipos de documento que listaba el README v1.0.0 — REQ, ADR, TES, INC, TDE, AILOG, AIDEC, ETH — siguen vivos. Después se agregaron otros (MCARD, SBOM, SEC, DPIA), pero ninguno desplazó a los originales. La taxonomía de enero se sostuvo.
+
+**El nombre se mueve cuatro veces, la idea no.** Lo que cambió en esos cuatro meses no fue el qué, sino la etiqueta que servía para nombrarlo.
+
+---
+
+## 4. El AIDEC con año tipográfico
+
+Hay una anécdota pequeña que me sigue gustando.
+
+El primer documento estructurado del proyecto — el primer AIDEC, el documento que en la propia taxonomía del framework registra una decisión tomada con asistencia de un agente — es `AIDEC-2025-01-27-001-i18n-strategy.md`. Está en el commit [`7b7193e`](https://github.com/StrangeDaysTech/straymark/commit/7b7193e), agregado a las 18:01 del 27 de enero de 2026, seis horas después del *initial commit*.
+
+El ID dice **2025**. El commit es de **2026**.
+
+El propio documento que sentó la convención de identificadores tipo `[TYPE]-[YYYY-MM-DD]-[NNN]` tiene un error tipográfico en el año. El framework arrancó imperfecto y nadie lo corrigió a tiempo. Si alguien clona el repo y mira al ID de ese AIDEC con cuidado, lo notará — y verá también que el commit que lo introdujo está fechado correctamente. Es la mejor evidencia que tengo de que la disciplina de auditoría es algo que llega después; no nace con el repo.
+
+Pero más interesante que el error es lo que decide ese AIDEC. La pregunta que se planteó José en enero, con asistencia de Claude Opus 4.5, era: ¿cómo internacionalizamos un framework que existe para los humanos pero cuya configuración la leen agentes? La respuesta, en la sección de justificación del propio AIDEC:
+
+> *"AI agents (Claude, Gemini, Copilot, Cursor) process instructions equally well in any language, so translating their config files provides no functional benefit."*
+
+La decisión que tomó ese documento — traducir lo que leen humanos (documentación, plantillas), mantener en inglés lo que leen agentes (CLAUDE.md, GEMINI.md, .cursorrules) — fue una intuición temprana sobre que el framework tiene dos audiencias distintas. Hoy el blog mismo ratifica esa intuición: bilingüe español/inglés para los humanos que lo lean, mientras las skills y prompts que orquestan agentes siguen viviendo solo en inglés. Tres meses después, sigue siendo la decisión correcta.
+
+---
+
+## 5. El nacimiento del CLI — y el número que faltó
+
+### 5a. El día que el proyecto se volvió software
+
+El 1 de marzo de 2026, a las 19:05, entró el commit [`c7e9026`](https://github.com/StrangeDaysTech/straymark/commit/c7e9026):
+
+> *"feat: rebrand to Strange Days Tech, add CLI scaffolder, restructure repo"*
+
+Hasta ese día, el proyecto era prosa. Eran templates, skills, reglas de gobernanza, y un montón de Markdown que dependía de que el operador (yo) los copiara a mano dentro de los repos donde quería usarlos. Había un script bash llamado `copy-devtrail.sh`. Era de juguete.
+
+Ese commit del 1 de marzo introdujo `cli/Cargo.toml` y `cli/src/main.rs`. El primer CLI se llamó `devtrail-cli`, versión `2.0.0`, y tenía tres comandos:
+
+```rust
+enum Commands {
+    Init { path: String },
+    Update,
+    Remove { full: bool },
+}
+```
+
+`init`, `update`, `remove`. Tres operaciones. El resto vino después: `status`, `repair`, `validate`, `new`, `compliance`, `metrics`, `analyze`, `audit`, `explore`. Pero los tres originales siguen ahí, casi sin tocar.
+
+Lo importante del commit no son los tres comandos: es que ese día el proyecto dejó de ser un cuerpo de documentación que vivía en su propio repo y empezó a ser una herramienta ejecutable que se instalaba en otros repos. La frontera entre *"proyecto de gobernanza documental"* y *"framework con tooling"* se cruzó ese domingo de marzo. Es más importante que cualquiera de los renames que vinieron antes.
+
+Es también, por cierto, el día en que el proyecto se mudó de cuenta en GitHub: de `enigmora/devtrail` a `StrangeDaysTech/devtrail`. La organización pasó de llamarse Enigmora a Strange Days Tech, S.A.S., en el mismo commit que estrenó el CLI. Renames simultáneos: el del producto (de Monimen a DevTrail) había ocurrido en enero; el de la empresa, en marzo. Dos capas separadas de identidad moviéndose en distintos relojes.
+
+(Una nota lateral, importante para el cuidado del archivo: la co-autoría con un agente — ese `Co-Authored-By: Claude Opus X.Y` que aparece en commits — no nace en marzo. El *initial commit* del 27 de enero ya viene firmado por Claude Opus 4.5. La transparencia de co-autoría con IA fue regla desde la primera línea de código. Lo que cambia el 1 de marzo no es la práctica, es la escala: el CLI es el primer artefacto donde la co-autoría produce *código ejecutable*, no documentación.)
+
+### 5b. El número que faltó
+
+Hay un detalle del versionado del framework que se entiende mejor mirando `git tag`:
+
+```
+fw-2.0.0
+fw-2.1.0
+fw-4.0.0
+fw-4.1.0
+...
+```
+
+No hay `fw-3.x.x`. El proyecto saltó deliberadamente del 2 al 4.
+
+El salto se sincroniza con el commit [`21e03b2`](https://github.com/StrangeDaysTech/straymark/commit/21e03b2), del 27 de marzo de 2026, cuyo cuerpo describe el cambio así:
+
+> *"Reposition DevTrail from 'documentation helper' to 'ISO 42001-aligned AI governance platform' across all user-facing docs. Lead with regulatory urgency (EU AI Act Aug 2026) and compliance value proposition."*
+
+Hasta marzo, DevTrail se presentaba como *ayudante de documentación*. A partir de ese commit, se presentó como *plataforma de gobernanza de IA alineada con ISO 42001*. El cambio de número (2 → 4, saltando el 3) marcó la magnitud del cambio de tesis. Fue una decisión consciente: una versión mayor no alcanzaba para señalar la diferencia.
+
+Y aquí es donde la prehistoria empieza a tener sentido retrospectivo. La intuición que estuvo en el repo desde enero — la idea de un sistema de registro robusto, normativo, alineable con estándares de gobernanza — solo se nombró explícitamente en marzo. Lo veremos con más claridad en la próxima sección, al hablar del segundo nombre.
+
+---
+
+## 6. Sobre los nombres
+
+Tres de los cuatro renames no tienen ADR. La justificación vive solo en los commit messages, y a veces ni siquiera ahí: el commit `chore: rebrand Chronicle to Monimen` no dice por qué Monimen. El siguiente, `chore: rebrand Monimen to DevTrail`, tampoco dice por qué DevTrail. La práctica del ADR como artefacto disciplinado llegó después; en enero el nombre cambiaba con un commit y la justificación se evaporaba en la conversación que la había producido.
+
+Pero algo de etimología sí podemos rescatar.
+
+- **Chronicle** *(27 ene)*. Registro histórico. Bitácora. El nombre habla por sí: lo que se hace con un *chronicle* es anotar lo que sucedió, en orden, para que se pueda revisar después. No hay ADR pero la palabra carga su propio sentido.
+
+- **Monimen** *(28 ene)*. Este es el único nombre cuya intuición sí recuerdo y vale contar. *Monimen* surgió como juego de palabras a partir de *Monumento* (Monument en inglés). La analogía que motivó la sugerencia: las normas que ya entonces se intuían — AIDEC, AILOG, alineables con la incipiente normativa ISO 42001 — representaban una estructura sólida, duradera. Un *monumento* es algo que se erige para durar; un pilar de referencia inamovible para una comunidad. Eso quería ser el framework. El sufijo cortado — *Monimen* en vez de *Monument* — buscaba darle al término un toque más ágil, más de software, menos de mármol. Duró 25 horas. Pero la intuición no se perdió: lo que en marzo terminó nombrándose explícitamente como *ISO 42001-aligned AI governance platform* es la versión madura de ese mismo impulso. Monimen era un nombre con la tesis correcta y la lengua equivocada.
+
+- **DevTrail** *(29 ene)*. El recorrido del developer. Menos solemne que Monimen, más concreto. El commit lo marcó `BREAKING CHANGE` — lo cual, mirado desde mayo, tiene una ironía: el rebrand más definitivo de los primeros tres fue precisamente el que duró tres meses y medio antes de ser sustituido.
+
+- **StrayMark** *(8-9 may)*. La marca, la seña que queda. Pero ese rebrand pide su propio post: ya hay ADR público (`2026-05-08-001`), un arco de cinco PRs nucleares (#114-#118), y un manifesto *"Why StrayMark?"* en el README que merece tratamiento aparte. Aquí solo lo cierro como el rebrand que vino con disciplina documental detrás.
+
+Lo importante no es la etimología en sí. Es que cada nombre ratifica una intuición distinta sobre qué es el producto: **bitácora** (Chronicle), **pilar normativo** (Monimen), **recorrido del developer** (DevTrail), **marca residual** (StrayMark). Cuatro nombres son cuatro hipótesis sobre el concepto. La búsqueda termina cuando el concepto se estabiliza — y solo entonces el nombre puede quedarse quieto.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **No buscábamos un nombre. Buscábamos al concepto.** Los cuatro renames son evidencia de búsqueda, no de indecisión. El concepto se fue afilando a través de los nombres que probaba.
+
+2. **Tres de cuatro renames sin ADR.** La práctica del ADR como artefacto disciplinado llegó después. En enero todavía no había hábito. Eso no es deuda: es honestidad sobre el ritmo. Los hábitos de gobernanza son el resultado de querer registrar lo que ya estaba pasando, no la precondición para empezar.
+
+3. **El proyecto se volvió software el 1 de marzo de 2026. Antes, era prosa.** El CLI Rust es la frontera. Cualquier discusión sobre StrayMark *como framework* tiene que reconocer que hay un antes y un después de ese commit.
+
+4. **Probablemente no vuelva a haber rebranding.** Pero el blog no lo promete. El proyecto es honesto sobre su propia mutabilidad, y prometerlo sería traicionar la primera tesis del primer post.
+
+Cuando empecé a escribir este blog, hace dos semanas, no tenía intención de cubrir la prehistoria. La idea era hablar de Charters, de observación emergente, de las cosas que el framework hoy hace. Pero el blog mismo es un acto retroactivo — nace porque algo me sorprendió lo suficiente como para empezar a escribir. Y una vez que decidí escribir hacia atrás, fue inevitable llegar a enero. A los tres renames en tres días. Al AIDEC con año tipográfico. A *Monimen*.
+
+Sigue, en el siguiente post, el primer experimento metodológico real del framework: los seis Planes de Sentinel y el día que *Plan* se renombró a *Charter*. Ahí empieza la historia que el blog vino a contar.
+
+---
+
+*Anclas: commits [`7c58b6d`](https://github.com/StrangeDaysTech/straymark/commit/7c58b6d) · [`0b772bc`](https://github.com/StrangeDaysTech/straymark/commit/0b772bc) · [`25ab7a4`](https://github.com/StrangeDaysTech/straymark/commit/25ab7a4) · [`7b7193e`](https://github.com/StrangeDaysTech/straymark/commit/7b7193e) · [`c7e9026`](https://github.com/StrangeDaysTech/straymark/commit/c7e9026) · [`21e03b2`](https://github.com/StrangeDaysTech/straymark/commit/21e03b2). README original: `git show v1.0.0:README.md`.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-04-27-exploring-the-framework.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-04-27-exploring-the-framework.md
@@ -1,0 +1,117 @@
+---
+slug: explorando-el-framework
+title: Explorando el framework
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - tui
+  - cli
+  - i18n
+  - visibilidad-estructural
+date: 2026-04-27T00:00:00.000Z
+description: La TUI que produjo visibilidad sin proponérselo
+---
+## 1. La herramienta que dos semanas después reveló el outlier
+
+El Post 8 de este blog cubrió un episodio muy específico: el descubrimiento del único archivo del framework cuyo idioma canónico era el español. El operador no lo encontró por inspección sistemática; lo encontró ejecutando `straymark explore --lang es` durante una preparación de auditoría y notando, visualmente, que un template estaba escrito al revés respecto a los demás. La frase de aquel post fue:
+
+> *"Una nueva superficie del framework (la TUI) puso todos los archivos en visión simultánea, y la inconsistencia se hizo evidente como cuando uno ordena los libros del librero y nota que uno tiene el lomo al revés."*
+
+Este post cubre la herramienta. La TUI `straymark explore` nació casi tres semanas antes del descubrimiento que reveló — el 25 de abril de 2026 en `cli-3.4.0` — y maduró en cuatro releases más, todos cerrados en menos de 48 horas. No es un post sobre código. Es un post sobre una pieza específica de tooling que ratifica una tesis que el blog ya nombró antes: las herramientas nuevas producen visibilidad sin proponérselo.
+
+---
+
+## 2. Por qué un TUI en un framework de Markdown
+
+A finales de abril de 2026, el framework tenía algo así como cincuenta archivos Markdown gobernados — `PRINCIPLES.md`, `AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `QUICK-REFERENCE.md`, `SPECKIT-CHARTER-BRIDGE.md`, plus templates en `dist/.straymark/templates/`, plus audit prompts, plus las versiones en tres idiomas de cada uno (`i18n/es/`, `i18n/zh-CN/`). Todo en disco, todo navegable con `find` y `cat`, todo perfectamente accesible.
+
+Y, al mismo tiempo, todo invisible. Para un adoptante que clonaba el framework por primera vez, la primera pregunta no era *"¿dónde está la regla N?"*. Era *"¿qué hay aquí?"*. Y un `ls` recursivo no responde esa pregunta — la abruma. Un `grep` requiere saber qué buscar. Un editor abre un archivo a la vez. El framework había llegado al tamaño donde su propia superficie se había vuelto opaca.
+
+`straymark explore` nació exactamente para resolver eso: una superficie navegable que respondiera *"¿qué hay aquí?"* en tres segundos. No un IDE; no un sistema de docs estilo Read-the-Docs; no un site estático. Un TUI — terminal user interface — que se ejecuta sobre el repo del adoptante, indexa los archivos canónicos del framework, los muestra agrupados por categoría, y permite leerlos con un visor de Markdown coloreado dentro de la terminal.
+
+La decisión de hacer TUI y no web está alineada con dos cosas que el blog ya argumentó. Primero, el principio #10 del Post 4 — *"StrayMark no es un LLM gateway"* — generaliza a *"StrayMark no es lo que ya hace otra cosa"*. No competimos con MkDocs ni con Material for MkDocs. Segundo, la decisión A1 del mismo Post 4: orchestration-only. El TUI no requiere servidor, no requiere build paso, no requiere conexión: corre sobre el repo del adoptante, donde ya está el framework. Es la pieza más humilde que podía resolver el problema.
+
+---
+
+## 3. Lo que entró en `cli-3.4.0`
+
+El [PR #57](https://github.com/StrangeDaysTech/straymark/pull/57) del 25 de abril, fusionado como `cli-3.4.0`, hizo tres cosas concretas:
+
+- Introdujo el comando `straymark explore`. Layout de dos paneles cuando la terminal tiene 100 columnas o más: navegación a la izquierda (30%), documento a la derecha (70%). Paneles más estrechos colapsan a un solo panel para terminales angostas. Status bar al pie con los atajos relevantes.
+- Indexó los archivos canónicos del framework en una jerarquía navegable: governance docs (`AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, ...), templates (`dist/.straymark/templates/`), audit prompts, y los directorios del adoptante (`docs/charters/`, `.straymark/07-ai-audit/`, ...). Cada nodo expansible con `Enter`.
+- Cableó el resolver i18n. La opción `--lang <code>` permite ejecutar `straymark explore --lang es` y obtener todos los governance docs en español *si* hay traducción disponible. Si no la hay, fallback silencioso al canónico EN. La descripción literal del commit:
+
+> *"Wire `language` config and a new `--lang` flag through the explore TUI so framework governance docs are served from `i18n/<lang>/` when a translation exists, falling back silently to English otherwise."*
+
+La parte del resolver i18n importa más que el TUI en sí. Hasta `cli-3.4.0`, el helper `resolve_localized_path` lo usaba solo `straymark new` (para resolver qué template inyectar al adoptante en el idioma correcto). El PR #57 lo extrajo a `cli/src/utils.rs:146` como helper compartido, de modo que **una sola definición de cómo se resuelven los overlays `i18n/<lang>/`** sostiene tanto el comando `new` como el comando `explore`. El comportamiento queda predecible para el adoptante: si traduce un template a `i18n/es/`, el TUI lo va a mostrar igual que la generación lo va a usar. Sin sorpresas.
+
+El renderizado del Markdown usa `pulldown-cmark` para el parser y los widgets de `ratatui` para pintar. Sintaxis coloreada, code blocks con borde, tablas con bordes redondeados, headings indentados según nivel. No es ostentoso; es legible.
+
+---
+
+## 4. Cuatro refinamientos en treinta y seis horas
+
+Lo que pasó entre el 25 y el 27 de abril es lo que el Post 9 nombró meses después como propiedad del proceso: cuando la propuesta es bien escrita, la implementación es ejecución. Cuatro PRs más, cerrados en menos de 36 horas, llevaron el TUI de "funciona" a "está terminado":
+
+| PR | Tag | Hora | Qué agregó |
+|---|---|---|---|
+| [#60](https://github.com/StrangeDaysTech/straymark/pull/60) | cli-3.5.0 | 25 abr 22:36 | **Live language switcher.** Tecla `L` cicla el idioma del display sin salir del TUI: `en → es → zh-CN → en`. El índice se reconstruye in-place. |
+| [#61](https://github.com/StrangeDaysTech/straymark/pull/61) | cli-3.5.0 (mismo release) | 25 abr 23:41 | **OS locale auto-detect.** Si el adoptante no tiene `config.yml`, el TUI lee `$LC_ALL` / `$LANG` y mapea el POSIX locale (e.g. `es_MX.UTF-8` → `es`) al idioma soportado más cercano. |
+| [#62](https://github.com/StrangeDaysTech/straymark/pull/62) | cli-3.5.1 | 26 abr 00:07 | **Metadata panel traducido.** 25 nuevas entradas i18n para labels y títulos, con padding visual para mantener alineación entre idiomas. |
+| [#63](https://github.com/StrangeDaysTech/straymark/pull/63) | cli-3.5.2 | 26 abr 00:13 | **Cleanup de keybindings.** Elimina los aliases vim `l` y `h` no documentados (la `l` chocaba con `L` del language switcher). Mantiene `j/k/g/G/n/N` documentados. |
+
+La velocidad del arco repite el patrón. Los cinco PRs de fw-4.11.0 que cubrió el Post 6 (rebrand a StrayMark) se cerraron en cuarenta y tres minutos. Los tres releases del audit cycle externo que cubrió el Post 4 se cerraron en un día. La curva del TUI es parecida: el diseño quedó claro en el PR #57, y los refinamientos vinieron cuando el operador empezó a usar el comando con frecuencia y notó las fricciones.
+
+La anécdota que vale la pena dejar registrada es el `cli-3.5.2`: las teclas `l` y `h` que eliminó eran aliases vim — el operador las usa de hábito muscular en su editor. Pero cuando se introdujo el language switcher en mayúsculas (`L`) horas antes, la `l` minúscula y la `L` mayúscula compartían la misma tecla física, y la transición visual era confusa. La solución fue eliminar los aliases no documentados: el ortografía completa (`j/k/g/G`) se mantiene; las abreviaturas que duplicaban funciones desaparecen. Es un detalle UX pequeño que ilustra cómo las decisiones del TUI van afinando contra el uso real, no contra teoría de UX.
+
+---
+
+## 5. Lo que la TUI reveló dos semanas después
+
+Aquí el post recoge el hilo del Post 8 desde el otro extremo. Lo que `cli-3.4.0` añadió al framework no fue solo un comando de navegación; fue una **superficie de visualización simultánea**. Es decir: antes del TUI, los archivos del framework existían pero se leían uno a uno. Después del TUI, podían verse todos a la vez, agrupados, etiquetados, en el mismo modo de presentación.
+
+Eso cambia lo que el operador puede notar.
+
+El 12 de mayo, dos semanas y media después del merge de `cli-3.4.0`, el operador ejecutó `straymark explore --lang es` antes de un ciclo de auditoría externa. Llegó al grupo de "audit prompts". Lo abrió. Y notó algo que llevaba existiendo un año: el `audit-prompt.md` en root del directorio estaba escrito *en español*, mientras todos los demás archivos canónicos del framework tenían inglés en root y overlays `i18n/es/`. Un solo archivo, al revés respecto a la convención.
+
+El detalle no se descubrió por revisión sistemática. Se descubrió por contraste visual. Es exactamente lo que el Post 8 §3 codificó como tesis:
+
+> *"Las herramientas nuevas producen visibilidad."*
+
+El TUI no causó el outlier — el outlier existía desde el primer commit que portó el skill `plan-audit` de Sentinel al framework canónico (Post 3 lo registra). El TUI tampoco buscó el outlier; no es una herramienta de detección de inconsistencias. Lo único que hizo fue poner todos los archivos en la misma pantalla, en el mismo modo de presentación, y permitir que el ojo humano notara lo que había estado ahí desde el principio. La conclusión que me interesa registrar es estructural: cualquier framework que pase de cincuenta archivos canónicos necesita una superficie de visualización simultánea, no porque la superficie sea pedagógicamente importante en sí, sino porque sin ella ciertas regularidades del repo se vuelven inobservables.
+
+---
+
+## 6. Pequeñas decisiones técnicas que importan
+
+Tres detalles del diseño del TUI que vale la pena dejar registrados, todos coherentes con principios del framework que el blog ya nombró:
+
+**Feature flag `tui`.** El `Cargo.toml` del CLI declara el TUI como dependencia opcional (`ratatui` + `crossterm` + `pulldown-cmark` viven detrás del flag `tui`, habilitado por defecto). Un adoptante que solo quiere `init`, `update`, `validate` puede compilar el binario sin TUI con `cargo build --no-default-features`. Cierra una sub-decisión arquitectónica que se repite en el framework: dar valor al adoptante por defecto, pero permitirle elegir un binario más liviano cuando el TUI no aporta nada al flow.
+
+**Lazy-load de documentos.** El `DocIndex` mantiene un `HashMap<PathBuf, Document>` que se llena al abrir cada nodo, no al arrancar. Para un repo con cien archivos governance, esto significa que `straymark explore` arranca en menos de 200ms y solo lee disco cuando el operador pulsa `Enter`. La decisión es trivial técnicamente; lo no trivial es que se tomó conscientemente. El TUI no compite con un IDE; compite con un `cat`. Tiene que sentirse igual de inmediato.
+
+**History stack para hipervínculos.** Cuando un documento del framework menciona a otro (e.g., `AGENT-RULES.md §3` refiere a `DOCUMENTATION-POLICY.md §6`), el TUI permite saltar al referenciado con un clic — y volver al anterior con `Esc`. Internamente hay una pila de navegación que restaura el scroll position del documento anterior. Es la pieza que convierte la lectura del framework de *"abro un archivo, lo cierro, abro otro"* a *"sigo una conversación entre documentos sin perder el hilo"*. La cantidad de cross-references que el framework tiene hoy — entre principios, agent rules, schemas, templates — hace que esta navegación sea estructuralmente importante, no cosmética.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Un framework que pasa cierto tamaño necesita una superficie de visualización simultánea.** No es ergonomía; es condición para que ciertas regularidades del repo sean observables. El Post 8 documentó la consecuencia; este post documenta la herramienta.
+
+2. **El TUI no causa los descubrimientos; los permite.** El outlier del audit-prompt existía desde mayo del año anterior. Lo único que cambió en abril fue que apareció una pantalla donde se podía ver junto a sus pares. La herramienta no opina sobre el contenido; cambia las condiciones bajo las cuales el ojo humano puede notar regularidades.
+
+3. **Cuando el diseño está claro, la implementación es cuestión de horas, no de sprints.** Cinco PRs en treinta y seis horas — language-aware, live switcher, OS detection, i18n del panel, cleanup de keybindings — solo son posibles porque el diseño quedó cerrado en el PR #57. Es el mismo patrón de los Posts 4, 6 y 9.
+
+4. **La decisión técnica más interesante puede ser una flag de compilación.** El feature flag `tui` declara explícitamente que el TUI es opcional, que el framework sigue funcionando sin él, que el adoptante decide. Esa humildad arquitectónica es la diferencia entre un CLI que asume cómo el adoptante trabaja y un CLI que se ofrece donde puede ser útil.
+
+Con este post el blog cubre el hito `H-14` que la primera tanda dejó como deuda explícita. Los hitos candidatos restantes que `PLAN-INVESTIGACION.md §1.43-55` registró — `AGENTS.md` universal inject, cobertura i18n completa, `straymark validate` como capa formal, CLA assistant — siguen disponibles para futuras tandas. Sin promesa de cadencia, pero registrados.
+
+---
+
+*Anclas: PR [#57](https://github.com/StrangeDaysTech/straymark/pull/57) — `cli-3.4.0` (language-aware explore, 25 abr 2026). PRs [#60](https://github.com/StrangeDaysTech/straymark/pull/60) · [#61](https://github.com/StrangeDaysTech/straymark/pull/61) · [#62](https://github.com/StrangeDaysTech/straymark/pull/62) · [#63](https://github.com/StrangeDaysTech/straymark/pull/63) — refinamientos `cli-3.5.0` a `cli-3.5.2` (25-26 abr 2026). Código: `cli/src/tui/` (15 archivos). Doc adopter: `docs/adopters/CLI-REFERENCE.md` §`straymark explore`.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-04-30-six-plans-and-the-rename-to-charter.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-04-30-six-plans-and-the-rename-to-charter.md
@@ -1,0 +1,151 @@
+---
+slug: seis-planes-y-el-rename-a-charter
+title: Seis Planes para una tesis (y el rename a Charter)
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - sentinel
+  - charters
+  - metodología
+  - governance
+date: 2026-04-30T00:00:00.000Z
+description: Primer experimento sistemático y el día que Plan se llamó Charter
+---
+## 1. Una nota al pie que dice mucho
+
+En la propuesta `charter-telemetry.md`, escrita el 30 de abril de 2026, hay una nota terminológica al inicio:
+
+> *"Lo que este documento llama 'Charter' se llamó 'Plan' en el experimento Sentinel (PLAN-01..06). Los datos empíricos citados abajo se refieren a esos Plans históricos por su nombre original; el shape del schema y los ejemplos prospectivos usan el nombre going-forward 'Charter'."*
+
+Es una nota al pie, técnica, sin drama. Pero registra el momento exacto en que el artefacto cambió de nombre — y, más interesante, registra una decisión de archivo que el blog también respeta: lo que se llamó *Plan* en su momento se sigue llamando *Plan* en los registros originales. Reescribir el nombre hacia atrás sería falsificar el rastro.
+
+Este post cubre dos cosas que pasaron en cinco días: el primer experimento sistemático del framework — los seis Planes de Sentinel, ejecutados entre el 25 y el 28 de abril — y el rename que vino después, el 30. No son dos eventos separados. Uno trajo al otro.
+
+---
+
+## 2. Seis Planes en el papel, cinco en la realidad
+
+El experimento se diseñó con seis Planes (`PLAN-01` a `PLAN-06`) y se ejecutó con cinco. PLAN-04 nunca corrió: quedó como un catálogo de siete *features* diferidas, una lista de cosas que se quería hacer pero que el ciclo de pruebas no alcanzaba a cubrir. Es honesto decirlo así, porque el propio documento que valida la tesis (`thesis-validation.md`) lo registra abiertamente en su tabla resumen:
+
+| Plan | Escala | Lo que hizo | Formato |
+|---|---|---|---|
+| PLAN-01 | XS | Deploy de docs de gobernanza | v1 |
+| PLAN-02 | S | Endpoint admin (`gcp-resource`) | v1 |
+| PLAN-03 | XS | Bumps de contrato | v1 |
+| PLAN-05 | M | Per-service anomaly thresholds | **v2** |
+| PLAN-06 | XS | Recompute manual de baseline | **v3** |
+| *(PLAN-04 catalog)* | — | Roadmap de 7 features diferidas, no ejecutado | — |
+
+Cinco Planes, cuatro escalas distintas: tres XS, una S, una M. Dominios deliberadamente heterogéneos — un deploy operativo, dos endpoints administrativos, un bump de contrato, una feature de backend con lógica de configuración. No era un benchmark sintético. Era el código real de Sentinel del 25 al 28 de abril, partido en unidades acotadas y auditado pieza por pieza con tres modelos (Copilot, Gemini, Claude) actuando como auditores externos.
+
+El sexto Plan no haberse ejecutado importa por dos razones. La primera es la obvia: el experimento se quedó sin tiempo. La segunda es más interesante: PLAN-04 era el único Plan grande del lote — siete features acumuladas, sin acotamiento natural. Que justamente ese Plan fuera el que no entró ya estaba diciendo algo sobre el tamaño que podía tolerar el formato. Los Planes pequeños sí; los Planes-roadmap, no. Esa lección se canonizó después, sin que nadie tuviera que escribirla: los Charters de StrayMark hoy son *"unidades acotadas, de horas a días, una rama"*, no roadmaps trimestrales.
+
+---
+
+## 3. El experimento iteró sobre sí mismo
+
+Cinco Planes ejecutados produjeron tres formatos distintos. No fue por capricho; fue porque cada ciclo dejó al descubierto algo que el formato anterior no capturaba.
+
+- **v1** — los tres primeros Planes (`01`, `02`, `03`) corrieron con un formato originario. Se identificaron cinco patrones recurrentes en los AILOGs de auditoría, pero ninguno estaba formalizado en una plantilla. Existían como costumbre, no como contrato.
+
+- **v2** — para PLAN-05, esos cinco patrones se materializaron en `TEMPLATE.md`, más una sección *"Format conventions"* en el README. Doc-only: nada ejecutable todavía. La hipótesis: si el formato es explícito, los auditores externos convergen mejor. El propio AILOG-020 lo dice sin adorno: *"Los patrones internos que llevan tiempo aplicándose pero no tienen nombre quedan invisibles a auditores externos. Nombrarlos formalmente convierte la práctica en señal pública."*
+
+- **v3** — para PLAN-06, se sumó un patrón nuevo (auto-checklist drift) y, esta vez, *tooling ejecutable*: `scripts/check-plan-drift.sh`, ~145 líneas de bash que validan si la entrega real coincide con lo declarado en el Plan. Por primera vez el formato dejó de ser solo prosa y empezó a tener un verificador.
+
+Lo que me interesa señalar aquí es la forma de la curva. v1 capturó práctica latente. v2 le puso nombre. v3 le puso un programa que la chequea. Es el arco completo de cualquier estandarización útil — y lo recorrimos en cinco Planes, no en cinco años.
+
+Es también la primera evidencia concreta de algo que dos meses después se nombraría explícitamente como Pattern 1 (*pre-declare refresh*) y Pattern 2 (*amend-on-emergence*) en `CHARTER-CHAIN-EVOLUTION.md`. Lo que ahí se canonizó como meta-patrón empezó aquí, en abril, como costumbre sin nombre.
+
+---
+
+## 4. La evidencia más dura: auditores externos convergiendo
+
+El supuesto más cargado de la tesis era: *"notas estructuradas reducen modos de falla, y se nota cuando auditores externos miran"*. La forma de probarlo: enviar el output de cada Plan — los archivos modificados, el AILOG, el Plan-doc bajo TEMPLATE — a tres auditores que no participaron en el desarrollo (Copilot, Gemini, y un análisis crítico de Claude) y comparar las calificaciones agregadas.
+
+El número que `thesis-validation.md` reporta para PLAN-05 (el primer Plan bajo v2 y bajo escala M) es claro:
+
+> *"Mejor calibración combinada de auditores en 5 ciclos (Copilot 9.25, Gemini 9.5). Hipótesis acumulada confirmada: TEMPLATE v2 + AILOGs ricos reducen el espacio de ambigüedad para auditoría externa."*
+
+Dos modelos heterogéneos, instrucciones diferentes, convergiendo en torno a 9.3 sobre 10 — sobre el Plan más grande del lote, además, no el más chico. Eso es señal, no ruido. Y se replicó al ejercitar el `check-plan-drift.sh` de v3:
+
+> *"PLAN-05 (con drifts conocidos): script reporta 3 omitted files: `evaluator_test.go` (F4), `repository.go` (F1/R6), `statuscenter/service.go` (F5) — exactamente los 3 drifts que Copilot+Gemini capturaron en sus auditorías. Cero falsos positivos."*
+
+El script automatizado y los dos auditores externos coincidieron exactamente en qué archivos del Plan habían quedado a deber. No es un argumento sobre que el script sea inteligente — es bash y *grep*, no podría ser más tonto. Es un argumento sobre que el formato del Plan, ya formalizado, hace que *cualquier inspector* (humano, agente, script) vea las mismas cosas. La disciplina estructurada no requiere inteligencia para auditarse: requiere claridad.
+
+---
+
+## 5. Lo que el experimento *no* demostró
+
+Esta es la sección que más me interesa que quede registrada, porque es donde se prueba si el blog está dispuesto a ser honesto.
+
+`thesis-validation.md` se diseñó explícitamente para romper la tesis, no para defenderla. La primera línea del documento dice:
+
+> *"Este documento confronta esa tesis con datos. No la defiende; intenta romperla. El objetivo es que un lector que no compró la tesis pueda, leyendo solo este texto, decidir si la evidencia disponible la sostiene, la matiza o la refuta."*
+
+El veredicto final, con los seis supuestos de la tesis enfrentados a la evidencia, es éste:
+
+| # | Supuesto | Veredicto |
+|---|---|---|
+| 1 | Vibe coding no escala | Validado parcialmente *(sin brazo de control)* |
+| 2 | Notas estructuradas reducen modos de falla | Validado |
+| 3 | Subproducto regulatorio sin trabajo extra | Validado *(pendiente prueba con auditor humano real)* |
+| 4 | Aprobaciones rara vez binarias | Sin evidencia — pendiente proyecto multi-actor |
+| 5 | Stage > commit como unidad de trazabilidad | Validado |
+| 6 | Firma in-situ > reconstrucción posterior | Validado parcialmente *(sin firma criptográfica probada)* |
+
+Tres supuestos validados completos, dos parciales, uno *sin evidencia*, cero refutados. El supuesto sobre aprobaciones no binarias se quedó sin probar porque Sentinel es un proyecto de un solo responsable; haría falta un equipo real con varios firmantes para ejercitarlo. Y la firma criptográfica — Sigstore, hash-chaining, las garantías técnicas de un append-only log — no se ejercitó porque ningún Plan tocó esa parte del flujo. Eso queda en el documento como *gap* explícito, no como afirmación al aire.
+
+Lo que el experimento no demostró importa más que lo que sí demostró. Si en lugar de cinco veredictos honestos hubiéramos publicado seis verdes, el blog sería marketing. La forma de evitarlo es decir, sin atenuar: aquí hay supuestos sobre los que no tenemos evidencia, y un proyecto de un solo operador no puede generarla. Otros la generarán; el framework irá madurando con esos datos.
+
+---
+
+## 6. Por qué Plan se volvió Charter
+
+El rename del 30 de abril no fue de marketing. La razón está escrita literal en `WHAT-IS-A-CHARTER.md`:
+
+> *"GitHub SpecKit already uses the word 'plan' (`/speckit.plan`, `plan.md`) for a different artifact, and the nominal collision generated friction in adopter docs that combine both flows."*
+
+SpecKit ya tenía un `plan.md`. StrayMark también. En la documentación de un adopter que usara ambos, *plan* significaba cosas distintas en párrafos contiguos. El rename existió para arreglar esa colisión.
+
+Pero detrás del pragmatismo hay un matiz que sí vale la pena nombrar. Los dos artefactos *son* distintos, y la distinción es estructural:
+
+| | **`plan.md` de SpecKit** | **Charter de StrayMark** |
+|---|---|---|
+| Granularidad | Feature completa (semanas, varias stories) | Unidad acotada (horas a días, una rama) |
+| Contenido dominante | Stack, dependencias, estructura del proyecto, constitution gates | Archivos concretos a tocar, comandos de verificación, riesgos `R<N>` |
+| Validación | Constitution Check (gate *ex-ante*) | Drift-check + auditoría externa (gates *ex-post*) |
+| Optimización | *Claridad anticipada* | *Trazabilidad ex-post* |
+
+Lo que SpecKit llama *plan* se parece más a un ADR con esqueleto arquitectónico. Lo que StrayMark llama *Charter* se parece más a una task-card con verificación contractual y anclaje de auditoría. Son artefactos complementarios, no competidores; eso lo hace explícito `SPECKIT-CHARTER-BRIDGE.md` después, en mayo. Pero la nomenclatura tenía que dejar de chocar antes de que se pudiera hablar de complementariedad.
+
+La parte que me parece importante destacar es la decisión adyacente: los registros históricos de Sentinel — los AILOGs, las telemetrías, el `check-plan-drift.sh`, las carpetas `sentinel/docs/plans/` — conservan el nombre *Plan*. El propio `WHAT-IS-A-CHARTER.md` lo argumenta así:
+
+> *"Sentinel's historical records (Plans 01–06, `sentinel/docs/plans/`, `sentinel/scripts/check-plan-drift.sh`, AILOGs and YAML telemetries `PLAN-NN.telemetry.yaml`) preserve the original name — they are empirical evidence of a specific moment in time, and rewriting history would falsify the record."*
+
+*Rewriting history would falsify the record.* Esa frase es, para mí, el verdadero corazón del rename. El framework existe para preservar rastro, no para reescribirlo. Cuando el artefacto cambió de nombre, el cambio fue prospectivo: a partir del 30 de abril, los nuevos se llaman Charters. Los viejos, los del experimento, siguen siendo Planes. La inconsistencia es deliberada, y la inconsistencia es la evidencia.
+
+El otro acoplamiento del 30 de abril — la propuesta de telemetría — vino el mismo día por razones que ahora resultan obvias: si el patrón emergente merecía un nombre nuevo, también merecía medición estructurada. El schema `charter-telemetry.schema.v0.json`, con sus campos sobre tiempo invertido, drifts detectados, escala, dominio, es la maquinaria que ejecuta hoy lo que en Sentinel todavía se medía a mano en YAML. Plan se renombró a Charter el mismo día en que se decidió empezar a contar Charters.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **El experimento se diseñó para romperse, no para confirmarse.** *"No la defiende; intenta romperla"* — eso fue, literal, la consigna del documento que validó la tesis. Cualquier blog técnico que se respete tiene que tolerar esa formulación.
+
+2. **Cinco Planes ejecutados, de seis diseñados, en cuatro días.** El que no se ejecutó (el más grande, un roadmap de siete features) fue, sin querer, la primera evidencia de qué tamaño tolera la unidad. Hoy los Charters son acotados por contrato. En abril, lo eran por accidente.
+
+3. **El formato evolucionó dentro del experimento mismo: de costumbre, a plantilla, a script.** Los cinco Planes produjeron tres versiones del formato. La curva de v1 → v2 → v3 es la curva de cualquier estandarización útil — solo que comprimida.
+
+4. **El rename fue de pragmatismo, no de marketing. Y la preservación histórica fue de principio.** *Plan* siguió llamándose *Plan* en Sentinel, donde así se llamó. *Charter* empezó a usarse de abril para adelante. El framework no reescribe su propio archivo: por eso vale la pena rastrearlo.
+
+Sigue, en el siguiente post, dos hitos cercanos que codifican capacidades cualitativamente nuevas: *Charters como entidad de primera clase* (PR #65, fw-4.4.0) y *el audit cycle externo multi-modelo* (`audit-skills-design`, `audit-cli-flow`, releases fw-4.7 → fw-4.9). Es donde el experimento de Sentinel se convirtió en funcionalidad de CLI.
+
+---
+
+*Anclas: propuestas [`thesis-validation.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-04-30-thesis-validation.md) y [`charter-telemetry.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-04-30-charter-telemetry.md) (ambas 2026-04-30). Definición canónica del Charter: [`WHAT-IS-A-CHARTER.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/contributors/WHAT-IS-A-CHARTER.md). Schema operacional: `dist/.straymark/schemas/charter-telemetry.schema.v0.json`.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-06-charters-and-the-external-audit-cycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-06-charters-and-the-external-audit-cycle.md
@@ -1,0 +1,146 @@
+---
+slug: charters-y-el-audit-cycle-externo
+title: 'Charters como entidad de primera clase, y el audit cycle externo'
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - audit
+  - cli
+  - governance
+date: 2026-05-06T00:00:00.000Z
+description: De ritual manual en Sentinel a comando CLI canonizado
+---
+## 1. Cuando la disciplina amenaza con volverse ceremonia
+
+A finales de abril, Sentinel cerró su cuarto Charter del mes con una sensación que, escrita, suena un poco patética: la auditoría externa funcionaba — Copilot 9.25, Gemini 9.5, el drift script con cero falsos positivos — pero cada cierre me hacía abrir tres archivos a mano, copiar tres prompts a tres ventanas distintas, esperar respuestas, copiar tres YAMLs de calibración de vuelta al archivo de telemetría, y verificar a ojo que los hashes coincidían. Cuarenta minutos de copy-paste por Charter, sobre un trabajo que tomaba dos horas. La disciplina estaba funcionando; el ritual estaba volviéndose un problema.
+
+La propuesta `audit-skills-design.md`, escrita el 3 de mayo, lo nombró sin atenuar:
+
+> *"Si en cada cierre el operador tuviera que mover datos manualmente entre archivos, el throughput colapsaría y la disciplina dejaría de ser fricción virtuosa para volverse ceremonia. Lo que se pueda automatizar de forma reversible debe automatizarse; los documentos quedan para auditoría humana ex-post."*
+
+Este post cubre tres días — del 2 al 6 de mayo de 2026 — en los que dos arcos paralelos terminaron a la vez. Uno: el Charter dejó de ser práctica artesanal y se volvió entidad de primera clase del CLI. Dos: el audit cycle externo dejó de ser ritual manual con prompts ad-hoc y se volvió comando canónico (con una decisión arquitectónica contraintuitiva detrás que merece su propio párrafo).
+
+---
+
+## 2. Lo que Sentinel ya hacía, y lo que StrayMark no tenía
+
+La propuesta del 3 de mayo lo dice con una frase que se queda corta de elegante pero precisa exactamente lo que estaba pasando:
+
+> *"Sentinel tiene los skills, StrayMark no."*
+
+Lo que Sentinel tenía: `sentinel/.claude/skills/plan-audit/` y `plan-audit-review/` — skills locales que generaban un prompt, calibraban la respuesta al regreso, y la fusionaban en la telemetría. Funcionaban. Llevaban seis ciclos validándose. Pero estaban acoplados a paths Sentinel-específicos (`docs/plans/`, `internal/modules/`, `go vet`) y al vocabulario *"Plan"*, que ya había sido renombrado a Charter una semana antes.
+
+Lo que StrayMark no tenía: nada equivalente. El framework hasta abril era documentación + skills + un CLI con `init`, `update`, `remove`. La unidad que en Sentinel se llamaba *Plan* — la unidad acotada, declarada *ex-ante*, auditada *ex-post* — no existía como artefacto del CLI. Existía como práctica.
+
+El arco de fw-4.4.0 (2 de mayo) y de fw-4.7 → 4.9 (3-5 de mayo) consiste, casi al pie de la letra, en portar lo que Sentinel hacía a mano hacia comandos genéricos que cualquier adoptante del framework pueda invocar. La tabla de migración, copiada del `cli-roadmap.md`, es honesta sobre el origen:
+
+| Artefacto Sentinel *(abril 2026)* | Equivalente StrayMark *(mayo 2026)* |
+|---|---|
+| `TEMPLATE.md` (v3) en `docs/plans/` | `dist/.straymark/templates/charter-template.md` |
+| `scripts/check-plan-drift.sh` (145 líneas bash) | `straymark charter drift` (subcomando Rust) |
+| Skill local `plan-audit` | Skill genérica `straymark-audit-prepare` |
+| Reportes duales en `audit/plans/05,06/{copilot,gemini,claude}.md` | Output canónico de `straymark charter audit` |
+| YAML de telemetría a mano | `dist/.straymark/schemas/charter-telemetry.schema.v0.json` |
+
+El CHANGELOG de fw-4.4.0 lo enmarca sin metáfora: *"Crystallizes the Charter pattern — bounded, auditable units of work declared ex-ante and validated ex-post — that emerged from the 6-cycle Sentinel /plan-audit experiment."* La cristalización es el punto. Lo que en abril era costumbre con script bash, en mayo es comando con schema validable.
+
+---
+
+## 3. Qué pasa cuando algo se vuelve "entidad de primera clase"
+
+PR #65 (fw-4.4.0 / cli-3.6.0, 2 de mayo) hace tres cosas concretas:
+
+- Crea el comando `straymark charter new`. Auto-incrementa el número (`NN-slug.md`), pre-popula el origen (`originating_ailogs` si nace de un AILOG previo; `originating_spec` si nace de un SpecKit `plan.md`), y soporta el flag `--type X|S|M|L` para fijar la escala desde el primer momento.
+- Introduce `charter-template.md` portado del `TEMPLATE.md` v3 de Sentinel. Lleva embebidas las seis convenciones que el experimento de abril fue cristalizando ciclo a ciclo: separación Local/Production checks, esfuerzo en tiempo (no en story points), sub-secciones estructuradas, documentación de riesgos `R<N>`, cierre con reconciliación post-merge vía AILOG, y auto-checklist drift.
+- Publica `dist/.straymark/schemas/charter.schema.v0.json` — el schema marcado como `v0` deliberadamente, no `v1`, porque el principio #12 del framework dice que ningún schema cristaliza sin un segundo dominio que lo valide. Sentinel es un dominio. Falta el segundo.
+
+PR #68 (3 de mayo) hace algo que parece pequeño pero importa: el *atomic Charter closure pattern*, format v4. En Sentinel, el paso *"actualizar el Plan-doc post-merge si el AILOG documenta divergencias"* existía como nota en el TEMPLATE pero no tenía gatillo sistemático. En la práctica, eso significaba que cuando había diferencia entre lo declarado y lo entregado, el operador (yo) confiaba en la memoria para reconciliar el documento — y la memoria fallaba. El drift quedaba en el repo días, a veces semanas, hasta que el siguiente ciclo lo descubría. Format v4 vuelve la reconciliación un paso obligatorio del cierre, no una nota al margen.
+
+PR #69 (mismo día) cierra un detalle de fricción: la numeración manual. Antes había que decidir si el siguiente Charter era 11 o 12; ahora `straymark charter new` lee el directorio y propone el siguiente número. UX puro. Pero es la clase de fricción que, sumada sobre veinte Charters, decide si el framework se usa o se abandona.
+
+Los tres PRs salieron en el mismo *commit storm* de un domingo y un lunes. Esa cadencia es deliberada: una vez que el patrón se cristaliza, los detalles UX hay que cerrarlos *junto*, no en bumps separados que dejen al adoptante con una mitad del flujo.
+
+---
+
+## 4. Tres releases en un día
+
+Lo que vino después — fw-4.7.0, fw-4.8.0, fw-4.9.0 — son releases consecutivos del audit cycle externo. La propuesta `audit-skills-rollout.md` registra el ritmo sin disimular:
+
+> *"Fase 1 ejecutada en 1 día calendar (5 PRs secuenciales el 3 de mayo de 2026), substancialmente más rápido que la estimación de 1.5-2 semanas focused. El throughput se debe a que el diseño en `audit-skills-design.md` ya tenía las decisiones cristalizadas (D1/D2/D3) y la heurística arborist con graceful-degradation explícita — no hubo decisiones pendientes durante la implementación. Sirve como evidencia operativa adicional para principio #6 (cuando la propuesta es bien escrita, la implementación es ejecución, no diseño)."*
+
+El audit cycle externo concreto consiste en tres comandos encadenados:
+
+1. `straymark charter audit prepare <CHARTER-NN>` — genera prompts canónicos para auditores externos a partir del Charter cerrado, su AILOG asociado, y el diff de archivos tocados. Output: tres archivos `.prompt.md` en `audit/<CHARTER-NN>/{copilot,gemini,claude}.prompt.md`.
+2. *(El humano lleva esos prompts a su auditor de elección, recibe respuestas, las pega de vuelta.)*
+3. `straymark charter audit collect <CHARTER-NN>` — toma las respuestas, valida cada una contra el schema de auditoría, fusiona calibraciones en la telemetría del Charter, y produce un summary con la convergencia (o divergencia) entre auditores.
+
+Decisión D1 de la propuesta es la que sostiene todo lo demás:
+
+> *"Las skills delegan vía `Bash(straymark charter audit *)` a la implementación canónica. Plantillas viven solo en `dist/.straymark/audit-prompts/`. Cero drift posible entre skill y CLI."*
+
+Hay solo un lugar donde los prompts viven, una sola implementación del flow, y las skills (Claude, Cursor) lo invocan vía Bash. Es un patrón humilde — el CLI es la fuente única — pero evita lo que en cualquier framework con dos surfaces (skill + CLI) termina siendo el problema crónico: que el skill y el CLI digan cosas distintas según quién los actualizó la última vez.
+
+---
+
+## 5. Por qué el CLI orquesta pero no invoca APIs
+
+Esta es la decisión más rara de mayo, y la que más me costó tomar. Está documentada literal en `cli-roadmap.md` §0 como *"decisión arquitectónica A1"*:
+
+> *"A1 (Phase 3): orchestration-only, no HTTP API clients en v0. El roadmap §5.4 originalmente sugería 'soportar OpenAI/Google/Anthropic en v0' con manejo de API keys. La realidad implementada es que el CLI prepara prompts, valida outputs contra schema, e integra con telemetría — pero NO invoca APIs. El operador pega los prompts en su auditor de elección manualmente."*
+
+El razonamiento, también literal:
+
+> *"Implementar 3 clientes HTTP es 1-2 semanas + mantenimiento perpetuo cuando cambian las APIs (premature para una v0 experimental); el patrón humano-en-el-loop coincide con `/plan-audit` de Sentinel; cumple principio #10 ('no es un LLM gateway'); cierra RFC #82 por diseño. Los HTTP clients se reabren en v1 cuando un adoptante real lo justifique con datos."*
+
+Tres argumentos, cada uno con peso propio.
+
+**El primero es pragmático**. Tres clientes HTTP — OpenAI, Anthropic, Google — son entre una y dos semanas de implementación, más mantenimiento permanente cada vez que alguno de los tres cambia algo. Para un comando que en su forma manual ya estaba funcionando empíricamente en Sentinel, ese es un costo absurdo. Es ingeniería para resolver un problema que ningún adoptante había pedido resolver.
+
+**El segundo es de continuidad**. Lo que Sentinel validó en abril fue precisamente el patrón humano-en-el-loop: el operador pega el prompt en Copilot/Gemini/Claude *a mano*, lee la respuesta, la pega de vuelta. El experimento de los seis Planes que dio origen a este arco completo *nunca* invocó APIs. Si el CLI ahora invocara APIs por su cuenta, estaría sustituyendo el patrón validado con uno no validado, sin razón empírica.
+
+**El tercero es de identidad**. StrayMark no es un *LLM gateway*. El principio #10 del framework lo dice explícitamente. Hay docenas de productos que sí lo son — LangChain, LiteLLM, LiteLLM Proxy, OpenRouter, todos los wrappers — y son útiles para lo que hacen. StrayMark hace otra cosa: estructura la disciplina alrededor del trabajo que se hace *con* esos modelos, sea cual sea el modelo. Que el CLI invoque o no invoque APIs cambia lo que el framework es; mantenerlo *orchestration-only* mantiene la identidad limpia.
+
+La parte que más me importa del párrafo: *"Los HTTP clients se reabren en v1 cuando un adoptante real lo justifique con datos."* La decisión no se cerró por dogma; se difirió por umbral de evidencia. Si en seis meses un adoptante demuestra que el flow humano-en-el-loop le rompe el throughput, los HTTP clients aterrizan. Hasta entonces, la fricción manual de los cuarenta segundos que toma pegar el prompt en otra ventana es trivial comparada con el costo de mantener tres SDKs vivos.
+
+---
+
+## 6. Lo que el framework decidió *no* automatizar
+
+Vale la pena cerrar con la otra cara de la misma decisión. La propuesta `audit-skills-design.md` dice:
+
+> *"Lo que se pueda automatizar de forma reversible debe automatizarse; los documentos quedan para auditoría humana ex-post."*
+
+La primera mitad explica los tres releases de mayo: prompts generados automáticamente, calibraciones fusionadas automáticamente, drift detectado automáticamente. La segunda mitad — *"los documentos quedan para auditoría humana ex-post"* — explica qué se decidió mantener manual a propósito.
+
+Lo que el framework *no* automatiza:
+
+- **La lectura del AILOG por parte del operador antes de cerrar el Charter.** El comando `straymark charter audit prepare` genera los prompts, pero el operador *tiene* que abrir el AILOG y leerlo. Si automatizáramos eso — un agente que lee, resume, decide — perderíamos el momento de juicio humano que justifica que el Charter exista.
+- **La decisión de aceptar o rechazar la auditoría externa.** El CLI fusiona las calibraciones en la telemetría, pero no actúa sobre ellas. Si un auditor califica el Charter con un 4, el Charter no se reabre automáticamente: el operador decide si reabrir, si argumentar, si declararlo *acceptable-with-known-debt*. Esa decisión es la disciplina; automatizarla la destruiría.
+- **La invocación de los modelos.** Como ya argumenté arriba: la pausa donde el operador copia el prompt es exactamente donde decide qué modelo usar, qué prompt ajustar, si la pregunta tal cual está formulada le parece justa. Esa pausa es feature, no bug.
+
+El criterio que recorre las tres es uno solo: *automatizar lo que sea reversible y mecánico; preservar como manual lo que sea juicio*. Cuarenta segundos de copy-paste no son demasiados si compran que el juicio sigue siendo humano.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Una práctica que funciona empíricamente no necesita ser reinventada para canonizarse.** Sentinel hizo el trabajo de validación en abril; mayo solo lo trasladó al framework. La cristalización es traslado, no diseño desde cero.
+
+2. **Cuando la propuesta está bien escrita, la implementación es ejecución.** Tres releases en un día solo son posibles cuando todas las decisiones quedaron cerradas antes de tocar código. El principio #6 lo dice más prosaicamente, pero esto es lo que significa.
+
+3. **No todo lo automatizable debe automatizarse.** La decisión A1 — el CLI orquesta pero no invoca APIs — es la versión técnica de una decisión filosófica: el humano-en-el-loop no es legacy del que hay que deshacerse, es feature que sostiene la disciplina.
+
+4. **La identidad del framework se define tanto por lo que hace como por lo que no hace.** *"No es un LLM gateway"* es una de las pocas frases del principio #10 que vale la pena recordar literal. Lo que StrayMark hace lo hace bien porque hay muchas cosas que se niega a hacer.
+
+Sigue, en el siguiente post, el episodio metodológico que conecta con el inicio mismo del blog — *Issue #113: Charters invisibles para los agentes* — donde el framework descubre que crear comandos y schemas no basta si la *superficie* del repo no le habla al agente. Es el contrapeso natural a este post: aquí hablamos de lo que se canonizó; allá hablamos de lo que no se vio.
+
+---
+
+*Anclas: PRs [#65](https://github.com/StrangeDaysTech/straymark/pull/65) · [#68](https://github.com/StrangeDaysTech/straymark/pull/68) · [#69](https://github.com/StrangeDaysTech/straymark/pull/69) (Charters first-class). Propuestas [`audit-skills-design.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-03-audit-skills-design.md) · [`audit-skills-rollout.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-03-audit-skills-rollout.md) · [`audit-cli-flow.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-04-audit-cli-flow.md) · [`cli-roadmap.md`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/proposals/2026-05-03-cli-roadmap.md) (decisión A1 §0). Releases fw-4.4.0 → fw-4.9.0.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-charters-invisible-to-agents.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-charters-invisible-to-agents.md
@@ -1,0 +1,129 @@
+---
+slug: charters-invisibles-para-los-agentes
+title: Charters invisibles para los agentes
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - agentes
+  - observabilidad
+  - governance
+date: 2026-05-09T00:00:00.000Z
+description: 'Issue #113 — la brecha entre tener un artefacto y que el agente lo vea'
+---
+## 1. Seis horas para no verlo, cinco minutos para verlo
+
+El Issue [#113](https://github.com/StrangeDaysTech/straymark/issues/113) abre con una de esas frases que, cuando uno la lee de regreso meses después, suena obvia y al mismo tiempo costó mucho llegar:
+
+> *"Time to detect: ~6 hours of session work; never autonomously surfaced. Time to resolve once user prompted: ~5 minutes."*
+
+Seis horas trabajando con un agente capaz, atento, con todo el aparato canónico de onboarding del framework cargado — `STRAYMARK.md`, la constitución del proyecto, el checklist de `CLAUDE.md`, las skills `/straymark-*` disponibles, `/straymark-status` ejecutado al inicio — y nunca, en seis horas, el agente sugirió usar un Charter. Cuando se lo pedí directamente, el flujo se incorporó en cinco minutos. La asimetría no es de capacidad. Es de visibilidad.
+
+Este post cubre un episodio corto y específico: el Issue #113, abierto el 7 de mayo de 2026, tres días después de que Charters se cristalizaran como entidad de primera clase del framework (fw-4.4.0, 2 de mayo). Es el contrapeso natural del primer post del blog. Aquel post nombró una propiedad que apareció cuando todo estaba en su sitio. Este post documenta lo que pasa cuando una pieza estructural existe pero *no está en la superficie que el agente lee primero*.
+
+---
+
+## 2. El experimento accidental
+
+El setup no estaba pensado como experimento. Era un proyecto real: un *greenfield* en Rust, suite CLI+TUI, en su primera versión `v0.1`. El agente era Claude Opus 4.7 con ventana de 1M tokens, suficiente para tener todo el repo en contexto sin tener que paginar. El flujo era el canónico de SpecKit: `/speckit-specify`, `/speckit-plan`, `/speckit-tasks`, y entre tasks e implement debía aparecer — *en teoría* — la idea de cortar en Charters.
+
+El Issue lo formula con precisión casi fría:
+
+> *"A capable, attentive agent following the canonical project onboarding (`DEVTRAIL.md`, the project constitution, `CLAUDE.md` checklist, available `/devtrail-*` skills, `/devtrail-status`) did not autonomously identify Charters as a workflow concept during plan/tasks generation, even though the project clearly fit their use case (multi-session implementation, multi-phase tasks, audit value)."*
+
+*(El Issue todavía usa `DEVTRAIL.md` porque, recordando la cronología, el rebrand a StrayMark estaba siendo merged casi al mismo tiempo. La nomenclatura mixta es residuo del calendario, no descuido.)*
+
+El proyecto cumplía cada una de las condiciones donde un Charter es la unidad correcta: implementación multi-sesión, varias fases, valor de auditoría. El agente hizo todo bien — leyó la constitución, ejecutó status, identificó skills disponibles, generó un plan de SpecKit razonable — y nunca conectó con Charters. Como si el concepto no existiera. Para él, en su modelo del repo, no existía.
+
+Lo más incómodo del Issue, mirado desde mayo, es que el agente no falló por incapacidad. Falló porque el framework, sin proponérselo, le había construido un mapa en el que los Charters no aparecían marcados.
+
+---
+
+## 3. Nueve gaps que convergen en uno
+
+Cuando el operador (yo) abrió el Issue y se sentó a auditar por qué había pasado, el problema no era una cosa. Eran nueve. Y todas eran versiones del mismo defecto:
+
+| # | Gap | Dónde |
+|---|---|---|
+| 1 | El documento canónico del framework no listaba Charter como concepto | `STRAYMARK.md` (entonces `DEVTRAIL.md`) §6/9/10/11/13/15 |
+| 2 | El checklist de `CLAUDE.md` no tenía trigger para sugerir Charter | `dist/dist-templates/directives/CLAUDE.md` (y `GEMINI.md`, `copilot-instructions.md`) |
+| 3 | Las constituciones de proyecto heredan la brecha del framework | Cualquier `*-constitution.md` instalado vía `straymark init` |
+| 4 | No existía skill `/straymark-charter-new` | Skills directory |
+| 5 | `/straymark-status` no listaba Charters en su output | Skill + CLI subcommand `straymark status` |
+| 6 | Las skills de auditoría hablaban del Charter como artefacto *externo*, no como superficie a generar | `/straymark-audit-*` skills |
+| 7 | Los templates de Charter convivían indistinguibles con otros templates | `dist/.straymark/templates/` (raíz) |
+| 8 | No había puente conceptual entre SpecKit (`plan.md`) y Charter | Ningún documento explícito |
+| 9 | El modelo mental que el agente terminaba construyendo era binario: o SpecKit, o nada | Efecto compuesto |
+
+Nueve fallas y un solo defecto: el Charter existía como artefacto técnico (schema válido, comando funcional, template portado de Sentinel), pero no estaba nombrado en ninguno de los lugares donde el agente construye su modelo mental del proyecto al entrar.
+
+El agente lee el `STRAYMARK.md` y la constitución para entender de qué trata el proyecto. Si Charter no aparece, no está. El agente revisa qué skills tiene disponibles para usar. Si no hay `/straymark-charter-new`, no está. El agente corre `/straymark-status` para entender qué tipos de archivo viven en el repo. Si la salida no menciona Charters, no están. Cada superficie por la que el agente pasa al onboarding repite el mismo silencio. Y la suma de silencios convence al agente de que el concepto no es parte de este proyecto.
+
+---
+
+## 4. Por qué este episodio importa más allá del Issue
+
+Vale la pena hacer una pausa aquí, porque este es exactamente el episodio que el meta-patrón de fw-4.17.0 — el patrón de *observación emergente* — necesitaba haber existido *antes* para poder formularse.
+
+Una semana después de #113, en `EMERGENT-OBSERVATION-DESIGN.md`, el framework nombró dos propiedades cuya composición produce que el agente note cosas que nadie le pidió notar: vínculos formales entre artefactos (`originating_charter`, `originating_ailog`, `originating_spec` en frontmatter), y permiso cultural para señalar disonancias entre fuentes. Esas dos propiedades, *compuestas*, producen que el agente lea el AILOG, cuente las entradas `R<N>(new, not in Charter)`, y señale el delta sin que nadie se lo pida.
+
+Pero hay un prerrequisito que esa formulación da por sentado: que el agente *vea* los Charters al entrar al repo. Si los Charters no están en la superficie visible, ningún vínculo formal entre artefactos puede componerse en observación emergente — porque uno de los términos de la composición no existe para el agente.
+
+El Issue #113 es el episodio que documentó esa precondición desde la inversa. Fw-4.17.0 nombró el patrón cuando estaba presente; fw-4.12.0 (cinco días antes) cerró la brecha que impedía que estuviera presente en absoluto. Sin el Issue #113 y su corrección, el meta-patrón no tendría dónde apoyarse. El framework no señala lo que no ve, y no ve lo que la superficie no nombra.
+
+---
+
+## 5. La respuesta: multiplicar superficies
+
+El PR [#122](https://github.com/StrangeDaysTech/straymark/pull/122) (`fw-4.12.0`, 9 de mayo) cubrió los nueve gaps con una sola estrategia operativa: *nombrar Charter en cada lugar donde el agente construye su modelo del proyecto*. Las cifras del PR son honestas: +1211 líneas, −92 líneas, 36 archivos modificados, casi todo documentación y plantillas. No hubo refactor de código. Hubo redistribución de visibilidad.
+
+Cambios principales, agrupados:
+
+- **En el documento canónico** (`STRAYMARK.md`): una sección nueva dedicada al Charter como concepto (§15), más filas en las tablas de §6/9/10/11/13 que listaban tipos de documento sin Charter.
+- **En las directivas de agentes** (`CLAUDE.md`, `GEMINI.md`, `copilot-instructions.md`): un trigger explícito que enseña al agente cuándo *sugerir* un Charter, no solo cuándo crearlo si se le pide.
+- **En las skills**: nueva `/straymark-charter-new` (versiones Claude, Gemini, agnóstica). `/straymark-status` actualizada para listar Charters activos.
+- **En el CLI**: bloque `Charters` añadido a la salida de `straymark status`, para que el agente que ejecuta el comando lo vea entre los signals iniciales.
+- **En los templates**: movidos a un subdirectorio dedicado `dist/.straymark/templates/charter/`, ya no mezclados con templates de otros tipos.
+- **Documento nuevo**: `SPECKIT-CHARTER-BRIDGE.md` (171 líneas, EN/ES/zh-CN). Hace explícito el puente entre el `plan.md` de SpecKit y el Charter de StrayMark — los cuatro criterios para que una feature de SpecKit produzca uno o varios Charters, los tres casos donde no aplica, las cuatro heurísticas de granularidad, el enlace de frontmatter `originating_spec ↔ originating_charter ↔ originating_ailog`.
+
+El epílogo de `SPECKIT-CHARTER-BRIDGE.md` registra el caso que originó todo el cambio sin metáfora:
+
+> *"Cited the empirical context (issue #113): Greenfield Rust CLI/TUI suite, Claude Opus 4.7 onboarding via canonical entry points. Charters were eventually adopted (2 Charters: foundation + MVP) only after explicit user prompt — confirming the gap was systemic, not session-specific. This document removes the gap."*
+
+*The gap was systemic, not session-specific.* Esa frase es la lección operativa del Issue. No fue un agente distraído un día; era el framework el que no le hablaba al agente sobre Charters en ningún lugar donde el agente miraba.
+
+---
+
+## 6. Lo que aprendí sobre visibilidad estructural
+
+La lección, escrita en prosa y no en tabla:
+
+Crear un artefacto en un framework no es lo mismo que hacerlo visible para los agentes que trabajan en repos del framework. Son dos pasos. El primero — esquema, comando, template, ejemplos — es el paso visible: queda en el CHANGELOG, sale en el release, se ve en el `git log`. El segundo — anclar el artefacto en cada superficie por donde el agente entra al repo — es invisible: nada del segundo paso aparece como *feature* en sí; son referencias cruzadas, líneas en checklists, items en outputs, secciones en docs. Pero el segundo paso es el que decide si el primero existe para el agente.
+
+El framework gobierna agentes que leen el repo desde fuera de la sesión donde se creó el artefacto. Cada agente que entra al repo construye su modelo mental desde cero, leyendo los documentos canónicos, las skills disponibles, los outputs de status. Si el artefacto no está nombrado ahí, no existe en su modelo. Y un modelo sin el artefacto no propone usarlo, no audita su ausencia, no señala disonancias relacionadas. La capacidad técnica del agente es irrelevante si la superficie del repo no le da el sustantivo correcto al entrar.
+
+Eso es lo que ahora llamo, internamente, *visibilidad estructural*. No es una propiedad del agente. Es una propiedad del repo, y por extensión, una responsabilidad del framework: cada vez que cristaliza un concepto nuevo, tiene que multiplicar las superficies donde ese concepto se nombra. Una sola superficie — el schema, el comando, el template — no alcanza. Son nueve, mínimo, y son las nueve del Issue #113.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Existir como artefacto no es lo mismo que ser visible para el agente.** Charters tenían schema, comando, template, ejemplos — y aun así eran invisibles. La diferencia entre los dos estados son las nueve superficies del Issue #113.
+
+2. **Seis horas vs. cinco minutos.** Un agente capaz puede pasar horas sin detectar lo que, una vez nombrado, le toma minutos integrar. La asimetría no diagnostica al agente; diagnostica al repo.
+
+3. **La visibilidad estructural es responsabilidad del framework.** Cuando cristaliza un concepto, no termina en el comando que lo crea. Termina cuando el concepto está nombrado en cada superficie donde el agente construye su modelo del repo: documento canónico, directiva, skill, status, template, puente con otros frameworks.
+
+4. **Sin visibilidad estructural no hay observación emergente.** Las propiedades que después hicieron posible que un agente señalara disonancias entre fuentes — vínculos formales + permiso cultural — necesitan, como precondición, que los artefactos sean visibles desde el primer momento del onboarding. El Issue #113 documenta qué pasa cuando esa precondición falta.
+
+Sigue, en el siguiente post, un episodio adyacente al de este: *el rebranding a StrayMark* (`H-08`). El Issue #113 se resolvió en el mismo arco temporal que el rename de DevTrail a StrayMark, y los dos comparten algo que vale la pena nombrar — la responsabilidad de que un framework declare con claridad su identidad, hacia sus agentes y hacia sus adopters.
+
+---
+
+*Anclas: [Issue #113](https://github.com/StrangeDaysTech/straymark/issues/113) (abierto 2026-05-07). [PR #122](https://github.com/StrangeDaysTech/straymark/pull/122) — `fw-4.12.0` (fusionado 2026-05-09). Documento generado por el PR: [`SPECKIT-CHARTER-BRIDGE.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/SPECKIT-CHARTER-BRIDGE.md).*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-the-rebrand-to-straymark.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-the-rebrand-to-straymark.md
@@ -1,0 +1,145 @@
+---
+slug: el-rebrand-a-straymark
+title: El rebrand a StrayMark
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - rebranding
+  - governance
+  - identidad
+date: 2026-05-09T00:00:00.000Z
+description: 'El cuarto rename, esta vez con ADR público y arco disciplinado'
+---
+## 1. El rename que no buscaba el concepto
+
+El ADR `2026-05-08-001` se abre con una frase que, para cualquiera que haya leído el Post 2 de este blog, suena ajena:
+
+> *"The decision is motivated by legal certainty over the trademark rather than by product strategy or user feedback."*
+
+Los tres renames de enero (Chronicle → Monimen → DevTrail) fueron búsqueda apurada del concepto. Cada uno ratificaba una intuición distinta sobre qué era el producto. Ninguno tenía ADR; los commit messages eran toda la justificación documental que existió.
+
+El cuarto rename, el de mayo, es de otra naturaleza. No nace de buscar al concepto. Nace de una investigación de conflicto de *trademark* — comisionada vía sesión de Claude.ai a inicios de mayo — que arrojó *"legal uncertainty about trademark ownership as the project gained adopters"*. En enero el proyecto tenía cero adopters y los renames podían improvisarse. En mayo el proyecto tenía un adoptante (Sentinel), 286 descargas del *crate*, dos issues abiertos, y un manifesto público que prometía gobernanza estructurada. El umbral para improvisar otro rebrand ya había sido cruzado.
+
+Este post cubre tres cosas: la decisión disciplinada que se tomó el 8 de mayo, el arco operativo de cinco PRs en cuarenta y tres minutos del día siguiente, y los residuos que aparecieron dos días después. Y, por dentro, una distinción más sutil: cuándo un rebrand es solo de superficie y cuándo, sin proponérselo del todo, cambia también la identidad.
+
+---
+
+## 2. El primer rename disciplinado
+
+Lo nuevo del 8 de mayo es la forma. Esta vez había:
+
+- **Una investigación previa.** No se decidió rebrand y luego se justificó; primero hubo un conflicto detectado y luego, en consecuencia, la decisión.
+- **Un ADR público.** Tres alternativas consideradas explícitamente (mantener "DevTrail" y aceptar el riesgo; branding híbrido legacy + nuevo en paralelo; reset a v0.1.0 bajo StrayMark como "proyecto nuevo"). Las tres descartadas con argumento literal.
+- **Un cálculo temporal.** El propio ADR enmarca el costo así: *"The rename window narrows over time — every new adopter increases the cost of changing later... The legal risk dominates. Acting now, with one self-owned adopter, is materially cheaper than acting later under pressure."*
+
+La razón por la que el cálculo importa es estructural. Si el rebrand hubiera esperado dos meses más — hasta que apareciera el segundo adopter, o el tercero — el costo de migración se habría multiplicado. Cada repo adopter habría tenido que ejecutar el `mv .devtrail .straymark`, actualizar sus `CLAUDE.md`/`AGENT.md`, regenerar sus pipelines. Con un solo adopter (el propio operador), el costo era contenido y revertible. Lo que el ADR llama *"acting now is materially cheaper"* es exactamente eso: el rebrand fue una operación de minimización de deuda futura, no una decisión de marketing.
+
+Hay un eco no buscado con el Post 2. Aquel cerró con la frase *"probablemente no vuelva a haber rebranding"*. Este post, escrito desde mayo, sabe que sí lo hubo. La diferencia entre prometer y ratificar es que el cuarto rename, a diferencia de los tres primeros, fue forzado por circunstancias externas que ningún operador puede prever — un conflicto de trademark — y se enfrentó con la disciplina que enero no tenía.
+
+---
+
+## 3. *In scope*, *out of scope* — la pieza maestra del ADR
+
+La sección del ADR que da forma al resto del post es la que distingue qué se renombra y qué se preserva. Citada literal:
+
+> *"In scope (the 'live state' of the project): all identifiers in source code, Cargo metadata, source-of-truth path, 30 skill/workflow files, public documentation, CI workflows, GitHub repository name."*
+
+> *"Out of scope (immutable history, preserved verbatim): all commits, commit messages, and git history; all tags published before this ADR; all release titles and bodies of releases published before; all prior CHANGELOG.md sections."*
+
+Esa distinción es la armadura del rebrand. Lo *live* — paths, comandos, URLs, assets de release, README — se renombra de un golpe. Lo *historic* — git log, tags `devtrail-cli@3.10.0`, sections previas del CHANGELOG, issues cerrados — se preserva literal. El proyecto no se reescribe hacia atrás.
+
+Es la misma disciplina archivística que el Post 3 documentó para el rename Plan → Charter, ahora aplicada al rebrand operativo del framework completo. Lo expreso en una tabla porque ayuda a verlo:
+
+| Capa | Se renombra | Se preserva |
+|---|---|---|
+| Paths del filesystem | `.devtrail/` → `.straymark/` | — |
+| Source Rust | `devtrail-cli` → `straymark-cli` | — |
+| Skills/workflows | 30 archivos `devtrail-*` → `straymark-*` | — |
+| Docs públicas | README, CLAUDE.md, ADOPTION-GUIDE | — |
+| CI/CD | nombres de assets, paths de binarios | Prefijos de tag (`fw-`, `cli-`) sin tocar |
+| Repositorio GitHub | `StrangeDaysTech/devtrail` → `StrangeDaysTech/straymark` | — |
+| CHANGELOG | Nueva entrada `fw-4.11.0` arriba | Secciones previas literal |
+| Tags publicados | — | `fw-4.10.0`, `cli-3.10.0`, etc. preservados |
+| Git log entero | — | Mensajes con "DevTrail" intactos |
+| *Crate* legacy | — | `devtrail-cli@3.10.0` en crates.io, no *yanked* |
+
+La continuidad de versiones es la prueba más visible. El siguiente release no fue `0.1.0` ni `1.0.0`; fue `fw-4.11.0` y `cli-3.11.0`. La numeración declara, sin metáfora, que el proyecto es el mismo proyecto.
+
+---
+
+## 4. Cinco PRs, cuarenta y tres minutos
+
+El 9 de mayo, entre las 06:05 y las 06:48 UTC, se fusionaron cinco PRs en cadena:
+
+| PR | Hora UTC | Qué hizo |
+|---|---|---|
+| [#114](https://github.com/StrangeDaysTech/straymark/pull/114) | 06:05 | Merge del ADR mismo. Cero cambios de código — primero se fija la decisión. |
+| [#115](https://github.com/StrangeDaysTech/straymark/pull/115) | 06:42 | 174 *renames* + 74 modificaciones. Source Rust (38 archivos), tests (18), `dist/.devtrail/` → `dist/.straymark/` (122 archivos vía `git mv`), 30 skills × 3 plataformas. |
+| [#116](https://github.com/StrangeDaysTech/straymark/pull/116) | 06:44 | Docs públicas en tres idiomas (EN/ES/zh-CN). Preámbulo del CHANGELOG actualizado: *"StrayMark (formerly DevTrail; rebranded 2026-05-08)"*. |
+| [#117](https://github.com/StrangeDaysTech/straymark/pull/117) | 06:45 | Workflows de release. Nombres de assets (`straymark-cli-*`), títulos de release. Prefijos de tag intactos. |
+| [#118](https://github.com/StrangeDaysTech/straymark/pull/118) | 06:48 | Bump `fw-4.11.0` / `cli-3.11.0`. Nueva sección del CHANGELOG. |
+
+El orden es deliberado y va de afuera hacia adentro: primero la ley (ADR), después el código interno, después lo que ven los adopters (docs), después la distribución (CI), finalmente el hecho consumado (release). Esta secuencia tiene una lectura archivística: cuando alguien dentro de seis meses revise `git log` en orden cronológico, primero verá la decisión, después la implementación. La causalidad queda en el repo.
+
+Vale la pena nombrar una pieza del arco que rompió el plan original. El ADR había contemplado nueve PRs distintos (uno por capa lógica). En la práctica, los tests del CLI dependían de paths *hardcoded* — `include_str!("../../dist/.devtrail/...")` — y romper el path sin actualizar los tests al mismo tiempo dejaba CI en rojo. El plan se compactó a cinco porque las capas estaban acopladas técnicamente, no porque la disciplina conceptual fallara. La nota del PR #115 lo registra sin atenuar: *"The consolidation was forced by tight coupling: tests use `include_str!` on `dist/.devtrail/` paths."*
+
+Cuarenta y tres minutos para un rebrand que tocó alrededor de doscientos sesenta archivos. La cadencia solo es posible porque el ADR había cerrado todas las decisiones antes de tocar código. El principio #6 del framework — *"cuando la propuesta es bien escrita, la implementación es ejecución, no diseño"* — encontró otro caso de validación, parecido al del audit cycle externo del Post 4.
+
+---
+
+## 5. Por qué StrayMark sí cambia algo más que el nombre
+
+Hasta aquí el ADR es claro: el rebrand es de superficie, la identidad conceptual se preserva. Pero hay un matiz que vale la pena nombrar.
+
+El PR [#120](https://github.com/StrangeDaysTech/straymark/pull/120) — fusionado horas después del arco principal, el mismo 9 de mayo — añadió al README la sección *"Why StrayMark?"*. No es código; es un manifesto. Y dice cosas que ningún documento previo del proyecto había articulado:
+
+> *"Code is just the fossil trace of a mental battle. Real engineering happens in the chaos of decisions, calculated risks, and the paths you chose not to take. Traditionally, all that human trail is discarded as stray marks (accidental smudges) in a project's history. At Strange Days Tech, we believe those marks are the signal, not the noise."*
+
+La elección del nombre, vista desde el manifesto, no es arbitraria. Las *stray marks* — las marcas erráticas, las trazas accidentales que la mayoría de proyectos descartan — son exactamente lo que el framework arrastra a primer plano: AIDECs, AILOGs, TDEs, Charters. Lo que en cualquier proyecto convencional sería ruido descartable, en este proyecto es la materia prima de la auditoría. El nombre encarna la tesis del producto en una forma que *DevTrail* nunca lo hizo. *DevTrail* era un recorrido neutro; *StrayMark* es una afirmación.
+
+El manifesto cierra con tres líneas que después se volvieron lo que un editor llamaría *tagline* operativo:
+
+> *"Capture the noise. Weave the signal. Humanize the machine."*
+
+Aquí está la pequeña tensión interesante del rebrand. El ADR dice que solo cambió la superficie; el manifesto del mismo día sugiere que también se articuló — quizás por primera vez con claridad — la identidad. No es contradicción: el momento del rebrand operativo fue aprovechado para escribir lo que ya estaba en el proyecto pero no se había nombrado todavía. La identidad no cambió. Se hizo legible.
+
+---
+
+## 6. Lo que quedó pendiente
+
+Aun con ADR público y arco disciplinado, *"completo"* sigue siendo aproximación.
+
+Dos días después del rebrand, mientras Sentinel preparaba su siguiente ciclo de auditoría externa, el agente señaló tres clases de residuos. La cronología — captura honesta en `CHANGELOG.md` como erratas inline — vale la pena dejarla a la vista:
+
+- **PR [#137](https://github.com/StrangeDaysTech/straymark/pull/137)** (11 may, 22:55) — *Skill directories órfanos*. El rebrand reescribió el campo `name:` dentro de cada `SKILL.md`, pero no renombró los directorios de las tres plataformas (`.gemini/skills/devtrail-*`, `.claude/skills/devtrail-*`, `.agent/workflows/devtrail-*.md`). Treinta artefactos órfanos: nombre nuevo, ruta vieja. Gemini CLI lo reportó como diez warnings de conflicto al arrancar.
+- **PR [#138](https://github.com/StrangeDaysTech/straymark/pull/138)** (11 may, 23:32) — *Charter paths legacy*. Tres artefactos del framework seguían referenciando `docs/charters/` después de que `fw-4.12.0` migró el path canónico a `.straymark/charters/`. Lo más grave: el hook `pre-pr.sh` estaba gated en `[ ! -d docs/charters ]`, lo cual hacía *exit 0* silencioso para cualquier adopter post-4.12.0. El drift check llevaba siete meses instalado pero no-op.
+- **PR [#139](https://github.com/StrangeDaysTech/straymark/pull/139)** (12 may, 12:02) — *Instaladores rotos*. `install.sh` e `install.ps1` aún apuntaban a `REPO=StrangeDaysTech/devtrail`, `BINARY=devtrail`, asset name `devtrail-cli-v*`. El README — ya rebranded — apuntaba a la nueva URL. Resultado: cualquier usuario que copiara el comando del README desde el 9 de mayo recibía un 404 de GitHub al ejecutar el instalador. *El producto estuvo roto en producción durante setenta y dos horas.*
+- **PR [#140](https://github.com/StrangeDaysTech/straymark/pull/140)** (12 may, 16:49) — *Micro-residuo*. La línea uno de `.gitignore` decía aún `# DevTrail - .gitignore`. Más una entrada nueva para `Aparador/` en patterns internos.
+
+La lección no es que la disciplina fue insuficiente. Es que la disciplina *no previene* residuos — los hace encontrables, documentables, y reparables en errata inline pública. Los tres primeros renames (enero) probablemente tuvieron residuos equivalentes; nunca los catalogamos porque no había hábito documental. El cuarto rebrand los catalogó. Es el primer rebrand del proyecto que admite, en el repo público y en el CHANGELOG mismo, que el operario no atrapó todo a la primera.
+
+El detalle más incómodo — los instaladores rotos por setenta y dos horas — es el que más me importa registrar. Si en lugar de un adopter solo (el operador) hubiera habido un equipo, esa ventana habría afectado a usuarios reales. Acting now, with one self-owned adopter, was materially cheaper, says the ADR. Eso es exactamente lo que esa frase compraba: el derecho a equivocarse durante setenta y dos horas sin lastimar a nadie.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **No todos los renames son del mismo tipo.** Los tres de enero buscaban al concepto; el de mayo defendía al proyecto contra deuda futura legal. Solo el de mayo podía hacerse con ADR público, porque solo el de mayo nacía de evidencia externa y no de intuición interna.
+
+2. **La distinción superficie vs. identidad pertenece al documento, no a la retórica.** El ADR mismo declara qué se renombra y qué se preserva. Esa lista — paths sí, git log no; release titles sí, tags previos no — es la armadura del rebrand. Sin esa lista explícita, *"rebrand"* significa cualquier cosa.
+
+3. **La identidad puede hacerse legible aunque no cambie.** El manifesto *"Why StrayMark?"* no inventó lo que el proyecto era; lo articuló por primera vez con claridad. El rebrand operativo fue aprovechado para escribir lo que ya estaba en el código pero no había salido al README. La identidad no se reescribió, se publicó.
+
+4. **La disciplina no previene residuos; los hace encontrables.** Cuatro PRs *errata* dos días después no son falla del rebrand; son evidencia de que el rebrand fue lo suficientemente honesto como para admitir qué se le escapó. Los tres renames de enero probablemente tuvieron equivalentes; nunca aparecieron documentados.
+
+Sigue, en el siguiente post, un episodio que conecta directamente con el último punto: *TDE como mecanismo para nombrar deuda transversal* (`H-09`). El primer caso real que el framework usó para articular cómo evidenciar la deuda — y que dejó una lección dura sobre stacked-PRs que merece su propio párrafo cuando llegue ahí.
+
+---
+
+*Anclas: ADR [`2026-05-08-001`](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-05-08-rebranding-straymark.md). Arco nuclear: PRs [#114](https://github.com/StrangeDaysTech/straymark/pull/114) · [#115](https://github.com/StrangeDaysTech/straymark/pull/115) · [#116](https://github.com/StrangeDaysTech/straymark/pull/116) · [#117](https://github.com/StrangeDaysTech/straymark/pull/117) · [#118](https://github.com/StrangeDaysTech/straymark/pull/118). Manifesto: PR [#120](https://github.com/StrangeDaysTech/straymark/pull/120). Residuos: PRs [#137](https://github.com/StrangeDaysTech/straymark/pull/137) · [#138](https://github.com/StrangeDaysTech/straymark/pull/138) · [#139](https://github.com/StrangeDaysTech/straymark/pull/139) · [#140](https://github.com/StrangeDaysTech/straymark/pull/140). Release: `fw-4.11.0` / `cli-3.11.0`.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
@@ -1,0 +1,136 @@
+---
+slug: validate-y-los-schemas-como-capa-formal
+title: Validate y los schemas como capa formal
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - validate
+  - schemas
+  - governance
+  - phase-2
+date: 2026-05-11T00:00:00.000Z
+description: 'Phase 2: cuando el framework empieza a verificar lo que prometía'
+---
+## 1. Tener schemas no es lo mismo que validar contra schemas
+
+`straymark validate` existía desde el 25 de marzo de 2026 — PR #27, parte del primer arco de Phase 1 del CLI. Lo que hacía entonces era pequeño: verificar que los documentos en `.straymark/` tuvieran sintaxis Markdown válida, frontmatter parseable, y los campos mínimos del tipo correcto. Era útil. No era *enforcement*.
+
+Lo que cambió el 11 de mayo de 2026, con el release `fw-4.6.0 / cli-3.7.0`, fue otra cosa: Phase 2 del roadmap del CLI cerró un arco completo de siete PRs (#73 a #79) y los consolidó en uno solo (#80). El CHANGELOG lo dice sin metáfora:
+
+> *"The first feature-bearing release since the repositioning... Phase 2 of `Propuesta/devtrail-cli-roadmap.md` lands as 7 bisect-safe PRs (#73–#79), grouped here for reviewers. The release closes the empirical loop the Sentinel experiment opened: telemetry at Charter close, drift detection at Charter close, and a canonical approval signal for `review_required: true` documents."*
+
+Lo que importa para este post no son los siete PRs como hitos individuales; son los tres que tocaron el comando `validate` y los schemas. Lo que en marzo era *"verifico que esto parece un documento"* en mayo se volvió *"verifico que esto cumple el schema canónico del tipo, en el modo que pidas, con consecuencias operativas concretas"*.
+
+---
+
+## 2. Del bash artesanal al flag de comando
+
+Una de las piezas más visibles del cambio es pequeña: el flag `--staged`.
+
+Hasta Phase 2, el patrón recomendado para que los adoptantes validaran sus documentos antes de un commit era un script bash llamado `pre-commit-docs.sh`. Vivía en `dist/.straymark/scripts/` y tenía 464 líneas. Hacía lo razonable: leer `git diff --cached --name-only`, filtrar archivos en `.straymark/`, parsear su frontmatter con `awk`, verificar campos. Funcionaba. Y era 464 líneas de bash que cada adoptante tenía que confiar en que ejecutaba lo correcto, en su versión correcta, con su parser de YAML correcto.
+
+PR del 28 de marzo (commit `d9ea874`) reemplazó las 464 líneas por un flag:
+
+```bash
+straymark validate --staged
+```
+
+Lee los staged files igual, filtra por `.straymark/` igual, valida igual. La diferencia: hoy todo eso vive en Rust dentro del binario, no en bash en disco. El adoptante no tiene que mantener el script; el script no puede divergir entre versiones; el comportamiento es el mismo en Linux, macOS y Windows. El framework dejó de pedirle al adoptante que confiara en un script suelto y empezó a darle un comando con la promesa implícita del binario versionado.
+
+Es el mismo patrón que el Post 6 documentó para la disciplina de archivo (preservar git history en lugar de reescribir) o que el Post 4 documentó con la decisión A1 (orquestar sin invocar APIs): pasar de *"el operador hace X manualmente con riesgo de divergir"* a *"el framework canoniza X en un comando declarativo"*. El `--staged` no es feature exótico; es deuda manual barrida.
+
+---
+
+## 3. Los tres schemas v0
+
+Phase 2 también consolidó los tres schemas que viven en `dist/.straymark/schemas/`:
+
+| Schema | Qué describe | Origen |
+| --- | --- | --- |
+| `charter.schema.v0.json` | Estructura del Charter como entidad de primera clase (Post 4) | Sentinel `/plan-audit` (6 ciclos, format v1 → v2 → v3) |
+| `charter-telemetry.schema.v0.json` | Telemetría de Charters (Post 3, ampliado en Post 10) | 5 archivos `PLAN-NN.telemetry.yaml` de Sentinel |
+| `audit-output.schema.v0.json` | Output canónico de auditoría externa (Post 4 + Post 10) | Sentinel dual-audit (Copilot + Gemini + Claude crítico) |
+
+Cada schema lleva un campo `$comment` en su raíz. El de `charter.schema.v0.json` dice literal:
+
+> *"EXPERIMENTAL v0. Crystallized from Sentinel /plan-audit (6 cycles, format v1 → v2 → v3). Will not stabilize to v1.0 until validated in a second domain (frontend, ML pipeline, or infra-as-code)."*
+
+El de `charter-telemetry.schema.v0.json`, parecido:
+
+> *"EXPERIMENTAL v0. Derived from 5 PLAN-NN.telemetry.yaml files in Sentinel (one project, Go backend) — same N=1-domain caveat as charter.schema.v0.json. Will not stabilize to v1.0 until validated in a second domain."*
+
+El de `audit-output.schema.v0.json`, idem:
+
+> *"EXPERIMENTAL v0.x. Phase 3 of the CLI roadmap. Crystallized from the dual-audit pattern validated empirically in Sentinel."*
+
+Los tres comparten una declaración explícita: *no crystallizes without a second domain*. Es el principio #12 del framework, no como párrafo aparte en una documentación de gobernanza, sino **dentro del propio JSON Schema, en un campo que cualquier validador estándar lee y cualquier herramienta de schema-explorer renderiza al usuario**. El framework no esconde la provisionalidad de sus schemas; la pone donde nadie pueda perderla.
+
+Esto importa más de lo que parece. La práctica habitual en ecosistemas de schemas (JSON Schema, OpenAPI, Avro) es publicar `v1` y luego bumpear conforme cambias. Marcar `v0` con un `$comment` que dice *"esto es experimental hasta que un segundo dominio lo valide"* es admitir, de origen, que la primera cristalización no es la definitiva. La schema misma es honesta.
+
+---
+
+## 4. Tres modos del comando
+
+`straymark validate` ya no es un comando con un solo flujo. Después de Phase 2 tiene tres modos operativos, cada uno acoplado a un momento del ciclo de vida:
+
+- **Modo `all` (default)** — `straymark validate` sin flags. Camina recursivamente `.straymark/`, parsea cada archivo `.md`, intenta resolver su tipo (AILOG, AIDEC, ADR, ETH, REQ, TES, INC, TDE, MCARD, SBOM, SEC, DPIA, Charter), aplica el schema correspondiente, y reporta violaciones por archivo. Es el modo *auditoría completa*. Útil para CI, útil para revisar un repo nuevo, útil cuando el adoptante quiere medir cuánta deuda formal acumuló.
+
+- **Modo `--staged`** — `straymark validate --staged`. El que reemplazó al bash. Solo valida archivos que `git diff --cached --name-only` reporta como staged dentro de `.straymark/`. Su lugar natural es `.git/hooks/pre-commit`, y desde fw-4.6.0 hay un `straymark init --hooks` que lo instala automáticamente. Es el modo *gate operativo* — el que evita que documentos rotos lleguen a `main`.
+
+- **Modo `--check-pending-reviews`** — `straymark validate --check-pending-reviews`. El más sutil de los tres, y el que justifica más párrafos.
+
+Hasta Phase 2, un documento que el agente marcaba `review_required: true` en el frontmatter (un AIDEC con confianza baja, un AILOG con riesgo alto, etc.) quedaba esperando *aprobación humana*. Pero no había una forma canónica de *señalar* esa aprobación. El operador leía el documento, mentalmente lo aprobaba, seguía. No quedaba rastro estructural de la aprobación. Esto era exactamente el Issue [#67](https://github.com/StrangeDaysTech/straymark/issues/67).
+
+`--check-pending-reviews` cierra ese hueco. El comando recorre todos los documentos con `review_required: true` y los listsa con su `confidence`, su `risk_level`, su autor (humano o agente), y su fecha. La aprobación es un commit que cambia `review_required: true` → `review_required: false` con co-autoría humana en el commit message — y `validate --check-pending-reviews` deja de listar el documento. La aprobación es un *signal canónico*, no un acuerdo verbal con uno mismo.
+
+Es la pieza que cierra el ciclo del agente. El framework permite al agente crear documentos sin pre-aprobación humana (Post 1, propiedad #2: *"permiso cultural sin control bloqueante"*); pero los marca para revisión cuando corresponde; y ahora tiene un comando para listar lo pendiente, sin escapatoria. Ningún documento de auditoría se pierde en silencio.
+
+---
+
+## 5. Phase 2 cierra el loop empírico
+
+Vale la pena rescatar la frase del CHANGELOG entera porque condensa lo que el release significa:
+
+> *"The release closes the empirical loop the Sentinel experiment opened: telemetry at Charter close, drift detection at Charter close, and a canonical approval signal for `review_required: true` documents (resolving issue #67)."*
+
+Tres piezas que cierran un arco que arrancó en el experimento de los seis Planes (Post 3):
+
+1. **Telemetría al cierre del Charter** — el bloque YAML que Sentinel llenaba a mano durante el experimento se convirtió en el schema `charter-telemetry.schema.v0.json` validable.
+2. **Drift detection al cierre del Charter** — el script bash de 145 líneas (`check-plan-drift.sh`) se convirtió en el subcomando `straymark charter drift`, integrado al validate flow.
+3. **Approval signal canónico** — lo que el operador hacía mentalmente se convirtió en un comando con consecuencias estructurales: `--check-pending-reviews`.
+
+Es el patrón que el blog ha visto repetirse: cada vez que el framework cristaliza una práctica que Sentinel hacía manualmente, lo hace después de validar empíricamente que la práctica funciona. La diferencia esta vez es que **el comando que verifica la cristalización es parte del paquete**. Antes del Phase 2, Sentinel tenía templates, schemas declarados, y la promesa implícita de que los documentos seguían los schemas. Después de Phase 2, hay un comando que **lo comprueba**. No es un cambio de capacidad; es un cambio de garantías.
+
+---
+
+## 6. El principio #12, hecho schema
+
+La pieza filosófica del post — y la que más me interesa dejar registrada — es esta:
+
+Los `$comment` de los tres schemas v0 codifican un principio que el framework venía declarando en prosa desde abril. El Post 4 lo nombró así: *"schema marked `v0` on purpose, not `v1`, because the framework's principle #12 says no schema crystallizes without a second domain validating it"*. El Post 7 lo aplicó al diseño del TDE: *"the framework validated principle #12 again: no schema crystallizes without a second domain"*. El Post 10 lo aplicó a Pattern 1 y Pattern 2: *"the document says so without shortcuts: the pattern is empirically validated in Sentinel. Wait for the second domain before crystallizing it higher"*.
+
+Phase 2 hace algo distinto. **No declara el principio; lo escribe dentro del schema mismo, en un lugar que cualquier consumidor del schema va a leer.** El `$comment` no es marketing; es protocolo. Cualquier validador de JSON Schema 2020-12 lo expone; cualquier IDE que parsea el schema lo muestra. Es la primera vez que el framework formaliza la provisionalidad de sus formalizaciones.
+
+Si quisiera resumirlo en una sola frase: el framework valida lo que tiene, sabiendo que lo que tiene es provisional, y deja eso por escrito *en el lugar donde la validación ocurre*. Validar lo provisional es disciplina. Cristalizar prematuramente y validar lo cristalizado es teología.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Tener schemas no es lo mismo que validar contra schemas.** El primer paso es declarativo; el segundo es operativo. Phase 2 hizo el segundo, no el primero. La diferencia entre los dos modos del framework — *"tengo la promesa"* vs. *"tengo el comando que la comprueba"* — es lo que determina si el adoptante puede confiar en lo declarado.
+
+2. **El patrón "bash artesanal → flag de comando" es estructural.** El `--staged` no es feature aislado. Es la versión Phase 2 del mismo patrón que Post 4 documentó para el audit cycle externo, que Post 10 documentó para los CLI helpers de chain evolution: imperativo verboso → declarativo legible → versionado. Cada vez que el framework barre un script bash por un flag, sube una capa de garantías.
+
+3. **El `--check-pending-reviews` cierra el ciclo del agente.** Lo que Post 1 nombró como permiso cultural sin pre-aprobación se completa aquí: el agente puede crear, pero los documentos marcados para revisión no se pierden — el comando los lista hasta que un humano los apruebe con un commit explícito. Sin ese signal, el permiso cultural del Post 1 sería negligencia.
+
+4. **Provisionalidad declarada > formalización prematura.** Los `$comment` de los schemas v0 hacen el principio #12 protocolo, no doctrina. Cualquier herramienta que consuma el schema sabe que la formalización es provisional. Es la honestidad estructural más fuerte que puede tener un framework joven: validar lo que tiene, sin pretender que lo tenido es definitivo.
+
+---
+
+*Anclas: PR [#27](https://github.com/StrangeDaysTech/straymark/pull/27) — versión original de `validate` (marzo 2026). Phase 2: PRs #73 a #79 + PR [#80](https://github.com/StrangeDaysTech/straymark/pull/80) — `fw-4.6.0 / cli-3.7.0` (fusionado 2026-05-11). Schemas: `dist/.straymark/schemas/{charter,charter-telemetry,audit-output}.schema.v0.json`. [Issue #67](https://github.com/StrangeDaysTech/straymark/issues/67) — origen del `--check-pending-reviews`.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-12-tde-and-transversal-debt.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-12-tde-and-transversal-debt.md
@@ -1,0 +1,158 @@
+---
+slug: tde-y-la-deuda-transversal
+title: TDE y la deuda transversal
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - tde
+  - deuda-técnica
+  - governance
+  - git-workflow
+date: 2026-05-12T00:00:00.000Z
+description: El tipo existía. El trigger no. Y la lección stacked-PR que llegó de regalo.
+---
+## 1. Cero TDEs en trece Charters
+
+El Issue [#128](https://github.com/StrangeDaysTech/straymark/issues/128) abre con una asimetría inquietante:
+
+> *"Sentinel adopter (primary, fw-4.12.0) created zero TDEs across 13 closed Charters despite ≥7 instances of transversal debt routed through parallel mechanisms."*
+
+Trece Charters cerrados. Al menos siete piezas reconocibles de deuda transversal — heredada de Charters anteriores, atravesando módulos, persistente entre sesiones. Cero TDEs. Si el operador hubiera estado discutiendo cumplir cuotas, el dato no significaría nada. Pero el operador era yo y el adoptante era el mismo proyecto que valida empíricamente el framework. Si Sentinel — el repo donde más se intentó usar el framework completo — no producía TDEs ni una vez en trece intentos, había algo roto.
+
+Lo roto no era la deuda, que estaba siendo capturada por otros canales (`R<N> (new, not in Charter)` dentro de los AILOGs, entradas en `follow-ups-backlog.md`). Lo roto era que ningún criterio del framework decía *"esta pieza concreta merece TDE, no R<N>"*. El tipo de documento existía. El trigger operativo, no.
+
+Este post cubre el episodio del 11-12 de mayo de 2026: cómo se diagnosticó la falta del trigger, cómo se cerró con cuatro criterios canónicos (`fw-4.13.0`), y cómo el ciclo de PRs que arregló el problema dejó al pasar una lección operativa sobre stacked-PRs que terminó codificada en el `CLAUDE.md` del proyecto. Es el primer episodio del blog donde el framework arregla *dos cosas distintas* en el mismo arco, y donde la segunda es accidental.
+
+---
+
+## 2. El tipo existía. El trigger no.
+
+`TDE` — *Technical Debt Entry* — existe en el framework desde el primer commit de enero (Post 2 lo registra: estaba en la lista de ocho tipos originales del README v1.0.0). El template estaba. El campo en la taxonomía estaba. La carpeta `06-evolution/technical-debt/` estaba.
+
+Lo que no estaba era una frase, en algún sitio del aparato canónico, que dijera *"crea un TDE ahora"*. El Issue #128 lo formuló sin atenuar:
+
+> *"Reading the adopter-facing docs (`AGENT-RULES.md`, `DOCUMENTATION-POLICY.md`, `QUICK-REFERENCE.md`, `CLAUDE.md` autonomous rules), there is no clear trigger that says 'create a TDE now'. The trigger language exists for AILOG (creation freely), AIDEC (when alternatives considered), ETH (high risk PII), ADR (architectural decisions), but TDE is just listed as 'agent can Identify'."*
+
+*"Agent can identify."* Identifica si quiere. Un agente entrando al repo lee esa línea, encoge los hombros, y sigue con AILOG y AIDEC, que sí le dicen *cuándo*. El defecto es el mismo del Issue #113 (Post 5): el artefacto técnicamente existe, pero la *superficie* canónica no le da al agente el verbo necesario para activarlo. Lo que diferencia este caso del #113 es la consecuencia. Para Charters, no verlos significaba no usar el flujo nuevo. Para TDE, no verlos significaba mucho peor: la deuda transversal *se capturaba* — pero fragmentada, sin vista consolidada, sin priorización entre artefactos, sin campo `assigned_to` ni `priority` para que un revisor humano pudiera ordenarla.
+
+El Issue cita esa consecuencia con un nivel de detalle que da vergüenza, porque enumera todo lo que no estaba ocurriendo:
+
+> *"No queryable 'all open technical debts' view at the document level. No `impact × effort` prioritization matrix per item. No `assigned_to` / `priority` fields surfaced to the human reviewer. Architectural debt that legitimately spans multiple charters (e.g., scope authorization gap heritage across modules) gets fragmented into per-charter R-numbers instead of consolidated into a single TDE."*
+
+Trece Charters de deuda fragmentada en `R<N>` per-Charter. Vista del operador del repo: ninguna lista consolidada, ninguna heredada explícitamente nombrada como tal, ninguna pieza de deuda priorizable a nivel de proyecto. Todo estaba en el repo. Nada estaba en el sitio que el repo construye para los humanos que vienen a leerlo de afuera.
+
+---
+
+## 3. Cuatro criterios para una pieza de deuda
+
+El PR [#129](https://github.com/StrangeDaysTech/straymark/pull/129) (`fw-4.13.0`, fusionado el 11 de mayo a las 19:38 UTC, exactamente 13 horas después de abrirse el Issue) cerró el hueco con una sección nueva en `AGENT-RULES.md §3` titulada *"TDE vs `R<N> (new, not in Charter)"*. Los cuatro criterios literales:
+
+| Criterio | Cuándo aplica |
+|---|---|
+| **1. Heritage from a prior Charter** | La deuda viene heredada literalmente del Charter anterior (*strict heritage*) o reaparece al seguir el patrón del Charter anterior (*pattern propagation*). |
+| **2. Applies to multiple modules or Charter execution boundaries** | La deuda atraviesa módulos del código *o* atraviesa límites de ejecución entre Charters (governance-trail debt). |
+| **3. Requires a dedicated Charter outside current scope** | Resolverla requiere abrir un Charter propio, fuera del envelope del Charter actual. |
+| **4. Requires human prioritization/assignment** | Decidir prioridad o asignación está fuera del rango del agente. |
+
+La regla operativa: si una pieza de deuda satisface *al menos uno* de los cuatro criterios, es TDE. Si no satisface ninguno, sigue siendo `R<N>` dentro del Charter donde apareció.
+
+Los cuatro tienen su lógica. Heritage (1) captura la deuda que persiste a través del tiempo, lo que un revisor querría ver agrupado por origen, no por Charter. Multi-module o multi-Charter (2) captura la deuda que vive *entre* artefactos, no *dentro* de uno. Dedicated Charter (3) reconoce que algunas piezas de deuda son tan grandes que merecen su propio ciclo y, por tanto, no caben como riesgo declarado *ex-ante*. Human prioritization (4) reconoce el límite de autonomía: hay decisiones que el agente puede señalar pero no resolver, y esas decisiones merecen un documento donde un humano pueda hacer cola.
+
+El mismo PR añadió un campo nuevo al frontmatter del template TDE — `promoted_from_followup: FU-NNN | null` — y una sección en `FOLLOW-UPS-BACKLOG-PATTERN.md` que documenta cómo ascender una entrada de follow-ups a TDE. La promoción tiene dos formas, ambas registradas literalmente: promoción de entrada existente (un follow-up que llevaba semanas en la lista madura a TDE) y *retropromotion at creation* (al crear el TDE se reconoce que originó en un follow-up anterior y se anota). El campo del frontmatter cierra el rastro: cualquier TDE puede ahora apuntar hacia atrás al follow-up que lo originó, si existió.
+
+---
+
+## 4. Tres TDEs en Sentinel — el loop empírico cerrado
+
+El Issue #128 no cerró por argumento; cerró por evidencia. El mismo día, Sentinel — el mismo adoptante que llevaba trece Charters sin un solo TDE — creó tres:
+
+- Un TDE para una **brecha arquitectónica de RequireScope**, herencia que atravesaba módulos. Criterios 1 + 2 + 3.
+- Un TDE sobre **cobertura de tests faltante en la capa HTTP**, deuda que persistía a través de Charters de feature. Criterios 1 + 4.
+- Un TDE de **revisión de AILOGs legacy** anteriores al format v3 de Charter, una pieza que necesitaba su propio ciclo. Criterios 1 + 3.
+
+Tres documentos en horas. La velocidad importa menos que el hecho de que cada uno aplicó *al menos uno* de los criterios y ninguno cayó en zona gris. Los criterios funcionaron como heurística sin ambigüedad — el operador no tuvo que negociar consigo mismo sobre si una pieza era TDE o `R<N>`. El loop empírico que el Issue había abierto en la mañana cerró con tres documentos esa misma tarde.
+
+El PR [#136](https://github.com/StrangeDaysTech/straymark/pull/136) (`fw-4.13.1`, fusionado al día siguiente) refinó dos criterios a partir de esa misma experiencia. *Heritage* (1) se desdobló explícitamente en *strict heritage* vs *pattern propagation* porque uno de los tres TDEs de Sentinel mostraba el segundo caso de forma clara: la deuda no era heredada literal, era el mismo patrón reaparecido al seguir el mismo procedimiento. *Multi-module* (2) se reformuló como *"multiple modules **or Charter execution boundaries**"* porque otro de los tres TDEs era de governance-trail (cruzaba límites de sesión sin cruzar módulos de código). Los criterios crecieron una sola refinement-pass después de ejercerse en tres casos reales. El framework volvió a validar el principio #12: ningún schema cristaliza sin un segundo dominio.
+
+---
+
+## 5. La lección stacked-PR
+
+Aquí es donde el post se desvía con propósito. El arco de PRs #129 → #131 → #133 que cerró el Issue #128 dejó una lección operativa adyacente — no sobre TDE sino sobre cómo *no* hay que armar branches encadenadas. La lección está hoy documentada literal en `CLAUDE.md` (líneas 181-220) del repo público bajo la sección **"Stacked PRs — avoid, or use merge commits"**.
+
+### Cómo se rompió
+
+PR #131 (`cli-3.12.1`, fix del validator que rechazaba `status: identified` en TDEs) se abrió con `base = #129` porque `#131` necesitaba el código de `#129` para compilar sus tests. Después, `#129` se fusionó a `main` con *squash*. El `CLAUDE.md` actual lo describe con una precisión que vale la pena citar entera:
+
+> *"When you stack PR B on top of PR A's branch (base of B is A's head, not `main`), and A is squash-merged to `main`, B's content gets stranded:*
+>
+> *— The squash merge of A creates a new commit on `main` with content equivalent to A but a different SHA than A's original commits.*
+>
+> *— B's branch still points at A's original commits, which now have no descendant on `main`.*
+>
+> *— When B is merged, GitHub merges it into A's branch (its declared base), not `main`. The 'merge to main' never happens — even though GitHub UI shows B as MERGED."*
+
+Resultado en la práctica del ciclo #129/#131: la UI de GitHub mostraba `#131` como *MERGED*, los tests del validator estaban en main aparentemente, pero el contenido nunca llegó. PR #133 fue el sync procedural que tuvo que abrirse después para llevar el contenido a su destino. Tiempo perdido en diagnóstico: alrededor de tres horas. Tiempo de la operación de recuperación una vez entendida: cinco minutos.
+
+### Cómo se previene
+
+El `CLAUDE.md` documenta dos estrategias, una conservadora y una pragmática:
+
+> *"1. Sequential, not stacked. Wait for PR A to merge to `main`, then rebase B onto `main` and open B as a standalone PR with `base = main`. Slower but bulletproof.*
+>
+> *2. If you must stack, use merge commits (not squash) for the parent. A merge commit preserves shared history, so subsequent merges of stacked PRs into `main` resolve cleanly. Pay the cost of a noisier `git log` for the stacked-PR safety."*
+
+Sentinel y StrayMark por defecto usan squash. Esa elección es buena para tener un `git log` limpio, una decisión por feature, un commit por PR. Pero cuesta exactamente esto: incompatibilidad con stacked-PRs. La regla que el `CLAUDE.md` ahora codifica es honesta: o no apilas, o pagas en historia de commits para poder apilar. No hay tercera opción que no rompa algo.
+
+### Cómo se recupera (si ya pasó)
+
+La sección de recovery del `CLAUDE.md` es la pieza más operativa del documento. Cuatro pasos:
+
+> *"1. `git checkout -b chore/sync-<B-content>-to-main main`*
+>
+> *2. `git cherry-pick <B's merge commit SHA>` — should be clean because B touches files outside A's conflict zone (which is why it could be stacked in the first place).*
+>
+> *3. Push, open PR with `base = main, head = chore/sync-...`. Cherry-pick produces a fresh commit on top of `main`, so no conflicts.*
+>
+> *4. The branch protection may require `--admin` merge if the content was already reviewed in B (the original PR) — sync PRs are purely procedural."*
+
+El último paso es importante editorial mente: nota explícita de que un merge `--admin` está autorizado *solo* para PRs procedurales como este — donde el contenido ya fue revisado en el PR original. Es la única excepción a la regla *"el contenido va por revisión humana"* del proyecto.
+
+La razón por la que vale la pena registrar la lección como sub-sección del post sobre TDE — y no como post separado — es que comparten un rasgo: ambas son piezas de **deuda transversal de proceso** que el framework ahora nombra explícitamente. Una es deuda de código (TDE como tipo nuevo); la otra es deuda de workflow (stacked-PR como anti-patrón documentado). Las dos comparten origen: la fricción operativa real fue lo que disparó el documento.
+
+---
+
+## 6. Lo que el episodio dejó en el repo
+
+Cuatro PRs en menos de veinticuatro horas, tres lecciones registradas:
+
+- **PR [#129](https://github.com/StrangeDaysTech/straymark/pull/129)** (`fw-4.13.0`, 11 may 19:38 UTC) — TDE activation trigger. Cuatro criterios + sección nueva en `AGENT-RULES.md §3` + path FU → TDE.
+- **PR [#131](https://github.com/StrangeDaysTech/straymark/pull/131)** (`cli-3.12.1`, 11 may 19:39 UTC) — validator acepta `status: identified` en TDEs. Sin el fix, el primer TDE creado bajo el nuevo trigger fallaba la validación.
+- **PR [#134](https://github.com/StrangeDaysTech/straymark/pull/134)** (12 may 04:54 UTC) — la lección stacked-PR documentada en `CLAUDE.md`. No cambió código del framework; cambió las reglas operativas del repo.
+- **PR [#136](https://github.com/StrangeDaysTech/straymark/pull/136)** (`fw-4.13.1`, 12 may 04:54 UTC) — refinamientos del trigger TDE basados en los tres casos reales de Sentinel.
+
+Lo que más me interesa señalar de la cronología: el `CLAUDE.md` (PR #134) se actualizó el mismo arco que cerró el Issue #128. La lección stacked-PR no esperó a olvidarse. Si la disciplina del framework es *"todo cambio significativo deja rastro documentado"*, eso aplica también a la fricción operativa, no solo al diseño. El framework existe, en parte, para que los aprendizajes caros no se evaporen.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Un tipo de documento sin trigger es un tipo invisible.** Igual que en el Issue #113, lo que el agente no ve al entrar al repo no existe para él. TDE existía técnicamente desde enero, pero solo empezó a usarse cuando los cuatro criterios aparecieron en `AGENT-RULES.md §3`. Estructura sin verbo activador es decoración.
+
+2. **La deuda transversal merece tipo propio.** Fragmentar deuda en `R<N>` per-Charter destruye la propiedad más importante de un sistema de gobernanza: la vista consolidada. Cuatro criterios, cualquiera basta, sostienen la línea entre *este es riesgo del Charter* y *esto es deuda del proyecto*.
+
+3. **Los aprendizajes operativos también se documentan.** PR #134 actualizó el `CLAUDE.md` del proyecto el mismo día que la lección apareció. No es paranoia archivística; es la misma regla aplicada hacia los procesos: si la fricción te costó tres horas hoy, escribe la lección hoy.
+
+4. **El framework crece tanto por features como por anti-patrones.** Este episodio dejó un tipo nuevo (TDE como entidad operativa) *y* un anti-patrón documentado (stacked-PRs incompatibles con squash). Ambas cosas son material del framework, aunque solo una aparezca como bump de versión.
+
+Sigue, en el siguiente post, un episodio breve pero estructural: *"El audit-prompt en español era el outlier"* (`H-10`). Un detalle de convención i18n que reveló qué idioma estaba siendo el canónico — y por qué corregirlo cambió, sin proponérselo, cómo el framework piensa sobre traducción.
+
+---
+
+*Anclas: [Issue #128](https://github.com/StrangeDaysTech/straymark/issues/128). PRs [#129](https://github.com/StrangeDaysTech/straymark/pull/129) · [#131](https://github.com/StrangeDaysTech/straymark/pull/131) · [#134](https://github.com/StrangeDaysTech/straymark/pull/134) · [#136](https://github.com/StrangeDaysTech/straymark/pull/136). Releases: `fw-4.13.0` / `cli-3.12.1` / `fw-4.13.1`. Lección stacked-PR codificada en [`CLAUDE.md` líneas 181-220](https://github.com/StrangeDaysTech/straymark/blob/main/CLAUDE.md) del repo.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-13-the-audit-prompt-was-the-outlier.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-13-the-audit-prompt-was-the-outlier.md
@@ -1,0 +1,87 @@
+---
+slug: el-audit-prompt-era-el-outlier
+title: El audit-prompt era el outlier
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - i18n
+  - audit
+  - governance
+date: 2026-05-13T00:00:00.000Z
+description: El único archivo del framework que vivía en otro idioma
+---
+## 1. Una sola línea del commit
+
+Esta es la entrada operativa del post 8. El commit `a8a1ac5` del 12 de mayo de 2026 carga un cuerpo que se abre con esta frase:
+
+> *"The unified audit-prompt template at `dist/.straymark/audit-prompts/` was the only framework artifact whose canonical content lived in Spanish — every other template, skill, workflow, and governance doc follows the EN-canonical + `i18n/<lang>/` overlay pattern resolved by `cli/src/utils.rs:146`."*
+
+Un solo archivo. Entre docenas. Vivía al revés. Y vivía así desde mayo del año anterior, sin que nadie lo notara.
+
+Este post es corto a propósito. La corrección que cubre — PR [#142](https://github.com/StrangeDaysTech/straymark/pull/142), `fw-4.13.3` y `cli-3.12.3`, fusionado el 13 de mayo — no es un hito narrativo grande. Es una pieza de mantenimiento. Pero registra una de las regularidades que más me sigo encontrando en este oficio: los outliers son útiles. Te enseñan la convención por contraste.
+
+---
+
+## 2. De dónde venía el outlier
+
+El audit-prompt no nació en el framework. Nació como una *skill* local de Sentinel — `sentinel/.claude/skills/plan-audit/` — durante el experimento de los seis Planes que cubrió el Post 3, en abril. Era una skill *context-specific*, escrita por el operador (yo) en español por razones que ahora se pueden enumerar honestamente: era un experimento privado, el operador habla español, y nadie iba a leer la skill nunca más. La improvisé en mi idioma porque era para mí.
+
+Cuando el experimento se cristalizó en el framework — el arco de fw-4.4.0 a fw-4.9.0 que cubrió el Post 4 — la skill se portó al canonical path `dist/.straymark/audit-prompts/audit-prompt.md`. El porte fue mecánico: copiar el archivo, generalizarlo lo suficiente para que no mencionara componentes específicos de Sentinel, ajustar la nomenclatura *Plan* → *Charter*. Lo que no se hizo: traducirlo al inglés. El archivo entró al framework *en el idioma en que lo había escrito*. Sin que nadie lo decidiera, el español pasó a ser la versión canónica de ese único artefacto.
+
+El resto del framework — todos los demás templates, todas las skills, los governance docs canónicos — habían sido escritos en inglés desde enero, con español y zh-CN como overlays bajo `i18n/<lang>/`. El audit-prompt fue la excepción silenciosa, durante seis semanas, hasta el 12 de mayo.
+
+---
+
+## 3. Cómo se descubrió: por inspección visual
+
+No fue observación emergente del agente. Lo notó el operador, visualmente. La entrada del CHANGELOG lo registra sin metáfora:
+
+> *"Surfaced empirically when Sentinel audited the `straymark explore` rendering and the user noted that audit-cycle templates were ES while all other templates and skills were EN."*
+
+`straymark explore` es la TUI del framework — el navegador interactivo de documentación que el Post 14 cubrirá. Su valor es renderizar todos los templates lado a lado, en la misma vista. Y cuando todos los templates están lado a lado, uno en otro idioma se nota. Esa es la observación.
+
+Vale la pena dejar el dato porque importa para la honestidad del blog. El Post 1 articuló el patrón de *observación emergente* — un agente señalando algo que nadie le pidió señalar — y el Post 5 documentó qué pasa cuando ese patrón falta por *visibilidad estructural*. Este episodio no es ninguno de los dos. Es una observación más pedestre: una superficie nueva del framework (la TUI) puso todos los archivos en visión simultánea, y la inconsistencia se hizo evidente como cuando uno ordena los libros del librero y nota que uno tiene el lomo al revés. Las herramientas también producen visibilidad.
+
+---
+
+## 4. El fix: tres movimientos en un commit
+
+PR #142 hizo tres cosas en el mismo commit:
+
+- **`dist/.straymark/audit-prompts/audit-prompt.md`** reescrito en inglés como versión canónica. 312 líneas. La traducción cuidó preservar la estructura de severidad y los ejemplos de calibración del original.
+- **`dist/.straymark/audit-prompts/i18n/es/audit-prompt.md`** creado como overlay. 318 líneas. Es el contenido español que antes vivía en root, ahora en su lugar correcto.
+- **`cli/src/commands/charter/audit.rs`** cableado al resolver i18n. Hasta entonces, el subcomando hardcodeaba el path `dist/.straymark/audit-prompts/audit-prompt.md` sin consultar el `language` field del `.straymark/config.yml` del adopter. Después del PR, lee la configuración del proyecto y resuelve la ruta localizada — si el adopter tiene `language: es`, recibe el overlay español; si tiene `language: zh-CN`, hace fallback al EN canonical (no hay traducción zh-CN del audit-prompt todavía); si tiene `language: en` o no especifica, recibe el canonical.
+
+Tres tests nuevos cubren los tres caminos. Cero cambio funcional para usuarios en inglés (que es la mayoría). Para usuarios en español, mejora: antes recibían el prompt en español por accidente (porque el path canónico apuntaba al ES); ahora lo reciben en español por convención (porque el resolver lo decide).
+
+---
+
+## 5. El movimiento lateral
+
+Al hacer el switch de idioma, el operador aprovechó para extraer una especificidad que había quedado del origen Sentinel. La sección §Step 5 del prompt — sobre calibración de severidad de hallazgos — citaba un caso literal del experimento de abril: *"Etapa 12 Pub/Sub stub vs gochannel"*. Un ejemplo perfectamente didáctico, pero específico de un componente de Sentinel que ningún otro adopter conocería.
+
+La traducción al inglés reemplazó ese ejemplo por una formulación vendor-neutra: *"declared deferral, not a defect — a charter that introduces a thin adapter slated for replacement in a future Charter"*. La idea — un *stub* que es deuda declarada, no defecto — se preserva. Lo que se va es el nombre del componente.
+
+El movimiento es pequeño pero coherente con el principio del blog. Cuando hay oportunidad de desligar el framework de un adoptante específico sin perder pedagogía, vale la pena tomarla. Es la misma operación de generalización que Post 3 documentó para los seis Planes y Post 4 para el primer Charter: el contenido empírico se preserva *en* Sentinel; lo que entra al framework es la abstracción vendor-neutra. El audit-prompt, casi un año después, finalmente terminó de cumplir esa regla.
+
+---
+
+## 6. Cierre
+
+Tres tesis cortas:
+
+1. **En un framework con convención, un solo archivo que la viola es señal de legado, no de diseño.** El audit-prompt era el outlier porque nació antes, y nadie lo migró cuando los demás artefactos se alinearon. Los outliers acumulan procedencia.
+
+2. **Las herramientas nuevas producen visibilidad.** El switch ES → EN no se decidió por revisión sistemática del repo. Se decidió porque una TUI nueva puso todos los templates en la misma pantalla y la inconsistencia se hizo evidente. Lo mismo aplica a `grep`, a vistas agregadas, a outputs de `status`: cada superficie nueva expone qué estaba desalineado.
+
+3. **Los rebrands chicos son oportunidad de desidentificación.** Cuando tocas un archivo para cambiar idioma, costo marginal cero para también extraer la especificidad de adopter que quedó del origen. El blog ha registrado este patrón antes (Plan → Charter, DevTrail → StrayMark); este es la versión miniatura. El framework se vuelve más vendor-neutro un archivo a la vez.
+
+Sigue, en el siguiente post, un episodio que ya rozó al Post 1 pero merece su propio tratamiento: *"La disciplina manual antes del patrón"* (`H-11`). Cómo Sentinel manejó `CHARTER-18` antes de que existiera el `Pattern 1` de chain evolution — el aprendizaje empírico que el `Post 1` después nombró como meta-patrón.
+
+---
+
+*Anclas: PR [#142](https://github.com/StrangeDaysTech/straymark/pull/142). Releases: `fw-4.13.3` / `cli-3.12.3`. Commit clave: `a8a1ac5`. Archivos: `dist/.straymark/audit-prompts/audit-prompt.md` (EN canonical) + `dist/.straymark/audit-prompts/i18n/es/audit-prompt.md` (overlay). CLI: `cli/src/commands/charter/audit.rs` cableado al resolver i18n.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-14-manual-discipline-before-the-pattern.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-14-manual-discipline-before-the-pattern.md
@@ -1,0 +1,144 @@
+---
+slug: la-disciplina-manual-antes-del-patron
+title: La disciplina manual antes del patrón
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - speckit
+  - disciplina
+  - governance
+date: 2026-05-14T00:00:00.000Z
+description: >-
+  Doce aprendizajes en un Issue, tres gates en un PR, y un Charter que cerró
+  limpio antes de que existiera el nombre
+---
+## 1. La pregunta correcta
+
+El [Issue #150](https://github.com/StrangeDaysTech/straymark/issues/150), abierto el 14 de mayo a las 16:59 UTC, no buscaba un *yes/no*. Lo que el operador estaba pidiendo era reformular la pregunta:
+
+> *"The real question the bridge doc should address is how, not whether: what discipline ensures spec stays in sync with code during multi-Charter execution without the regeneration step lying about the parts that already shipped."*
+
+La disciplina ya existía. Se estaba aplicando en Sentinel en ese momento, sobre `CHARTER-18`, manualmente, con la sensación de que cualquier paso en falso enterraba el trabajo de seis Charters anteriores. Lo que faltaba — y lo que el Issue documentaba con precisión incómoda — era el nombre. El cuándo. Las reglas que un adoptante futuro pudiera seguir sin haber pasado por el dolor de inventarlas.
+
+Este post cubre las cinco horas que separan ese Issue del PR que canonizó la disciplina como gobernanza upstream, los 12 aprendizajes empíricos que justificaron la canonización, y el episodio operativo concreto — `CHARTER-18` de Sentinel — que ejerció el patrón antes de que el patrón existiera. El siguiente post cubrirá lo que vino 27 horas después: el nombre.
+
+---
+
+## 2. Siete Charters sobre un mismo plan
+
+El contexto, en una sola línea: Sentinel ejecutó `specs/002-commshub/plan.md` — escrito en el commit `be29421` el 21 de abril de 2026 — a través de **siete Charters consecutivos** (`CHARTER-07` a `CHARTER-17`), un mes calendario, sin refrescar el plan ni una vez.
+
+El plan original era bueno. Estaba escrito con cuidado, con las cuatro user stories (US1-US4) detalladas, con el data-model declarado, con los contracts esbozados. Pero el plan era una fotografía de cómo el operador imaginaba en abril que el código se iba a comportar. La ejecución descubrió cosas que el plan no podía haber anticipado:
+
+- Patrones de infraestructura que aparecieron *durante* la ejecución y resultaron reutilizables (un namespace en `core.processed_events`, un `withRLS` helper, triggers PL/pgSQL para invariantes).
+- Gaps de código que el plan asumió resueltos (`AnomalyDetector` *half-built*, idempotency dedup faltante, `Recipient.TenantID` schema gap).
+- Patrones de Charter/audit que se cristalizaron a lo largo del mes (cross-family audit cycle, HTTP layer test coverage gap, cursor pagination con strict-greater-than).
+
+Cuando llegó el momento de planear `CHARTER-18` para US5, el plan tenía un mes de antigüedad y el código tenía un mes de aprendizaje empírico encima. Las dos cosas no estaban sincronizadas. Y `SPECKIT-CHARTER-BRIDGE.md` — el documento del framework que normalmente respondería *"¿qué hago aquí?"* — guardaba silencio sobre el caso. La regla *"cómo se mantiene la spec sincronizada con el código durante ejecución multi-Charter"* no existía todavía.
+
+---
+
+## 3. Los doce aprendizajes empíricos
+
+El Issue #150 enumera los doce aprendizajes que se habían acumulado sin reflejar en el plan. La tabla literal, agrupada por tipo, vale la pena dejarla a la vista:
+
+| # | Tipo | Aprendizaje |
+|---|---|---|
+| 1 | Patrón de infra | `core.processed_events` con namespace `module='commshub'` reutilizable — el plan describe su propia tabla. |
+| 2 | Patrón de infra | `EnvSecretLoader` + Secret Manager projection (PRs #70/71) — el plan describe acceso directo. |
+| 3 | Patrón de infra | `withRLS` helper como single-source-of-truth para aislamiento por tenant — el plan no lo ancla. |
+| 4 | Patrón de infra | FR-005 triggers PL/pgSQL como enforcement de invariantes — el plan describe checks a nivel app. |
+| 5 | Gap de código | `AnomalyDetector` *half-built* — el plan implica funcional. |
+| 6 | Gap de código | Idempotency dedup en `delivery_log` faltante — el plan implica coordinado. |
+| 7 | Gap de código | `Recipient.TenantID` schema gap — el plan referencia `tenant_id` como si existiera. |
+| 8 | Gap de código | Per-tier rate limit overrides ausentes — el plan dice *"3-tier hierarchy"* sin mencionar que US1 implementó un tier uniforme. |
+| 9 | Patrón de Charter | Cross-family external audit cycle obligatorio (6 consecutivos) — el plan silencioso. |
+| 10 | Patrón de Charter | HTTP layer test coverage gap — el plan silencioso en test layering. |
+| 11 | Patrón de Charter | Cursor pagination tuple con strict-greater-than — el plan silencioso. |
+| 12 | Patrón de Charter | Dispatcher interface-stable swap pattern — el plan silencioso. |
+
+Cuatro patrones de infraestructura descubiertos o refinados durante la ejecución. Cuatro gaps de código que el plan no anticipó. Cuatro patrones de Charter/audit cristalizados sobre la marcha. Doce piezas, en un solo mes, todas reales. El plan no las tenía. Y el siguiente Charter — `CHARTER-18` — iba a leer el plan como si no existieran.
+
+La estimación que el operador documentó en el Issue es honesta:
+
+> *"Estimated probability of ≥1 critical/high finding from stale-premise inheritance: ~50%."*
+
+Cara o cruz, en una palabra. La mitad de los Charters arrancados sobre plan rancio terminan con un finding crítico que un audit cycle posterior debe remediar atomicamente pre-close. Y la otra mitad solo se libra por suerte.
+
+---
+
+## 4. Alternative 4: la disciplina aplicada a mano
+
+Lo que pasó dentro de Sentinel, ese mismo día, antes de que la disciplina tuviera nombre: el operador evaluó cinco alternativas concretas y eligió la cuarta. El AIDEC privado de Sentinel — `AIDEC-2026-05-14-001-speckit-plan-scope-limited-us5-refresh.md` — registra el análisis sin atenuar. Lo parafraseo aquí porque el contenido detallado vive en el repo privado, pero la estructura del razonamiento es lo que importa:
+
+- **Alternative 1 — *"Léelo como antes"*.** Mantener el plan desactualizado y leerlo como las seis veces anteriores. Costo: pagar la deuda en audit cycle posterior, ~50% probabilidad de finding crítico.
+- **Alternative 2 — Regenerar todo con `/speckit-plan`.** Riesgo: sobreescribir aserciones sobre US1-US4 que el código real *no* cumple; el regenerador no sabe del estado actual.
+- **Alternative 3 — Refresh en otro PR sin restricciones.** Mismo riesgo que Alt 2 más fricción de revisión.
+- **Alternative 4 — Scope-limited refresh + 3 gates.** La elegida.
+- **Alternative 5 — Diferir CHARTER-18, hacer un Charter de refactor first.** Costo de calendario alto, beneficio marginal sobre Alt 4.
+
+La cuarta consistió en tres mecanismos concretos:
+
+**Primer mecanismo — *scope-limited prompt*.** Ejecutar `/speckit-plan` con un *prompt* explícitamente restrictivo: regenera solo la Phase 7+8 correspondiente a US5; deja US1-US4 byte por byte como están, marcadas con comentarios `<!-- LOCKED: prior US shipped -->` que el agente debe respetar. Sin esa restricción explícita, la regeneración de SpecKit es destructiva: rescribe todo el plan, sobreescribiendo descripciones que el código real ya contradice.
+
+**Segundo mecanismo — *Gate (a): validación contra realidad de código*.** Un script ad-hoc, ~30 líneas de bash + grep, que difea cada entidad non-US5 de `data-model.md` contra el schema real en `db/migrations/*.sql`, y cada endpoint non-US5 de `contracts/*.md` contra los handler signatures reales en `internal/modules/commshub/handler_*.go`. Cualquier divergencia bloquea merge. El script existe en el repo de Sentinel; no es elegante, es operativo. Lo que el framework canonizará después como gate (a) ya estaba ahí, como bash artesanal.
+
+**Tercer mecanismo — *Gate (b): revisión granular hunk-por-hunk*.** Revisar `git diff` archivo por archivo, hunk por hunk, sin aceptar cambios a secciones *locked* sin justificación. El operador anota explícitamente la fricción esperada en R1 del AIDEC: si el agente regenera más hunks que los necesarios, el revisor humano se cansa y la disciplina colapsa. Mitigación: hunks de más de 50 líneas disparan revisión P1.
+
+**Cuarto mecanismo — *Gate (c): two-PR split*.** El refresh es un PR independiente, revisado contra **código actual**. El Charter-fill que sigue, otro PR, revisado contra el plan ya refrescado. No mezclar las dos revisiones — porque si se mezclan, la deuda del refresh se esconde detrás del trabajo nuevo.
+
+Cuatro mecanismos. Aplicados manualmente, sin documentación upstream que los avalara. Un solo adoptante (yo), una sola sesión, y la sensación todo el tiempo de estar resolviendo un caso que nadie había resuelto antes.
+
+---
+
+## 5. El resultado
+
+`CHARTER-18` cerró el mismo día. Las métricas del Charter Telemetry, registradas literal en el YAML del cierre:
+
+- `estimation_drift_factor: 1.0` — el Charter terminó exactamente en el rango de horas estimado.
+- `pre_work.items_discovered_during_planning: 0` — ningún ítem inesperado apareció durante la fase de planning.
+- `overall_satisfaction: 5/5` — la mejor calibración subjetiva del operador en toda la cadena.
+
+Más importante que las métricas: `CHARTER-18` fue el **primer Charter de la cadena de siete que cerró sin un Charter de remediación mid-flight**. Los seis anteriores habían necesitado, cada uno, al menos una remediación atómica pre-close para cubrir divergencias entre lo declarado y lo entregado. CHARTER-18 no. El statement del operador en el cierre, citado literal del `CHARTER-CHAIN-EVOLUTION.md` posterior:
+
+> *"The SpecKit refresh from PR #76 eliminated most ambiguity that drove drift in prior Charters. No mid-flight remediation Charter required — the EC1..EC15 empirical-corrections inventory in research.md absorbed what would have been pre-execution risk into in-execution awareness."*
+
+La disciplina manual funcionó. No solo cerró el Charter limpio; cambió la naturaleza del riesgo. Lo que antes era riesgo pre-ejecución (descubrir divergencias durante la ejecución del Charter, remediar atomicamente) se volvió consciencia pre-planning (el inventario `EC1..EC15` enumera las correcciones empíricas antes de declarar el Charter). El riesgo no se elimina; se mueve a un momento donde es manejable.
+
+---
+
+## 6. Cuatro horas y cuarenta minutos
+
+La cronología vale la pena dejarla precisa, porque es lo que el blog viene a registrar:
+
+- **14 may, 16:59 UTC** — Issue #150 abierto. Los doce aprendizajes enumerados, los tres gates propuestos, el análisis de probabilidad publicado.
+- **14 may, 21:39 UTC** — PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152) fusionado. `fw-4.14.3` shipped. *"Spec maintenance during multi-Charter execution"* añadido como sección nueva a `SPECKIT-CHARTER-BRIDGE.md` con los tres gates canonizados literalmente como gobernanza del framework. **Cuatro horas y cuarenta minutos** entre la pregunta y la respuesta upstream.
+
+Lo que el PR #152 documentó como gobernanza es exactamente lo que el AIDEC privado había aplicado a mano horas antes. Las tres gates con los mismos nombres: validation against code reality (gate a), granular hunk-by-hunk review (gate b), two-PR split (gate c). Más cuatro heurísticas de *cuándo refrescar*: ≥3 Charters cerrados sobre el mismo plan, ≥4 semanas + ≥2 Charters, conteo de `R<N>(new)` > 6, target US toca infra refinada. Más una nota explícita sobre por qué NO volver a correr `/speckit-tasks` (porque destruye los marcadores `[X]` y las anotaciones `*CHARTER-NN:* <sha>` que forman el rastro histórico). Más una nota de roadmap mencionando un futuro `straymark spec-drift` CLI que mecanizaría gate (a).
+
+Cuatro horas. No es exagerado decir que el framework escribió la guía mientras el operador todavía tenía el `git diff` abierto en otra ventana. La disciplina y su canonización fueron prácticamente simultáneas. Y eso me importa registrarlo porque es el orden inverso al que el aparato académico de governance suele asumir: primero la teoría, después la práctica. Aquí fue al revés. Primero la práctica, mientras dolía. Después la teoría, mientras el dolor todavía estaba fresco.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **El patrón nace de la disciplina, no al revés.** Los tres gates de `fw-4.14.3` no se diseñaron en abstracto; se *extrajeron* de un episodio operativo concreto, horas después de aplicarse manualmente. La gobernanza es post-empírica cuando el framework respeta el orden.
+
+2. **La probabilidad explícita es disciplina.** *"~50% probabilidad de finding crítico por herencia de premisa rancia"* no es exactitud bayesiana; es una afirmación pública que obliga a justificar la decisión. Sin esa cifra, la pregunta *"¿refrescamos?"* se decide por intuición. Con esa cifra, se decide por aritmética de riesgo.
+
+3. **Doce aprendizajes en treinta días es la cadencia real.** No es ruido capturable con *"déjame leerlo después"*. Es densidad empírica que el plan original no podía haber anticipado, y que destruye cualquier asunción de planning de largo plazo. La cadencia del desarrollo con agentes es esto.
+
+4. **Cuatro horas no es récord; es propiedad del proceso.** Cuando la disciplina ya está aplicada en un dominio, canonizarla upstream es ejecución, no diseño. Lo mismo que vimos en el Post 4 sobre el audit cycle externo (*"cinco PRs en un día"*), lo mismo en el Post 6 sobre el rebrand (*"cuarenta y tres minutos"*). El framework no inventó la disciplina; la extrajo y le puso nombre.
+
+Sigue, en el siguiente post, el último episodio del arco que el blog vino a contar: *"Pattern 1 + Pattern 2 — chain evolution"* (`H-12`). Veintisiete horas después del PR #152, los tres gates de gobernanza se cristalizaron como dos meta-patrones nombrados — *pre-declare refresh* y *amend-on-emergence* — con telemetry schema y CLI helpers. Es el cierre del arco que el Post 1 abrió por delante.
+
+---
+
+*Anclas: [Issue #150](https://github.com/StrangeDaysTech/straymark/issues/150) (14 may 16:59 UTC). PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152) — `fw-4.14.3` (14 may 21:39 UTC). Sección canonizada: `SPECKIT-CHARTER-BRIDGE.md §"Spec maintenance during multi-Charter execution"`. Métricas del CHARTER-18 reportadas en `CHARTER-CHAIN-EVOLUTION.md` (fw-4.16.0). Fuente privada parafraseada conforme `GUIA-EDITORIAL.md §7`: `AIDEC-2026-05-14-001-speckit-plan-scope-limited-us5-refresh.md` en el repo de Sentinel.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-agents-md-as-a-universal-standard.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-agents-md-as-a-universal-standard.md
@@ -1,0 +1,132 @@
+---
+slug: agents-md-como-estandar-universal
+title: AGENTS.md como estándar universal
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - agents-md
+  - governance
+  - estándares-abiertos
+  - i18n
+date: 2026-05-15T00:00:00.000Z
+description: Cuatro meses entre la intuición y el estándar abierto
+---
+## 1. Cuatro meses entre la intuición y el estándar
+
+El 15 de mayo de 2026, a las 19:05 UTC, el PR [#155](https://github.com/StrangeDaysTech/straymark/pull/155) cerró el framework como `fw-4.15.0 / cli-3.13.2`. Lo que trajo es un solo archivo nuevo en la lista de directivas que el CLI inyecta: `AGENTS.md`, en la raíz del repo del adoptante, paralelo a los que ya estaban (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`).
+
+Esto sería trivial si no fuera porque hace exactamente cuatro meses, el 27 de enero de 2026, el primer AIDEC del proyecto — el que el Post 2 cubrió con la anécdota del año tipográfico — había declarado:
+
+> *"AI agents (Claude, Gemini, Copilot, Cursor) process instructions equally well in any language, so translating their config files provides no functional benefit."*
+
+Esa frase, escrita seis horas después del *initial commit* del proyecto, contenía una intuición que el framework venía operativizando desde entonces: los agentes son un solo público técnico. Mantenían los archivos de configuración en inglés (mientras la documentación humana se traducía a tres idiomas) porque la audiencia "agentes IA" no se beneficiaba de la traducción. Lo que faltaba para cerrar esa intuición era darle un solo lugar al que apuntar, sin tener que clonar el archivo cuatro o cinco veces para cada vendor distinto.
+
+Este post cubre exactamente eso: cómo `AGENTS.md` — un estándar abierto donado a la Agentic AI Foundation en diciembre de 2025 — completó cuatro meses después la decisión que el primer AIDEC había abierto en enero.
+
+---
+
+## 2. La fragmentación que `AGENTS.md` resuelve
+
+Entre 2024 y 2026, mientras los CLIs de agentes IA proliferaban, cada uno inventó su propio formato de archivo de instrucciones:
+
+- Anthropic publicó `CLAUDE.md` con la primera versión de Claude Code.
+- Google adoptó `GEMINI.md` para Gemini CLI.
+- GitHub estableció `.github/copilot-instructions.md` para Copilot CLI.
+- Cursor empezó con `.cursorrules` y migró luego a `.cursor/rules/*.md`.
+- OpenAI usó otro path para Codex CLI; Aider, Devin, Continue, Roo Code, Factory Droids, Sourcegraph Amp, Zed AI, Windsurf, Amazon Q tenían cada uno el suyo.
+
+Un adoptante de StrayMark que usara dos o tres de esos CLIs tenía que mantener dos o tres copias del mismo contenido, sincronizadas a mano, esperando que ninguna divergiera. El framework hasta `fw-4.14.x` reconocía esa fragmentación en su comando `straymark init`: inyectaba en los cinco archivos vendor-específicos más comunes. Pero los otros diez o quince CLIs quedaban fuera. El adoptante los manejaba copiando contenido a mano.
+
+A finales de 2025, la comunidad de proyectos open-source que producía CLIs de agentes hizo lo que se hace cuando una fragmentación se vuelve costosa: acordaron un estándar. `AGENTS.md` en la raíz del repo, leído por todos. La donación a la Agentic AI Foundation (Linux Foundation, diciembre 2025) le dio gobernanza institucional. La especificación es deliberadamente mínima: un archivo Markdown, sin schema impuesto, en una ubicación predecible. Lo que cada CLI hace con ese archivo es asunto suyo; la pregunta canónica — *"¿dónde está la configuración de agentes para este repo?"* — tiene ahora una sola respuesta.
+
+Para mayo de 2026, la lista de CLIs que leen `AGENTS.md` incluye (cita literal del cuerpo del PR #155):
+
+> *"Claude Code, OpenAI Codex CLI, Cursor, Aider, Devin, Sourcegraph Amp, Google Jules, Zed AI, Continue, Roo Code, Factory Droids, GitHub Copilot, Gemini CLI, Windsurf, Amazon Q and others."*
+
+Quince CLIs. Algunos siguen leyendo *también* sus archivos vendor-específicos por compatibilidad histórica. Pero los quince saben buscar `AGENTS.md` primero.
+
+---
+
+## 3. Adoptar sin matar lo propio
+
+La decisión más interesante de `fw-4.15.0` no es adoptar `AGENTS.md`; eso era inevitable una vez que el estándar tenía masa crítica. Lo interesante es *cómo*. El cuerpo del PR lo articula sin atenuar:
+
+> *"Parallel to CLAUDE.md / GEMINI.md: marker block points to STRAYMARK.md, with a minimum-viable body below for readers that cannot follow relative links."*
+
+Tres palabras clave: **parallel**, **marker block**, **minimum-viable body**.
+
+*Parallel* significa que `AGENTS.md` no reemplaza los archivos vendor-específicos. Coexiste. El framework sigue inyectando `CLAUDE.md`, `GEMINI.md`, `.cursorrules` y los demás. La razón es pragmática: algunos CLIs (notablemente Cursor en su versión legacy) requieren que el contenido completo esté embebido, no detrás de un link relativo. Mantener los archivos hermanos preserva esa compatibilidad sin que cada adoptante tenga que pelear con su CLI específico.
+
+*Marker block* es la convención que el framework ya usaba en los demás archivos vendor-específicos: un bloque HTML-commented entre `<!-- straymark:begin -->` y `<!-- straymark:end -->` que apunta a `STRAYMARK.md` como source-of-truth. Cualquier `straymark update-framework` reemplaza solo lo que está entre esos marcadores. Lo que el adoptante haya escrito *afuera* de ellos — por ejemplo, instrucciones propias del proyecto — se preserva intacto. El framework respeta el archivo del adoptante; solo gobierna su propia sección.
+
+*Minimum-viable body* es la concesión a los CLIs que no siguen relative links. Debajo del bloque de marcadores, `AGENTS.md` tiene un cuerpo corto con lo esencial: identidad del agente, requisitos de revisión, checklist pre-commit, snippet de frontmatter regulatorio, categorías de riesgo NIST AI 600-1, reglas de observabilidad, convención de nombrado. Es suficiente para que un agente que no pueda leer `STRAYMARK.md` opere correctamente; es insuficiente para reemplazar al documento canónico. La asimetría es deliberada: queremos que el agente *quiera* abrir `STRAYMARK.md`.
+
+El detalle defensivo del CLI (`cli/src/commands/remove.rs:13`) cierra el flanco operativo: `AGENTS.md` se agregó a `LEGACY_DIRECTIVE_TARGETS`. Si un adoptante pierde su `.straymark/dist-manifest.yml` y ejecuta `straymark remove`, el fallback legacy limpia también `AGENTS.md` en lugar de dejarlo huérfano. Es housekeeping aburrido, pero es la diferencia entre un framework que se desinstala completamente y uno que deja basura.
+
+---
+
+## 4. Sin ADR
+
+Vale la pena nombrar una ausencia. La decisión de adoptar `AGENTS.md` no tuvo ADR propio.
+
+Es un contraste deliberado con el rebrand a StrayMark del Post 6, que sí tuvo `ADR-2026-05-08-001` público con tres alternativas evaluadas y consecuencias enumeradas. Es también contraste con Phase 2 del Post 12, que tuvo una entrada de CHANGELOG densa con justificación arquitectónica. `fw-4.15.0` tuvo solo el cuerpo del PR como justificación documental — un cuerpo bueno, con argumento claro, pero no un ADR.
+
+¿Por qué? La respuesta operativa: la decisión se percibió como **agregativa**, no estructural. Adoptar un estándar abierto que coexiste con los formatos existentes no cambia el modelo del framework; solo lo extiende. No hay alternativa cuyo descarte requiera justificación formal: no adoptar `AGENTS.md` significaría dejar fuera a 15 CLIs por preferencia estética, y nadie tenía ese argumento que hacer.
+
+Pero hay una lección registrable aquí. El blog ha visto el patrón antes — Phase 2 cierra un loop empírico, el rebrand cambia identidad, los meta-patrones del Post 10 nombran lo que ya estaba — y en cada caso la pregunta *"¿esto amerita ADR?"* tiene una respuesta distinta. La regla operativa que el framework parece haber adoptado, sin nombrarla, es esta: **un ADR se justifica cuando la decisión cierra alternativas costosas y deja registro de las que no se eligieron**. `fw-4.15.0` no cerró alternativas costosas — solo agregó una capa. Por eso bastó con el PR.
+
+Lo dejo registrado aquí porque vale la pena reconocer que no todo cambio merece ADR, ni todo PR es un documento histórico. La disciplina archivística tiene sus propios criterios.
+
+---
+
+## 5. Visibilidad para agentes, dos capas
+
+Diez días antes de `fw-4.15.0`, el 9 de mayo, se cerró el Issue [#113](https://github.com/StrangeDaysTech/straymark/issues/113) — el episodio que el Post 5 documentó como *"Charters invisibles para los agentes"*. El operador había trabajado seis horas con un agente capaz, atento, con el aparato canónico de onboarding cargado, y el agente nunca había propuesto usar un Charter. La conclusión que aquel post canonizó: la *visibilidad estructural* es responsabilidad del framework, no propiedad del agente.
+
+`fw-4.15.0` cubre la otra cara del mismo problema.
+
+El Post 5 trataba de **visibilidad estructural interna**: cómo aseguramos que un agente que ya está leyendo nuestro repo descubra los conceptos centrales del framework. La respuesta del PR #122 (Post 5) fue multiplicar las superficies internas donde Charter aparece como concepto: `STRAYMARK.md §15`, directivas `CLAUDE.md`/`GEMINI.md`, skills `/straymark-*`, output de `status`, templates, puente con SpecKit. Nueve superficies internas.
+
+Este post trata de **visibilidad estructural externa**: cómo aseguramos que cualquier agente que entra al repo, sin importar su vendor, encuentre el aparato del framework. La respuesta de `fw-4.15.0` es adoptar el punto de encuentro canónico que la comunidad eligió. Una superficie externa, leída por quince vendors.
+
+Las dos capas tienen el mismo eje conceptual — *un artefacto técnico solo existe para el agente si la superficie lo nombra* — pero distinto alcance. Visibilidad interna garantiza que el agente vea los Charters cuando está leyendo `STRAYMARK.md`. Visibilidad externa garantiza que el agente vea `STRAYMARK.md` cuando entra al repo. Una capa sin la otra es incompleta.
+
+---
+
+## 6. Lo que el adoptante hace al ejecutar `update-framework`
+
+La parte operativa del release, citada literal del CHANGELOG:
+
+> *"straymark update-framework brings the new template and injects AGENTS.md at the project root. The injection follows the same rules as every other directive target: it creates the file if absent, replaces the marker block on subsequent runs, and appends safely when the file pre-exists without StrayMark markers (very common in 2026 — many adopters already hand-maintain an AGENTS.md)."*
+
+Tres comportamientos importantes:
+
+1. **Si no existe**, el CLI lo crea con el template canónico.
+2. **Si ya existe y tiene marcadores StrayMark**, el CLI reemplaza solo el contenido entre marcadores.
+3. **Si ya existe sin marcadores** — caso muy común en 2026, porque muchos adoptantes ya escribían su propio `AGENTS.md` a mano — el CLI **agrega sus marcadores al final del archivo**, sin tocar lo que el adoptante había escrito.
+
+Es el mismo respeto archivístico que el blog ya documentó en Posts 3 y 6: el framework gobierna *su sección*, no el archivo entero. Si el adoptante quiere escribir instrucciones propias del proyecto en su `AGENTS.md` — políticas internas, convenciones de naming, instrucciones específicas para una codebase particular — esas instrucciones quedan intactas en cada `update`. El bloque de StrayMark vive en su pequeña frontera marcada, y se actualiza dentro de esa frontera.
+
+La nota del CHANGELOG cierra con una pequeña advertencia operativa que vale la pena registrar: *"If your .gitignore excludes AGENTS.md, adjust it before update-framework so the injection lands in version control."* Es honesta sobre los edge cases que el framework no puede resolver por su cuenta — la elección del adoptante de ignorar el archivo es soberanía, no error.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Cuatro meses entre intuición y materialización es lo que toma cerrar bien un loop.** El AIDEC de enero contenía la intuición — *"los agentes son un solo público"*. `fw-4.15.0` la cerró con un estándar abierto. Entre las dos, el framework iteró sobre arquetipos vendor-específicos hasta que apareció el sustituto universal. La intuición temprana fue correcta; el plazo fue el que la maduración del ecosistema requería.
+
+2. **Adoptar un estándar abierto no exige renunciar al formato propio.** `AGENTS.md` coexiste con `CLAUDE.md`, `GEMINI.md`, `.cursorrules`. La decisión no es "uno reemplaza a los demás" sino "uno se suma a los demás cuando aporta". El framework gana visibilidad externa sin perder compatibilidad con CLIs que requieren formatos específicos.
+
+3. **No todo cambio amerita ADR.** El rebrand a StrayMark cerró alternativas costosas y dejó registro formal de las descartadas. `fw-4.15.0` solo agregó una capa universal: ningún ADR habría enriquecido la decisión. La disciplina archivística tiene criterios operativos, no doctrinas.
+
+4. **Visibilidad para agentes opera en dos capas.** La capa interna (Post 5, `fw-4.12.0`) asegura que el agente vea los conceptos del framework cuando está leyendo el repo. La capa externa (`fw-4.15.0`) asegura que el agente entre al repo por la puerta correcta sin importar qué CLI lo orqueste. Una sin la otra deja agentes capaces leyendo en silencio o agentes desorientados sin punto de entrada.
+
+---
+
+*Anclas: PR [#155](https://github.com/StrangeDaysTech/straymark/pull/155) — `fw-4.15.0 / cli-3.13.2` (fusionado 2026-05-15 19:05 UTC). AIDEC original (Post 2): `.chronicle/07-ai-audit/decisions/AIDEC-2025-01-27-001-i18n-strategy.md` (commit `7b7193e`, ID con año tipográfico). Template inyectado: `dist/dist-templates/directives/AGENTS.md`. Especificación del estándar: [agents.md](https://agents.md) — donado a la Agentic AI Foundation (Linux Foundation), diciembre 2025.*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-opening-the-framework.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-opening-the-framework.md
@@ -1,0 +1,132 @@
+---
+slug: abrir-el-framework
+title: Abrir el framework
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - i18n
+  - cla
+  - governance
+  - apertura
+date: 2026-05-15T00:00:00.000Z
+description: Setenta y dos horas de gestos que sólo cobran sentido juntos
+---
+## 1. Dos gestos en setenta y dos horas
+
+El 13 de mayo de 2026, a las 06:20 UTC, se fusionó `fw-4.13.4`. Cerró dos huecos pequeños de cobertura i18n — el documento de referencia ISO-25010 que solo estaba en inglés, y el template del Charter que faltaba en chino simplificado. Veintidós archivos canónicos del framework alcanzaron paridad estructural EN/ES/zh-CN.
+
+El 15 de mayo, a las 00:14 UTC, sesenta y cinco horas después, se fusionó el PR [#154](https://github.com/StrangeDaysTech/straymark/pull/154). Agregó un badge al README — el de CLA Assistant, ese cuadrito visible que avisa al visitante que el repo acepta contribuciones bajo un Contributor License Agreement. La política del CLA ya existía desde meses antes en `CONTRIBUTING.md`; lo único que cambió fue que ahora aparece en el README al primer vistazo.
+
+Este post cubre los dos gestos. Vistos por separado, son pequeños — uno completa el último 5% de un trabajo técnico, el otro publica algo que ya estaba escrito. Vistos juntos, son el momento en que el framework decide presentarse al exterior. La pieza que un proyecto open-source hace cuando deja de hablar solo consigo mismo y empieza a hablar con quien quiera leerlo.
+
+---
+
+## 2. El último 5% de la cobertura i18n
+
+`fw-4.13.4` no es un release grande. El PR [#144](https://github.com/StrangeDaysTech/straymark/pull/144) tiene 511 líneas de adición y casi todas son traducciones. Pero el resumen del PR dice algo que vale la pena registrar:
+
+> *"Brings governance docs to full 20/20/20 parity across EN + ES + zh-CN."*
+
+Veinte sobre veinte sobre veinte. Veintidós archivos canónicos en `dist/.straymark/00-governance/` (el conteo creció después; en mayo eran veinte), todos con su contraparte en `i18n/es/` y `i18n/zh-CN/`. Paridad completa, no aproximada.
+
+Los dos archivos que cerraron la paridad son específicos:
+
+- `ISO-25010-2023-REFERENCE.md` — la referencia normativa al estándar internacional de calidad de software, citada desde principios del framework. Hasta `fw-4.13.4` existía solo en inglés. El release añadió `i18n/es/ISO-25010-2023-REFERENCE.md` y `i18n/zh-CN/ISO-25010-2023-REFERENCE.md`, 150 líneas cada uno.
+- `charter-template.md` en zh-CN. El template del Charter ya estaba traducido al español; faltaba el chino simplificado, 211 líneas.
+
+No es un trabajo glamoroso. Es la pieza que cierra un cuadro. Pero importa por dos cosas. La primera: hasta ese release, un adoptante chino que clonara el framework iba a encontrar templates esenciales en inglés solamente, lo cual contradice la promesa de que el framework está disponible en tres idiomas. La segunda: el blog ya documentó en Post 8 que la cobertura i18n del framework era casi completa, con dos gaps menores quedando como deuda anotada. `fw-4.13.4` cerró esa deuda. Lo que parecía una nota lateral en un post sobre el outlier del audit-prompt resultó ser un release entero, con su propia entrada en CHANGELOG.
+
+---
+
+## 3. Lo que se traduce y lo que no
+
+Hay una regla operativa que el PR #144 codifica explícitamente y que vale la pena dejar registrada, porque es la regla más clara del framework respecto a i18n:
+
+> *"LLM-processed assets (skills, workflows, schemas) stay EN-only; human-primary artifacts get translated."*
+
+Es decir: lo que leen los agentes IA — skills, workflows en `.claude/`, `.gemini/`, `.agent/`, schemas en `dist/.straymark/schemas/`, prompts en `dist/.straymark/audit-prompts/` — vive solo en inglés. Lo que leen los humanos — documentación, principios, guías de contribución, templates con copy human-facing — se traduce a los tres idiomas.
+
+Es el mismo principio que el Post 13 documentó como ancestro intelectual del AGENTS.md universal: los agentes son un solo público técnico que no se beneficia de traducción. Lo registrable aquí es que la regla, en mayo, está escrita en un PR como criterio operativo, no como intuición. Las propuestas técnicas la citan; los reviewers la usan para decidir si un archivo nuevo va a `i18n/` o no.
+
+Un detalle adicional del PR #144 vale la pena registrar literal:
+
+> *"docs/contributors/TRANSLATION-GUIDE.md gap was left intentional — its target audience already reads English to read the guide."*
+
+La guía de traducción quedó intencionalmente en inglés porque su audiencia — los contribuidores que traducen el framework a otros idiomas — necesariamente lee inglés ya. Es honestidad operativa: la paridad 20/20/20 no es 22/22/22 para todos los archivos del repo. Es 20/20/20 para los archivos cuya traducción aporta valor al usuario. La diferencia entre cobertura total y cobertura aplicable.
+
+---
+
+## 4. El badge que no introdujo nada nuevo
+
+PR #154 es el opuesto pedagógico de `fw-4.13.4`. Donde `fw-4.13.4` cierra un trabajo técnico, PR #154 publica algo que ya estaba ahí. Sus 12 líneas de cambio agregan exactamente esto al README (en inglés, español y chino):
+
+```markdown
+[![CLA assistant](https://cla-assistant.io/readme/badge/StrangeDaysTech/straymark)](https://cla-assistant.io/StrangeDaysTech/straymark)
+```
+
+Un badge. Una imagen pequeña que aparece arriba del README, junto a los demás badges del proyecto (licencia, versión, downloads). Visualmente nada del otro mundo.
+
+Pero el badge no es decoración. Es señal. Y la señal dice algo concreto: *"este repo acepta contribuciones externas, y aquí están las reglas"*. Cualquier visitante que abra el README puede hacer clic en el badge y llegar al CLA Assistant — el servicio que automáticamente comenta en el primer pull request de cualquier contribuidor, pidiendo que firme el Contributor License Agreement. Una sola firma cubre todas las futuras contribuciones al proyecto.
+
+Lo importante es que el CLA, el `CONTRIBUTING.md`, la política completa de revisión, todo eso ya existía antes de PR #154. Estaba codificado, vivo, operativo. El framework ya aceptaba contribuciones externas — solo que el visitante casual del repo tenía que abrir `CONTRIBUTING.md` para enterarse de cómo funcionaba.
+
+PR #154 hace una distinción que vale la pena nombrar: **tener la política** y **publicar la política** son dos cosas distintas. La primera es disciplina interna; la segunda es invitación pública. Hasta el 15 de mayo, el framework tenía la política. Desde el 15 de mayo, la publica.
+
+Es un cambio editorial, no arquitectónico. Pero el día que un proyecto open-source decide poner el badge de CLA Assistant arriba del README es el día que decide presentarse formalmente como adoptable por terceros. Es el momento en que el framework deja de ser un proyecto-de-uno-y-su-adopter (Sentinel) y se vuelve un proyecto que *acepta* tener más adopters, más contribuidores, más manos.
+
+---
+
+## 5. Cuándo un framework se siente listo para ser visto
+
+Estos dos hitos, leídos juntos, registran un momento específico en la vida de un framework joven: el momento en que se siente listo para ser visto por gente que no lo escribió.
+
+`fw-4.13.4` cierra la promesa técnica. Si el framework dice ser bilingüe español-inglés con soporte experimental para chino simplificado, los veintidós archivos canónicos deben estar en los tres idiomas. No diecinueve sobre veinte. No veinte sobre veintiuno con dos pendientes. Veinte sobre veinte sobre veinte. La paridad completa es lo que vuelve la promesa creíble cuando el visitante revisa.
+
+PR #154 cierra la promesa social. Si el framework dice aceptar contribuciones externas, el badge del CLA en el README es la forma estándar de la industria de decirlo. Sin el badge, la apertura existe pero hay que descubrirla; con el badge, está señalada. El primer click del visitante encuentra el camino.
+
+Vale la pena nombrar la asimetría de los dos gestos. Cerrar el último 5% de un trabajo técnico cuesta exactamente eso — un release dedicado, dos archivos traducidos, una entrada de CHANGELOG. Publicar una política preexistente cuesta doce líneas de Markdown. El cuesta-poco es a veces el gesto operativamente más significativo, porque cambia cómo el mundo exterior percibe el proyecto sin cambiar nada del proyecto en sí.
+
+Es la versión "abrir el framework" del patrón que el Post 5 documentó como *visibilidad estructural*: lo que existe pero no está nombrado, no existe para el agente. Aquí: lo que existe pero no está publicado, no existe para el adoptante externo. Setenta y dos horas en mayo, dos hitos pequeños — uno técnico, uno editorial — y el framework cruza la línea entre *"funciona pero quien lo escribió lo sabe"* y *"funciona y cualquiera puede verlo"*.
+
+---
+
+## 6. Cierre simbólico del arco
+
+Con este post, el blog cubre los últimos hitos pendientes de la segunda tanda que `RETOMAR-AQUI.md §5` listó después del cierre del arco principal H-01 → H-13. Los cuatro candidatos identificados — `H-?-C` (validate + schemas), `H-?-A` (AGENTS.md universal), `H-?-B` (cobertura i18n completa), `H-?-E` (CLA badge) — están todos cubiertos: tres en posts propios (Posts 12, 13, este) y uno combinado.
+
+Lo que aprendí escribiendo la segunda tanda, mirando los cuatro hitos juntos:
+
+- **Phase 2 / validate** (Post 12) es estructural: el framework empieza a verificar lo que prometía.
+- **TUI explore** (Post 11) es de visibilidad: el framework se vuelve navegable.
+- **AGENTS.md universal** (Post 13) es de alcance: el framework se vuelve descubrible por cualquier CLI.
+- **Cobertura i18n completa + CLA badge** (este post) es de apertura: el framework se vuelve visible al visitante externo.
+
+Cada uno cubre una dimensión distinta de la misma idea, que el blog ya dejó codificada en posts anteriores: lo que un framework dice que es no basta para que sea; tiene que estar presente en cada superficie donde alguien — agente, adopter externo, visitante — pueda construir un modelo del proyecto. Los hitos de la segunda tanda son la versión madura de la *visibilidad estructural* que el Post 5 nombró con un Issue de gobernanza.
+
+Ahora sí, después de Post 14, no hay candidatos más en la cola. Si emergen nuevos hitos del framework entre hoy y cuando la próxima sesión del blog se active, RETOMAR-AQUI volverá a usarse como punto de retomo. Si no emergen, este post es el cierre real — el cierre con el que el blog completa el inventario que se propuso cubrir.
+
+---
+
+## 7. Cierre
+
+Lo que aprendí del proceso, en cuatro tesis:
+
+1. **Cobertura total cuesta poco al final del trabajo y mucho al principio.** El último 5% — esos dos archivos en chino — son release dedicado. Pero solo son trivialmente cerrables porque el otro 95% ya estaba hecho. La paridad 20/20/20 no nace al principio; se persigue durante meses y se cierra al final con un PR pequeño.
+
+2. **Tener una política y publicarla son dos cosas distintas.** El CLA del framework existía meses antes que el badge. Doce líneas de Markdown convirtieron una política interna en una invitación pública. El día que pones el badge no inventas nada; declaras que estás listo para que te encuentren.
+
+3. **La regla operativa de qué se traduce es archivística.** Lo que leen humanos se traduce; lo que leen agentes vive en inglés. Esa distinción, intuida desde el primer AIDEC de enero, se vuelve criterio explícito de revisión en mayo. Cada archivo nuevo del framework pasa por esa pregunta antes de elegir destino.
+
+4. **Cuándo un framework se vuelve adoptable por terceros es decisión, no estado.** Hay un día en el que el operador decide que el framework ya puede ser visto sin pena por gente que no lo escribió. Ese día se materializa en gestos pequeños — completar traducciones, publicar el badge — que no cambian la funcionalidad pero cambian la postura. El framework deja de hablar consigo mismo.
+
+Con esto el blog cierra la segunda tanda. El arco que arrancó retroactivamente con la prehistoria del proyecto (Post 2, enero) y se completó con los meta-patrones (Post 10, mayo) tiene ahora también su corolario: los hitos que volvieron al framework adoptable. Catorce posts, veintiocho archivos (catorce ES + catorce EN), entre veinticinco y veintiséis mil palabras por idioma. Como decía el cierre del Post 10: *el blog termina de contar la historia. El framework sigue*.
+
+---
+
+*Anclas: PR [#144](https://github.com/StrangeDaysTech/straymark/pull/144) — `fw-4.13.4` (fusionado 2026-05-13 06:20 UTC, cobertura i18n completa). PR [#154](https://github.com/StrangeDaysTech/straymark/pull/154) — badge CLA Assistant en READMEs (fusionado 2026-05-15 00:14 UTC). Política completa: `CONTRIBUTING.md` (raíz del repo + traducciones en `docs/i18n/{es,zh-CN}/CONTRIBUTING.md`).*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*
+
+*— Fin de la segunda tanda del blog StrayMark.*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-emergent-observation-design.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-emergent-observation-design.md
@@ -1,0 +1,125 @@
+---
+slug: emergent-observation-design
+title: El día que el agente vio algo que nadie le pidió ver
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - agentes-ia
+  - governance
+  - diseño-emergente
+  - charter
+  - sentinel
+date: 2026-05-16T00:00:00.000Z
+description: >-
+  Cómo nombrar una propiedad de diseño que ya estaba haciendo su trabajo en
+  silencio
+---
+> *"Hola, ¿ya tratamos el Issue #153?"*
+
+Así empezó la conversación, hoy 16 de mayo a la mañana. Una pregunta corta, casi de housekeeping, antes de meterme en otra cosa. La respuesta era no — el Issue #153 estaba abierto a propósito, esperando un segundo dominio que ejercitara la mecánica antes de cristalizarla (Principio #12 de StrayMark, validación contra un segundo dominio antes de canonizar). Pero la pregunta abrió otra puerta, y al final de esa conversación había codificado una propiedad de diseño del framework que llevaba meses funcionando sin nombre, señalada por un episodio de hace apenas dos días.
+
+Este post es la reconstrucción del arco, porque vale la pena guardarla. No por el resultado — un nuevo doc canónico, un Principio #8, un PR ya fusionado — sino por el mecanismo que reveló. StrayMark tiene un proyecto humano detrás: que el desarrollo asistido por agentes no se nos escape de las manos a los ingenieros que somos responsables del software que producimos. Y este episodio expuso una propiedad concreta del diseño que empuja en esa dirección.
+
+Aclaración de oficio: StrayMark se prueba primero en mis propios proyectos. Sentinel es uno de ellos — privado, pero su interacción con StrayMark queda documentada en los Issues públicos del repo de StrayMark, así que el contexto es vinculable. Soy autor y primer adopter del framework. El Principio #12 me obliga a esperar un segundo dominio antes de declarar canónica cualquier mecánica nueva; pero el primero soy yo, y este post da cuenta de eso sin pudor.
+
+## El incidente: un agente que señaló lo que nadie le pidió señalar
+
+El **14 de mayo, hace dos días**, en Sentinel, un agente trajo a mi atención una observación que no le había pedido. Estaba a punto de ayudarme a completar el CHARTER-18 — una pieza de trabajo concreta dentro de una cadena ya larga — y antes de poner una línea de código dijo, en esencia:
+
+> *Hay un problema. El `specs/002-commshub/plan.md` se congeló el 21 de abril. Desde entonces han pasado siete Charters consecutivos, y a lo largo de los AILOGs de esa cadena hay doce aprendizajes empíricos no reflejados en el plan que afectan materialmente el alcance de US5. Si completamos CHARTER-18 leyendo el plan desactualizado, el próximo ciclo de auditoría va a remediar divergencias atómicamente pre-close — con aproximadamente 50% de probabilidad de al menos un hallazgo crítico o alto por herencia de premisa rancia.*
+
+Y citó los AILOGs específicos por ID. Y las referencias de código concretas.
+
+Nadie le pidió ese análisis. No había un disparador configurado. No había un comando CLI cuyo propósito fuera producir esa salida. El agente estaba allí para ayudarme con la siguiente tarea, no para auditar el estado del proyecto. Pero al posicionarse para esa siguiente tarea, vio una divergencia entre dos fuentes que la documentación StrayMark conecta explícitamente, y eligió señalarla antes de proceder.
+
+Abrí el Issue [#150](https://github.com/StrangeDaysTech/straymark/issues/150) ese mismo día por la tarde como RFC, y entre las 17:00 y la noche se discutió y aterrizó la disciplina manual de spec-refresh en `fw-4.14.3`. Al día siguiente, **15 de mayo**, levanté el Issue [#156](https://github.com/StrangeDaysTech/straymark/issues/156) para llevar upstream los dos patrones que el ejercicio había revelado: un *pre-declare SpecKit refresh* y una *post-close Batch N.4 amendment*. Para la madrugada del **16 de mayo** estaban canonizados en `fw-4.16.0` como `CHARTER-CHAIN-EVOLUTION.md`, con telemetría dedicada y un helper CLI (`straymark charter refresh-suggest`). El comportamiento se reprodujo, los patrones se cristalizaron, ciclo cerrado.
+
+Pero cuando me senté esa misma mañana del 16 a abrir la conversación con el Issue #153 — *"¿ya tratamos esto?"* — y me devolví la pregunta inversa — *"un momento, ¿qué fue lo que hizo posible esa observación en primer lugar?"* — me di cuenta de que el ciclo había cerrado solamente a medias. Lo que se codificó en `fw-4.16.0` fue la **aplicación** del patrón. Lo que faltaba codificar era el **mecanismo** que la produjo.
+
+## La pregunta humana, dicha con palabras técnicas
+
+Se la formulé así, en la conversación con el agente que generó este post:
+
+> *Me resultó algo sorpresivo el comportamiento del agente que se percató de ese conocimiento acumulado que, de no aplicarse, ocasionaría problemas con la implementación del Charter 18. Es decir, que no era una tarea que se le pidió analizar, ni fue el resultado de la activación de un disparador de prompt, y me parece que fue gracias a la documentación StrayMark. Quisiera que ahondáramos más en cómo ocurrió esto, que creo que es positivo, de forma en que podamos aprovechar la experiencia y engancharla en el comportamiento habitual de StrayMark, este patrón emergente que provino del agente y su relación con la documentación generada, fue muy interesante.*
+
+Lo que estoy pidiendo ahí no es implementar un feature. Es entender un mecanismo para poder reproducirlo. La diferencia es importante. Cuando uno pide implementar algo, el camino es claro: spec → tasks → código. Cuando pide entender por qué algo funcionó, el camino es más raro: hay que diagnosticar un sistema funcional, identificar qué piezas lo hicieron funcionar, y separar lo accidental de lo estructural.
+
+Hay una urgencia particular en este tipo de pregunta cuando uno está construyendo herramientas para colaborar con agentes de IA. Porque si lo que funcionó fue accidente, el próximo agente — o la próxima versión del mismo agente — puede no reproducirlo. Si lo que funcionó fue estructura, entonces se puede preservar deliberadamente. La diferencia entre las dos cosas, para un proyecto que pretende dar a los ingenieros control sobre el desarrollo asistido por IA, es la diferencia entre suerte y diseño.
+
+## La auditoría: ¿qué piezas de StrayMark hicieron posible la observación?
+
+Le pedí a un agente que mapeara sistemáticamente la documentación StrayMark con tres preguntas concretas:
+
+1. ¿Qué mecanismos documentales conectan fuentes explícitamente entre sí? (Frontmatter, secciones canónicas, IDs estables, comandos CLI que cruzan fuentes.)
+2. ¿Dónde le da la documentación al agente *permiso explícito* para señalar cosas más allá de la tarea pedida?
+3. ¿Qué pares de fuentes existen, además del que originó este caso, que podrían producir observaciones emergentes similares si la infraestructura está presente?
+
+El reporte vino estructurado, con archivo:línea para cada hallazgo. Lo importante no fueron los detalles individuales (frontmatter con `originating_charter:`, secciones `§Risk: R<N>`, convenciones de IDs estables, comandos como `charter drift`) sino el patrón que emergió al verlos en conjunto. Dos propiedades coexistían consistentemente:
+
+**Propiedad 1: cross-referencing estructural obligatorio.** Cada tipo de documento tiene *campos obligatorios* y *secciones canónicas* que declaran, en la propia estructura del documento, a qué otros documentos apunta. Cuando un agente lee un AILOG, no tiene que adivinar a qué Charter pertenece — el `originating_charter:` se lo dice. Cuando ve un riesgo, no es una observación en prosa libre — es una entrada `R<N>` en una sección canónica, contable. Cuando el spec apunta a Charters, lo hace formalmente; cuando los Charters apuntan a AILOGs, igual. Es un grafo de enlaces explícito que el agente puede triangular sin trabajo creativo.
+
+**Propiedad 2: permiso cultural sin control bloqueante.** AGENT-RULES §6 le dice al agente: *"Be Proactive — Identify potential risks, Suggest improvements when evident, Alert about technical debt"*. PRINCIPLES §2 le dice: *"Not hide relevant information"*. Y críticamente, AGENT-RULES §3 le da autonomía para *crear* documentos (AILOG, AIDEC, TDE) sin pre-aprobación del operador. El operador retiene la priorización, no la creación. El agente no tiene que pedir permiso para señalar algo: señalarlo es ejecución de una regla, no juicio de valor.
+
+Lo interesante es que ninguna de las dos propiedades por sí sola produce el comportamiento. Si tuvieras solamente enlaces formales (Propiedad 1) sin permiso cultural, tendrías un corpus consultable que ningún agente se atreve a consultar proactivamente. Si tuvieras solamente permiso cultural (Propiedad 2) sin estructura, tendrías señales vagas — *"creo que algo podría estar mal en algún lado"* — que los operadores no podemos accionar.
+
+Combinadas, producen algo que merece nombre propio: el agente externalizó *"¿debo decir algo?"* como *"¿existe una sección canónica donde esto encaja?"*. Si la respuesta es sí, señalarlo deja de ser una decisión emocional y se vuelve ejecución mecánica. El costo de señalar baja porque el destino — la sección canónica — ya existe.
+
+## Por qué esto importa más allá de StrayMark
+
+Estamos en un momento donde los agentes de IA pueden escribir código tan rápido como pensamos, y la pregunta de cómo *no perder el control* del proceso es genuinamente urgente. No es una pregunta apocalíptica — es una pregunta operativa, de oficio, de personas que estamos construyendo software ahora mismo y tenemos que entregar. Lo evidencia el ritmo mismo de este episodio: del diagnóstico del agente al meta-patrón canonizado pasaron menos de **72 horas**. Esa velocidad es ganancia, pero también es la razón por la cual los mecanismos de visibilidad importan tanto.
+
+La respuesta dominante en la industria hoy es alguna variante de *prompts más estrictos, más reglas en el contexto, más gates en CI*. Esos enfoques son válidos pero tienen una característica que vale la pena nombrar: convierten al agente en algo más cercano a un trabajador que ejecuta órdenes en pipelines verificables. Eso resuelve la confiabilidad pero al costo de la observación emergente. Un agente que solo hace lo que se le ordena no va a señalar algo que nadie le pidió señalar, por buen razonamiento que tenga.
+
+Lo que el episodio de Sentinel mostró es una respuesta diferente, complementaria: **construir el aparato documental de tal forma que las divergencias importantes sean estructuralmente visibles, y dar al agente permiso cultural para señalarlas sin pedir aprobación.** Eso preserva la observación emergente como propiedad del sistema, no como suerte de qué tan bueno sea el agente o qué tan extenso sea el prompt.
+
+Hay algo casi taoísta en esta postura: no le decimos al agente qué buscar; construimos un entorno donde lo que hay que ver es visible. La pareja "estructura visible + permiso para nombrar" hace el trabajo. El agente se vuelve, parafraseando a algunos colegas, un *honest broker* entre la documentación viva y el estado del código.
+
+Y esto es lo que el proyecto humano detrás de StrayMark persigue, aunque rara vez se diga con esas palabras: que el cambio vertiginoso del desarrollo asistido por IA no nos arroje a un mundo donde los ingenieros perdemos visibilidad sobre lo que se está construyendo. La visibilidad no se preserva con más controles burocráticos; se preserva diseñando el entorno donde el agente trabaja para que lo importante sea naturalmente visible. El ingeniero no se vuelve un revisor de Pull Requests interminables — se vuelve un priorizador de observaciones que el agente trae estructuradas y nombradas.
+
+## Lo que hicimos al respecto
+
+Con el diagnóstico claro, la pregunta era cómo engancharlo al comportamiento habitual de StrayMark sin matar la calidad emergente. Esta tensión es real: cada vez que conviertes un comportamiento espontáneo en obligación, lo conviertes en otra cosa. Una regla dura puede ser robusta, pero también puede generar resistencia en el agente o falsa señal cuando se activa fuera de contexto.
+
+La decisión fue conservadora: **nombrar el meta-patrón, no obligar su uso.**
+
+Concretamente, en el PR [#160](https://github.com/StrangeDaysTech/straymark/pull/160) que salió como `fw-4.17.0`:
+
+- Un nuevo doc canónico — `EMERGENT-OBSERVATION-DESIGN.md` — articula la propiedad de diseño con sus dos componentes, presenta el caso empírico de Sentinel como ancla, y construye una *pirámide de instancias*: el meta-patrón en la cima, y abajo todas las aplicaciones que ya estaban canonizadas (Pattern 1 y Pattern 2 de la chain evolution; charter drift; follow-ups backlog drift; escalación TDE-vs-`R<N>`; audit checkpoint externo). Lo que antes parecían patrones ad hoc se revelan como aplicaciones del mismo principio subyacente. Esta visualización por sí sola vale la pena: cuando ves siete cosas que parecían distintas y de pronto reconoces que comparten una misma forma, el framework gana coherencia interna sin haber añadido nada.
+
+- Un nuevo Principio #8 — *Cross-Source Dissonance Surfacing* — en `PRINCIPLES.md`. Es la regla cultural condensada en cinco líneas. El agente la lee al incorporarse al proyecto y la aplica recursivamente.
+
+- Una expansión a `AGENT-RULES.md §6 "Be Proactive"` con ejemplos concretos de divergencia a vigilar: spec desactualizado, R<N> acumulados sin escalar a TDE, ADR contradicho por la implementación, follow-ups cruzando umbral del backlog pattern, hallazgos de auditoría emergiendo post-close. No son obligaciones; son *ejemplos de lo que un agente proactivo notaría*. La diferencia es importante para preservar lo emergente.
+
+- Cuatro ejes abiertos identificados como gaps — lugares donde la infraestructura de cross-referencing existe parcialmente pero el patrón no está nombrado: MCARD ↔ código del modelo desplegado, SBOM ↔ lockfiles, ADR vigente ↔ implementación que la contradice, Constitution Check ↔ bump de versión del framework. Cada uno requiere validación N=1 empírica antes de cristalizar — Principio #12 aplica. Quedaron registrados en el Issue [#161](https://github.com/StrangeDaysTech/straymark/issues/161) como tracking RFC, esperando que un segundo dominio empuje alguno de ellos.
+
+- Anti-patrones explícitos: cómo se rompe el meta. Si un nuevo tipo de documento sale con enlaces de frontmatter opcionales, el cross-referencing desarrolla puntos ciegos. Si una sección canónica se reemplaza por prosa libre, la consultabilidad se evapora. Si se introduce control bloqueante en la creación de AILOG/AIDEC/TDE, el permiso cultural se rompe. Si la telemetría evoluciona sin preservar señales como `r_n_plus_one_emergent_count`, el feedback loop se rompe. Estos anti-patrones son una protección barata pero efectiva contra la erosión accidental: cualquier futura propuesta de cambio se puede contrastar con la lista para detectar si está regresando el meta-patrón.
+
+Todo esto, del diagnóstico al merge y el tag `fw-4.17.0` con su release publicada, ocurrió entre las 09:00 y las 04:00 del mismo día. Quince horas. Lo cual es exactamente el tipo de ritmo que el blog admite: hay que aprender a operar bajo este reloj, o el control se nos va.
+
+## Lo que aprendí del proceso
+
+Tres cosas que no esperaba aprender cuando empecé respondiendo *"no, el Issue #153 sigue abierto"*:
+
+**Primero, que codificar un meta-patrón es distinto de codificar un patrón.** El meta-patrón no añade obligaciones; añade *vocabulario* y *visibilidad de la propiedad subyacente*. Esa propiedad ya estaba haciendo su trabajo; lo que faltaba era darle nombre para protegerla bajo evolución futura. Quien lee `EMERGENT-OBSERVATION-DESIGN.md` no aprende a hacer algo nuevo — aprende a *reconocer* algo que ya estaba ahí. Eso es lo que permite preservarlo deliberadamente.
+
+**Segundo, que la propiedad emergente desaparece si se sobre-regula.** Hubo un momento en la conversación donde elegí no convertir Pattern 1 en obligación dura (*"el agente DEBE ejecutar `refresh-suggest` antes de declarar Charter-(N+1)"*) y en cambio mantenerlo como recomendación más el nombramiento del meta. Esa decisión es contraintuitiva si uno viene del mundo de *"más controles = más confiabilidad"*, pero es correcta para este tipo de propiedad. La proactividad del agente es frágil: en cuanto se vuelve mandato, deja de ser proactividad. Lo que escala es el motor cultural ("Be Proactive") más los enlaces estructurales, no la lista de obligaciones específicas.
+
+**Tercero, que el aparato documental que construimos para los agentes también nos está educando a los humanos.** Cuando vi los siete patrones dispersos en distintos docs de governance y los reconocí como instancias del mismo meta, entendí algo sobre StrayMark que no había entendido antes — y StrayMark soy yo mismo construyéndolo a lo largo de meses. El framework está revelándole cosas a su propio autor. Esa propiedad — que la documentación estructurada produce *insights sobre sí misma* cuando se la audita — es una variante doméstica de lo que el agente hace cuando señala una divergencia. Es el mismo mecanismo, aplicado a una escala distinta.
+
+## El proyecto humano detrás
+
+Hablo en serio cuando digo que StrayMark tiene un proyecto humano. No estoy construyendo un framework de gobernanza documental porque me obsesionen los campos de frontmatter. Lo construyo porque tengo la sospecha — cada vez menos especulativa — de que los próximos cinco años de la ingeniería de software van a ser una negociación constante entre la velocidad que ofrecen los agentes y la visibilidad que los ingenieros necesitamos para seguir siendo responsables del producto. Si esa negociación se pierde del lado de los agentes, terminamos en un mundo donde el código se escribe y nadie sabe por qué. Si se pierde del lado del control burocrático, terminamos sin las ganancias de productividad que justificaron el experimento.
+
+El equilibrio no es teórico. Se construye con decisiones concretas: dónde poner un campo de frontmatter, qué sección debe ser canónica versus libre, cuándo dar al agente autonomía y cuándo retener priorización. Cada una de esas decisiones inclina la balanza en una dirección u otra. Y la única forma de saber si la balanza está bien es probarla — y nombrar lo que funciona cuando funciona, para que sobreviva al próximo cambio del framework.
+
+El episodio del CHARTER-18, hace dos días, fue una prueba. Funcionó. Lo que escribí hoy fue darle nombre. La siguiente prueba ya tiene candidatos: MCARD, SBOM, ADR vigente vs implementación, Constitution Check ↔ framework bump. Cuatro ejes donde el meta-patrón podría reproducirse si cerramos los gaps de infraestructura. Esperaré a que un segundo dominio empuje uno empíricamente antes de codificarlo. Principio #12 — validación contra un segundo dominio antes de cristalizar — sigue siendo el guardarraíl.
+
+Si estás leyendo esto y trabajas con agentes para desarrollar software, te invito a mirar tu propio aparato documental con estas dos preguntas: *¿qué fuentes están conectadas formalmente, con enlaces explícitos que un agente pueda triangular sin trabajo creativo?* y *¿qué tan barato es para el agente señalar algo no pedido cuando detecta una divergencia?* Si la respuesta a la primera pregunta es "pocas" y a la segunda es "caro", probablemente estás dejando observaciones emergentes sobre la mesa. Lo cual no es el fin del mundo — pero es exactamente lo que separa un proceso de desarrollo asistido por IA *bajo control humano* de uno que se nos va de las manos.
+
+---
+
+*StrayMark fw-4.17.0 — Issue [#150](https://github.com/StrangeDaysTech/straymark/issues/150) · [#156](https://github.com/StrangeDaysTech/straymark/issues/156) · [#161](https://github.com/StrangeDaysTech/straymark/issues/161) · PR [#160](https://github.com/StrangeDaysTech/straymark/pull/160) · tag [`fw-4.17.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.17.0)*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
@@ -1,0 +1,191 @@
+---
+slug: pattern-1-y-pattern-2-chain-evolution
+title: Pattern 1 y Pattern 2 — chain evolution
+authors:
+  - jose
+  - claude-opus-47
+tags:
+  - straymark
+  - charters
+  - chain-evolution
+  - governance
+date: 2026-05-16T00:00:00.000Z
+description: Cuando la disciplina deja de ser hábito y se vuelve nombre
+---
+## 1. Veintisiete horas para nombrarlos
+
+El PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152), que cerró el episodio del Post 9, se fusionó el 14 de mayo a las 21:39 UTC. Trajo `fw-4.14.3` y los tres gates canonizados del refresh manual.
+
+El PR [#157](https://github.com/StrangeDaysTech/straymark/pull/157) — el que este post viene a contar — se fusionó el 16 de mayo a las 00:31 UTC. Veintisiete horas después. Trajo `fw-4.16.0 / cli-3.14.0` y, con eso, dos meta-patrones nombrados:
+
+- **Pattern 1 — *pre-declare SpecKit refresh***. Refrescar la spec antes de declarar el siguiente Charter en una cadena.
+- **Pattern 2 — *post-close audit-driven Batch N.4***. Amendar un Charter ya cerrado cuando la auditoría externa señala findings post-close, sin abrir un Charter nuevo.
+
+El Post 9 cubrió la disciplina aplicada manualmente sobre CHARTER-18. Este post cubre lo que vino después: los dos patrones nombrados, el documento canónico que los nombra (`CHARTER-CHAIN-EVOLUTION.md`), el schema de telemetría que los mide, los dos *CLI helpers* que los scaffold-ean — y, como cierre del arco editorial entero, una hora y diecisiete minutos más tarde, un meta-patrón filosófico que reabsorbe ambos hacia arriba.
+
+Es el último post del arco. El blog que el Post 1 abrió por delante cierra aquí por atrás.
+
+---
+
+## 2. Pattern 1 — Pre-declare refresh
+
+La definición literal, copiada del documento canónico:
+
+> *"A dedicated refresh PR lands between Charter-N close and Charter-(N+1) declare. It touches only the non-locked sections of the SpecKit artifacts (plan.md, data-model.md, contracts, quickstart.md, research.md)."*
+
+Esto es exactamente lo que Sentinel hizo manualmente para CHARTER-18 en el Post 9. La diferencia entre Post 9 y Post 10 es de tipo: el Post 9 documenta el procedimiento; el Post 10 documenta su *activación condicionada* — cuándo el framework recomienda al adoptante que aplique Pattern 1.
+
+Los criterios de activación son cuantificables, y el documento los nombra sin atenuar:
+
+- El módulo tiene **≥ 3 Charters cerrados** sobre la misma spec.
+- La media móvil (últimos 3 Charters) del campo `agent_quality.r_n_plus_one_emergent_count` en la telemetría es **mayor a 6**.
+- No ha aterrizado un *refresh PR* desde el último *branch point*.
+
+El umbral `> 6` no es arbitrario. Es Sentinel CHARTER-18 convertido en regla: el promedio de hallazgos emergentes (riesgos descubiertos durante el Charter que no estaban declarados en el plan original) durante CHARTER-15, 16, 17 fue exactamente lo que disparó la sensación de que la spec estaba acumulando demasiada deuda. El framework, en lugar de pedirle al adoptante que confíe en su intuición, le da un número que su telemetría puede comparar.
+
+Lo que produce Pattern 1, cuando se aplica:
+
+- Una tabla categorizada en `research.md` que enumera lo descubierto en los Charters anteriores en cuatro tipos: *reusable patterns*, *code gaps*, *discipline patterns*, *empirical corrections*.
+- Decisiones operacionales explícitas (`D1`, `D2`, etc.) si la categorización evidencia trade-offs.
+- Citas en el `§Context` del siguiente Charter, por `id`, hacia los items integrados.
+- Un bloque de telemetría `pre_declare_refresh:` opt-in en el `charter-telemetry.yaml` del Charter que recibe el refresh.
+
+La métrica que sostiene el patrón viene de Sentinel CHARTER-18 mismo, citada literal en `CHARTER-CHAIN-EVOLUTION.md`:
+
+> *"Sentinel CHARTER-18 was the first Charter in a 7-Charter chain to close cleanly without a mid-flight remediation Charter. `estimation_drift_factor: 1.0`, `pre_work.items_discovered_during_planning: 0`, `overall_satisfaction: 5/5`."*
+
+Un solo dominio. `N=1`. El documento lo dice sin atajos: el patrón está validado empíricamente *en Sentinel*. Esperar al segundo dominio antes de cristalizarlo más alto.
+
+---
+
+## 3. Pattern 2 — Amend-on-emergence
+
+La definición literal:
+
+> *"The amendment rides the same execute branch as the original Charter (the branch is still mergeable to main; the amendment commit lands on top)."*
+
+La idea: cuando un Charter ya cerrado recibe findings de auditoría externa post-close — *critical* o *high* — el framework no obliga a abrir un Charter nuevo. El operador puede *amendar* el Charter cerrado mientras la rama `execute` sigue mergeable a `main`.
+
+La justificación, también literal del documento:
+
+> *"A new Charter would have created multi-week governance overhead for ~6h of focused engineering."*
+
+Esa asimetría — semanas de gobernanza vs. seis horas de ingeniería — es lo que el patrón resuelve. Abrir un Charter nuevo para arreglar cinco findings post-close significa: declarar contexto nuevo, repetir auditoría externa, generar AILOG nuevo, registrar telemetría desde cero. Para una corrección que en código toma una tarde. Pattern 2 dice: no.
+
+Los criterios de activación, también cuantificables:
+
+- *Findings* Critical/High aparecen post-close, después de la auditoría externa.
+- El criterio de cierre del Charter resultó materialmente incumplido por esos findings.
+- La superficie del fix es menor a 25 archivos.
+- No requiere reapertura arquitectónica (decisiones de diseño que el Charter original asumió como cerradas).
+
+Si los cuatro criterios se cumplen, Pattern 2 aplica. Si alguno falla, hay que abrir Charter nuevo.
+
+Lo que produce, cuando se aplica:
+
+- Un commit de *amendment* sobre la misma rama `execute` del Charter original.
+- Un AILOG nuevo (no editar el original) con `risk_level: high`, `review_required: true`, y un campo `amends:` que apunta al AILOG original.
+- Una sección `## Historical correction (YYYY-MM-DD)` en el AILOG original que apunta *forward* al nuevo. Es archivística: el AILOG original no se reescribe; se enlaza.
+- Un bloque de telemetría `post_close_amendment:` en el `charter-telemetry.yaml`.
+
+La métrica empírica que sostiene Pattern 2, citada literal:
+
+> *"Sentinel CHARTER-18 closed 2026-05-15 with audit reports landing 2026-05-15..05-17. Five findings (4 from gpt-5.3-codex, 1 from gemini-2.5-pro) were code-level fixes — DI wiring, retry header parsing, multi-tenant filter, timeout default. The Batch 7.4 amendment closed all five in one cohesive commit (19 files, +2257/-106 lines)."*
+
+Un commit, 19 archivos, dos modelos auditores convergiendo en hallazgos similares, cinco fixes. Si hubiera sido Charter nuevo: dos semanas mínimo entre declare, audit externa, y close. En cambio: un *amendment* en la misma rama, seis horas.
+
+---
+
+## 4. Composición, no exclusión
+
+La pieza más interesante del documento — y, creo, la que cierra mejor el arco — es la sección sobre cómo se relacionan los dos patrones. Cita literal:
+
+> *"A Charter that received Pattern 1 is more likely to avoid Pattern 2, because the refresh absorbs pre-execution risk that would otherwise surface as post-close findings. But CHARTER-18 needed both — the refresh handled spec-level drift; the amendment handled runtime-level drift the refresh did not reach into."*
+
+No son patrones rivales. Son aplicaciones del mismo principio en momentos distintos del ciclo. Pattern 1 absorbe deriva *de spec* — lo que el plan original ya no describe correctamente. Pattern 2 absorbe deriva *de runtime* — lo que solo se ve cuando el código corre, los auditores externos lo miran fresco, y emerge desde el código mismo.
+
+Sentinel CHARTER-18 necesitó los dos. La spec refrescada eliminó los hallazgos emergentes que un audit cycle posterior habría tenido que remediar atomicamente; la *amendment* posterior absorbió lo que el refresh no podía haber predicho — wiring de DI, parsing de headers de retry, un filtro multi-tenant, un default de timeout. Cosas que el plan no podía conocer y que solo emergieron cuando el código existió.
+
+El framework, al nombrar los dos patrones y declarar su composición explícita, hace algo que me importa subrayar: deja constancia de que la disciplina no es lineal. No hay un solo punto de inspección antes de cada Charter; hay un punto antes (Pattern 1) y un punto después (Pattern 2), y ambos pueden ser necesarios en el mismo Charter. La cadena evoluciona; los patrones también.
+
+---
+
+## 5. El schema y los helpers
+
+Lo que `fw-4.16.0` añadió al schema de telemetría son dos sub-objetos opcionales en `charter-telemetry.schema.v0.json` v0.2:
+
+```yaml
+pre_declare_refresh:
+  enabled: boolean
+  refresh_pr: string | null
+  refresh_aidec: string | null
+  reusable_patterns_integrated: integer  # ≥ 0
+  code_gaps_integrated: integer
+  discipline_patterns_integrated: integer
+  empirical_corrections_integrated: integer
+  operator_decisions_ratified: integer
+
+post_close_amendment:
+  applied: boolean
+  trigger: external_audit | production_incident | deferred_implementation
+  ailog_id: string
+  findings_closed: integer
+  files_modified: integer
+  effort_hours: number
+```
+
+Contadores enteros, no narrativas. La decisión es deliberada: lo que el telemetry schema captura es lo que el agente o el operador pueden contar mecánicamente. Lo que no se puede contar — *qué tan profundo era el problema, qué tan astuto fue el fix* — vive en el AILOG, no en la telemetría. El schema mide la *forma* del trabajo; los documentos llevan el *contenido*.
+
+Y `cli-3.14.0` añadió dos helpers, ninguno mutador:
+
+- **`straymark charter refresh-suggest <module> [--threshold N]`** — *read-only*. Lee la telemetría de los últimos tres Charters cerrados del módulo, computa la media móvil de `r_n_plus_one_emergent_count`, y emite una recomendación: *refresh-now*, *not-needed*, o *insufficient-data*. *Exit 0* siempre. Es informacional, nunca CI gate.
+
+- **`straymark charter amend <CHARTER-ID> --trigger <kind> --ailog-title <title> [--findings-closed N] [--merge-into <PATH>]`** — scaffolding. Crea un AILOG stub con los campos correctos (`risk_level: high`, `review_required: true`, `amends:` apuntando al original), añade la sección `## Historical correction` al AILOG original, y renderiza el bloque YAML de `post_close_amendment:`. **No toca git.**
+
+La elección de mantener los dos helpers humildes — uno solo recomienda, el otro solo prepara — es coherente con la decisión A1 del Post 4: *"el CLI orquesta pero no invoca APIs"*. Aquí: el CLI sugiere pero no decide; scaffold-ea pero no muta. El humano sigue siendo el punto donde la disciplina ocurre. El framework solo le pone las herramientas a la mano.
+
+---
+
+## 6. Setenta y siete minutos después
+
+Hay una pieza más que vale la pena registrar antes del cierre del arco. PR #157 se fusionó a las 00:31 UTC del 16 de mayo. PR #160 — el del Post 1, `EMERGENT-OBSERVATION-DESIGN.md`, fw-4.17.0 — se fusionó a las 01:48 UTC del mismo día. Setenta y siete minutos después.
+
+Lo que pasó en esos setenta y siete minutos es el cierre invertido del arco. El meta-patrón filosófico que el Post 1 nombró — *observación emergente compuesta de vínculos formales más permiso cultural para señalar* — se cristalizó **una hora y diecisiete minutos** después de los dos meta-patrones operativos de este post. El meta-patrón filosófico no precede a la disciplina; la sucede. Es la lectura ascendente de la misma evidencia.
+
+`CHARTER-CHAIN-EVOLUTION.md` lo registra explícitamente en su sección `§Related`:
+
+> *"EMERGENT-OBSERVATION-DESIGN.md — the meta-pattern of which Pattern 1 and Pattern 2 are applications (formal cross-referencing + cultural permission to surface)."*
+
+Pattern 1 es composición de vínculos formales (la telemetría `r_n_plus_one_emergent_count`, las citas por `id` en el `§Context`, los AILOGs categorizados) con permiso cultural (la regla de que un agente debe señalar deriva entre spec y código cuando la encuentra). Pattern 2 es composición similar (los AILOGs con `amends:`, la sección `Historical correction` enlazando *forward*) con permiso para señalar findings post-close en lugar de absorberlos en silencio. Los dos patrones son aplicaciones del mismo principio cultural+estructural que el Post 1 nombró por encima.
+
+Es un final que me sigue gustando: el blog que abrió diciendo *"el agente vio algo que nadie le pidió ver"* cierra diciendo, en el episodio anterior por orden cronológico, *"aquí están las dos cosas que el agente puede ver bien porque el framework las nombra"*.
+
+---
+
+## 7. Cierre del arco
+
+Diez posts. Once episodios cubiertos (`H-01` a `H-13`, con varios agrupados). Una decisión editorial — la publicación retroactiva — que el Post 2 introdujo y que los nueve posts siguientes ejercieron sin violar. Un compromiso bilingüe que se mantuvo en cada cierre.
+
+Algunas cosas que aprendí escribiendo el blog y que vale la pena registrar antes de cerrarlo:
+
+1. **El patrón nace de la disciplina.** La frase ya apareció en el Post 9, pero el arco completo la sostiene. Los meta-patrones de este post no se diseñaron; se extrajeron. Cada hito documentado tuvo primero su episodio operativo y después su nombre.
+
+2. **La cadencia no es uniforme.** Diecinueve días entre el primer commit (Post 2, 27 enero) y la primera unidad acotada con auditoría externa (Post 3, 25 abril). Cinco horas entre disciplina aplicada y disciplina canonizada (Post 9, 14 mayo). Setenta y siete minutos entre dos meta-patrones y su lectura filosófica (Posts 10 y 1, 16 mayo). El proyecto pasó por todas las velocidades, y el blog las registra todas.
+
+3. **El framework no es neutro respecto a su adopter.** Sentinel hizo posible que cada patrón se validara empíricamente antes de cristalizarse. El blog no esconde esa procedencia; la subraya como precondición metodológica.
+
+4. **Lo que no se nombra, no se ve.** El Post 5 lo formuló como *visibilidad estructural*; el Post 7 lo aplicó a la deuda transversal; el Post 8 lo señaló sobre el outlier de idioma. Es la regularidad más persistente del arco. Existir como artefacto técnico no basta. El nombre activa el artefacto.
+
+El arco que el blog vino a contar — los hitos `H-01` a `H-13`, los cuatro nombres del proyecto, los seis Planes, los Charters first-class, el audit cycle externo, el Issue #113, el rebrand a StrayMark, el TDE, el outlier del audit-prompt, la disciplina manual, y los dos meta-patrones — cierra aquí. Lo que queda en deuda explícita: `H-14`, la TUI `straymark explore` (que apareció lateralmente en el Post 8 como herramienta de visibilidad), y los hitos candidatos `H-?-A` a `H-?-E` que `PLAN-INVESTIGACION.md §1.43-55` listó como pendientes de decisión. Posible segunda tanda futura. Sin promesa.
+
+Una última observación, simétrica al Post 1. Aquel post abrió diciendo: *"el agente vio algo que nadie le pidió ver"*. Lo que el blog cierra registrando, después de diez episodios, es la otra mitad de la frase: el agente vio porque el framework lo había puesto en condiciones de ver. La observación emergente del Post 1 es la prueba; los patrones nombrados de este post son las precondiciones. Cada cosa que el agente señaló durante los cuatro meses que cubre el arco fue posible porque algún episodio anterior había puesto un artefacto, un disparador, un vínculo formal, una superficie visible donde antes no había nada.
+
+El blog termina de contar la historia. El framework sigue.
+
+---
+
+*Anclas: [Issue #156](https://github.com/StrangeDaysTech/straymark/issues/156). PR [#157](https://github.com/StrangeDaysTech/straymark/pull/157) — `fw-4.16.0 / cli-3.14.0` (fusionado 2026-05-16 00:31 UTC). Documento canónico: [`CHARTER-CHAIN-EVOLUTION.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/CHARTER-CHAIN-EVOLUTION.md). Schema: `dist/.straymark/schemas/charter-telemetry.schema.v0.json` v0.2. Meta-patrón sucesor: [`EMERGENT-OBSERVATION-DESIGN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/EMERGENT-OBSERVATION-DESIGN.md), `fw-4.17.0` (fusionado 2026-05-16 01:48 UTC, 77 minutos después).*
+
+*Co-escrito por José Villaseñor Montfort (Strange Days Tech) y Claude Opus 4.7 (1M context).*
+
+*— Fin del arco H-01 → H-13 del blog StrayMark.*

--- a/website/i18n/es/docusaurus-plugin-content-blog/authors.yml
+++ b/website/i18n/es/docusaurus-plugin-content-blog/authors.yml
@@ -1,0 +1,13 @@
+jose:
+  name: José Villaseñor Montfort
+  title: Strange Days Tech
+  url: https://github.com/montfort
+  page: true
+  socials:
+    github: montfort
+
+claude-opus-47:
+  name: Claude Opus 4.7 (1M context)
+  title: Anthropic
+  url: https://www.anthropic.com/claude
+  page: false

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -22,6 +22,7 @@
         "@docusaurus/tsconfig": "3.10.1",
         "@docusaurus/types": "3.10.1",
         "@types/react": "^19.0.0",
+        "gray-matter": "^4.0.3",
         "tsx": "^4.19.0",
         "typescript": "~6.0.2"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "sync:docs": "tsx scripts/sync-docs-i18n.ts",
+    "migrate:blog": "tsx scripts/migrate-blog.ts",
     "prestart": "npm run sync:docs",
     "start": "docusaurus start",
     "prebuild": "npm run sync:docs",
@@ -32,6 +33,7 @@
     "@docusaurus/tsconfig": "3.10.1",
     "@docusaurus/types": "3.10.1",
     "@types/react": "^19.0.0",
+    "gray-matter": "^4.0.3",
     "tsx": "^4.19.0",
     "typescript": "~6.0.2"
   },

--- a/website/scripts/migrate-blog.ts
+++ b/website/scripts/migrate-blog.ts
@@ -1,0 +1,145 @@
+/**
+ * One-shot migrator: Aparador/Para blog/ -> website/blog/ + i18n/es/.
+ *
+ * Source files live outside the repo's public tree (Aparador/ is gitignored).
+ * Each post has an EN + ES pair, named `NN-<locale-slug>.<en|es>.md`, paired
+ * by the `NN-` numeric prefix. Frontmatter is normalized to Docusaurus blog
+ * conventions; the source files in Aparador stay as the editorial archive.
+ *
+ * Run once: `npm run migrate:blog` (from website/).
+ * Idempotent: deletes output dirs before writing, so re-running rewrites.
+ */
+import {readdirSync, readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, unlinkSync} from 'node:fs';
+import {join, resolve} from 'node:path';
+import matter from 'gray-matter';
+
+const ROOT = resolve(__dirname, '..');
+const APARADOR = resolve(ROOT, '../Aparador/Para blog');
+const OUT_EN = resolve(ROOT, 'blog');
+const OUT_ES = resolve(ROOT, 'i18n/es/docusaurus-plugin-content-blog');
+
+const FILE_RE = /^(\d{2})-(.+)\.(en|es)\.md$/;
+
+type Post = {
+  prefix: string;
+  enSlug?: string;
+  esSlug?: string;
+  enPath?: string;
+  esPath?: string;
+};
+
+function collect(): Map<string, Post> {
+  const posts = new Map<string, Post>();
+  for (const name of readdirSync(APARADOR)) {
+    const m = name.match(FILE_RE);
+    if (!m) continue;
+    const [, prefix, slug, locale] = m;
+    const post = posts.get(prefix) ?? {prefix};
+    const path = join(APARADOR, name);
+    if (locale === 'en') {
+      post.enSlug = slug;
+      post.enPath = path;
+    } else {
+      post.esSlug = slug;
+      post.esPath = path;
+    }
+    posts.set(prefix, post);
+  }
+  return posts;
+}
+
+function stripLeadingH1(body: string, title: string): string {
+  // Strip a leading `# <title>` if it duplicates the frontmatter title.
+  const lines = body.split('\n');
+  let i = 0;
+  while (i < lines.length && lines[i].trim() === '') i++;
+  if (i < lines.length) {
+    const m = lines[i].match(/^#\s+(.+?)\s*$/);
+    if (m && m[1].trim() === title.trim()) {
+      // Drop the H1 line and one blank line after it.
+      lines.splice(i, lines[i + 1]?.trim() === '' ? 2 : 1);
+      return lines.join('\n').replace(/^\n+/, '');
+    }
+  }
+  return body;
+}
+
+function transformFrontmatter(fm: Record<string, unknown>, slug: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    slug,
+    title: fm.title,
+    authors: ['jose', 'claude-opus-47'],
+    tags: fm.tags ?? [],
+    date: fm.date,
+  };
+  if (fm.subtitle) out.description = fm.subtitle;
+  return out;
+}
+
+function emit(srcPath: string, slug: string, outDir: string): {date: string; filename: string} {
+  const raw = readFileSync(srcPath, 'utf8');
+  const parsed = matter(raw);
+  const fm = parsed.data;
+  const title = String(fm.title ?? '');
+  const date = fm.date instanceof Date
+    ? fm.date.toISOString().slice(0, 10)
+    : String(fm.date);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Invalid date "${date}" in ${srcPath}`);
+  }
+  const body = stripLeadingH1(parsed.content, title);
+  const outFm = transformFrontmatter(fm, slug);
+  const filename = `${date}-${slug}.md`;
+  const outPath = join(outDir, filename);
+  const yaml = matter.stringify(body, outFm);
+  writeFileSync(outPath, yaml);
+  return {date, filename};
+}
+
+function main() {
+  if (!existsSync(APARADOR)) {
+    throw new Error(`Source not found: ${APARADOR}`);
+  }
+  // Clean only the migrator's own output (.md files) so curated assets like
+  // authors.yml / tags.yml in these directories are preserved across re-runs.
+  mkdirSync(OUT_EN, {recursive: true});
+  mkdirSync(OUT_ES, {recursive: true});
+  for (const dir of [OUT_EN, OUT_ES]) {
+    for (const name of readdirSync(dir)) {
+      if (name.endsWith('.md')) unlinkSync(join(dir, name));
+    }
+  }
+
+  const posts = collect();
+  const sorted = [...posts.values()].sort((a, b) => a.prefix.localeCompare(b.prefix));
+  let enCount = 0;
+  let esCount = 0;
+
+  for (const post of sorted) {
+    if (!post.enPath || !post.esPath || !post.enSlug || !post.esSlug) {
+      console.warn(`[migrate-blog] post ${post.prefix} is missing a locale pair; skipping`);
+      continue;
+    }
+    // EN file under blog/, using EN slug both as filename and frontmatter slug.
+    const en = emit(post.enPath, post.enSlug, OUT_EN);
+    // ES file under i18n/es/, using EN slug as filename (Docusaurus pairs by
+    // filename) but ES slug in frontmatter for a clean Spanish URL.
+    emit(post.esPath, post.esSlug, OUT_ES);
+    // Rename the ES output to match the EN filename for i18n pairing.
+    const esFilename = `${en.date}-${post.enSlug}.md`;
+    const esWritten = join(OUT_ES, `${en.date}-${post.esSlug}.md`);
+    const esTarget = join(OUT_ES, esFilename);
+    if (esWritten !== esTarget) {
+      const content = readFileSync(esWritten, 'utf8');
+      writeFileSync(esTarget, content);
+      rmSync(esWritten);
+    }
+    enCount++;
+    esCount++;
+    console.log(`[migrate-blog] ${post.prefix} -> ${en.filename}`);
+  }
+
+  console.log(`[migrate-blog] done. EN: ${enCount}, ES: ${esCount}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Second of three planned PRs for the website rollout. Migrates the editorial archive (`Aparador/Para blog/`, gitignored) into the Docusaurus blog plugin — 14 bilingual posts (28 files) about the framework's emergence and the patterns that crystallized during it.

- `scripts/migrate-blog.ts` — one-shot migrator. Pairs source files by their `NN-` prefix; normalizes the editorial frontmatter to Docusaurus blog convention; strips duplicate H1s; writes ES files using the EN slug as filename so Docusaurus pairs locales correctly, while keeping each locale's native slug in frontmatter for clean URLs.
- `website/blog/` and `website/i18n/es/docusaurus-plugin-content-blog/` — 14 + 14 migrated posts, filenames `YYYY-MM-DD-<EN-slug>.md`.
- `authors.yml` in both locales — registers `jose` (montfort) and `claude-opus-47`.
- `docusaurus.config.ts` — `blog: false` → blog plugin config: RSS + Atom feeds, locale-aware `editUrl`, navbar and footer links to `/blog`.

Source files in `Aparador/Para blog/` stay as the editorial archive (the migrator reads them but does not move them). Re-running `npm run migrate:blog` is safe — only cleans `.md` files, preserves `authors.yml` / `tags.yml`.

## Frontmatter normalization

| Source | Destination |
|---|---|
| `title`, `date`, `tags` | preserved |
| `subtitle` | renamed to `description` |
| `author` + `co-author` | replaced with `authors: [jose, claude-opus-47]` |
| `lang`, `translation_of`, `status` | dropped |
| (none) | `slug` added per-locale: EN slug in EN file, ES slug in ES file |

The per-file `status: draft` from the editorial archive is dropped — the author considers the set ready to publish at merge. To hold a post back, add `draft: true` to its frontmatter in a follow-up.

## URLs

| Locale | URL pattern | Example |
|---|---|---|
| EN | `/blog/<en-slug>` | `/blog/four-names-in-four-months` |
| ES | `/es/blog/<es-slug>` | `/es/blog/cuatro-nombres-en-cuatro-meses` |

Locale switcher works because both files share the same filename (`2026-04-05-four-names-in-four-months.md`).

## Out of scope

PR3 (`feat/website-landing`) — Hero + Mermaid workflow diagram + FeatureGrid custom landing. Can ship in parallel from `main`.

## Known follow-ups (non-blocking)

- The 8 broken-link warnings on the build come from PR1 (`docs/i18n/es/**` cross-locale and `../README.md` refs). No new warnings from the blog.
- `tags.yml` not provided — Docusaurus auto-generates tag pages from the per-post `tags:` arrays. A curated `tags.yml` with labels/descriptions can come later if needed.
- A few post slugs share a date (e.g. two on `2026-05-09`). Docusaurus disambiguates by slug, no conflict.

## Test plan

- [ ] `cd website && npm install`
- [ ] `npm run migrate:blog` re-runs cleanly (verifies idempotency); `git diff` shows no spurious changes
- [ ] `npm run start` boots; navbar shows "Blog"; `/blog` lists the 14 posts newest-first
- [ ] `npm run start -- --locale es`; `/es/blog` lists the 14 Spanish posts; switcher between EN/ES on a post lands on the paired translation
- [ ] `/blog/rss.xml` and `/blog/atom.xml` validate (W3C feed validator)
- [ ] `npm run build` exits 0 with no new warnings beyond the pre-existing PR1 set
- [ ] After merge, `Deploy Website` runs green and the live site at `https://strangedaystech.github.io/straymark/blog` shows the posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)