### PR TITLE
chore(docs+website): docs link cleanup and Docusaurus deprecation fix

### DIFF
--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**Languages**: English | [Español](../i18n/es/adopters/ADOPTION-GUIDE.md) | [简体中文](../i18n/zh-CN/adopters/ADOPTION-GUIDE.md)
 
 ---
 
@@ -580,7 +579,7 @@ A: StrayMark rules are instructions, not enforcement. If an AI assistant creates
 - **Workflows**: [WORKFLOWS.md](WORKFLOWS.md) — recommended daily usage patterns
 - **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
-- **Contributing**: See [CONTRIBUTING.md](../../CONTRIBUTING.md)
+- **Contributing**: See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md)
 
 ---
 
@@ -590,6 +589,6 @@ A: StrayMark rules are instructions, not enforcement. If an AI assistant creates
 
 **StrayMark** — Because every change tells a story.
 
-[Back to README](../../README.md) • [Strange Days Tech](https://strangedays.tech)
+[Back to README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**Languages**: English | [Español](../i18n/es/adopters/CLI-REFERENCE.md) | [简体中文](../i18n/zh-CN/adopters/CLI-REFERENCE.md)
 
 ---
 
@@ -20,7 +19,7 @@
 
 ## Installation
 
-Install the StrayMark CLI using one of the methods below. For full setup instructions, see the [README](../../README.md#getting-started).
+Install the StrayMark CLI using one of the methods below. For full setup instructions, see the [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md#getting-started).
 
 **Quick install (prebuilt binary):**
 
@@ -1252,6 +1251,6 @@ Adopters using StrayMark without an AI assistant in the loop can drive the same 
 
 **StrayMark** — Because every change tells a story.
 
-[Back to docs](../README.md) • [README](../../README.md) • [Strange Days Tech](https://strangedays.tech)
+[Back to docs](https://github.com/StrangeDaysTech/straymark/blob/main/docs/README.md) • [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/adopters/WORKFLOWS.md
+++ b/docs/adopters/WORKFLOWS.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**Languages**: English | [Español](../i18n/es/adopters/WORKFLOWS.md) | [简体中文](../i18n/zh-CN/adopters/WORKFLOWS.md)
 
 ---
 
@@ -126,7 +125,7 @@ StrayMark has two documentation systems:
 | `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **Run inside an auditor-side CLI** (gemini-cli, claude-cli, copilot-cli, codex-cli). Reads the prompt from disk, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id. Argument optional — auto-discovers prompts pending from this model. |
 | `/straymark-audit-review CHARTER-XX` *(fw-4.8.0+, expanded in fw-4.9.0)* | Counterpart to `audit-prompt`. Reads N reports, verifies findings against actual code, produces `review.md` consolidated 6-section analysis (Executive summary / Scope / Per-auditor evaluation / Remediation plan P0-P4 / Discarded / Auditor ratings), and merges `external_audit:` YAML into telemetry. |
 
-For full skill details, see the [README](../../README.md#skills).
+For full skill details, see the [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md#skills).
 
 ### Charter audit checkpoint *(fw-4.8.0+)*
 
@@ -257,6 +256,6 @@ For detailed CLI information, see the [CLI Reference](CLI-REFERENCE.md#versionin
 
 **StrayMark** — Because every change tells a story.
 
-[Back to docs](../README.md) • [README](../../README.md) • [Strange Days Tech](https://strangedays.tech)
+[Back to docs](https://github.com/StrangeDaysTech/straymark/blob/main/docs/README.md) • [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/contributors/DESIGN-PRINCIPLES.md
+++ b/docs/contributors/DESIGN-PRINCIPLES.md
@@ -4,7 +4,6 @@
 **Date:** 2026-05-02
 **Author:** Jose Villaseñor Montfort — StrangeDaysTech
 **Purpose:** Articulate the product philosophy in compact form, to serve as a reference against design decisions and as a criterion for saying no to features that don't fit.
-**Languages:** English | [Español](../i18n/es/contributors/DESIGN-PRINCIPLES.md) | [简体中文](../i18n/zh-CN/contributors/DESIGN-PRINCIPLES.md)
 
 ---
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -2,7 +2,6 @@
 
 Resources for people contributing to StrayMark — whether reading the code, writing translations, proposing changes, or trying to understand the *why* behind the framework's shape.
 
-**Languages:** English | [Español](../i18n/es/contributors/README.md) | [简体中文](../i18n/zh-CN/contributors/README.md)
 
 ---
 
@@ -38,4 +37,4 @@ Decision records (ADRs) for the live codebase live on GitHub at [`docs/decisions
 
 ---
 
-*See also: [`../adopters/`](../adopters/) for documentation aimed at teams adopting StrayMark in their own projects, including [`ADOPTION-GUIDE.md`](../adopters/ADOPTION-GUIDE.md), [`CLI-REFERENCE.md`](../adopters/CLI-REFERENCE.md), and [`WORKFLOWS.md`](../adopters/WORKFLOWS.md).*
+*See also: [`../adopters/`](../adopters/ADOPTION-GUIDE.md) for documentation aimed at teams adopting StrayMark in their own projects, including [`ADOPTION-GUIDE.md`](../adopters/ADOPTION-GUIDE.md), [`CLI-REFERENCE.md`](../adopters/CLI-REFERENCE.md), and [`WORKFLOWS.md`](../adopters/WORKFLOWS.md).*

--- a/docs/contributors/TRANSLATION-GUIDE.md
+++ b/docs/contributors/TRANSLATION-GUIDE.md
@@ -366,7 +366,7 @@ To contribute a new translation:
 3. Submit a pull request with all translated files
 4. Include the language code in PR title: `i18n(XX): Add [Language] translation`
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for general contribution guidelines.
+See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md) for general contribution guidelines.
 
 ---
 

--- a/docs/contributors/WHAT-IS-A-CHARTER.md
+++ b/docs/contributors/WHAT-IS-A-CHARTER.md
@@ -4,7 +4,6 @@
 **Date:** 2026-04-30
 **Author:** Jose Villaseñor Montfort — StrangeDaysTech
 **Purpose:** Pin the conceptual scope of the **Charter** artifact as it emerges from the Sentinel experiment (where it was called *Plan*), and explain how it coexists with design and development flows already using SpecKit (spec → plan → tasks).
-**Languages:** English | [Español](../i18n/es/contributors/WHAT-IS-A-CHARTER.md) | [简体中文](../i18n/zh-CN/contributors/WHAT-IS-A-CHARTER.md)
 **Related documents:** `straymark-cli-roadmap.md` (§3 Phase 1, §6 Sentinel→CLI mapping), `straymark-thesis-validation.md`, `straymark-charter-telemetry.md` — all preserved in `docs/decisions/proposals/` for historical reference.
 
 ---

--- a/docs/i18n/es/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/es/adopters/ADOPTION-GUIDE.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**Idiomas**: [English](../../../adopters/ADOPTION-GUIDE.md) | Español | [简体中文](../../zh-CN/adopters/ADOPTION-GUIDE.md)
 
 ---
 
@@ -574,7 +573,7 @@ R: Las reglas de StrayMark son instrucciones, no cumplimiento forzado. Si un asi
 - **Flujos de Trabajo**: [WORKFLOWS.md](WORKFLOWS.md) — patrones de uso diario recomendados
 - **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
 - **Discusiones**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
-- **Contribuir**: Ver [CONTRIBUTING.md](../CONTRIBUTING.md)
+- **Contribuir**: Ver [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/CONTRIBUTING.md)
 
 ---
 
@@ -582,6 +581,6 @@ R: Las reglas de StrayMark son instrucciones, no cumplimiento forzado. Si un asi
 
 **StrayMark** — Porque cada cambio cuenta una historia.
 
-[Volver al README](../README.md) • [Strange Days Tech](https://strangedays.tech)
+[Volver al README](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**Idiomas**: [English](../../../adopters/CLI-REFERENCE.md) | Español | [简体中文](../../zh-CN/adopters/CLI-REFERENCE.md)
 
 ---
 
@@ -20,7 +19,7 @@
 
 ## Instalación
 
-Instala el CLI de StrayMark usando uno de los métodos a continuación. Para instrucciones completas de configuración, consulta el [README](../README.md#inicio-rápido).
+Instala el CLI de StrayMark usando uno de los métodos a continuación. Para instrucciones completas de configuración, consulta el [README](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md#inicio-rápido).
 
 **Instalación rápida (binario precompilado):**
 
@@ -973,6 +972,6 @@ Adoptantes que usen StrayMark sin asistente IA en el loop pueden manejar el mism
 
 **StrayMark** — Porque cada cambio cuenta una historia.
 
-[Volver a docs](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
+[Volver a docs](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md) • [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/i18n/es/adopters/WORKFLOWS.md
+++ b/docs/i18n/es/adopters/WORKFLOWS.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**Idiomas**: [English](../../../adopters/WORKFLOWS.md) | Español | [简体中文](../../zh-CN/adopters/WORKFLOWS.md)
 
 ---
 
@@ -126,7 +125,7 @@ StrayMark tiene dos sistemas de documentación:
 | `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **Corre dentro de una CLI auditora** (gemini-cli, claude-cli, copilot-cli, codex-cli). Lee el prompt del disco, audita con tool use citando `path:línea`, escribe un report con el id del modelo. Argumento opcional — auto-descubre prompts pendientes de este modelo. |
 | `/straymark-audit-review CHARTER-XX` *(fw-4.8.0+, expandida en fw-4.9.0)* | Contraparte de `audit-prompt`. Lee N reports, verifica findings contra el código real, produce `review.md` consolidado de 6 secciones (Resumen ejecutivo / Alcance / Evaluación por auditor / Plan de remediación P0-P4 / Descartados / Calificación de auditores), y mergea YAML `external_audit:` en la telemetría. |
 
-Para detalles completos de skills, consulta el [README](../README.md#skills).
+Para detalles completos de skills, consulta el [README](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md#skills).
 
 ### Charter audit checkpoint *(fw-4.8.0+)*
 
@@ -257,6 +256,6 @@ Para información detallada del CLI, consulta la [Referencia CLI](CLI-REFERENCE.
 
 **StrayMark** — Porque cada cambio cuenta una historia.
 
-[Volver a docs](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
+[Volver a docs](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/es/README.md) • [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/i18n/es/contributors/DESIGN-PRINCIPLES.md
+++ b/docs/i18n/es/contributors/DESIGN-PRINCIPLES.md
@@ -5,7 +5,6 @@
 **Autor:** Jose Villaseñor Montfort — StrangeDaysTech
 **Propósito:** Articular la filosofía del producto en forma compacta, para servir como referencia frente a decisiones de diseño y como criterio para decir no a features que no encajan.
 **Documentos relacionados:** `straymark-thesis-validation.md` (cuerpo de evidencia que motivó las anotaciones de v0.2; preservado en `docs/decisions/proposals/`).
-**Idiomas:** [English](../../../contributors/DESIGN-PRINCIPLES.md) | Español | [简体中文](../../zh-CN/contributors/DESIGN-PRINCIPLES.md)
 
 ---
 

--- a/docs/i18n/es/contributors/README.md
+++ b/docs/i18n/es/contributors/README.md
@@ -2,7 +2,6 @@
 
 Recursos para personas que contribuyen a StrayMark — ya sea leyendo el código, escribiendo traducciones, proponiendo cambios, o tratando de entender el *por qué* detrás de la forma del framework.
 
-**Idiomas:** [English](../../../contributors/README.md) | Español | [简体中文](../../zh-CN/contributors/README.md)
 
 ---
 
@@ -19,7 +18,7 @@ El material atemporal — leer esto para entender *qué* es StrayMark y *por qu�
 
 | Documento | Qué cubre |
 |---|---|
-| [`TRANSLATION-GUIDE.md`](../../../contributors/TRANSLATION-GUIDE.md) | Reglas y convenciones para traducir la documentación de StrayMark a idiomas adicionales. Leer antes de enviar un PR que agregue o modifique un archivo de `i18n/`. *(Solo en inglés por ahora.)* |
+| [`TRANSLATION-GUIDE.md`](/docs/contributors/TRANSLATION-GUIDE) | Reglas y convenciones para traducir la documentación de StrayMark a idiomas adicionales. Leer antes de enviar un PR que agregue o modifique un archivo de `i18n/`. *(Solo en inglés por ahora.)* |
 
 ## Propuestas históricas (archivadas)
 
@@ -38,4 +37,4 @@ Los ADRs (registros de decisión arquitectónica) del código actual viven en Gi
 
 ---
 
-*Ver también: [`../adopters/`](../adopters/) para documentación dirigida a equipos que adoptan StrayMark en sus propios proyectos, incluyendo [`ADOPTION-GUIDE.md`](../adopters/ADOPTION-GUIDE.md), [`CLI-REFERENCE.md`](../adopters/CLI-REFERENCE.md) y [`WORKFLOWS.md`](../adopters/WORKFLOWS.md).*
+*Ver también: [`../adopters/`](../adopters/ADOPTION-GUIDE.md) para documentación dirigida a equipos que adoptan StrayMark en sus propios proyectos, incluyendo [`ADOPTION-GUIDE.md`](../adopters/ADOPTION-GUIDE.md), [`CLI-REFERENCE.md`](../adopters/CLI-REFERENCE.md) y [`WORKFLOWS.md`](../adopters/WORKFLOWS.md).*

--- a/docs/i18n/es/contributors/WHAT-IS-A-CHARTER.md
+++ b/docs/i18n/es/contributors/WHAT-IS-A-CHARTER.md
@@ -4,7 +4,6 @@
 **Fecha:** 30 de abril de 2026
 **Autor:** Jose Villaseñor Montfort — StrangeDaysTech
 **Propósito:** Fijar el alcance conceptual del artefacto **Charter** tal como emerge del experimento Sentinel (donde se llamó *Plan*), y explicar cómo coexiste con flujos de diseño y desarrollo que ya usan SpecKit (spec → plan → tasks).
-**Idiomas:** [English](../../../contributors/WHAT-IS-A-CHARTER.md) | Español | [简体中文](../../zh-CN/contributors/WHAT-IS-A-CHARTER.md)
 **Documentos relacionados:** `straymark-cli-roadmap.md` (§3 Fase 1, §6 mapeo Sentinel→CLI), `straymark-thesis-validation.md`, `straymark-charter-telemetry.md` — todos preservados en `docs/decisions/proposals/` para referencia histórica.
 
 ---

--- a/docs/i18n/es/intro.md
+++ b/docs/i18n/es/intro.md
@@ -18,7 +18,7 @@ StrayMark externaliza la disciplina cognitiva de la ingeniería asistida por IA 
 
 - [Principios de diseño](./contributors/DESIGN-PRINCIPLES.md) — las restricciones que dan forma al framework.
 - [Qué es un charter](./contributors/WHAT-IS-A-CHARTER.md) — el artefacto central.
-- [Guía de traducción](./contributors/TRANSLATION-GUIDE.md) — cómo se localizan docs y posts.
+- [Guía de traducción](/docs/contributors/TRANSLATION-GUIDE) — cómo se localizan docs y posts.
 
 ## Decisiones
 

--- a/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTION-GUIDE.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**语言**: [English](../../../adopters/ADOPTION-GUIDE.md) | [Español](../../es/adopters/ADOPTION-GUIDE.md) | 简体中文
 
 ---
 
@@ -581,7 +580,7 @@ Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成�
 - **工作流**: [WORKFLOWS.md](WORKFLOWS.md) — 推荐的日常使用模式
 - **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
 - **讨论**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
-- **贡献**: 参见 [CONTRIBUTING.md](../CONTRIBUTING.md)
+- **贡献**: 参见 [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/CONTRIBUTING.md)
 
 ---
 
@@ -591,6 +590,6 @@ Agent 会在工作流的特定时刻**主动提议**审计 — 当实现完成�
 
 **StrayMark** — 因为每一次变更都值得被记录。
 
-[返回 README](../README.md) • [Strange Days Tech](https://strangedays.tech)
+[返回 README](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**语言**: [English](../../../adopters/CLI-REFERENCE.md) | [Español](../../es/adopters/CLI-REFERENCE.md) | 简体中文
 
 ---
 
@@ -20,7 +19,7 @@
 
 ## 安装
 
-使用以下方法之一安装 StrayMark CLI。完整安装说明参见 [README](../README.md#快速开始)。
+使用以下方法之一安装 StrayMark CLI。完整安装说明参见 [README](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md#快速开始)。
 
 **快速安装（预编译二进制文件）：**
 
@@ -991,7 +990,6 @@ $ straymark audit --output markdown
 |------|--------|------|
 | `--lang <代码>` | 从项目解析（见下方） | TUI 界面与框架治理文档的显示语言（`en`、`es`、`zh-CN`）。缺少翻译时静默回退到英文。 |
 
-**语言解析顺序**（自 cli-3.5.2 起）：
 
 1. 提供 `--lang <代码>` 标志时优先
 2. `.straymark/config.yml` 文件存在时使用其中的 `language` 字段（即便是显式的 `language: en` 也视为用户的明确选择）
@@ -1107,6 +1105,6 @@ StrayMark 提供一组 skills（slash 命令）供 AI 助手内使用（Claude C
 
 **StrayMark** — 因为每一次变更都值得被记录。
 
-[返回文档](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
+[返回文档](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md) • [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/i18n/zh-CN/adopters/WORKFLOWS.md
+++ b/docs/i18n/zh-CN/adopters/WORKFLOWS.md
@@ -4,7 +4,6 @@
 
 [![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
 
-**语言**: [English](../../../adopters/WORKFLOWS.md) | [Español](../../es/adopters/WORKFLOWS.md) | 简体中文
 
 ---
 
@@ -126,7 +125,7 @@ StrayMark 有两个文档系统：
 | `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | **在审计员 CLI 中运行**（gemini-cli、claude-cli、copilot-cli、codex-cli）。从磁盘读取 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。参数可选 — 自动发现此模型待处理的 prompts。 |
 | `/straymark-audit-review CHARTER-XX` *(fw-4.8.0+，在 fw-4.9.0 中扩展)* | `audit-prompt` 的对应。读取 N 个 reports，对 findings 与实际代码交叉验证，生成 `review.md` 六节合并分析（执行摘要 / 范围 / 按审计员评估 / 修复计划 P0-P4 / 丢弃 / 审计员评分），并将 `external_audit:` YAML 合并到遥测。 |
 
-完整 Skill 详情参见 [README](../README.md#skills)。
+完整 Skill 详情参见 [README](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md#skills)。
 
 ### Charter 审计检查点 *(fw-4.8.0+)*
 
@@ -257,6 +256,6 @@ straymark status    # 完整的健康报告，包含版本信息
 
 **StrayMark** — 因为每一次变更都值得被记录。
 
-[返回文档](../../README.md) • [README](../README.md) • [Strange Days Tech](https://strangedays.tech)
+[返回文档](https://github.com/StrangeDaysTech/straymark/blob/main/docs/i18n/zh-CN/README.md) • [README](https://github.com/StrangeDaysTech/straymark/blob/main/README.md) • [Strange Days Tech](https://strangedays.tech)
 
 </div>

--- a/docs/i18n/zh-CN/contributors/DESIGN-PRINCIPLES.md
+++ b/docs/i18n/zh-CN/contributors/DESIGN-PRINCIPLES.md
@@ -4,7 +4,6 @@
 **日期：** 2026-05-02
 **作者：** Jose Villaseñor Montfort — StrangeDaysTech
 **目的：** 以紧凑形式阐明产品哲学，作为设计决策的参考依据，以及对不相契合的功能说"不"的判断标准。
-**语言：** [English](../../../contributors/DESIGN-PRINCIPLES.md) | [Español](../../es/contributors/DESIGN-PRINCIPLES.md) | 简体中文
 
 ---
 

--- a/docs/i18n/zh-CN/contributors/README.md
+++ b/docs/i18n/zh-CN/contributors/README.md
@@ -2,7 +2,6 @@
 
 为 StrayMark 贡献者准备的资源——不论是阅读代码、撰写翻译、提议变更，还是想理解 framework 形成现貌背后的*为什么*。
 
-**语言：** [English](../../../contributors/README.md) | [Español](../../es/contributors/README.md) | 简体中文
 
 ---
 
@@ -19,7 +18,7 @@
 
 | 文档 | 涵盖什么 |
 |---|---|
-| [`TRANSLATION-GUIDE.md`](../../../contributors/TRANSLATION-GUIDE.md) | 将 StrayMark 文档翻译为其他语言的规则与约定。在提交新增或修改 `i18n/` 文件的 PR 之前请先阅读。*（目前仅英文版。）* |
+| [`TRANSLATION-GUIDE.md`](/docs/contributors/TRANSLATION-GUIDE) | 将 StrayMark 文档翻译为其他语言的规则与约定。在提交新增或修改 `i18n/` 文件的 PR 之前请先阅读。*（目前仅英文版。）* |
 
 ## 历史提案（已归档）
 
@@ -38,4 +37,4 @@
 
 ---
 
-*另请参阅：[`../adopters/`](../adopters/) 是面向在自有项目中采用 StrayMark 的团队的文档，包括 [`ADOPTION-GUIDE.md`](../adopters/ADOPTION-GUIDE.md)、[`CLI-REFERENCE.md`](../adopters/CLI-REFERENCE.md) 与 [`WORKFLOWS.md`](../adopters/WORKFLOWS.md)。*
+*另请参阅：[`../adopters/`](../adopters/ADOPTION-GUIDE.md) 是面向在自有项目中采用 StrayMark 的团队的文档，包括 [`ADOPTION-GUIDE.md`](../adopters/ADOPTION-GUIDE.md)、[`CLI-REFERENCE.md`](../adopters/CLI-REFERENCE.md) 与 [`WORKFLOWS.md`](../adopters/WORKFLOWS.md)。*

--- a/docs/i18n/zh-CN/contributors/WHAT-IS-A-CHARTER.md
+++ b/docs/i18n/zh-CN/contributors/WHAT-IS-A-CHARTER.md
@@ -4,7 +4,6 @@
 **日期：** 2026-04-30
 **作者：** Jose Villaseñor Montfort — StrangeDaysTech
 **目的：** 锁定 **Charter** 工件的概念范围——按其在 Sentinel 实验中（彼时称为 *Plan*）所呈现的样子——并解释它如何与已使用 SpecKit（spec → plan → tasks）的设计与开发流程共存。
-**语言：** [English](../../../contributors/WHAT-IS-A-CHARTER.md) | [Español](../../es/contributors/WHAT-IS-A-CHARTER.md) | 简体中文
 **相关文档：** `straymark-cli-roadmap.md`（§3 阶段 1，§6 Sentinel→CLI 映射）、`straymark-thesis-validation.md`、`straymark-charter-telemetry.md` — 均保存在 `docs/decisions/proposals/` 中，以供历史参考。
 
 ---

--- a/docs/i18n/zh-CN/intro.md
+++ b/docs/i18n/zh-CN/intro.md
@@ -18,8 +18,8 @@ StrayMark 将 AI 协同工程的认知纪律外化出来 —— 原生于仓库�
 
 - [设计原则](./contributors/DESIGN-PRINCIPLES.md) —— 塑造这个框架的约束条件。
 - [什么是 charter](./contributors/WHAT-IS-A-CHARTER.md) —— 核心产物。
-- [翻译指南](./contributors/TRANSLATION-GUIDE.md) —— 文档与博文如何本地化。
+- [翻译指南](/docs/contributors/TRANSLATION-GUIDE) —— 文档与博文如何本地化。
 
 ## 决策
 
-[决策（Decisions）](./decisions) 目录追踪所有 ADR —— 每一个承重的技术或流程选择，及其背后的理由。
+[决策（Decisions）](https://github.com/StrangeDaysTech/straymark/tree/main/docs/decisions) 目录追踪所有 ADR —— 每一个承重的技术或流程选择，及其背后的理由。

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -22,11 +22,13 @@ const config: Config = {
   trailingSlash: false,
 
   onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
 
   markdown: {
     format: 'detect',
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
   },
 
   themes: ['@docusaurus/theme-mermaid'],


### PR DESCRIPTION
## Summary

Two small, independent hygiene changes that were already in the working tree before the branding/favicon PR landed. Splitting them off as their own PR so they don't get buried inside an unrelated branding squash.

- **`chore(docs):`** — across 21 docs (EN + ES + zh-CN mirrors): drop the redundant `**Languages:**` line (the Docusaurus locale switcher already exposes this in the navbar), and replace relative `.md` links that broke when served from Docusaurus with either absolute GitHub URLs (for paths outside the docs root, like `../../CONTRIBUTING.md`) or Docusaurus route links (`/docs/contributors/TRANSLATION-GUIDE`).
- **`chore(website):`** — migrate `onBrokenMarkdownLinks` from the top-level config to `markdown.hooks.onBrokenMarkdownLinks` per Docusaurus 3.x. Same behavior, but suppresses the deprecation warning at boot.

## Commits in this PR

- `7022343` chore(docs): clean redundant Language banners and modernize link targets
- `ef9b174` chore(website): migrate onBrokenMarkdownLinks to markdown.hooks

## Relationship to PR #179

Both PRs are independent and branch from `main`. They can merge in either order — there is **zero file overlap** except for `website/docusaurus.config.ts`, where the hunks are at different line ranges (this PR: lines 22–32; PR #179: lines 8–11 and ~149). Git resolves both cleanly.

## Test plan

- [ ] `cd website && npm run build` — should no longer print the `onBrokenMarkdownLinks` deprecation warning.
- [ ] Browse rendered docs on the build (`npm run serve`) and confirm: no inline `**Languages:**` line at the top of pages; navbar locale dropdown is the only language affordance.
- [ ] Click through the modernized links (e.g. `CONTRIBUTING.md` from `ADOPTION-GUIDE`, `TRANSLATION-GUIDE` from `intro.md`) and confirm they resolve (GitHub for the former, Docusaurus route for the latter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)