### PR TITLE
feat(website): blueprint-style workflow diagrams with tabs and animated edges

### DIFF
--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -23,14 +23,6 @@
     "message": "Leer la bitácora",
     "description": "Hero CTA — read the blog"
   },
-  "workflow.title": {
-    "message": "El flujo de trabajo",
-    "description": "Workflow section title"
-  },
-  "workflow.caption": {
-    "message": "Cada paso deja un artefacto versionado en el repo. Sin sistemas externos, sin decisiones implícitas.",
-    "description": "Workflow section caption"
-  },
   "why.eyebrow": {
     "message": "Por qué existe esto",
     "description": "Why this exists eyebrow"
@@ -90,5 +82,507 @@
   "features.tde.body": {
     "message": "El Transversal Debt Engine expone el acoplamiento oculto entre charters antes de que se acumule en incidentes.",
     "description": "Feature: TDE drift detection (body)"
+  },
+  "workflow.section.title": {
+    "message": "Cinco flujos, un repositorio",
+    "description": "Workflow section title"
+  },
+  "workflow.section.caption": {
+    "message": "Cada paso deja un artefacto versionado en tu repo. Sin sistemas externos, sin decisiones implícitas.",
+    "description": "Workflow section caption"
+  },
+  "workflow.controls.previous": {
+    "message": "Flujo anterior",
+    "description": "Aria label for the previous-workflow button"
+  },
+  "workflow.controls.next": {
+    "message": "Flujo siguiente",
+    "description": "Aria label for the next-workflow button"
+  },
+  "workflow.charter.short": {
+    "message": "Charter"
+  },
+  "workflow.charter.title": {
+    "message": "Charter — unidad de trabajo acotada"
+  },
+  "workflow.charter.caption": {
+    "message": "Declara alcance, archivos, verificación y riesgos ex-ante. Tras la ejecución, la deriva entre la declaración y la realidad se reconcilia en el mismo PR o el charter no se cierra."
+  },
+  "workflow.charter.node.scaffold": {
+    "message": "Crear charter"
+  },
+  "workflow.charter.node.scope": {
+    "message": "Definir alcance y archivos"
+  },
+  "workflow.charter.node.verification": {
+    "message": "Escribir verificación"
+  },
+  "workflow.charter.node.risks": {
+    "message": "Listar riesgos"
+  },
+  "workflow.charter.node.execute": {
+    "message": "Ejecutar y emitir AILOG"
+  },
+  "workflow.charter.node.drift": {
+    "message": "¿Hay deriva?"
+  },
+  "workflow.charter.node.reconcile": {
+    "message": "Reconciliar en el PR"
+  },
+  "workflow.charter.node.close": {
+    "message": "Cerrar charter"
+  },
+  "workflow.ailog.short": {
+    "message": "AILOG"
+  },
+  "workflow.ailog.title": {
+    "message": "AILOG — registro de acciones de IA"
+  },
+  "workflow.ailog.caption": {
+    "message": "El libro de ejecución de cada cambio: qué se hizo, por qué, los riesgos descubiertos en marcha y las alternativas consideradas. Un AILOG por commit, con número de secuencia diario."
+  },
+  "workflow.ailog.node.context": {
+    "message": "Reunir contexto"
+  },
+  "workflow.ailog.node.sequence": {
+    "message": "Calcular secuencia #"
+  },
+  "workflow.ailog.node.template": {
+    "message": "Cargar plantilla"
+  },
+  "workflow.ailog.node.metadata": {
+    "message": "Rellenar metadatos"
+  },
+  "workflow.ailog.node.changes": {
+    "message": "Documentar cambios"
+  },
+  "workflow.ailog.node.risks": {
+    "message": "Registrar riesgos"
+  },
+  "workflow.ailog.node.commit": {
+    "message": "Commit con referencia al AILOG"
+  },
+  "workflow.tde.short": {
+    "message": "TDE"
+  },
+  "workflow.tde.title": {
+    "message": "TDE — deuda técnica transversal"
+  },
+  "workflow.tde.caption": {
+    "message": "Cuando la deuda es heredada, cruza módulos, necesita su propio charter o requiere priorización humana, deja de ser un riesgo por charter y pasa a ser un TDE rastreado y valorado."
+  },
+  "workflow.tde.node.identify": {
+    "message": "Identificar deuda"
+  },
+  "workflow.tde.node.eligible": {
+    "message": "¿Cumple criterios?"
+  },
+  "workflow.tde.node.drop": {
+    "message": "Registrar como R<N>"
+  },
+  "workflow.tde.node.create": {
+    "message": "Crear documento TDE"
+  },
+  "workflow.tde.node.score": {
+    "message": "Valorar impacto × esfuerzo"
+  },
+  "workflow.tde.node.prioritize": {
+    "message": "Priorización humana"
+  },
+  "workflow.tde.node.remediate": {
+    "message": "Remediar"
+  },
+  "workflow.tde.node.resolved": {
+    "message": "Marcar resuelto"
+  },
+  "workflow.compliance.short": {
+    "message": "Compliance"
+  },
+  "workflow.compliance.title": {
+    "message": "Compliance — barrido regulatorio"
+  },
+  "workflow.compliance.caption": {
+    "message": "El CLI recorre los documentos de .straymark/, parsea el frontmatter y los contrasta con los estándares en alcance (EU AI Act, ISO 42001, NIST, TC260, PIPL...). Las brechas aparecen como sugerencias accionables."
+  },
+  "workflow.compliance.node.scope": {
+    "message": "Cargar alcance regional"
+  },
+  "workflow.compliance.node.discover": {
+    "message": "Descubrir .straymark/"
+  },
+  "workflow.compliance.node.parse": {
+    "message": "Parsear frontmatter"
+  },
+  "workflow.compliance.node.scan": {
+    "message": "Escanear estándares"
+  },
+  "workflow.compliance.node.gaps": {
+    "message": "¿Hay brechas?"
+  },
+  "workflow.compliance.node.pass": {
+    "message": "Reportar conformidad"
+  },
+  "workflow.compliance.node.suggest": {
+    "message": "Sugerir DPIA/MCARD/ETH"
+  },
+  "workflow.audit.short": {
+    "message": "Auditoría"
+  },
+  "workflow.audit.title": {
+    "message": "Audit trail — verificación multi-modelo"
+  },
+  "workflow.audit.caption": {
+    "message": "Varios CLIs auditores (gemini, claude, copilot...) leen el mismo prompt y auditan un Charter cerrado. Los hallazgos se deduplican, se verifican contra el código, se reclasifican y se fusionan en la telemetría como un bloque de evidencia firmado."
+  },
+  "workflow.audit.node.resolve": {
+    "message": "Resolver charter"
+  },
+  "workflow.audit.node.prompt": {
+    "message": "Generar prompt de auditoría"
+  },
+  "workflow.audit.node.run": {
+    "message": "Ejecutar N auditores"
+  },
+  "workflow.audit.node.collect": {
+    "message": "Recoger reportes"
+  },
+  "workflow.audit.node.verify": {
+    "message": "Verificar hallazgos"
+  },
+  "workflow.audit.node.reclassify": {
+    "message": "Reclasificar severidad"
+  },
+  "workflow.audit.node.plan": {
+    "message": "Plan de remediación"
+  },
+  "workflow.audit.node.merge": {
+    "message": "Fusionar en telemetría"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "Esta página ha fallado.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archivo",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archivo",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Volver al principio",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegación por la página de la lista de blogs ",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Entradas más recientes",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Entradas más antiguas",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Barra de paginación de publicaciones del blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Publicación más reciente",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Publicación más antigua",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver Todas las Etiquetas",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "modo claro",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "modo oscuro",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Cambiar entre modo oscuro y claro (actualmente {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Rastro de navegación",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Página del documento",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Siguiente",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Un documento etiquetado|{count} documentos etiquetados",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} con \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta es la documentación sin publicar para {siteTitle}, versión {versionLabel}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta es la documentación para {siteTitle} {versionLabel}, que ya no se mantiene activamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para la documentación actualizada, vea {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "última versión",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar esta página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Enlace directo al {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " en {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última actualización{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.NotFound.title": {
+    "message": "Página No Encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versiones",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Etiquetas:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Cerrar",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "precaución",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "peligro",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "nota",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "aviso",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navegación de publicaciones recientes",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Ampliar la categoría '{label}' de la barra lateral",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Colapsar categoría '{label}' de la barra lateral",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Principal",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "No pudimos encontrar lo que buscaba.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Comuníquese con el dueño del sitio que le proporcionó la URL original y hágale saber que su vínculo está roto.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Idiomas",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "En esta página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Leer Más",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Leer más acerca de {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Lectura de un minuto|{readingTime} min de lectura",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Alternar ajuste de palabras",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Página de Inicio",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Colapsar barra lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Colapsar barra lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Barra lateral de Documentos",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Cerrar barra de lateral",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Volver al menú principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Alternar barra lateral",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir barra lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir barra lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Una publicación|{count} publicaciones",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} etiquetados con \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Authors",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "View All Authors",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "This author has not written any posts yet.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Página sin clasificar",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "Esta página está sin clasificar. Los motores de búsqueda no la indexaran, y solo los usuarios con el enlace directo podrán acceder a esta.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "description": "The draft content banner message"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 artículo|{count} artículos",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Intente de nuevo",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Saltar al contenido principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Etiquetas",
+    "description": "The title of the tag list page"
   }
 }

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -83,14 +83,6 @@
     "message": "整个行业都在忙于模型、防护栏（guardrails）与合规。最缺失的一环却在所有这些之上游：与智能体协作的团队的认知纪律。没有结构，智能体就会漂移，决策会被遗忘，风险无人记录，监管证据只能临时拼凑。StrayMark 直接结构化工作本身 —— 原生于仓库、感知智能体、按构造即可审计。",
     "description": "Why this exists body paragraph"
   },
-  "workflow.title": {
-    "message": "工作流",
-    "description": "Workflow section title"
-  },
-  "workflow.caption": {
-    "message": "每一步都在仓库里留下版本化的产物。没有外部系统，没有隐含决策。",
-    "description": "Workflow section caption"
-  },
   "theme.ErrorPageContent.title": {
     "message": "页面已崩溃。",
     "description": "The title of the fallback page when the page crashed"
@@ -417,5 +409,180 @@
   "theme.tags.tagsPageTitle": {
     "message": "标签",
     "description": "The title of the tag list page"
+  },
+  "workflow.section.title": {
+    "message": "五条工作流，一个仓库",
+    "description": "Workflow section title"
+  },
+  "workflow.section.caption": {
+    "message": "每一步都在你的仓库里留下版本化的产物。没有外部系统，没有隐含决策。",
+    "description": "Workflow section caption"
+  },
+  "workflow.controls.previous": {
+    "message": "上一个工作流",
+    "description": "Aria label for the previous-workflow button"
+  },
+  "workflow.controls.next": {
+    "message": "下一个工作流",
+    "description": "Aria label for the next-workflow button"
+  },
+  "workflow.charter.short": {
+    "message": "Charter"
+  },
+  "workflow.charter.title": {
+    "message": "Charter —— 有界的工作单元"
+  },
+  "workflow.charter.caption": {
+    "message": "事前声明范围、文件、验证方式与风险。执行之后，声明与现实之间的漂移要在同一个 PR 中被对齐，否则该 charter 无法关闭。"
+  },
+  "workflow.charter.node.scaffold": {
+    "message": "创建 charter"
+  },
+  "workflow.charter.node.scope": {
+    "message": "定义范围与文件"
+  },
+  "workflow.charter.node.verification": {
+    "message": "编写验证方式"
+  },
+  "workflow.charter.node.risks": {
+    "message": "列出风险"
+  },
+  "workflow.charter.node.execute": {
+    "message": "执行并产出 AILOG"
+  },
+  "workflow.charter.node.drift": {
+    "message": "是否漂移？"
+  },
+  "workflow.charter.node.reconcile": {
+    "message": "在 PR 中对齐"
+  },
+  "workflow.charter.node.close": {
+    "message": "关闭 charter"
+  },
+  "workflow.ailog.short": {
+    "message": "AILOG"
+  },
+  "workflow.ailog.title": {
+    "message": "AILOG —— AI 动作日志"
+  },
+  "workflow.ailog.caption": {
+    "message": "每一次变更的执行账本：做了什么、为什么、过程中发现的风险，以及考虑过的备选方案。每个 commit 一份 AILOG，按日期顺序编号。"
+  },
+  "workflow.ailog.node.context": {
+    "message": "收集上下文"
+  },
+  "workflow.ailog.node.sequence": {
+    "message": "计算序号 #"
+  },
+  "workflow.ailog.node.template": {
+    "message": "加载模板"
+  },
+  "workflow.ailog.node.metadata": {
+    "message": "填写元数据"
+  },
+  "workflow.ailog.node.changes": {
+    "message": "记录变更"
+  },
+  "workflow.ailog.node.risks": {
+    "message": "登记风险"
+  },
+  "workflow.ailog.node.commit": {
+    "message": "Commit 引用 AILOG"
+  },
+  "workflow.tde.short": {
+    "message": "TDE"
+  },
+  "workflow.tde.title": {
+    "message": "TDE —— 跨越式技术债"
+  },
+  "workflow.tde.caption": {
+    "message": "当技术债是历史遗留、跨越多个模块、需要专属 charter，或需要人来排优先级时，它就不再只是某个 charter 的风险，而成为被追踪、被打分的 TDE。"
+  },
+  "workflow.tde.node.identify": {
+    "message": "识别技术债"
+  },
+  "workflow.tde.node.eligible": {
+    "message": "符合条件？"
+  },
+  "workflow.tde.node.drop": {
+    "message": "登记为 R<N>"
+  },
+  "workflow.tde.node.create": {
+    "message": "创建 TDE 文档"
+  },
+  "workflow.tde.node.score": {
+    "message": "打分：影响 × 投入"
+  },
+  "workflow.tde.node.prioritize": {
+    "message": "由人排优先级"
+  },
+  "workflow.tde.node.remediate": {
+    "message": "修复"
+  },
+  "workflow.tde.node.resolved": {
+    "message": "标记为已解决"
+  },
+  "workflow.compliance.short": {
+    "message": "合规"
+  },
+  "workflow.compliance.title": {
+    "message": "Compliance —— 监管扫描"
+  },
+  "workflow.compliance.caption": {
+    "message": "CLI 遍历 .straymark/ 下的文档，解析 frontmatter，按生效范围中的标准（EU AI Act、ISO 42001、NIST、TC260、PIPL……）进行扫描。发现的缺口会以可执行的建议呈现。"
+  },
+  "workflow.compliance.node.scope": {
+    "message": "加载区域范围"
+  },
+  "workflow.compliance.node.discover": {
+    "message": "发现 .straymark/ 文档"
+  },
+  "workflow.compliance.node.parse": {
+    "message": "解析 frontmatter"
+  },
+  "workflow.compliance.node.scan": {
+    "message": "扫描标准"
+  },
+  "workflow.compliance.node.gaps": {
+    "message": "存在缺口？"
+  },
+  "workflow.compliance.node.pass": {
+    "message": "报告通过"
+  },
+  "workflow.compliance.node.suggest": {
+    "message": "建议 DPIA/MCARD/ETH"
+  },
+  "workflow.audit.short": {
+    "message": "审计轨迹"
+  },
+  "workflow.audit.title": {
+    "message": "Audit trail —— 多模型验证"
+  },
+  "workflow.audit.caption": {
+    "message": "多个审计方 CLI（gemini、claude、copilot……）读取同一份提示，对一个已关闭的 Charter 进行审计。发现项会被去重、对照代码核实、重新分级，并以签名的证据块形式合并入遥测数据。"
+  },
+  "workflow.audit.node.resolve": {
+    "message": "解析 charter"
+  },
+  "workflow.audit.node.prompt": {
+    "message": "生成审计提示"
+  },
+  "workflow.audit.node.run": {
+    "message": "运行 N 个审计方"
+  },
+  "workflow.audit.node.collect": {
+    "message": "收集报告"
+  },
+  "workflow.audit.node.verify": {
+    "message": "核实发现项"
+  },
+  "workflow.audit.node.reclassify": {
+    "message": "重新分级"
+  },
+  "workflow.audit.node.plan": {
+    "message": "构建修复计划"
+  },
+  "workflow.audit.node.merge": {
+    "message": "合并入遥测"
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,6 +14,7 @@
         "@docusaurus/theme-mermaid": "3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "embla-carousel-react": "^8.6.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -9090,6 +9091,34 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.357",
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "@docusaurus/theme-mermaid": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "embla-carousel-react": "^8.6.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/website/src/components/WorkflowDiagram/diagrams.tsx
+++ b/website/src/components/WorkflowDiagram/diagrams.tsx
@@ -1,0 +1,375 @@
+import Translate from '@docusaurus/Translate';
+import type {ReactNode} from 'react';
+import styles from './styles.module.css';
+import {BlueprintDefs, Edge, Node, type Point} from './primitives';
+
+const VB_W = 900;
+const VB_H = 380;
+
+/* Standard 5-column grid: 5 nodes of width 160 with 20px gaps and 10px margins. */
+const COLS = [10, 190, 370, 550, 730];
+
+function Canvas({id, children}: {id: string; children: ReactNode}) {
+  return (
+    <svg
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      preserveAspectRatio="xMidYMid meet"
+      className={styles.svg}
+      role="img"
+      aria-hidden="true"
+    >
+      <BlueprintDefs id={id} />
+      <rect width={VB_W} height={VB_H} fill={`url(#${id}-grid-major)`} />
+      {children}
+    </svg>
+  );
+}
+
+const R = {w: 160, h: 46};
+const D = {w: 122, h: 78};
+
+const left = (x: number, y: number, h = R.h): Point => ({x, y: y + h / 2});
+const right = (x: number, y: number, w = R.w, h = R.h): Point => ({x: x + w, y: y + h / 2});
+const top = (x: number, y: number, w = R.w): Point => ({x: x + w / 2, y});
+const bottom = (x: number, y: number, w = R.w, h = R.h): Point => ({x: x + w / 2, y: y + h});
+
+const dLeft = (x: number, y: number): Point => ({x, y: y + D.h / 2});
+const dRight = (x: number, y: number): Point => ({x: x + D.w, y: y + D.h / 2});
+const dTop = (x: number, y: number): Point => ({x: x + D.w / 2, y});
+const dBottom = (x: number, y: number): Point => ({x: x + D.w / 2, y: y + D.h});
+
+/* -------------------------------------------------------------- */
+/* 1. CHARTER                                                     */
+/* -------------------------------------------------------------- */
+export function CharterDiagram() {
+  const id = 'bp-charter';
+  const arrow = `${id}-arrow`;
+  const row1y = 60;
+  const n1 = {x: COLS[0], y: row1y};
+  const n2 = {x: COLS[1], y: row1y};
+  const n3 = {x: COLS[2], y: row1y};
+  const n4 = {x: COLS[3], y: row1y};
+  const n5 = {x: COLS[4], y: row1y};
+  // Decision diamond centered under n5 (column center at 730+80=810; diamond w=122 → x=749)
+  const dec = {x: 749, y: 200};
+  // Bottom branch row
+  const recon = {x: 320, y: 215};
+  const close = {x: 730, y: 300};
+  return (
+    <Canvas id={id}>
+      <Node x={n1.x} y={n1.y} w={R.w} h={R.h} shape="terminal" kind="terminal">
+        <Translate id="workflow.charter.node.scaffold">Scaffold charter</Translate>
+      </Node>
+      <Node x={n2.x} y={n2.y} w={R.w} h={R.h}>
+        <Translate id="workflow.charter.node.scope">Define scope &amp; files</Translate>
+      </Node>
+      <Node x={n3.x} y={n3.y} w={R.w} h={R.h}>
+        <Translate id="workflow.charter.node.verification">Write verification</Translate>
+      </Node>
+      <Node x={n4.x} y={n4.y} w={R.w} h={R.h}>
+        <Translate id="workflow.charter.node.risks">List risks</Translate>
+      </Node>
+      <Node x={n5.x} y={n5.y} w={R.w} h={R.h}>
+        <Translate id="workflow.charter.node.execute">Execute &amp; emit AILOG</Translate>
+      </Node>
+      <Node x={dec.x} y={dec.y} w={D.w} h={D.h} shape="diamond" kind="decision">
+        <Translate id="workflow.charter.node.drift">Drift detected?</Translate>
+      </Node>
+      <Node x={recon.x} y={recon.y} w={R.w} h={R.h}>
+        <Translate id="workflow.charter.node.reconcile">Reconcile in PR</Translate>
+      </Node>
+      <Node x={close.x} y={close.y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.charter.node.close">Close charter</Translate>
+      </Node>
+
+      <Edge from={right(n1.x, n1.y)} to={left(n2.x, n2.y)} markerId={arrow} />
+      <Edge from={right(n2.x, n2.y)} to={left(n3.x, n3.y)} markerId={arrow} />
+      <Edge from={right(n3.x, n3.y)} to={left(n4.x, n4.y)} markerId={arrow} />
+      <Edge from={right(n4.x, n4.y)} to={left(n5.x, n5.y)} markerId={arrow} />
+      <Edge
+        from={bottom(n5.x, n5.y)}
+        to={dTop(dec.x, dec.y)}
+        via={{x: n5.x + R.w / 2, y: 160}}
+        markerId={arrow}
+      />
+      <Edge
+        from={dLeft(dec.x, dec.y)}
+        to={right(recon.x, recon.y)}
+        via={{x: (dec.x + recon.x + R.w) / 2, y: dec.y + D.h / 2 - 10}}
+        label="yes"
+        markerId={arrow}
+      />
+      <Edge
+        from={dBottom(dec.x, dec.y)}
+        to={top(close.x, close.y)}
+        via={{x: dec.x + D.w / 2 + 10, y: dec.y + D.h + 8}}
+        label="no"
+        markerId={arrow}
+      />
+      <Edge
+        from={bottom(recon.x, recon.y)}
+        to={left(close.x, close.y)}
+        via={{x: (recon.x + close.x) / 2, y: close.y + R.h / 2 + 18}}
+        markerId={arrow}
+      />
+    </Canvas>
+  );
+}
+
+/* -------------------------------------------------------------- */
+/* 2. AILOG                                                       */
+/* -------------------------------------------------------------- */
+export function AilogDiagram() {
+  const id = 'bp-ailog';
+  const arrow = `${id}-arrow`;
+  const row1y = 80;
+  const row2y = 240;
+  const n = [
+    {x: COLS[0], y: row1y},
+    {x: COLS[1], y: row1y},
+    {x: COLS[2], y: row1y},
+    {x: COLS[3], y: row1y},
+    {x: COLS[4], y: row1y},
+    {x: COLS[2], y: row2y}, // Record risks (under Load template)
+    {x: COLS[1], y: row2y}, // Commit (under Compute sequence)
+  ];
+  return (
+    <Canvas id={id}>
+      <Node x={n[0].x} y={n[0].y} w={R.w} h={R.h} shape="terminal" kind="terminal">
+        <Translate id="workflow.ailog.node.context">Gather context</Translate>
+      </Node>
+      <Node x={n[1].x} y={n[1].y} w={R.w} h={R.h}>
+        <Translate id="workflow.ailog.node.sequence">Compute sequence #</Translate>
+      </Node>
+      <Node x={n[2].x} y={n[2].y} w={R.w} h={R.h}>
+        <Translate id="workflow.ailog.node.template">Load template</Translate>
+      </Node>
+      <Node x={n[3].x} y={n[3].y} w={R.w} h={R.h}>
+        <Translate id="workflow.ailog.node.metadata">Fill metadata</Translate>
+      </Node>
+      <Node x={n[4].x} y={n[4].y} w={R.w} h={R.h}>
+        <Translate id="workflow.ailog.node.changes">Document changes</Translate>
+      </Node>
+      <Node x={n[5].x} y={n[5].y} w={R.w} h={R.h}>
+        <Translate id="workflow.ailog.node.risks">Record risks</Translate>
+      </Node>
+      <Node x={n[6].x} y={n[6].y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.ailog.node.commit">Commit with AILOG ref</Translate>
+      </Node>
+
+      <Edge from={right(n[0].x, n[0].y)} to={left(n[1].x, n[1].y)} markerId={arrow} />
+      <Edge from={right(n[1].x, n[1].y)} to={left(n[2].x, n[2].y)} markerId={arrow} />
+      <Edge from={right(n[2].x, n[2].y)} to={left(n[3].x, n[3].y)} markerId={arrow} />
+      <Edge from={right(n[3].x, n[3].y)} to={left(n[4].x, n[4].y)} markerId={arrow} />
+      {/* Drop down + over: from Document changes bottom → Record risks right */}
+      <Edge
+        from={bottom(n[4].x, n[4].y)}
+        to={right(n[5].x, n[5].y)}
+        via={{x: n[4].x + R.w / 2, y: row2y + R.h / 2}}
+        markerId={arrow}
+      />
+      <Edge from={left(n[5].x, n[5].y)} to={right(n[6].x, n[6].y)} markerId={arrow} />
+    </Canvas>
+  );
+}
+
+/* -------------------------------------------------------------- */
+/* 3. TDE — Technical Debt Entry                                  */
+/* -------------------------------------------------------------- */
+export function TdeDiagram() {
+  const id = 'bp-tde';
+  const arrow = `${id}-arrow`;
+  const row1y = 80;
+  const row2y = 215;
+  const identify = {x: COLS[0], y: row1y};
+  // Diamond centered at column 1 (190 + 80 = 270; diamond w=122 → x=209)
+  const dec = {x: 209, y: 65};
+  const create = {x: COLS[2], y: row1y};
+  const score = {x: COLS[3], y: row1y};
+  const prioritize = {x: COLS[4], y: row1y};
+  const drop = {x: COLS[1], y: row2y};
+  const remediate = {x: COLS[3], y: row2y};
+  const resolve = {x: COLS[4], y: row2y};
+  return (
+    <Canvas id={id}>
+      <Node x={identify.x} y={identify.y} w={R.w} h={R.h} shape="terminal" kind="terminal">
+        <Translate id="workflow.tde.node.identify">Identify debt</Translate>
+      </Node>
+      <Node x={dec.x} y={dec.y} w={D.w} h={D.h} shape="diamond" kind="decision">
+        <Translate id="workflow.tde.node.eligible">Eligible?</Translate>
+      </Node>
+      <Node x={drop.x} y={drop.y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.tde.node.drop">Track as R&lt;N&gt;</Translate>
+      </Node>
+      <Node x={create.x} y={create.y} w={R.w} h={R.h}>
+        <Translate id="workflow.tde.node.create">Create TDE doc</Translate>
+      </Node>
+      <Node x={score.x} y={score.y} w={R.w} h={R.h}>
+        <Translate id="workflow.tde.node.score">Score impact × effort</Translate>
+      </Node>
+      <Node x={prioritize.x} y={prioritize.y} w={R.w} h={R.h}>
+        <Translate id="workflow.tde.node.prioritize">Human prioritization</Translate>
+      </Node>
+      <Node x={remediate.x} y={remediate.y} w={R.w} h={R.h}>
+        <Translate id="workflow.tde.node.remediate">Remediate</Translate>
+      </Node>
+      <Node x={resolve.x} y={resolve.y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.tde.node.resolved">Mark resolved</Translate>
+      </Node>
+
+      <Edge from={right(identify.x, identify.y)} to={dLeft(dec.x, dec.y)} markerId={arrow} />
+      <Edge
+        from={dRight(dec.x, dec.y)}
+        to={left(create.x, create.y)}
+        label="yes"
+        markerId={arrow}
+      />
+      <Edge
+        from={dBottom(dec.x, dec.y)}
+        to={top(drop.x, drop.y)}
+        via={{x: dec.x + D.w / 2, y: 180}}
+        label="no"
+        markerId={arrow}
+      />
+      <Edge from={right(create.x, create.y)} to={left(score.x, score.y)} markerId={arrow} />
+      <Edge from={right(score.x, score.y)} to={left(prioritize.x, prioritize.y)} markerId={arrow} />
+      <Edge
+        from={bottom(prioritize.x, prioritize.y)}
+        to={top(remediate.x, remediate.y)}
+        markerId={arrow}
+      />
+      <Edge from={right(remediate.x, remediate.y)} to={left(resolve.x, resolve.y)} markerId={arrow} />
+    </Canvas>
+  );
+}
+
+/* -------------------------------------------------------------- */
+/* 4. COMPLIANCE                                                  */
+/* -------------------------------------------------------------- */
+export function ComplianceDiagram() {
+  const id = 'bp-compliance';
+  const arrow = `${id}-arrow`;
+  const row1y = 80;
+  const row2y = 230;
+  const load = {x: COLS[0], y: row1y};
+  const discover = {x: COLS[1], y: row1y};
+  const parse = {x: COLS[2], y: row1y};
+  const scan = {x: COLS[3], y: row1y};
+  // Diamond centered at col 4: 730 + 80 = 810 → x = 749
+  const dec = {x: 749, y: 65};
+  const pass = {x: COLS[4], y: row2y};
+  const suggest = {x: COLS[2], y: row2y};
+  return (
+    <Canvas id={id}>
+      <Node x={load.x} y={load.y} w={R.w} h={R.h} shape="terminal" kind="terminal">
+        <Translate id="workflow.compliance.node.scope">Load regional scope</Translate>
+      </Node>
+      <Node x={discover.x} y={discover.y} w={R.w} h={R.h}>
+        <Translate id="workflow.compliance.node.discover">Discover .straymark/</Translate>
+      </Node>
+      <Node x={parse.x} y={parse.y} w={R.w} h={R.h}>
+        <Translate id="workflow.compliance.node.parse">Parse frontmatter</Translate>
+      </Node>
+      <Node x={scan.x} y={scan.y} w={R.w} h={R.h}>
+        <Translate id="workflow.compliance.node.scan">Scan standards</Translate>
+      </Node>
+      <Node x={dec.x} y={dec.y} w={D.w} h={D.h} shape="diamond" kind="decision">
+        <Translate id="workflow.compliance.node.gaps">Gaps?</Translate>
+      </Node>
+      <Node x={pass.x} y={pass.y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.compliance.node.pass">Report pass</Translate>
+      </Node>
+      <Node x={suggest.x} y={suggest.y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.compliance.node.suggest">Suggest DPIA/MCARD/ETH</Translate>
+      </Node>
+
+      <Edge from={right(load.x, load.y)} to={left(discover.x, discover.y)} markerId={arrow} />
+      <Edge from={right(discover.x, discover.y)} to={left(parse.x, parse.y)} markerId={arrow} />
+      <Edge from={right(parse.x, parse.y)} to={left(scan.x, scan.y)} markerId={arrow} />
+      <Edge from={right(scan.x, scan.y)} to={dLeft(dec.x, dec.y)} markerId={arrow} />
+      <Edge
+        from={dBottom(dec.x, dec.y)}
+        to={top(pass.x, pass.y)}
+        via={{x: dec.x + D.w / 2, y: dec.y + D.h + 15}}
+        label="no"
+        markerId={arrow}
+      />
+      <Edge
+        from={dLeft(dec.x, dec.y)}
+        to={right(suggest.x, suggest.y)}
+        via={{x: (dec.x + suggest.x + R.w) / 2, y: dec.y + D.h / 2 + 70}}
+        label="yes"
+        markerId={arrow}
+      />
+
+      {/* Stack hint above the scan step */}
+      <text x={scan.x + R.w / 2} y={scan.y - 14} className={styles.edgeLabel} textAnchor="middle">
+        EU AI · ISO 42001 · NIST · TC260
+      </text>
+    </Canvas>
+  );
+}
+
+/* -------------------------------------------------------------- */
+/* 5. AUDIT TRAIL                                                 */
+/* -------------------------------------------------------------- */
+export function AuditDiagram() {
+  const id = 'bp-audit';
+  const arrow = `${id}-arrow`;
+  const row1y = 80;
+  const row2y = 230;
+  const resolve = {x: COLS[0], y: row1y};
+  const prompt = {x: COLS[1], y: row1y};
+  const run = {x: COLS[2], y: row1y};
+  const collect = {x: COLS[3], y: row1y};
+  const verify = {x: COLS[4], y: row1y};
+  const reclass = {x: COLS[3], y: row2y};
+  const plan = {x: COLS[1], y: row2y}; // gap = COLS[2] is empty in bottom row to let the wire breathe
+  const merge = {x: COLS[0], y: row2y};
+  return (
+    <Canvas id={id}>
+      <Node x={resolve.x} y={resolve.y} w={R.w} h={R.h} shape="terminal" kind="terminal">
+        <Translate id="workflow.audit.node.resolve">Resolve charter</Translate>
+      </Node>
+      <Node x={prompt.x} y={prompt.y} w={R.w} h={R.h}>
+        <Translate id="workflow.audit.node.prompt">Generate audit prompt</Translate>
+      </Node>
+      <Node x={run.x} y={run.y} w={R.w} h={R.h}>
+        <Translate id="workflow.audit.node.run">Run N auditors</Translate>
+      </Node>
+      <Node x={collect.x} y={collect.y} w={R.w} h={R.h}>
+        <Translate id="workflow.audit.node.collect">Collect reports</Translate>
+      </Node>
+      <Node x={verify.x} y={verify.y} w={R.w} h={R.h}>
+        <Translate id="workflow.audit.node.verify">Verify findings</Translate>
+      </Node>
+      <Node x={reclass.x} y={reclass.y} w={R.w} h={R.h}>
+        <Translate id="workflow.audit.node.reclassify">Reclassify severity</Translate>
+      </Node>
+      <Node x={plan.x} y={plan.y} w={R.w} h={R.h}>
+        <Translate id="workflow.audit.node.plan">Build remediation plan</Translate>
+      </Node>
+      <Node x={merge.x} y={merge.y} w={R.w} h={R.h} shape="terminal" kind="output">
+        <Translate id="workflow.audit.node.merge">Merge into telemetry</Translate>
+      </Node>
+
+      <Edge from={right(resolve.x, resolve.y)} to={left(prompt.x, prompt.y)} markerId={arrow} />
+      <Edge from={right(prompt.x, prompt.y)} to={left(run.x, run.y)} markerId={arrow} />
+      <Edge from={right(run.x, run.y)} to={left(collect.x, collect.y)} markerId={arrow} />
+      <Edge from={right(collect.x, collect.y)} to={left(verify.x, verify.y)} markerId={arrow} />
+      <Edge
+        from={bottom(verify.x, verify.y)}
+        to={right(reclass.x, reclass.y)}
+        via={{x: verify.x + R.w / 2, y: reclass.y + R.h / 2}}
+        markerId={arrow}
+      />
+      <Edge from={left(reclass.x, reclass.y)} to={right(plan.x, plan.y)} markerId={arrow} />
+      <Edge from={left(plan.x, plan.y)} to={right(merge.x, merge.y)} markerId={arrow} />
+
+      {/* Parallel fan-out hint at "Run N auditors" */}
+      <text x={run.x + R.w / 2} y={run.y - 14} className={styles.edgeLabel} textAnchor="middle">
+        gemini · claude · copilot
+      </text>
+    </Canvas>
+  );
+}

--- a/website/src/components/WorkflowDiagram/flowAnimations.module.css
+++ b/website/src/components/WorkflowDiagram/flowAnimations.module.css
@@ -1,0 +1,34 @@
+/*
+ * Paths use pathLength="1", so all dash/offset values below are in path-unit
+ * space (0 = origin, 1 = full path length). 4% dash + 2.5% gap = ~16 dashes
+ * along any edge — chunky enough to read clearly as marching ants.
+ *
+ * Negative dashoffset moves the dashes forward along the path (toward the
+ * arrowhead). 0.13 per 1.2s = roughly 2 pattern cycles per second.
+ */
+.edgeFlow {
+  stroke-dasharray: 0.04 0.025;
+  stroke-dashoffset: 0;
+  animation: dashFlow 1.2s linear infinite;
+}
+
+@keyframes dashFlow {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -0.13;
+  }
+}
+
+/* Kept as a no-op class so the Edge component can pass it through harmlessly. */
+.edgeDraw {
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .edgeFlow {
+    animation: none !important;
+    stroke-dasharray: 1 !important;
+    stroke-dashoffset: 0 !important;
+  }
+}

--- a/website/src/components/WorkflowDiagram/index.tsx
+++ b/website/src/components/WorkflowDiagram/index.tsx
@@ -1,52 +1,265 @@
-import type {ReactNode} from 'react';
-import Mermaid from '@theme/Mermaid';
-import Translate from '@docusaurus/Translate';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import useEmblaCarousel from 'embla-carousel-react';
 import styles from './styles.module.css';
+import {BlueprintFrame} from './primitives';
+import {
+  AilogDiagram,
+  AuditDiagram,
+  CharterDiagram,
+  ComplianceDiagram,
+  TdeDiagram,
+} from './diagrams';
 
-const DIAGRAM = `flowchart LR
-  classDef human fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e
-  classDef agent fill:#fef3c7,stroke:#d97706,color:#78350f
-  classDef framework fill:#dcfce7,stroke:#16a34a,color:#14532d
+const FRAMEWORK_VERSION = 'fw-4.2.0';
 
-  subgraph H["Human"]
-    direction LR
-    spec["Spec / intent"]:::human
-    review["Review & merge"]:::human
-  end
+type Workflow = {
+  slug: string;
+  short: ReactNode;
+  title: ReactNode;
+  caption: ReactNode;
+  diagram: ReactNode;
+};
 
-  subgraph A["Agent"]
-    direction LR
-    plan["Plan & implement"]:::agent
-    audit["Self-audit"]:::agent
-  end
-
-  subgraph F["StrayMark"]
-    direction LR
-    charter["Charter"]:::framework
-    ailog["AILOG"]:::framework
-    tde["TDE"]:::framework
-    trail["Audit trail"]:::framework
-  end
-
-  spec --> charter --> plan --> ailog --> audit --> tde --> review --> trail
-`;
+function workflows(): Workflow[] {
+  return [
+    {
+      slug: 'charter',
+      short: <Translate id="workflow.charter.short">Charter</Translate>,
+      title: <Translate id="workflow.charter.title">Charter — bounded unit of work</Translate>,
+      caption: (
+        <Translate id="workflow.charter.caption">
+          Declare scope, files, verification and risks ex-ante. After execution, drift between
+          declaration and reality is reconciled in the same PR or the charter cannot close.
+        </Translate>
+      ),
+      diagram: <CharterDiagram />,
+    },
+    {
+      slug: 'ailog',
+      short: <Translate id="workflow.ailog.short">AILOG</Translate>,
+      title: <Translate id="workflow.ailog.title">AILOG — AI action log</Translate>,
+      caption: (
+        <Translate id="workflow.ailog.caption">
+          The execution ledger for every change: what was done, why, the risks discovered in flight,
+          and the alternatives considered. One AILOG per commit, sequence-numbered per day.
+        </Translate>
+      ),
+      diagram: <AilogDiagram />,
+    },
+    {
+      slug: 'tde',
+      short: <Translate id="workflow.tde.short">TDE</Translate>,
+      title: (
+        <Translate id="workflow.tde.title">TDE — transversal technical debt</Translate>
+      ),
+      caption: (
+        <Translate id="workflow.tde.caption">
+          When debt is heritage, crosses modules, needs its own charter or requires human
+          prioritization, it stops being a per-charter risk and becomes a tracked, scored TDE.
+        </Translate>
+      ),
+      diagram: <TdeDiagram />,
+    },
+    {
+      slug: 'compliance',
+      short: <Translate id="workflow.compliance.short">Compliance</Translate>,
+      title: (
+        <Translate id="workflow.compliance.title">
+          Compliance — regulatory scanning
+        </Translate>
+      ),
+      caption: (
+        <Translate id="workflow.compliance.caption">
+          The CLI walks .straymark/ documents, parses frontmatter, and scans them against the
+          standards in scope (EU AI Act, ISO 42001, NIST, TC260, PIPL...). Gaps surface as
+          actionable suggestions.
+        </Translate>
+      ),
+      diagram: <ComplianceDiagram />,
+    },
+    {
+      slug: 'audit',
+      short: <Translate id="workflow.audit.short">Audit trail</Translate>,
+      title: (
+        <Translate id="workflow.audit.title">Audit trail — multi-model verification</Translate>
+      ),
+      caption: (
+        <Translate id="workflow.audit.caption">
+          Several auditor CLIs (gemini, claude, copilot...) read the same prompt and audit a closed
+          Charter. Findings are deduplicated, verified against code, reclassified and merged into
+          telemetry as a signed evidence block.
+        </Translate>
+      ),
+      diagram: <AuditDiagram />,
+    },
+  ];
+}
 
 export default function WorkflowDiagram(): ReactNode {
+  const items = workflows();
+  const total = items.length;
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    loop: false,
+    containScroll: 'trimSnaps',
+    align: 'start',
+  });
+  const [selected, setSelected] = useState(0);
+  const [canPrev, setCanPrev] = useState(false);
+  const [canNext, setCanNext] = useState(true);
+  const tablistId = useId();
+
+  const sync = useCallback(() => {
+    if (!emblaApi) return;
+    setSelected(emblaApi.selectedScrollSnap());
+    setCanPrev(emblaApi.canScrollPrev());
+    setCanNext(emblaApi.canScrollNext());
+  }, [emblaApi]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+    sync();
+    emblaApi.on('select', sync);
+    emblaApi.on('reInit', sync);
+    return () => {
+      emblaApi.off('select', sync);
+      emblaApi.off('reInit', sync);
+    };
+  }, [emblaApi, sync]);
+
+  const scrollTo = useCallback(
+    (index: number) => {
+      emblaApi?.scrollTo(index);
+    },
+    [emblaApi],
+  );
+
+  const onTabKey = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        scrollTo(Math.min(selected + 1, total - 1));
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        scrollTo(Math.max(selected - 1, 0));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        scrollTo(0);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        scrollTo(total - 1);
+      }
+    },
+    [scrollTo, selected, total],
+  );
+
   return (
     <section className={styles.section}>
       <div className={styles.inner}>
         <h2 className={styles.title}>
-          <Translate id="workflow.title" description="Workflow section title">
-            The workflow
+          <Translate id="workflow.section.title" description="Workflow section title">
+            Five workflows, one repo
           </Translate>
         </h2>
         <p className={styles.caption}>
-          <Translate id="workflow.caption" description="Workflow section caption">
-            Every step leaves a versioned artifact in the repo. No external systems, no implicit decisions.
+          <Translate id="workflow.section.caption" description="Workflow section caption">
+            Every step leaves a versioned artifact in your repo. No external systems, no implicit
+            decisions.
           </Translate>
         </p>
-        <div className={styles.diagram}>
-          <Mermaid value={DIAGRAM} />
+
+        <ul className={styles.tablist} role="tablist" aria-label="StrayMark workflows">
+          {items.map((w, i) => (
+            <li key={w.slug} role="presentation">
+              <button
+                type="button"
+                role="tab"
+                id={`${tablistId}-tab-${w.slug}`}
+                aria-controls={`${tablistId}-panel-${w.slug}`}
+                aria-selected={i === selected}
+                tabIndex={i === selected ? 0 : -1}
+                className={styles.tabButton}
+                onClick={() => scrollTo(i)}
+                onKeyDown={onTabKey}
+              >
+                {w.short}
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className={styles.viewport} ref={emblaRef}>
+          <div className={styles.container}>
+            {items.map((w, i) => (
+              <div
+                key={w.slug}
+                className={styles.slide}
+                role="tabpanel"
+                id={`${tablistId}-panel-${w.slug}`}
+                aria-labelledby={`${tablistId}-tab-${w.slug}`}
+                aria-hidden={i !== selected}
+              >
+                <BlueprintFrame
+                  index={i}
+                  total={total}
+                  title={w.title}
+                  caption={w.caption}
+                  version={FRAMEWORK_VERSION}
+                >
+                  {w.diagram}
+                </BlueprintFrame>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.controls} aria-hidden="false">
+          <button
+            type="button"
+            className={styles.controlButton}
+            onClick={() => emblaApi?.scrollPrev()}
+            disabled={!canPrev}
+            aria-label={translate({
+              id: 'workflow.controls.previous',
+              message: 'Previous workflow',
+              description: 'Aria label for the previous-workflow button',
+            })}
+          >
+            ‹
+          </button>
+          <div className={styles.dots} role="tablist" aria-label="Workflow indicators">
+            {items.map((w, i) => (
+              <button
+                key={w.slug}
+                type="button"
+                role="tab"
+                className={styles.dot}
+                aria-selected={i === selected}
+                aria-label={`${i + 1} / ${total}`}
+                onClick={() => scrollTo(i)}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            className={styles.controlButton}
+            onClick={() => emblaApi?.scrollNext()}
+            disabled={!canNext}
+            aria-label={translate({
+              id: 'workflow.controls.next',
+              message: 'Next workflow',
+              description: 'Aria label for the next-workflow button',
+            })}
+          >
+            ›
+          </button>
         </div>
       </div>
     </section>

--- a/website/src/components/WorkflowDiagram/primitives.tsx
+++ b/website/src/components/WorkflowDiagram/primitives.tsx
@@ -1,0 +1,223 @@
+import type {ReactNode} from 'react';
+import styles from './styles.module.css';
+import flow from './flowAnimations.module.css';
+
+export type Point = {x: number; y: number};
+
+export type NodeShape = 'rect' | 'diamond' | 'capsule' | 'terminal';
+export type NodeKind = 'main' | 'decision' | 'terminal' | 'output';
+
+type NodeProps = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  shape?: NodeShape;
+  kind?: NodeKind;
+  children: ReactNode;
+  labelLines?: number;
+};
+
+export function Node({
+  x,
+  y,
+  w,
+  h,
+  shape = 'rect',
+  kind = 'main',
+  children,
+  labelLines = 1,
+}: NodeProps) {
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const kindClass =
+    kind === 'decision'
+      ? styles.shapeDecision
+      : kind === 'terminal'
+        ? styles.shapeTerminal
+        : kind === 'output'
+          ? styles.shapeOutput
+          : styles.shapeMain;
+
+  let shapeEl: ReactNode;
+  if (shape === 'diamond') {
+    const points = `${cx},${y} ${x + w},${cy} ${cx},${y + h} ${x},${cy}`;
+    shapeEl = <polygon points={points} className={`${styles.nodeShape} ${kindClass}`} />;
+  } else if (shape === 'capsule') {
+    shapeEl = (
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={h / 2}
+        ry={h / 2}
+        className={`${styles.nodeShape} ${kindClass}`}
+      />
+    );
+  } else if (shape === 'terminal') {
+    shapeEl = (
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={12}
+        ry={12}
+        className={`${styles.nodeShape} ${kindClass}`}
+      />
+    );
+  } else {
+    shapeEl = (
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={3}
+        ry={3}
+        className={`${styles.nodeShape} ${kindClass}`}
+      />
+    );
+  }
+
+  const lineHeight = 14;
+  const textY = cy - ((labelLines - 1) * lineHeight) / 2 + 4;
+
+  return (
+    <g className={styles.node}>
+      {shapeEl}
+      <text x={cx} y={textY} className={styles.nodeLabel} textAnchor="middle">
+        {children}
+      </text>
+    </g>
+  );
+}
+
+type EdgeProps = {
+  from: Point;
+  to: Point;
+  via?: Point;
+  label?: string;
+  flow?: boolean;
+  draw?: boolean;
+  markerId: string;
+};
+
+export function Edge({from, to, via, label, flow: hasFlow = true, draw = true, markerId}: EdgeProps) {
+  let d: string;
+  if (via) {
+    d = `M ${from.x} ${from.y} Q ${via.x} ${via.y} ${to.x} ${to.y}`;
+  } else {
+    const midX = (from.x + to.x) / 2;
+    const midY = (from.y + to.y) / 2;
+    const dx = Math.abs(to.x - from.x);
+    const dy = Math.abs(to.y - from.y);
+    if (dy < 6 || dx < 6) {
+      d = `M ${from.x} ${from.y} L ${to.x} ${to.y}`;
+    } else {
+      d = `M ${from.x} ${from.y} C ${midX} ${from.y}, ${midX} ${to.y}, ${to.x} ${to.y}`;
+    }
+  }
+
+  const classes = [styles.edge];
+  if (hasFlow) classes.push(flow.edgeFlow);
+  if (draw) classes.push(flow.edgeDraw);
+
+  let labelEl: ReactNode = null;
+  if (label) {
+    const lx = via ? via.x : (from.x + to.x) / 2;
+    const ly = via ? via.y : (from.y + to.y) / 2;
+    labelEl = (
+      <text x={lx} y={ly - 6} className={styles.edgeLabel} textAnchor="middle">
+        {label}
+      </text>
+    );
+  }
+
+  return (
+    <g>
+      <path
+        d={d}
+        className={classes.join(' ')}
+        fill="none"
+        markerEnd={`url(#${markerId})`}
+        pathLength={1}
+      />
+      {labelEl}
+    </g>
+  );
+}
+
+type DefsProps = {
+  id: string;
+};
+
+export function BlueprintDefs({id}: DefsProps) {
+  const gridId = `${id}-grid`;
+  const arrowId = `${id}-arrow`;
+  return (
+    <defs>
+      <pattern id={gridId} width="22" height="22" patternUnits="userSpaceOnUse">
+        <path
+          d="M 22 0 L 0 0 0 22"
+          fill="none"
+          stroke="var(--bp-grid)"
+          strokeWidth="0.5"
+        />
+      </pattern>
+      <pattern id={`${id}-grid-major`} width="110" height="110" patternUnits="userSpaceOnUse">
+        <rect width="110" height="110" fill={`url(#${gridId})`} />
+        <path
+          d="M 110 0 L 0 0 0 110"
+          fill="none"
+          stroke="var(--bp-grid-major)"
+          strokeWidth="0.6"
+        />
+      </pattern>
+      <marker
+        id={arrowId}
+        viewBox="0 0 10 10"
+        refX="9"
+        refY="5"
+        markerWidth="6"
+        markerHeight="6"
+        orient="auto-start-reverse"
+      >
+        <path d="M 0 0 L 10 5 L 0 10 z" className={styles.arrowHead} />
+      </marker>
+    </defs>
+  );
+}
+
+type FrameProps = {
+  index: number;
+  total: number;
+  title: ReactNode;
+  caption?: ReactNode;
+  version: string;
+  children: ReactNode;
+};
+
+export function BlueprintFrame({index, total, title, caption, version, children}: FrameProps) {
+  const indexStr = `${String(index + 1).padStart(2, '0')}/${String(total).padStart(2, '0')}`;
+  return (
+    <div className={styles.frame}>
+      <div className={styles.frameHeader}>
+        <span className={styles.frameStamp}>STRAYMARK</span>
+        <span className={styles.frameSeparator}>·</span>
+        <span className={styles.frameIndex}>{indexStr}</span>
+        <span className={styles.frameTitle}>{title}</span>
+        <span className={styles.frameVersion}>{version}</span>
+      </div>
+      <div className={styles.frameCanvas}>
+        <span className={`${styles.corner} ${styles.cornerTL}`} aria-hidden="true" />
+        <span className={`${styles.corner} ${styles.cornerTR}`} aria-hidden="true" />
+        <span className={`${styles.corner} ${styles.cornerBL}`} aria-hidden="true" />
+        <span className={`${styles.corner} ${styles.cornerBR}`} aria-hidden="true" />
+        {children}
+      </div>
+      {caption ? <div className={styles.frameFooter}>{caption}</div> : null}
+    </div>
+  );
+}

--- a/website/src/components/WorkflowDiagram/styles.module.css
+++ b/website/src/components/WorkflowDiagram/styles.module.css
@@ -1,12 +1,43 @@
+/* Blueprint theme tokens — light (drafting paper) by default, overridden in dark. */
 .section {
-  padding: 4rem 1rem;
+  /* Light: drafting paper */
+  --bp-bg: #eef3fb;
+  --bp-bg-deep: #e3eaf6;
+  --bp-grid: #c6d4e6;
+  --bp-grid-major: #98aecd;
+  --bp-stroke: #1a3a6b;
+  --bp-stroke-dim: #6b87b0;
+  --bp-stroke-faint: rgba(26, 58, 107, 0.4);
+  --bp-accent: #0b66c2;
+  --bp-text: #0b1f3a;
+  --bp-text-dim: #4a6285;
+  --bp-fill-soft: rgba(11, 102, 194, 0.06);
+  --bp-fill-decision: rgba(11, 102, 194, 0.08);
+  --bp-fill-output: rgba(11, 102, 194, 0.14);
+
+  padding: 5rem 1rem 4.5rem;
   background: var(--ifm-background-color);
 }
 
+:global([data-theme='dark']) .section {
+  --bp-bg: #0b1f3a;
+  --bp-bg-deep: #081730;
+  --bp-grid: #1c3963;
+  --bp-grid-major: #2b507f;
+  --bp-stroke: #cfe2ff;
+  --bp-stroke-dim: #6f8db3;
+  --bp-stroke-faint: rgba(207, 226, 255, 0.35);
+  --bp-accent: #4fc3ff;
+  --bp-text: #e8f0ff;
+  --bp-text-dim: #97b1d4;
+  --bp-fill-soft: rgba(79, 195, 255, 0.08);
+  --bp-fill-decision: rgba(79, 195, 255, 0.1);
+  --bp-fill-output: rgba(79, 195, 255, 0.18);
+}
+
 .inner {
-  max-width: 980px;
+  max-width: 1080px;
   margin: 0 auto;
-  text-align: center;
 }
 
 .title {
@@ -14,25 +45,306 @@
   font-weight: 700;
   letter-spacing: -0.01em;
   margin: 0 0 0.75rem;
+  text-align: center;
 }
 
 .caption {
   color: var(--ifm-color-emphasis-700);
-  max-width: 620px;
+  max-width: 640px;
   margin: 0 auto 2.5rem;
   font-size: 1.05rem;
-  line-height: 1.5;
+  line-height: 1.55;
+  text-align: center;
 }
 
-.diagram {
-  background: var(--ifm-background-surface-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 12px;
-  padding: 1.5rem;
-  overflow-x: auto;
+/* ---- Tablist (desktop) ---- */
+.tablist {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0 auto 1.25rem;
+  padding: 0;
+  list-style: none;
 }
 
-.diagram :global(svg) {
-  max-width: 100%;
+.tabButton {
+  font-family: var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.55rem 0.95rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.tabButton:hover {
+  color: var(--ifm-color-emphasis-900);
+  border-color: var(--ifm-color-emphasis-500);
+}
+
+.tabButton[aria-selected='true'] {
+  color: var(--bp-accent);
+  border-color: var(--bp-accent);
+  background: var(--bp-fill-soft);
+}
+
+.tabButton:focus-visible {
+  outline: 2px solid var(--bp-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .tablist {
+    display: none;
+  }
+}
+
+/* ---- Embla viewport ---- */
+.viewport {
+  overflow: hidden;
+}
+
+.container {
+  display: flex;
+  align-items: stretch;
+}
+
+.slide {
+  flex: 0 0 100%;
+  min-width: 0;
+  padding: 0 0.25rem;
+}
+
+/* ---- Blueprint frame ---- */
+.frame {
+  position: relative;
+  background: var(--bp-bg);
+  border: 1px solid var(--bp-stroke-faint);
+  border-radius: 4px;
+  overflow: hidden;
+  font-family: var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--bp-text);
+  box-shadow: 0 1px 0 var(--bp-stroke-faint), 0 10px 32px -20px rgba(11, 31, 58, 0.4);
+}
+
+.frameHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: var(--bp-bg-deep);
+  border-bottom: 1px solid var(--bp-stroke-faint);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--bp-text-dim);
+}
+
+.frameStamp {
+  font-weight: 700;
+  color: var(--bp-text);
+  letter-spacing: 0.22em;
+}
+
+.frameSeparator {
+  opacity: 0.5;
+}
+
+.frameIndex {
+  color: var(--bp-accent);
+  font-weight: 600;
+}
+
+.frameTitle {
+  margin-left: 0.25rem;
+  flex: 1;
+  color: var(--bp-text);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+}
+
+.frameVersion {
+  font-size: 0.7rem;
+  color: var(--bp-text-dim);
+  letter-spacing: 0.14em;
+}
+
+.frameCanvas {
+  position: relative;
+  padding: 1.5rem 1.25rem;
+  background: var(--bp-bg);
+}
+
+.corner {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--bp-stroke-dim);
+  pointer-events: none;
+}
+
+.cornerTL {
+  top: 8px;
+  left: 8px;
+  border-right: none;
+  border-bottom: none;
+}
+.cornerTR {
+  top: 8px;
+  right: 8px;
+  border-left: none;
+  border-bottom: none;
+}
+.cornerBL {
+  bottom: 8px;
+  left: 8px;
+  border-right: none;
+  border-top: none;
+}
+.cornerBR {
+  bottom: 8px;
+  right: 8px;
+  border-left: none;
+  border-top: none;
+}
+
+.frameFooter {
+  padding: 0.55rem 1rem 0.7rem;
+  border-top: 1px solid var(--bp-stroke-faint);
+  background: var(--bp-bg-deep);
+  font-size: 0.78rem;
+  color: var(--bp-text-dim);
+  letter-spacing: 0.04em;
+}
+
+/* ---- SVG primitives ---- */
+.svg {
+  display: block;
+  width: 100%;
   height: auto;
+}
+
+.node {
+  /* group for hover effects */
+}
+
+.nodeShape {
+  fill: var(--bp-fill-soft);
+  stroke: var(--bp-stroke);
+  stroke-width: 1.25;
+  vector-effect: non-scaling-stroke;
+}
+
+.shapeDecision {
+  fill: var(--bp-fill-decision);
+}
+
+.shapeTerminal {
+  fill: transparent;
+  stroke-width: 1.5;
+}
+
+.shapeOutput {
+  fill: var(--bp-fill-output);
+  stroke: var(--bp-accent);
+}
+
+.nodeLabel {
+  fill: var(--bp-text);
+  font-family: var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+}
+
+.edge {
+  stroke: var(--bp-stroke-dim);
+  stroke-width: 1.1;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.edgeLabel {
+  fill: var(--bp-text-dim);
+  font-family: var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.arrowHead {
+  fill: var(--bp-stroke-dim);
+}
+
+.axisLabel {
+  fill: var(--bp-text-dim);
+  font-family: var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* ---- Carousel controls (mobile) ---- */
+.controls {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 767px) {
+  .controls {
+    display: flex;
+  }
+}
+
+.controlButton {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.controlButton:hover:not(:disabled) {
+  color: var(--bp-accent);
+  border-color: var(--bp-accent);
+}
+
+.controlButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.dots {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.dot[aria-selected='true'] {
+  background: var(--bp-accent);
+  border-color: var(--bp-accent);
 }


### PR DESCRIPTION
## Summary

- Replace the single Mermaid workflow on the landing with **five hand-authored SVG diagrams** (Charter, AILOG, TDE, Compliance, Audit trail), one per tab.
- **Blueprint aesthetic** with CSS variables under `[data-theme]` — navy grid in dark mode, drafting paper in light, no flashes on theme toggle.
- **Marching-ant edges**: `stroke-dasharray` cycling along `pathLength="1"` paths; honors `prefers-reduced-motion`.
- **Tabs + carousel**: `embla-carousel-react` (~6 KB) with keyboard-accessible `role="tablist"` on desktop and swipe + dots + arrows on mobile.
- **Full i18n**: ~55 strings wrapped in `<Translate>`, populated for `es` and `zh-CN`. Old `workflow.title` / `workflow.caption` keys removed.

## Why

The Mermaid diagram couldn't theme dark/light (its `classDef` colors were hardcoded hex), its node labels were never wrapped in `<Translate>` so `es` and `zh-CN` showed English boxes, and one diagram hid that StrayMark is five distinct workflows that deserve their own visual story.

## Test plan

- [ ] `npm run typecheck` passes (verified locally).
- [ ] `npm run build` succeeds for all three locales: en, es, zh-CN (verified locally — `build/{,es/,zh-CN/}index.html` all contain the new section title in their respective language).
- [ ] On `/`, `/es/`, `/zh-CN/`: five tabs visible, click switches panel, marching-ant dashes flow along every edge in the direction of the arrow.
- [ ] Toggle dark / light: blueprint background, grid, strokes and text all swap without flashes.
- [ ] Mobile (< 768px): tabs hidden, swipe between panels works, dots + ‹ › arrows appear and are accessible.
- [ ] Keyboard: tablist navigable with `Arrow Left/Right`, `Home`, `End`; `aria-selected` updates.
- [ ] `prefers-reduced-motion: reduce` (DevTools → Rendering): edges visible and static, no animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)