### PR TITLE
fix(website): translate hero tagline on the landing

### DIFF
--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -1,4 +1,8 @@
 {
+  "hero.tagline": {
+    "message": "Disciplina cognitiva para la ingeniería asistida por IA",
+    "description": "Hero tagline (H1 on the landing)"
+  },
   "hero.pillar1": {
     "message": "Cada decisión queda en el repo",
     "description": "First hero pillar"

--- a/website/src/components/Hero/index.tsx
+++ b/website/src/components/Hero/index.tsx
@@ -2,17 +2,19 @@ import type {ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import CodeBlock from '@theme/CodeBlock';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './styles.module.css';
 
 const INSTALL = 'curl -fsSL https://raw.githubusercontent.com/StrangeDaysTech/straymark/main/install.sh | sh';
 
 export default function Hero(): ReactNode {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <header className={styles.hero}>
       <div className={styles.inner}>
-        <h1 className={styles.tagline}>{siteConfig.tagline}</h1>
+        <h1 className={styles.tagline}>
+          <Translate id="hero.tagline" description="Hero tagline (H1 on the landing)">
+            Cognitive discipline for AI-assisted engineering
+          </Translate>
+        </h1>
         <ul className={styles.pillars}>
           <li>
             <Translate id="hero.pillar1" description="First hero pillar">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,15 +1,19 @@
 import type {ReactNode} from 'react';
 import Layout from '@theme/Layout';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {translate} from '@docusaurus/Translate';
 import Hero from '@site/src/components/Hero';
 import WorkflowDiagram from '@site/src/components/WorkflowDiagram';
 import WhyExists from '@site/src/components/WhyExists';
 import FeatureGrid from '@site/src/components/FeatureGrid';
 
 export default function Home(): ReactNode {
-  const {siteConfig} = useDocusaurusContext();
+  const description = translate({
+    id: 'hero.tagline',
+    message: 'Cognitive discipline for AI-assisted engineering',
+    description: 'Hero tagline (H1 on the landing)',
+  });
   return (
-    <Layout title={siteConfig.title} description={siteConfig.tagline}>
+    <Layout description={description}>
       <Hero />
       <WorkflowDiagram />
       <WhyExists />


### PR DESCRIPTION
## Summary

PR3 left the home H1 rendered via `{siteConfig.tagline}` from `docusaurus.config.ts`, bypassing the i18n pipeline. The Spanish landing at `/es/` displayed the English headline even though pillars / CTAs / captions / features / why-paragraph were all wrapped in `<Translate>` correctly.

## Fix

- `src/components/Hero/index.tsx` — wrap the H1 in `<Translate id="hero.tagline">`; drop the now-unused `useDocusaurusContext` import.
- `src/pages/index.tsx` — use the imperative `translate({id: 'hero.tagline', ...})` for the Layout `description` prop so the `<meta name="description">` tag also localizes (was previously the English tagline on every locale).
- `i18n/es/code.json` — add `hero.tagline` → "Disciplina cognitiva para la ingeniería asistida por IA".

## Test plan

- [x] `npm run build` produces `build/index.html` with English `<h1>` and `build/es/index.html` with Spanish `<h1>`
- [ ] After merge, `/es/` shows the Spanish tagline as the H1 and as the meta description

🤖 Generated with [Claude Code](https://claude.com/claude-code)