### PR TITLE
feat(website): switch to custom domain straymark.dev

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -14,8 +14,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://strangedaystech.github.io',
-  baseUrl: '/straymark/',
+  url: 'https://straymark.dev',
+  baseUrl: '/',
 
   organizationName: 'StrangeDaysTech',
   projectName: 'straymark',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+straymark.dev


### PR DESCRIPTION
## Summary

- `docusaurus.config.ts`: `url` → `https://straymark.dev`, `baseUrl` → `/` (was `strangedaystech.github.io` + `/straymark/`).
- New `website/static/CNAME` containing `straymark.dev`, so the file ships with every build and the deploy target carries the custom-domain hint.

## Why now

DNS for `straymark.dev` already resolves to GitHub Pages but the deployed site is still configured under the project-pages path. Carved out of `feat/website-zh-CN` so the domain switch lands ahead of the zh-CN content rollout — the public URL stops being a moving target.

## Post-merge checklist

- [ ] Workflow run completes; new build published.
- [ ] Settings → Pages → Custom domain shows `straymark.dev` (auto-detected from CNAME).
- [ ] Let's Encrypt cert provisions (a few minutes); then check **Enforce HTTPS**.
- [ ] `https://straymark.dev/` serves the site.
- [ ] `https://strangedaystech.github.io/straymark/` 301-redirects to `https://straymark.dev/` (GitHub Pages handles this automatically once the custom domain is configured).
- [ ] Sanity-click a couple of internal links and the locale switcher (en ↔ es) — assets should resolve at `/` paths, not `/straymark/...`.

## Coordination with other open PRs

- #168 (credit disclosure cleanup): unrelated, independent.
- #169 (Pages CI to official actions): unrelated; if merged first, this PR's deploy will run under the new flow. Order doesn't matter.
- `feat/website-zh-CN` (still local): zh-CN locale change drops in cleanly on top of this PR's `url`/`baseUrl`/`CNAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)