### PR TITLE
chore(ci): bump Pages actions to Node 24 majors

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -39,10 +39,10 @@ jobs:
         run: npm run build
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Silences the Node 20 deprecation warnings on every `Deploy Website` run by bumping the three Pages actions to their Node 24 majors:

| Action | Before | After |
|---|---|---|
| `actions/configure-pages` | `v5` | `v6` |
| `actions/upload-pages-artifact` | `v3` | `v5` |
| `actions/deploy-pages` | `v4` | `v5` |

All three new majors run on Node 24 per their release notes (`actions/configure-pages` v6 changelog: *"upgrade to node 24"*; `actions/deploy-pages` v5 changelog: *"Update Node.js version to 24.x"*; `actions/upload-pages-artifact` v5 bundles upload-artifact v7). Input/output contracts used here (`path` on upload, no inputs on configure/deploy) are unchanged across these majors.

Context: after #169 migrated to the official Pages pipeline, runs started emitting:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/configure-pages@v5, actions/upload-artifact@v4.

GitHub will force Node 24 on June 2, 2026 and remove Node 20 from runners on September 16, 2026, so this is preemptive cleanup.

## Test plan

- [ ] Merge to `main`, confirm the auto-triggered `Deploy Website` run (path filter matches `.github/workflows/deploy-website.yml`) succeeds.
- [ ] Confirm the deprecation annotation is gone from the run summary.
- [ ] `curl -sI https://straymark.dev/` still returns `HTTP/2 200`.