### PR TITLE
fix(website): hand-authored excerpts on the blog listing

### DIFF
--- a/website/blog/2026-04-05-four-names-in-four-months.md
+++ b/website/blog/2026-04-05-four-names-in-four-months.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-04-05T00:00:00.000Z
 description: Looking for the concept by trying out names
 ---
+*Chronicle → Monimen → DevTrail → Strange Days Tech → StrayMark. The project's prehistoric arc of four renames in four months — three rushed ones in January and a disciplined one in May. The idea didn't move; the name did.*
+
+<!-- truncate -->
+
 > **Editorial note**: this is the first post published retroactively on the blog. The `date` in the frontmatter corresponds to a point inside the arc the post narrates, not the day it was written. The entire blog is being built this way, backwards, starting from the episode that triggered me to write it at all (`emergent-observation-design`, 2026-05-16). Pretending otherwise wouldn't help anyone.
 
 ---

--- a/website/blog/2026-04-27-exploring-the-framework.md
+++ b/website/blog/2026-04-27-exploring-the-framework.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-04-27T00:00:00.000Z
 description: The TUI that produced visibility without meaning to
 ---
+*By April 2026 the framework had ~50 governed Markdown files and they had become opaque. `straymark explore` — a TUI that renders the whole repo as a navigable surface — was born three weeks before it accidentally revealed the outlier from Post 8. New tools produce visibility without meaning to.*
+
+<!-- truncate -->
+
 ## 1. The tool that two weeks later revealed the outlier
 
 Post 8 of this blog covered a very specific episode: the discovery of the only framework file whose canonical language was Spanish. The operator didn't find it through systematic inspection; they found it by running `straymark explore --lang es` during an audit preparation and noticing, visually, that one template was written backwards relative to the rest. The line from that post:

--- a/website/blog/2026-04-30-six-plans-and-the-rename-to-charter.md
+++ b/website/blog/2026-04-30-six-plans-and-the-rename-to-charter.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-04-30T00:00:00.000Z
 description: 'The first systematic experiment, and the day Plan became Charter'
 ---
+*Six Plans on paper, five in practice — Sentinel's first systematic experiment between April 25 and 28. The cycle that turned an artisanal pattern into Charters, the framework's bounded unit of work.*
+
+<!-- truncate -->
+
 ## 1. A footnote that says a lot
 
 In the `charter-telemetry.md` proposal, written on 30 April 2026, there's a terminological note at the top:

--- a/website/blog/2026-05-06-charters-and-the-external-audit-cycle.md
+++ b/website/blog/2026-05-06-charters-and-the-external-audit-cycle.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-06T00:00:00.000Z
 description: From manual ritual in Sentinel to canonized CLI command
 ---
+*Forty minutes of copy-paste per Charter on top of two hours of work. Discipline was working; the ritual was becoming the problem. How the Charter became a first-class CLI entity, and the architectural decision that left audit orchestration to the framework and the prompt-eval to anyone else.*
+
+<!-- truncate -->
+
 ## 1. When discipline starts to feel like ceremony
 
 By late April, Sentinel closed its fourth Charter of the month with a feeling that, in writing, sounds slightly pathetic: external audit was working — Copilot 9.25, Gemini 9.5, the drift script with zero false positives — but every close had me opening three files by hand, copying three prompts into three different windows, waiting for replies, pasting three calibration YAMLs back into the telemetry file, and eyeballing the hashes to make sure they matched. Forty minutes of copy-paste per Charter on top of work that took two hours. Discipline was working; the ritual was becoming a problem.

--- a/website/blog/2026-05-09-charters-invisible-to-agents.md
+++ b/website/blog/2026-05-09-charters-invisible-to-agents.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-09T00:00:00.000Z
 description: 'Issue #113 — the gap between having an artifact and the agent seeing it'
 ---
+*Six hours of session work with a capable agent and the framework's full onboarding loaded — and not once did Charters get suggested. Five minutes to apply them when asked directly. The asymmetry isn't about capability; it's about visibility.*
+
+<!-- truncate -->
+
 ## 1. Six hours not to see it, five minutes to see it
 
 Issue [#113](https://github.com/StrangeDaysTech/straymark/issues/113) opens with one of those sentences that, read back months later, sounds obvious and at the same time cost a lot to reach:

--- a/website/blog/2026-05-09-the-rebrand-to-straymark.md
+++ b/website/blog/2026-05-09-the-rebrand-to-straymark.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-05-09T00:00:00.000Z
 description: The fourth rename — this time with a public ADR and a disciplined arc
 ---
+*The fourth rename, unlike the first three, wasn't searching for the concept — it came from a trademark conflict investigation. Eight days, an ADR, five PRs in forty-three minutes. The first disciplined rebrand of the project, and what "in scope / out of scope" meant when applied to its own past.*
+
+<!-- truncate -->
+
 ## 1. The rename that wasn't looking for the concept
 
 ADR `2026-05-08-001` opens with a sentence that, for anyone who read Post 2 of this blog, sounds out of place:

--- a/website/blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
+++ b/website/blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-11T00:00:00.000Z
 description: 'Phase 2: when the framework starts to verify what it had been promising'
 ---
+*464 lines of bash got replaced with a flag. From "I check this looks like a document" to "I check this satisfies the canonical schema, in the mode you ask for, with concrete operational consequences." Phase 2 of the CLI roadmap and the formalization of validate.*
+
+<!-- truncate -->
+
 ## 1. Having schemas is not the same as validating against schemas
 
 `straymark validate` had existed since 25 March 2026 — PR #27, part of the first arc of CLI Phase 1. What it did back then was small: verify that documents in `.straymark/` had valid Markdown syntax, parseable frontmatter, and the minimum fields of the correct type. It was useful. It was not *enforcement*.

--- a/website/blog/2026-05-12-tde-and-transversal-debt.md
+++ b/website/blog/2026-05-12-tde-and-transversal-debt.md
@@ -15,6 +15,10 @@ description: >-
   The type existed. The trigger didn't. And the stacked-PR lesson that came
   along for the ride.
 ---
+*Zero TDEs across thirteen closed Charters in Sentinel, despite at least seven recognizable pieces of transversal debt. The document type existed; the operational trigger didn't. How fw-4.13.0 closed the gap — and how its PR chain accidentally codified a lesson about stacked PRs.*
+
+<!-- truncate -->
+
 ## 1. Zero TDEs across thirteen Charters
 
 Issue [#128](https://github.com/StrangeDaysTech/straymark/issues/128) opens with a disquieting asymmetry:

--- a/website/blog/2026-05-13-the-audit-prompt-was-the-outlier.md
+++ b/website/blog/2026-05-13-the-audit-prompt-was-the-outlier.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-05-13T00:00:00.000Z
 description: The only file in the framework that lived in another language
 ---
+*One file among dozens lived backwards — Spanish-canonical in an EN-canonical framework, for six weeks, without anyone noticing. A maintenance fix that records something the blog keeps running into: outliers teach you the convention by contrast.*
+
+<!-- truncate -->
+
 ## 1. One line from the commit
 
 This is the post's operational opening. Commit `a8a1ac5` from 12 May 2026 carries a body that begins with this sentence:

--- a/website/blog/2026-05-14-manual-discipline-before-the-pattern.md
+++ b/website/blog/2026-05-14-manual-discipline-before-the-pattern.md
@@ -15,6 +15,10 @@ description: >-
   Twelve learnings in an Issue, three gates in a PR, and a Charter that closed
   cleanly before the name existed
 ---
+*Seven consecutive Charters on a one-month-old plan in Sentinel, executing CHARTER-18 by hand with the feeling that any false step would bury six Charters of work. Five hours to canonize the manual discipline as upstream governance — without naming the pattern yet.*
+
+<!-- truncate -->
+
 ## 1. The right question
 
 [Issue #150](https://github.com/StrangeDaysTech/straymark/issues/150), opened on 14 May at 16:59 UTC, wasn't looking for a *yes/no*. What the operator was asking was for the question to be reframed:

--- a/website/blog/2026-05-15-agents-md-as-a-universal-standard.md
+++ b/website/blog/2026-05-15-agents-md-as-a-universal-standard.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-15T00:00:00.000Z
 description: Four months between the intuition and the open standard
 ---
+*Four months between the project's first AIDEC — "AI agents are a single technical audience" — and the open standard that operationalized it. `AGENTS.md` at the repo root, read by fifteen vendor CLIs, replacing the proliferation of CLAUDE.md / GEMINI.md / .cursorrules and a dozen more.*
+
+<!-- truncate -->
+
 ## 1. Four months between intuition and standard
 
 On 15 May 2026, at 19:05 UTC, PR [#155](https://github.com/StrangeDaysTech/straymark/pull/155) closed the framework as `fw-4.15.0 / cli-3.13.2`. What it brought is a single new file in the list of directives the CLI injects: `AGENTS.md`, at the adopter's repo root, parallel to the ones already there (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`).

--- a/website/blog/2026-05-15-opening-the-framework.md
+++ b/website/blog/2026-05-15-opening-the-framework.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-15T00:00:00.000Z
 description: Seventy-two hours of gestures that only make sense together
 ---
+*Two gestures in seventy-two hours: closing the last 5% of i18n parity (20/20/20 governance docs across EN + ES + zh-CN) and publishing the CLA badge in the README. Small separately; together, the moment the framework stops talking to itself and starts talking to whoever wants to read it.*
+
+<!-- truncate -->
+
 ## 1. Two gestures in seventy-two hours
 
 On 13 May 2026, at 06:20 UTC, `fw-4.13.4` merged. It closed two small i18n coverage gaps — the ISO-25010 reference document that was only in English, and the Charter template that was missing in Simplified Chinese. Twenty-two canonical framework files reached structural EN/ES/zh-CN parity.

--- a/website/blog/2026-05-16-emergent-observation-design.md
+++ b/website/blog/2026-05-16-emergent-observation-design.md
@@ -14,6 +14,10 @@ tags:
 date: 2026-05-16T00:00:00.000Z
 description: Naming a design property that was already silently doing its job
 ---
+*An agent flagged a stale spec before being asked to. The reconstruction of that morning, and the design property that surfaces it — codified after the fact as Principle #8 of StrayMark.*
+
+<!-- truncate -->
+
 > *"Hi, did we already deal with Issue #153?"*
 
 That's how the conversation started, today, May 16th, in the morning. A short, almost-housekeeping question, before getting into something else. The answer was no — Issue #153 was open on purpose, waiting for a second domain to exercise the mechanic before crystallizing it (StrayMark's Principle #12: validation against a second domain before canonization). But the question opened another door, and by the end of that conversation I had codified a design property of the framework that had been doing its job in silence for months, surfaced by an episode from just two days ago.

--- a/website/blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
+++ b/website/blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-05-16T00:00:00.000Z
 description: When discipline stops being habit and becomes name
 ---
+*Twenty-seven hours later, the manual discipline got two names: Pattern 1 — pre-declare SpecKit refresh, and Pattern 2 — post-close audit-driven Batch N.4. The canonical document, the telemetry schema, the CLI helpers — and one hour after that, a meta-pattern that reabsorbs both upward.*
+
+<!-- truncate -->
+
 ## 1. Twenty-seven hours to name them
 
 PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152), which closed the Post 9 episode, merged on 14 May at 21:39 UTC. It brought `fw-4.14.3` and the three canonized gates of the manual refresh.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -62,6 +62,8 @@ const config: Config = {
           routeBasePath: 'blog',
           blogTitle: 'Blog',
           blogDescription: 'The StrayMark chronicle — how the framework emerged, decision by decision.',
+          blogSidebarCount: 'ALL',
+          blogSidebarTitle: 'All posts',
           showReadingTime: true,
           feedOptions: {
             type: ['rss', 'atom'],

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-04-05-four-names-in-four-months.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-04-05-four-names-in-four-months.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-04-05T00:00:00.000Z
 description: Buscar el concepto buscando el nombre
 ---
+*Chronicle → Monimen → DevTrail → Strange Days Tech → StrayMark. El arco prehistórico de cuatro renames en cuatro meses — tres apresurados en enero y uno disciplinado en mayo. La idea no se movió; el nombre sí.*
+
+<!-- truncate -->
+
 > **Nota editorial**: este es el primer post publicado de forma retroactiva en el blog. La `date` del frontmatter corresponde a un momento dentro del arco que el post narra, no al día en que se escribió. El blog completo se está construyendo así, hacia atrás, desde el episodio que motivó empezar a escribirlo (`emergent-observation-design`, 2026-05-16). No tiene sentido fingir lo contrario.
 
 ---

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-04-27-exploring-the-framework.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-04-27-exploring-the-framework.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-04-27T00:00:00.000Z
 description: La TUI que produjo visibilidad sin proponérselo
 ---
+*Para abril de 2026 el framework tenía ~50 archivos Markdown gobernados y se había vuelto opaco. `straymark explore` — un TUI que renderiza todo el repo como superficie navegable — nació tres semanas antes de revelar accidentalmente el outlier del Post 8. Las herramientas nuevas producen visibilidad sin proponérselo.*
+
+<!-- truncate -->
+
 ## 1. La herramienta que dos semanas después reveló el outlier
 
 El Post 8 de este blog cubrió un episodio muy específico: el descubrimiento del único archivo del framework cuyo idioma canónico era el español. El operador no lo encontró por inspección sistemática; lo encontró ejecutando `straymark explore --lang es` durante una preparación de auditoría y notando, visualmente, que un template estaba escrito al revés respecto a los demás. La frase de aquel post fue:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-04-30-six-plans-and-the-rename-to-charter.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-04-30-six-plans-and-the-rename-to-charter.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-04-30T00:00:00.000Z
 description: Primer experimento sistemático y el día que Plan se llamó Charter
 ---
+*Seis Planes sobre el papel, cinco en la práctica — el primer experimento sistemático de Sentinel entre el 25 y el 28 de abril. El ciclo que convirtió un patrón artesanal en Charters, la unidad acotada de trabajo del framework.*
+
+<!-- truncate -->
+
 ## 1. Una nota al pie que dice mucho
 
 En la propuesta `charter-telemetry.md`, escrita el 30 de abril de 2026, hay una nota terminológica al inicio:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-06-charters-and-the-external-audit-cycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-06-charters-and-the-external-audit-cycle.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-06T00:00:00.000Z
 description: De ritual manual en Sentinel a comando CLI canonizado
 ---
+*Cuarenta minutos de copy-paste por Charter encima de dos horas de trabajo. La disciplina funcionaba; el ritual se estaba volviendo el problema. Cómo el Charter pasó a ser entidad de primera clase del CLI, y la decisión arquitectónica que dejó la orquestación de auditoría al framework y la evaluación del prompt a cualquier otro.*
+
+<!-- truncate -->
+
 ## 1. Cuando la disciplina amenaza con volverse ceremonia
 
 A finales de abril, Sentinel cerró su cuarto Charter del mes con una sensación que, escrita, suena un poco patética: la auditoría externa funcionaba — Copilot 9.25, Gemini 9.5, el drift script con cero falsos positivos — pero cada cierre me hacía abrir tres archivos a mano, copiar tres prompts a tres ventanas distintas, esperar respuestas, copiar tres YAMLs de calibración de vuelta al archivo de telemetría, y verificar a ojo que los hashes coincidían. Cuarenta minutos de copy-paste por Charter, sobre un trabajo que tomaba dos horas. La disciplina estaba funcionando; el ritual estaba volviéndose un problema.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-charters-invisible-to-agents.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-charters-invisible-to-agents.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-09T00:00:00.000Z
 description: 'Issue #113 — la brecha entre tener un artefacto y que el agente lo vea'
 ---
+*Seis horas de sesión con un agente capaz y todo el onboarding del framework cargado — y ni una vez se sugirieron los Charters. Cinco minutos para aplicarlos al pedirlos directamente. La asimetría no es de capacidad; es de visibilidad.*
+
+<!-- truncate -->
+
 ## 1. Seis horas para no verlo, cinco minutos para verlo
 
 El Issue [#113](https://github.com/StrangeDaysTech/straymark/issues/113) abre con una de esas frases que, cuando uno la lee de regreso meses después, suena obvia y al mismo tiempo costó mucho llegar:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-the-rebrand-to-straymark.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-09-the-rebrand-to-straymark.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-05-09T00:00:00.000Z
 description: 'El cuarto rename, esta vez con ADR público y arco disciplinado'
 ---
+*El cuarto rename, a diferencia de los tres primeros, no buscaba el concepto — vino de una investigación de conflicto de marca. Ocho días, un ADR, cinco PRs en cuarenta y tres minutos. El primer rebrand disciplinado del proyecto, y lo que "in scope / out of scope" significó al aplicarlo sobre su propio pasado.*
+
+<!-- truncate -->
+
 ## 1. El rename que no buscaba el concepto
 
 El ADR `2026-05-08-001` se abre con una frase que, para cualquiera que haya leído el Post 2 de este blog, suena ajena:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-11-validate-and-schemas-as-a-formal-layer.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-11T00:00:00.000Z
 description: 'Phase 2: cuando el framework empieza a verificar lo que prometía'
 ---
+*464 líneas de bash reemplazadas por una flag. De "verifico que esto parezca un documento" a "verifico que esto satisface el schema canónico, en el modo que pidas, con consecuencias operacionales concretas." Fase 2 del roadmap del CLI y la formalización de validate.*
+
+<!-- truncate -->
+
 ## 1. Tener schemas no es lo mismo que validar contra schemas
 
 `straymark validate` existía desde el 25 de marzo de 2026 — PR #27, parte del primer arco de Phase 1 del CLI. Lo que hacía entonces era pequeño: verificar que los documentos en `.straymark/` tuvieran sintaxis Markdown válida, frontmatter parseable, y los campos mínimos del tipo correcto. Era útil. No era *enforcement*.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-12-tde-and-transversal-debt.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-12-tde-and-transversal-debt.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-12T00:00:00.000Z
 description: El tipo existía. El trigger no. Y la lección stacked-PR que llegó de regalo.
 ---
+*Cero TDEs en trece Charters cerrados de Sentinel, a pesar de al menos siete piezas reconocibles de deuda transversal. El tipo documental existía; el trigger operacional no. Cómo fw-4.13.0 cerró el hueco — y cómo su cadena de PRs codificó accidentalmente una lección sobre stacked PRs.*
+
+<!-- truncate -->
+
 ## 1. Cero TDEs en trece Charters
 
 El Issue [#128](https://github.com/StrangeDaysTech/straymark/issues/128) abre con una asimetría inquietante:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-13-the-audit-prompt-was-the-outlier.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-13-the-audit-prompt-was-the-outlier.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-05-13T00:00:00.000Z
 description: El único archivo del framework que vivía en otro idioma
 ---
+*Un archivo entre decenas vivía al revés — canónico en español en un framework canónico en inglés, durante seis semanas, sin que nadie lo notara. Un fix de mantenimiento que registra algo con lo que el blog se encuentra una y otra vez: los outliers enseñan la convención por contraste.*
+
+<!-- truncate -->
+
 ## 1. Una sola línea del commit
 
 Esta es la entrada operativa del post 8. El commit `a8a1ac5` del 12 de mayo de 2026 carga un cuerpo que se abre con esta frase:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-14-manual-discipline-before-the-pattern.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-14-manual-discipline-before-the-pattern.md
@@ -15,6 +15,10 @@ description: >-
   Doce aprendizajes en un Issue, tres gates en un PR, y un Charter que cerró
   limpio antes de que existiera el nombre
 ---
+*Siete Charters consecutivos sobre un plan de un mes en Sentinel, ejecutando CHARTER-18 a mano con la sensación de que cualquier paso en falso enterraría seis Charters de trabajo. Cinco horas para canonizar la disciplina manual como gobernanza upstream — sin nombrar todavía el patrón.*
+
+<!-- truncate -->
+
 ## 1. La pregunta correcta
 
 El [Issue #150](https://github.com/StrangeDaysTech/straymark/issues/150), abierto el 14 de mayo a las 16:59 UTC, no buscaba un *yes/no*. Lo que el operador estaba pidiendo era reformular la pregunta:

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-agents-md-as-a-universal-standard.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-agents-md-as-a-universal-standard.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-15T00:00:00.000Z
 description: Cuatro meses entre la intuición y el estándar abierto
 ---
+*Cuatro meses entre el primer AIDEC del proyecto — "los agentes de IA son una única audiencia técnica" — y el estándar abierto que lo operacionalizó. `AGENTS.md` en la raíz del repo, leído por quince CLIs de distintos vendors, reemplazando la proliferación de CLAUDE.md / GEMINI.md / .cursorrules y una docena más.*
+
+<!-- truncate -->
+
 ## 1. Cuatro meses entre la intuición y el estándar
 
 El 15 de mayo de 2026, a las 19:05 UTC, el PR [#155](https://github.com/StrangeDaysTech/straymark/pull/155) cerró el framework como `fw-4.15.0 / cli-3.13.2`. Lo que trajo es un solo archivo nuevo en la lista de directivas que el CLI inyecta: `AGENTS.md`, en la raíz del repo del adoptante, paralelo a los que ya estaban (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursorrules`, `.cursor/rules/straymark.md`).

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-opening-the-framework.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-15-opening-the-framework.md
@@ -13,6 +13,10 @@ tags:
 date: 2026-05-15T00:00:00.000Z
 description: Setenta y dos horas de gestos que sólo cobran sentido juntos
 ---
+*Dos gestos en setenta y dos horas: cerrar el último 5% de la paridad i18n (20/20/20 docs de gobernanza en EN + ES + zh-CN) y publicar el badge de CLA en el README. Pequeños por separado; juntos, el momento en que el framework deja de hablarse a sí mismo y empieza a hablarle a cualquiera que quiera leerlo.*
+
+<!-- truncate -->
+
 ## 1. Dos gestos en setenta y dos horas
 
 El 13 de mayo de 2026, a las 06:20 UTC, se fusionó `fw-4.13.4`. Cerró dos huecos pequeños de cobertura i18n — el documento de referencia ISO-25010 que solo estaba en inglés, y el template del Charter que faltaba en chino simplificado. Veintidós archivos canónicos del framework alcanzaron paridad estructural EN/ES/zh-CN.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-emergent-observation-design.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-emergent-observation-design.md
@@ -16,6 +16,10 @@ description: >-
   Cómo nombrar una propiedad de diseño que ya estaba haciendo su trabajo en
   silencio
 ---
+*Un agente señaló un spec desactualizado sin que nadie se lo pidiera. La reconstrucción de esa mañana y la propiedad de diseño que lo hace posible — codificada a posteriori como Principio #8 de StrayMark.*
+
+<!-- truncate -->
+
 > *"Hola, ¿ya tratamos el Issue #153?"*
 
 Así empezó la conversación, hoy 16 de mayo a la mañana. Una pregunta corta, casi de housekeeping, antes de meterme en otra cosa. La respuesta era no — el Issue #153 estaba abierto a propósito, esperando un segundo dominio que ejercitara la mecánica antes de cristalizarla (Principio #12 de StrayMark, validación contra un segundo dominio antes de canonizar). Pero la pregunta abrió otra puerta, y al final de esa conversación había codificado una propiedad de diseño del framework que llevaba meses funcionando sin nombre, señalada por un episodio de hace apenas dos días.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-16-pattern-1-and-pattern-2-chain-evolution.md
@@ -12,6 +12,10 @@ tags:
 date: 2026-05-16T00:00:00.000Z
 description: Cuando la disciplina deja de ser hábito y se vuelve nombre
 ---
+*Veintisiete horas después, la disciplina manual obtuvo dos nombres: Patrón 1 — pre-declare SpecKit refresh, y Patrón 2 — post-close audit-driven Batch N.4. El documento canónico, el schema de telemetría, los helpers del CLI — y una hora después, un meta-patrón que reabsorbe ambos hacia arriba.*
+
+<!-- truncate -->
+
 ## 1. Veintisiete horas para nombrarlos
 
 El PR [#152](https://github.com/StrangeDaysTech/straymark/pull/152), que cerró el episodio del Post 9, se fusionó el 14 de mayo a las 21:39 UTC. Trajo `fw-4.14.3` y los tres gates canonizados del refresh manual.

--- a/website/scripts/blog-excerpts.json
+++ b/website/scripts/blog-excerpts.json
@@ -1,0 +1,73 @@
+{
+  "_comment": "Excerpts shown above the <!-- truncate --> marker on /blog and /es/blog listings. Keyed by canonical (EN) slug; both locales are required. Edit here, then re-run `npm run migrate:blog`.",
+
+  "emergent-observation-design": {
+    "en": "An agent flagged a stale spec before being asked to. The reconstruction of that morning, and the design property that surfaces it — codified after the fact as Principle #8 of StrayMark.",
+    "es": "Un agente señaló un spec desactualizado sin que nadie se lo pidiera. La reconstrucción de esa mañana y la propiedad de diseño que lo hace posible — codificada a posteriori como Principio #8 de StrayMark."
+  },
+
+  "four-names-in-four-months": {
+    "en": "Chronicle → Monimen → DevTrail → Strange Days Tech → StrayMark. The project's prehistoric arc of four renames in four months — three rushed ones in January and a disciplined one in May. The idea didn't move; the name did.",
+    "es": "Chronicle → Monimen → DevTrail → Strange Days Tech → StrayMark. El arco prehistórico de cuatro renames en cuatro meses — tres apresurados en enero y uno disciplinado en mayo. La idea no se movió; el nombre sí."
+  },
+
+  "six-plans-and-the-rename-to-charter": {
+    "en": "Six Plans on paper, five in practice — Sentinel's first systematic experiment between April 25 and 28. The cycle that turned an artisanal pattern into Charters, the framework's bounded unit of work.",
+    "es": "Seis Planes sobre el papel, cinco en la práctica — el primer experimento sistemático de Sentinel entre el 25 y el 28 de abril. El ciclo que convirtió un patrón artesanal en Charters, la unidad acotada de trabajo del framework."
+  },
+
+  "charters-and-the-external-audit-cycle": {
+    "en": "Forty minutes of copy-paste per Charter on top of two hours of work. Discipline was working; the ritual was becoming the problem. How the Charter became a first-class CLI entity, and the architectural decision that left audit orchestration to the framework and the prompt-eval to anyone else.",
+    "es": "Cuarenta minutos de copy-paste por Charter encima de dos horas de trabajo. La disciplina funcionaba; el ritual se estaba volviendo el problema. Cómo el Charter pasó a ser entidad de primera clase del CLI, y la decisión arquitectónica que dejó la orquestación de auditoría al framework y la evaluación del prompt a cualquier otro."
+  },
+
+  "charters-invisible-to-agents": {
+    "en": "Six hours of session work with a capable agent and the framework's full onboarding loaded — and not once did Charters get suggested. Five minutes to apply them when asked directly. The asymmetry isn't about capability; it's about visibility.",
+    "es": "Seis horas de sesión con un agente capaz y todo el onboarding del framework cargado — y ni una vez se sugirieron los Charters. Cinco minutos para aplicarlos al pedirlos directamente. La asimetría no es de capacidad; es de visibilidad."
+  },
+
+  "the-rebrand-to-straymark": {
+    "en": "The fourth rename, unlike the first three, wasn't searching for the concept — it came from a trademark conflict investigation. Eight days, an ADR, five PRs in forty-three minutes. The first disciplined rebrand of the project, and what \"in scope / out of scope\" meant when applied to its own past.",
+    "es": "El cuarto rename, a diferencia de los tres primeros, no buscaba el concepto — vino de una investigación de conflicto de marca. Ocho días, un ADR, cinco PRs en cuarenta y tres minutos. El primer rebrand disciplinado del proyecto, y lo que \"in scope / out of scope\" significó al aplicarlo sobre su propio pasado."
+  },
+
+  "tde-and-transversal-debt": {
+    "en": "Zero TDEs across thirteen closed Charters in Sentinel, despite at least seven recognizable pieces of transversal debt. The document type existed; the operational trigger didn't. How fw-4.13.0 closed the gap — and how its PR chain accidentally codified a lesson about stacked PRs.",
+    "es": "Cero TDEs en trece Charters cerrados de Sentinel, a pesar de al menos siete piezas reconocibles de deuda transversal. El tipo documental existía; el trigger operacional no. Cómo fw-4.13.0 cerró el hueco — y cómo su cadena de PRs codificó accidentalmente una lección sobre stacked PRs."
+  },
+
+  "the-audit-prompt-was-the-outlier": {
+    "en": "One file among dozens lived backwards — Spanish-canonical in an EN-canonical framework, for six weeks, without anyone noticing. A maintenance fix that records something the blog keeps running into: outliers teach you the convention by contrast.",
+    "es": "Un archivo entre decenas vivía al revés — canónico en español en un framework canónico en inglés, durante seis semanas, sin que nadie lo notara. Un fix de mantenimiento que registra algo con lo que el blog se encuentra una y otra vez: los outliers enseñan la convención por contraste."
+  },
+
+  "manual-discipline-before-the-pattern": {
+    "en": "Seven consecutive Charters on a one-month-old plan in Sentinel, executing CHARTER-18 by hand with the feeling that any false step would bury six Charters of work. Five hours to canonize the manual discipline as upstream governance — without naming the pattern yet.",
+    "es": "Siete Charters consecutivos sobre un plan de un mes en Sentinel, ejecutando CHARTER-18 a mano con la sensación de que cualquier paso en falso enterraría seis Charters de trabajo. Cinco horas para canonizar la disciplina manual como gobernanza upstream — sin nombrar todavía el patrón."
+  },
+
+  "pattern-1-and-pattern-2-chain-evolution": {
+    "en": "Twenty-seven hours later, the manual discipline got two names: Pattern 1 — pre-declare SpecKit refresh, and Pattern 2 — post-close audit-driven Batch N.4. The canonical document, the telemetry schema, the CLI helpers — and one hour after that, a meta-pattern that reabsorbs both upward.",
+    "es": "Veintisiete horas después, la disciplina manual obtuvo dos nombres: Patrón 1 — pre-declare SpecKit refresh, y Patrón 2 — post-close audit-driven Batch N.4. El documento canónico, el schema de telemetría, los helpers del CLI — y una hora después, un meta-patrón que reabsorbe ambos hacia arriba."
+  },
+
+  "exploring-the-framework": {
+    "en": "By April 2026 the framework had ~50 governed Markdown files and they had become opaque. `straymark explore` — a TUI that renders the whole repo as a navigable surface — was born three weeks before it accidentally revealed the outlier from Post 8. New tools produce visibility without meaning to.",
+    "es": "Para abril de 2026 el framework tenía ~50 archivos Markdown gobernados y se había vuelto opaco. `straymark explore` — un TUI que renderiza todo el repo como superficie navegable — nació tres semanas antes de revelar accidentalmente el outlier del Post 8. Las herramientas nuevas producen visibilidad sin proponérselo."
+  },
+
+  "validate-and-schemas-as-a-formal-layer": {
+    "en": "464 lines of bash got replaced with a flag. From \"I check this looks like a document\" to \"I check this satisfies the canonical schema, in the mode you ask for, with concrete operational consequences.\" Phase 2 of the CLI roadmap and the formalization of validate.",
+    "es": "464 líneas de bash reemplazadas por una flag. De \"verifico que esto parezca un documento\" a \"verifico que esto satisface el schema canónico, en el modo que pidas, con consecuencias operacionales concretas.\" Fase 2 del roadmap del CLI y la formalización de validate."
+  },
+
+  "agents-md-as-a-universal-standard": {
+    "en": "Four months between the project's first AIDEC — \"AI agents are a single technical audience\" — and the open standard that operationalized it. `AGENTS.md` at the repo root, read by fifteen vendor CLIs, replacing the proliferation of CLAUDE.md / GEMINI.md / .cursorrules and a dozen more.",
+    "es": "Cuatro meses entre el primer AIDEC del proyecto — \"los agentes de IA son una única audiencia técnica\" — y el estándar abierto que lo operacionalizó. `AGENTS.md` en la raíz del repo, leído por quince CLIs de distintos vendors, reemplazando la proliferación de CLAUDE.md / GEMINI.md / .cursorrules y una docena más."
+  },
+
+  "opening-the-framework": {
+    "en": "Two gestures in seventy-two hours: closing the last 5% of i18n parity (20/20/20 governance docs across EN + ES + zh-CN) and publishing the CLA badge in the README. Small separately; together, the moment the framework stops talking to itself and starts talking to whoever wants to read it.",
+    "es": "Dos gestos en setenta y dos horas: cerrar el último 5% de la paridad i18n (20/20/20 docs de gobernanza en EN + ES + zh-CN) y publicar el badge de CLA en el README. Pequeños por separado; juntos, el momento en que el framework deja de hablarse a sí mismo y empieza a hablarle a cualquiera que quiera leerlo."
+  }
+}

--- a/website/scripts/migrate-blog.ts
+++ b/website/scripts/migrate-blog.ts
@@ -17,6 +17,10 @@ const ROOT = resolve(__dirname, '..');
 const APARADOR = resolve(ROOT, '../Aparador/Para blog');
 const OUT_EN = resolve(ROOT, 'blog');
 const OUT_ES = resolve(ROOT, 'i18n/es/docusaurus-plugin-content-blog');
+const EXCERPTS_PATH = resolve(__dirname, 'blog-excerpts.json');
+
+type Excerpt = {en: string; es: string};
+const excerpts: Record<string, Excerpt> = JSON.parse(readFileSync(EXCERPTS_PATH, 'utf8'));
 
 const FILE_RE = /^(\d{2})-(.+)\.(en|es)\.md$/;
 
@@ -76,7 +80,15 @@ function transformFrontmatter(fm: Record<string, unknown>, slug: string): Record
   return out;
 }
 
-function emit(srcPath: string, slug: string, outDir: string): {date: string; filename: string} {
+function prependExcerpt(body: string, excerpt: string | undefined): string {
+  if (!excerpt) return body;
+  // Lead paragraph (italics, since it's an editorial excerpt) + truncate
+  // marker. Everything above the marker is what Docusaurus shows on the
+  // /blog and /es/blog listings.
+  return `*${excerpt}*\n\n<!-- truncate -->\n\n${body.replace(/^\n+/, '')}`;
+}
+
+function emit(srcPath: string, slug: string, outDir: string, canonicalSlug: string, locale: 'en' | 'es'): {date: string; filename: string} {
   const raw = readFileSync(srcPath, 'utf8');
   const parsed = matter(raw);
   const fm = parsed.data;
@@ -87,7 +99,8 @@ function emit(srcPath: string, slug: string, outDir: string): {date: string; fil
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
     throw new Error(`Invalid date "${date}" in ${srcPath}`);
   }
-  const body = stripLeadingH1(parsed.content, title);
+  let body = stripLeadingH1(parsed.content, title);
+  body = prependExcerpt(body, excerpts[canonicalSlug]?.[locale]);
   const outFm = transformFrontmatter(fm, slug);
   const filename = `${date}-${slug}.md`;
   const outPath = join(outDir, filename);
@@ -121,10 +134,10 @@ function main() {
       continue;
     }
     // EN file under blog/, using EN slug both as filename and frontmatter slug.
-    const en = emit(post.enPath, post.enSlug, OUT_EN);
+    const en = emit(post.enPath, post.enSlug, OUT_EN, post.enSlug, 'en');
     // ES file under i18n/es/, using EN slug as filename (Docusaurus pairs by
     // filename) but ES slug in frontmatter for a clean Spanish URL.
-    emit(post.esPath, post.esSlug, OUT_ES);
+    emit(post.esPath, post.esSlug, OUT_ES, post.enSlug, 'es');
     // Rename the ES output to match the EN filename for i18n pairing.
     const esFilename = `${en.date}-${post.enSlug}.md`;
     const esWritten = join(OUT_ES, `${en.date}-${post.esSlug}.md`);


### PR DESCRIPTION
## Summary

The PR2 blog migration didn't add per-post excerpts, so `/blog` rendered the full body of the latest post (with the other 13 behind pagination) instead of a useful index. The first paragraph of each post is an epigraph or editorial note — auto-cutting there would have given the reader nothing.

This change writes a real excerpt for each post.

## What landed

- **`website/scripts/blog-excerpts.json`** — 14 hand-authored excerpts (1–2 sentences each), EN + ES, keyed by canonical (EN) slug. Each one names the actual move of the post: what happened, what got named, what the post is for. Voice mirrors the posts (specific, dated, not generic).
- **`scripts/migrate-blog.ts`** — reads the JSON and prepends each excerpt as an italic lead paragraph followed by the `<!-- truncate -->` marker during migration. Posts without an excerpt entry pass through unchanged.
- **28 migrated `.md` files** — regenerated by `npm run migrate:blog`. The excerpt also acts as an editorial lead paragraph on the full post page.
- **`docusaurus.config.ts`** — `blogSidebarCount: 'ALL'` + `blogSidebarTitle: 'All posts'` so the right-rail sidebar shows all 14 entries instead of Docusaurus's default 5.

## Sample excerpts (EN)

> *An agent flagged a stale spec before being asked to. The reconstruction of that morning, and the design property that surfaces it — codified after the fact as Principle #8 of StrayMark.*

> *Zero TDEs across thirteen closed Charters in Sentinel, despite at least seven recognizable pieces of transversal debt. The document type existed; the operational trigger didn't.*

> *Six hours of session work with a capable agent and the framework's full onboarding loaded — and not once did Charters get suggested. Five minutes to apply them when asked directly. The asymmetry isn't about capability; it's about visibility.*

## Verified locally

- `build/blog.html` shows ten excerpts on page 1; `/blog/page/2` exists for the remaining four
- `build/es/blog.html` mirrors with the ES excerpts
- Right sidebar lists all 14 posts under "All posts"
- Build exit 0 (only the pre-existing PR1 docs/i18n broken-link warnings)

## How to revise an excerpt later

Edit `website/scripts/blog-excerpts.json` and re-run `npm run migrate:blog`. The JSON is the canonical source; the per-file leads are regenerated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)