### PR TITLE
fix(website): retranslate hero.pillar3 to clearer Spanish

### DIFF
--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -12,7 +12,7 @@
     "description": "Second hero pillar"
   },
   "hero.pillar3": {
-    "message": "Auditoría lista por construcción",
+    "message": "Preparado para auditoría por defecto",
     "description": "Third hero pillar"
   },
   "hero.cta.docs": {


### PR DESCRIPTION
## Summary

- `hero.pillar3` on the `/es/` landing changes from `Auditoría lista por construcción` to `Preparado para auditoría por defecto`.

## Why

"Auditoría lista por construcción" is an awkward calque of "audit-ready by construction" — grammatical but not idiomatic, and the "by construction" framing loses the "by default" intent of the English source ("Audit-ready by default"). "Preparado para auditoría por defecto" reads naturally and preserves the default-state meaning.

## Test plan

- [ ] `npm run build` succeeds (single-string change, builds clean).
- [ ] On `/es/`: hero shows the three pillars as `Cada decisión queda en el repo · Detecta la deriva empíricamente · Preparado para auditoría por defecto`.
- [ ] `/en/` and `/zh-CN/` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)