### PR TITLE
chore(ci): migrate deploy-website to official GitHub Pages actions

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,21 +10,23 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: deploy-website
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 
@@ -36,9 +38,21 @@ jobs:
         working-directory: website
         run: npm run build
 
-      - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: website/build
-          publish_branch: gh-pages
+          path: website/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Replaces `peaceiris/actions-gh-pages@v4` with the official GitHub Pages flow: `actions/configure-pages@v5` + `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`. Splits into `build` + `deploy` jobs per the GitHub-recommended pattern.
- Bumps `actions/checkout@v4 → v6` and `actions/setup-node@v4 → v5` to silence the Node.js 20 deprecation warning (jun 2026 cutoff). The release workflows are already on `@v6`.
- Bumps runtime to Node 22 LTS (current LTS).
- Tightens permissions to the minimum the official flow requires: `contents: read`, `pages: write`, `id-token: write` (OIDC for `deploy-pages`).

## Breaking deployment change

After merging this PR, the GitHub Pages source must be switched manually:

> Repo Settings → Pages → Source = **GitHub Actions** (currently "Deploy from a branch" → `gh-pages`)

The existing `gh-pages` branch is left untouched but stops being the publish target. The current site keeps serving from the `gh-pages` branch's last commit until the Settings flip — after the flip, the first run of this workflow will deploy from the workflow artifact.

## Test plan

- [ ] Merge → flip Pages source to "GitHub Actions" → trigger workflow_dispatch
- [ ] CI run shows no Node.js 20 deprecation warnings
- [ ] Site at https://strangedaystech.github.io/straymark/ continues to serve the same content
- [ ] Build job produces a Pages artifact; deploy job publishes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)