### PR TITLE
feat(website): activate zh-CN locale

### DIFF
--- a/docs/i18n/zh-CN/intro.md
+++ b/docs/i18n/zh-CN/intro.md
@@ -1,0 +1,25 @@
+---
+slug: /
+title: 欢迎使用 StrayMark
+sidebar_position: 1
+---
+
+# 欢迎使用 StrayMark
+
+StrayMark 将 AI 协同工程的认知纪律外化出来 —— 原生于仓库的治理、charters 与审计轨迹，让人与智能体的协作保持可读、可审。
+
+## 从哪里开始
+
+- [采用指南](./adopters/ADOPTION-GUIDE.md) —— 在你的项目中安装并启动 StrayMark。
+- [CLI 参考](./adopters/CLI-REFERENCE.md) —— 每一个 `straymark` 命令与参数。
+- [工作流](./adopters/WORKFLOWS.md) —— 人与智能体日常协作的模式。
+
+## 给贡献者
+
+- [设计原则](./contributors/DESIGN-PRINCIPLES.md) —— 塑造这个框架的约束条件。
+- [什么是 charter](./contributors/WHAT-IS-A-CHARTER.md) —— 核心产物。
+- [翻译指南](./contributors/TRANSLATION-GUIDE.md) —— 文档与博文如何本地化。
+
+## 决策
+
+[决策（Decisions）](./decisions) 目录追踪所有 ADR —— 每一个承重的技术或流程选择，及其背后的理由。

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -33,10 +33,11 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'es'],
+    locales: ['en', 'es', 'zh-CN'],
     localeConfigs: {
       en: {label: 'English'},
       es: {label: 'Español'},
+      'zh-CN': {label: '简体中文'},
     },
   },
 

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -1,0 +1,421 @@
+{
+  "hero.tagline": {
+    "message": "AI 协同工程的认知纪律",
+    "description": "Hero tagline (H1 on the landing)"
+  },
+  "features.title": {
+    "message": "StrayMark 提供什么",
+    "description": "Feature grid title"
+  },
+  "features.discipline.title": {
+    "message": "结构化的认知纪律",
+    "description": "Feature: structured cognitive discipline (title)"
+  },
+  "features.discipline.body": {
+    "message": "Charters 在代码之前定义目的与边界。AILOGs 捕获人/智能体的对话。AIDECs 记录决策与权衡。",
+    "description": "Feature: structured cognitive discipline (body)"
+  },
+  "features.repo.title": {
+    "message": "原生于仓库",
+    "description": "Feature: repo-native by design (title)"
+  },
+  "features.repo.body": {
+    "message": "所有内容都生活在你的 git 仓库里：产物、治理规则、智能体指令。没有外部平台，没有第二份事实来源。",
+    "description": "Feature: repo-native by design (body)"
+  },
+  "features.agents.title": {
+    "message": "声明式智能体治理",
+    "description": "Feature: declarative agent governance (title)"
+  },
+  "features.agents.body": {
+    "message": "STRAYMARK.md 与 AGENT-RULES 中版本化的规则在工作流层面约束智能体行为 —— 不在运行时，不在事后。",
+    "description": "Feature: declarative agent governance (body)"
+  },
+  "features.evidence.title": {
+    "message": "审计证据是副产品",
+    "description": "Feature: evidence as a byproduct (title)"
+  },
+  "features.evidence.body": {
+    "message": "对 EU AI Act、ISO 42001、NIST AI RMF 和 GDPR 的映射，从团队已经在生成的产物中自然涌现。无需另起一套纸面流程。",
+    "description": "Feature: evidence as a byproduct (body)"
+  },
+  "features.cli.title": {
+    "message": "一个真正做事的 CLI",
+    "description": "Feature: a CLI that does the work (title)"
+  },
+  "features.cli.body": {
+    "message": "init、validate、audit、analyze、compliance、metrics —— 一个二进制，十一个命令，可以 grep 与 pipe 的确定性输出。",
+    "description": "Feature: a CLI that does the work (body)"
+  },
+  "features.tde.title": {
+    "message": "TDE：漂移检测",
+    "description": "Feature: TDE drift detection (title)"
+  },
+  "features.tde.body": {
+    "message": "Transversal Debt Engine 让 Charters 之间隐藏的耦合在演化为事故前显形。",
+    "description": "Feature: TDE drift detection (body)"
+  },
+  "hero.pillar1": {
+    "message": "记录每一个决策",
+    "description": "First hero pillar"
+  },
+  "hero.pillar2": {
+    "message": "用经验数据检测漂移",
+    "description": "Second hero pillar"
+  },
+  "hero.pillar3": {
+    "message": "默认即可审计",
+    "description": "Third hero pillar"
+  },
+  "hero.cta.docs": {
+    "message": "阅读文档",
+    "description": "Hero CTA — read the docs"
+  },
+  "hero.cta.blog": {
+    "message": "阅读编年史",
+    "description": "Hero CTA — read the blog"
+  },
+  "why.eyebrow": {
+    "message": "为什么需要 StrayMark",
+    "description": "Why this exists eyebrow"
+  },
+  "why.body": {
+    "message": "整个行业都在忙于模型、防护栏（guardrails）与合规。最缺失的一环却在所有这些之上游：与智能体协作的团队的认知纪律。没有结构，智能体就会漂移，决策会被遗忘，风险无人记录，监管证据只能临时拼凑。StrayMark 直接结构化工作本身 —— 原生于仓库、感知智能体、按构造即可审计。",
+    "description": "Why this exists body paragraph"
+  },
+  "workflow.title": {
+    "message": "工作流",
+    "description": "Workflow section title"
+  },
+  "workflow.caption": {
+    "message": "每一步都在仓库里留下版本化的产物。没有外部系统，没有隐含决策。",
+    "description": "Workflow section caption"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "页面已崩溃。",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到顶部",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "历史博文",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "历史博文",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "博文列表分页导航",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "较新的博文",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "较旧的博文",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "博文分页导航",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "较新一篇",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "较旧一篇",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "查看所有标签",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "系统模式",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "浅色模式",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "暗黑模式",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "切换浅色/暗黑模式（当前为{mode}）",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "页面路径",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "文件选项卡",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "上一页",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "下一页",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count} 篇文档带有标签",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged}「{tagName}」",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版尚未发行的文档。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版的文档，现已不再积极维护。",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新的文档请参阅 {latestVersionLink} ({versionLabel})。",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新版本",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "编辑此页",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading}的直接链接",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "于 {date} ",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "由 {user} ",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "最后{byUser}{atDate}更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "选择版本",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "找不到页面",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "标签：",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "关闭",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "警告",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "危险",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "信息",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "备注",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "提示",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "注意",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "最近博文导航",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "展开侧边栏分类 '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "折叠侧边栏分类 '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "（在新标签页打开）",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "主导航",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "选择语言",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.NotFound.p1": {
+    "message": "我们找不到您要找的页面。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "本页总览",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "阅读更多",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "阅读 {title} 的全文",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "复制",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "复制成功",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "复制代码到剪贴板",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "切换自动换行",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "主页面",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "文档侧边栏",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "关闭导航栏",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 回到主菜单",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "切换导航栏",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "展开下拉菜单",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "收起下拉菜单",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count} 篇博文",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} 含有标签「{tagName}」",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "作者",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "查看所有作者",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "该作者尚未撰写任何文章。",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "未列出页",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "此页面未列出。搜索引擎不会对其索引，只有拥有直接链接的用户才能访问。",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "草稿页",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "此页面是草稿，仅在开发环境中可见，不会包含在正式版本中。",
+    "description": "The draft content banner message"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 个项目",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "重试",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "跳到主要内容",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "标签",
+    "description": "The title of the tag list page"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/authors.yml
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/authors.yml
@@ -1,0 +1,7 @@
+jose:
+  name: José Villaseñor Montfort
+  title: Strange Days Tech
+  url: https://github.com/montfort
+  page: true
+  socials:
+    github: montfort

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "博客",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "StrayMark 编年史 —— 这个框架是如何在一个又一个决策中浮现出来的。",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "全部文章",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -1,0 +1,50 @@
+{
+  "link.title.Docs": {
+    "message": "文档",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Project": {
+    "message": "项目",
+    "description": "The title of the footer links column with title=Project in the footer"
+  },
+  "link.title.Strange Days Tech": {
+    "message": "Strange Days Tech",
+    "description": "The title of the footer links column with title=Strange Days Tech in the footer"
+  },
+  "link.item.label.Adoption Guide": {
+    "message": "采用指南",
+    "description": "The label of footer link with label=Adoption Guide linking to /docs/adopters/ADOPTION-GUIDE"
+  },
+  "link.item.label.CLI Reference": {
+    "message": "CLI 参考",
+    "description": "The label of footer link with label=CLI Reference linking to /docs/adopters/CLI-REFERENCE"
+  },
+  "link.item.label.Workflows": {
+    "message": "工作流",
+    "description": "The label of footer link with label=Workflows linking to /docs/adopters/WORKFLOWS"
+  },
+  "link.item.label.Blog": {
+    "message": "博客",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/StrangeDaysTech/straymark"
+  },
+  "link.item.label.Releases": {
+    "message": "发布",
+    "description": "The label of footer link with label=Releases linking to https://github.com/StrangeDaysTech/straymark/releases"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/StrangeDaysTech/straymark/issues"
+  },
+  "link.item.label.Organization": {
+    "message": "组织",
+    "description": "The label of footer link with label=Organization linking to https://github.com/StrangeDaysTech"
+  },
+  "copyright": {
+    "message": "版权所有 © 2026 Strange Days Tech。基于 Docusaurus 构建。",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "message": "StrayMark",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "StrayMark",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "文档",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Blog": {
+    "message": "博客",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/website/scripts/sync-docs-i18n.ts
+++ b/website/scripts/sync-docs-i18n.ts
@@ -5,7 +5,7 @@ const ROOT = resolve(__dirname, '..');
 const DOCS_I18N = resolve(ROOT, '../docs/i18n');
 const SITE_I18N = resolve(ROOT, 'i18n');
 
-const LOCALES = ['es'];
+const LOCALES = ['es', 'zh-CN'];
 const SUBDIRS = ['adopters', 'contributors', 'decisions'];
 
 for (const locale of LOCALES) {


### PR DESCRIPTION
## Summary
Adds \`zh-CN\` (简体中文) as a third site locale, wired end-to-end but shipping with no translated blog posts yet — posts fall back to English until the companion translations PR lands.

This is the first of two PRs splitting the long-lived \`wip-zh-CN\` branch:
1. **This PR** — locale activation (config + UI strings + chrome + minimum docs)
2. Follow-up — 14 blog post translations + excerpts (depends on this)

Changes:
- \`docusaurus.config.ts\` — add \`'zh-CN'\` to \`locales\` + label \`简体中文\`
- \`scripts/sync-docs-i18n.ts\` — add \`'zh-CN'\` to the docs mirror
- \`website/i18n/zh-CN/code.json\` — translated UI strings (hero, workflow, features, ~420 lines)
- \`website/i18n/zh-CN/docusaurus-theme-classic/{navbar,footer}.json\` — chrome overrides
- \`website/i18n/zh-CN/docusaurus-plugin-content-blog/{authors,options}.json\` — blog plugin config (author \`jose\` only; \`claude-opus-47\` deliberately omitted from this locale)
- \`docs/i18n/zh-CN/intro.md\` — minimum docs landing so the locale renders

## Test plan
- [x] \`npm run build\` → exit 0, \`build/zh-CN/index.html\` generated
- [x] Remaining build warnings are pre-existing cross-tree links and one anchor fixed in #176 (the \`#straymark-charter-audit-...\` anchor will disappear once #176 merges)
- [ ] After merge: \`npm run start -- --locale zh-CN\` — home loads, language dropdown shows 简体中文

🤖 Generated with [Claude Code](https://claude.com/claude-code)