### PR TITLE
fix(docs): repoint decisions/ links to GitHub URLs

### DIFF
--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -23,7 +23,7 @@ The atemporal material — read these to understand *what* StrayMark is and *why
 
 ## Historical proposals (archived)
 
-Proposals and roadmaps from the project's pre-CLI evolution, preserved for context — they explain how the current shape emerged. They are **not** maintained going forward; the canonical source for current behavior is the code, the schemas under `dist/.straymark/schemas/`, and the CHANGELOG. Browse them at [`docs/decisions/proposals/`](../decisions/proposals/):
+Proposals and roadmaps from the project's pre-CLI evolution, preserved for context — they explain how the current shape emerged. They are **not** maintained going forward; the canonical source for current behavior is the code, the schemas under `dist/.straymark/schemas/`, and the CHANGELOG. Browse them on GitHub at [`docs/decisions/proposals/`](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions/proposals):
 
 | File | Snapshot date | What it captured |
 |---|---|---|
@@ -34,7 +34,7 @@ Proposals and roadmaps from the project's pre-CLI evolution, preserved for conte
 | `2026-05-03-audit-skills-rollout.md` | 2026-05-03 | Operational rollout plan for the audit skills (gating criteria, telemetry, phased shipping). |
 | `2026-05-04-audit-cli-flow.md` | 2026-05-04 | Redesign of the external-audit flow after the first empirical encounter with a multi-commit L Charter (Sentinel CHARTER-07). Implemented in `cli-3.10+`. |
 
-Decision records (ADRs) for the live codebase live at [`docs/decisions/`](../decisions/) one level up.
+Decision records (ADRs) for the live codebase live on GitHub at [`docs/decisions/`](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions).
 
 ---
 

--- a/docs/i18n/es/contributors/README.md
+++ b/docs/i18n/es/contributors/README.md
@@ -23,7 +23,7 @@ El material atemporal — leer esto para entender *qué* es StrayMark y *por qu�
 
 ## Propuestas históricas (archivadas)
 
-Propuestas y roadmaps de la evolución del proyecto previa al CLI, preservadas como contexto — explican cómo emergió la forma actual. **No** se mantienen hacia adelante; la fuente canónica del comportamiento actual son el código, los schemas bajo `dist/.straymark/schemas/` y el CHANGELOG. Examinarlas en [`docs/decisions/proposals/`](../../../decisions/proposals/):
+Propuestas y roadmaps de la evolución del proyecto previa al CLI, preservadas como contexto — explican cómo emergió la forma actual. **No** se mantienen hacia adelante; la fuente canónica del comportamiento actual son el código, los schemas bajo `dist/.straymark/schemas/` y el CHANGELOG. Examinarlas en GitHub en [`docs/decisions/proposals/`](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions/proposals):
 
 | Archivo | Fecha del snapshot | Qué capturó |
 |---|---|---|
@@ -34,7 +34,7 @@ Propuestas y roadmaps de la evolución del proyecto previa al CLI, preservadas c
 | `2026-05-03-audit-skills-rollout.md` | 2026-05-03 | Plan operacional de rollout de las audit skills (criterios de gating, telemetría, shipping por fases). |
 | `2026-05-04-audit-cli-flow.md` | 2026-05-04 | Rediseño del flujo de auditoría externa tras el primer encuentro empírico con un Charter L multi-commit (Sentinel CHARTER-07). Implementado en `cli-3.10+`. |
 
-Los ADRs (registros de decisión arquitectónica) del código actual viven en [`docs/decisions/`](../../../decisions/) un nivel más arriba.
+Los ADRs (registros de decisión arquitectónica) del código actual viven en GitHub en [`docs/decisions/`](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions).
 
 ---
 

--- a/docs/i18n/es/intro.md
+++ b/docs/i18n/es/intro.md
@@ -22,4 +22,4 @@ StrayMark externaliza la disciplina cognitiva de la ingeniería asistida por IA 
 
 ## Decisiones
 
-El directorio [Decisions](./decisions) registra los ADRs — cada decisión técnica o de proceso que carga peso, con su justificación.
+El [directorio Decisions en GitHub](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions) registra los ADRs — cada decisión técnica o de proceso que carga peso, con su justificación.

--- a/docs/i18n/zh-CN/contributors/README.md
+++ b/docs/i18n/zh-CN/contributors/README.md
@@ -23,7 +23,7 @@
 
 ## 历史提案（已归档）
 
-项目在 CLI 之前演化阶段的提案与路线图，作为上下文保留——它们解释了当前形态是如何浮现的。这些**不**在向前的方向上维护；当前行为的权威来源是代码、`dist/.straymark/schemas/` 下的 schema，以及 CHANGELOG。可在 [`docs/decisions/proposals/`](../../../decisions/proposals/) 中浏览：
+项目在 CLI 之前演化阶段的提案与路线图，作为上下文保留——它们解释了当前形态是如何浮现的。这些**不**在向前的方向上维护；当前行为的权威来源是代码、`dist/.straymark/schemas/` 下的 schema，以及 CHANGELOG。可在 GitHub 上的 [`docs/decisions/proposals/`](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions/proposals) 浏览：
 
 | 文件 | 快照日期 | 捕获了什么 |
 |---|---|---|
@@ -34,7 +34,7 @@
 | `2026-05-03-audit-skills-rollout.md` | 2026-05-03 | audit skill 的运营性铺开计划（gating 标准、遥测、分阶段发布）。 |
 | `2026-05-04-audit-cli-flow.md` | 2026-05-04 | 在首次实际遇到一个跨多次提交的 L 级 Charter（Sentinel CHARTER-07）之后，对外部审计流程的重新设计。在 `cli-3.10+` 中实施。 |
 
-当前代码库的 ADR（架构决策记录）位于上一级的 [`docs/decisions/`](../../../decisions/)。
+当前代码库的 ADR（架构决策记录）位于 GitHub 上的 [`docs/decisions/`](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions)。
 
 ---
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,4 +22,4 @@ StrayMark externalizes the cognitive discipline of AI-assisted engineering — r
 
 ## Decisions
 
-The [Decisions](./decisions) directory tracks ADRs — every load-bearing technical or process choice with its rationale.
+The [Decisions directory on GitHub](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions) tracks ADRs — every load-bearing technical or process choice with its rationale.


### PR DESCRIPTION
## Summary
- PR #172 excluded `docs/decisions/` from the public site, leaving relative Markdown links (`./decisions`, `../decisions/`, `../../../decisions/`) that resolved to nothing on https://straymark.dev.
- Replace those links with absolute GitHub tree URLs (`https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions`) so they work in both the published site and GitHub Markdown views.
- Affected: \`docs/intro.md\`, \`docs/contributors/README.md\` plus the ES and zh-CN mirrors.

zh-CN is bundled here for source consistency. The locale isn't active in \`docusaurus.config.ts\` yet — it ships in a follow-up PR from \`wip-zh-CN\`.

## Test plan
- [x] \`grep -rnE '\]\((\./|\.\./)+decisions' docs/\` → no matches
- [x] \`cd website && npm run build\` → exits 0, no broken-link warnings mention \`/decisions/\` (remaining warnings are pre-existing cross-tree links in ES and known anchor bugs tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)