### PR TITLE
fix(website): es translation gaps — navbar, footer, blog plugin and hero pillar

### DIFF
--- a/website/i18n/es/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/es/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "La bitácora de StrayMark — cómo emergió el framework, decisión a decisión.",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Todas las publicaciones",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -1,0 +1,50 @@
+{
+  "link.title.Docs": {
+    "message": "Documentación",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Project": {
+    "message": "Proyecto",
+    "description": "The title of the footer links column with title=Project in the footer"
+  },
+  "link.title.Strange Days Tech": {
+    "message": "Strange Days Tech",
+    "description": "The title of the footer links column with title=Strange Days Tech in the footer"
+  },
+  "link.item.label.Adoption Guide": {
+    "message": "Guía de adopción",
+    "description": "The label of footer link with label=Adoption Guide linking to /docs/adopters/ADOPTION-GUIDE"
+  },
+  "link.item.label.CLI Reference": {
+    "message": "Referencia del CLI",
+    "description": "The label of footer link with label=CLI Reference linking to /docs/adopters/CLI-REFERENCE"
+  },
+  "link.item.label.Workflows": {
+    "message": "Flujos de trabajo",
+    "description": "The label of footer link with label=Workflows linking to /docs/adopters/WORKFLOWS"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/StrangeDaysTech/straymark"
+  },
+  "link.item.label.Releases": {
+    "message": "Releases",
+    "description": "The label of footer link with label=Releases linking to https://github.com/StrangeDaysTech/straymark/releases"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/StrangeDaysTech/straymark/issues"
+  },
+  "link.item.label.Organization": {
+    "message": "Organización",
+    "description": "The label of footer link with label=Organization linking to https://github.com/StrangeDaysTech"
+  },
+  "copyright": {
+    "message": "Copyright © 2026 Strange Days Tech. Hecho con Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "message": "StrayMark",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "StrayMark",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "Documentación",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
## Summary

- Add Spanish translations for the navbar items (`Documentación`, `Blog`, `GitHub`), footer column titles (`Documentación`, `Proyecto`, `Strange Days Tech`), footer link labels (`Guía de adopción`, `Referencia del CLI`, `Flujos de trabajo`, `Organización`, ...), copyright line, and blog plugin SEO fields.
- `Releases` and `Issues` kept in English on purpose — they're GitHub-specific terms and the links point to GitHub itself, which is in English.

## Why

When the `es` locale was activated (PR #163) only `code.json` was translated. The navbar, footer and blog plugin strings silently fell through to their English fallback values — visible at https://straymark.dev/es/ where the menu reads "Docs / Blog / GitHub" instead of "Documentación / Blog / GitHub". `zh-CN` shipped these three files when its locale was activated (PR #177); this PR brings `es` to parity.

These three skeleton files were generated as a side-effect of running `npm run write-translations -- --locale es` in PR #181; rather than committing them with English defaults there, they're filled in here in their own PR.

## Test plan

- [ ] `npm run build` succeeds (verified locally — all 3 locales build clean).
- [ ] On `/es/`: navbar shows `Documentación`, `Blog`, `GitHub`; footer shows `Documentación`, `Proyecto`, `Strange Days Tech` as column titles and `Guía de adopción`, `Referencia del CLI`, `Flujos de trabajo`, `Organización` as link labels; copyright ends with `Hecho con Docusaurus.`.
- [ ] On `/es/blog`: page title is `Blog`, SEO description is `La bitácora de StrayMark — cómo emergió el framework, decisión a decisión.`, sidebar header is `Todas las publicaciones`.
- [ ] `/en/` and `/zh-CN/` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)