### PR TITLE
fix(cli): skip prompts TTY test when stdin is a TTY

### DIFF
--- a/cli/src/prompts.rs
+++ b/cli/src/prompts.rs
@@ -130,7 +130,12 @@ mod tests {
 
     #[test]
     fn require_interactive_errors_in_non_tty() {
-        // Cargo test runs without a TTY.
+        // Skip when stdin is a TTY (e.g. `cargo test` run from an interactive
+        // shell). Under `cargo test` in CI or piped invocations stdin is not a
+        // TTY and the assertion below exercises the real code path.
+        if std::io::stdin().is_terminal() {
+            return;
+        }
         let result = require_interactive();
         assert!(result.is_err());
     }


### PR DESCRIPTION
## Summary
- `require_interactive_errors_in_non_tty` (cli/src/prompts.rs) failed when `cargo test` ran from an interactive shell because stdin was inherited as a TTY, contradicting the test's assumption.
- Add a runtime guard: if stdin is a TTY, return early. Under CI / piped invocations the assertion still runs.

## Test plan
- [x] `cargo test --bin straymark` → 320 passed, 0 failed (TTY path: early return)
- [x] `cargo test --bin straymark < /dev/null` → 320 passed, 0 failed (non-TTY path: assertion exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)