### PR TITLE
feat(website): expand FeatureGrid with 3 cards and a landing page per feature

### DIFF
--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -96,7 +96,7 @@
     "description": "Feature: multi-model external audit (title)"
   },
   "features.audit.body": {
-    "message": "Tres CLIs auditores (gemini, claude, copilot) leen el mismo prompt y auditan un Charter cerrado de forma independiente. Un calibrador deduplica, reclasifica severidad y fusiona evidencia firmada en la telemetría.",
+    "message": "Tres CLIs auditores (ej. claude, copilot, gemini) leen el mismo prompt y auditan un Charter cerrado de forma independiente. Un calibrador deduplica, reclasifica severidad y fusiona evidencia firmada en la telemetría.",
     "description": "Feature: multi-model external audit (body)"
   },
   "features.eod.title": {

--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -83,6 +83,30 @@
     "message": "El Transversal Debt Engine expone el acoplamiento oculto entre charters antes de que se acumule en incidentes.",
     "description": "Feature: TDE drift detection (body)"
   },
+  "features.skills.title": {
+    "message": "Skills para agentes de IA",
+    "description": "Feature: skills for AI agents (title)"
+  },
+  "features.skills.body": {
+    "message": "Once slash-commands envuelven los rituales: /straymark-charter-new, /straymark-ailog, /straymark-audit-prompt, /straymark-status. El agente conduce el framework, no tú.",
+    "description": "Feature: skills for AI agents (body)"
+  },
+  "features.audit.title": {
+    "message": "Auditoría externa multi-modelo",
+    "description": "Feature: multi-model external audit (title)"
+  },
+  "features.audit.body": {
+    "message": "Tres CLIs auditores (gemini, claude, copilot) leen el mismo prompt y auditan un Charter cerrado de forma independiente. Un calibrador deduplica, reclasifica severidad y fusiona evidencia firmada en la telemetría.",
+    "description": "Feature: multi-model external audit (body)"
+  },
+  "features.eod.title": {
+    "message": "Observación emergente por diseño",
+    "description": "Feature: emergent observation by design (title)"
+  },
+  "features.eod.body": {
+    "message": "Las referencias cruzadas obligatorias entre documentos permiten que el agente detecte specs desactualizadas y deriva entre charters por sí mismo. La disciplina cognitiva eleva el piso sin endurecer el prompt.",
+    "description": "Feature: emergent observation by design (body)"
+  },
   "workflow.section.title": {
     "message": "Cinco flujos, un repositorio",
     "description": "Workflow section title"

--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -35,6 +35,10 @@
     "message": "Qué trae StrayMark",
     "description": "Feature grid title"
   },
+  "features.sidebar.title": {
+    "message": "Qué trae StrayMark",
+    "description": "Title for the left sidebar shared across feature pages"
+  },
   "features.discipline.title": {
     "message": "Disciplina cognitiva estructurada",
     "description": "Feature: structured cognitive discipline (title)"

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -55,6 +55,30 @@
     "message": "Transversal Debt Engine 让 Charters 之间隐藏的耦合在演化为事故前显形。",
     "description": "Feature: TDE drift detection (body)"
   },
+  "features.skills.title": {
+    "message": "面向 AI 智能体的 Skills",
+    "description": "Feature: skills for AI agents (title)"
+  },
+  "features.skills.body": {
+    "message": "十一个斜杠命令封装了仪式：/straymark-charter-new、/straymark-ailog、/straymark-audit-prompt、/straymark-status……由智能体驱动框架，而不是你。",
+    "description": "Feature: skills for AI agents (body)"
+  },
+  "features.audit.title": {
+    "message": "多模型外部审计",
+    "description": "Feature: multi-model external audit (title)"
+  },
+  "features.audit.body": {
+    "message": "三个审计方 CLI（gemini、claude、copilot）读取同一份提示，独立审计一个已关闭的 Charter。校准器去重、重新分级，并将签名后的证据合并入遥测数据。",
+    "description": "Feature: multi-model external audit (body)"
+  },
+  "features.eod.title": {
+    "message": "源自设计的涌现式观察",
+    "description": "Feature: emergent observation by design (title)"
+  },
+  "features.eod.body": {
+    "message": "文档之间强制的相互引用让智能体能够主动发现过时的规范和跨 Charter 的漂移。认知纪律提升基线，而无需收紧提示词。",
+    "description": "Feature: emergent observation by design (body)"
+  },
   "hero.pillar1": {
     "message": "记录每一个决策",
     "description": "First hero pillar"

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -68,7 +68,7 @@
     "description": "Feature: multi-model external audit (title)"
   },
   "features.audit.body": {
-    "message": "三个审计方 CLI（gemini、claude、copilot）读取同一份提示，独立审计一个已关闭的 Charter。校准器去重、重新分级，并将签名后的证据合并入遥测数据。",
+    "message": "三个审计方 CLI（如 claude、copilot、gemini）读取同一份提示，独立审计一个已关闭的 Charter。校准器去重、重新分级，并将签名后的证据合并入遥测数据。",
     "description": "Feature: multi-model external audit (body)"
   },
   "features.eod.title": {

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -7,6 +7,10 @@
     "message": "StrayMark 提供什么",
     "description": "Feature grid title"
   },
+  "features.sidebar.title": {
+    "message": "StrayMark 提供什么",
+    "description": "Title for the left sidebar shared across feature pages"
+  },
   "features.discipline.title": {
     "message": "结构化的认知纪律",
     "description": "Feature: structured cognitive discipline (title)"

--- a/website/src/components/FeatureGrid/index.tsx
+++ b/website/src/components/FeatureGrid/index.tsx
@@ -60,6 +60,30 @@ const FEATURES: Feature[] = [
       'The Transversal Debt Engine surfaces hidden coupling between charters before it compounds into incidents.',
     to: '/docs/contributors/DESIGN-PRINCIPLES',
   },
+  {
+    titleId: 'features.skills.title',
+    titleDefault: 'Skills for AI agents',
+    bodyId: 'features.skills.body',
+    bodyDefault:
+      'Eleven slash-commands wrap the rituals: /straymark-charter-new, /straymark-ailog, /straymark-audit-prompt, /straymark-status. The agent drives the framework, not you.',
+    to: '/docs/adopters/WORKFLOWS',
+  },
+  {
+    titleId: 'features.audit.title',
+    titleDefault: 'Multi-model external audit',
+    bodyId: 'features.audit.body',
+    bodyDefault:
+      'Three auditor CLIs (gemini, claude, copilot) read the same prompt and audit a closed Charter independently. A calibrator deduplicates, reclassifies severity, and merges signed evidence into telemetry.',
+    to: '/docs/adopters/WORKFLOWS',
+  },
+  {
+    titleId: 'features.eod.title',
+    titleDefault: 'Emergent observation by design',
+    bodyId: 'features.eod.body',
+    bodyDefault:
+      'Mandatory cross-references between documents let the agent spot stale specs and inter-charter drift on its own. Cognitive discipline raises the floor without tightening the prompt.',
+    to: '/blog/emergent-observation-design',
+  },
 ];
 
 export default function FeatureGrid(): ReactNode {

--- a/website/src/components/FeatureGrid/index.tsx
+++ b/website/src/components/FeatureGrid/index.tsx
@@ -18,7 +18,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.discipline.body',
     bodyDefault:
       'Charters define purpose and limits before code. AILOGs capture human/agent exchange. AIDECs record decisions and tradeoffs.',
-    to: '/docs/contributors/WHAT-IS-A-CHARTER',
+    to: '/features/cognitive-discipline',
   },
   {
     titleId: 'features.repo.title',
@@ -26,7 +26,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.repo.body',
     bodyDefault:
       'Everything lives in your git repo: artifacts, governance rules, agent directives. No external platform, no second source of truth.',
-    to: '/docs/adopters/ADOPTION-GUIDE',
+    to: '/features/repo-native',
   },
   {
     titleId: 'features.agents.title',
@@ -34,7 +34,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.agents.body',
     bodyDefault:
       'Versioned rules in STRAYMARK.md and AGENT-RULES bind agent behavior at the workflow level — not at runtime, not after the fact.',
-    to: '/docs/adopters/WORKFLOWS',
+    to: '/features/agent-governance',
   },
   {
     titleId: 'features.evidence.title',
@@ -42,7 +42,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.evidence.body',
     bodyDefault:
       'EU AI Act, ISO 42001, NIST AI RMF, and GDPR mappings emerge from the same artifacts the team already produces. No parallel paper trail.',
-    to: '/docs/adopters/CLI-REFERENCE',
+    to: '/features/evidence-byproduct',
   },
   {
     titleId: 'features.cli.title',
@@ -50,7 +50,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.cli.body',
     bodyDefault:
       'init, validate, audit, analyze, compliance, metrics — one binary, eleven commands, deterministic outputs you can grep and pipe.',
-    to: '/docs/adopters/CLI-REFERENCE',
+    to: '/features/cli',
   },
   {
     titleId: 'features.tde.title',
@@ -58,7 +58,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.tde.body',
     bodyDefault:
       'The Transversal Debt Engine surfaces hidden coupling between charters before it compounds into incidents.',
-    to: '/docs/contributors/DESIGN-PRINCIPLES',
+    to: '/features/tde',
   },
   {
     titleId: 'features.skills.title',
@@ -66,15 +66,15 @@ const FEATURES: Feature[] = [
     bodyId: 'features.skills.body',
     bodyDefault:
       'Eleven slash-commands wrap the rituals: /straymark-charter-new, /straymark-ailog, /straymark-audit-prompt, /straymark-status. The agent drives the framework, not you.',
-    to: '/docs/adopters/WORKFLOWS',
+    to: '/features/skills',
   },
   {
     titleId: 'features.audit.title',
     titleDefault: 'Multi-model external audit',
     bodyId: 'features.audit.body',
     bodyDefault:
-      'Three auditor CLIs (gemini, claude, copilot) read the same prompt and audit a closed Charter independently. A calibrator deduplicates, reclassifies severity, and merges signed evidence into telemetry.',
-    to: '/docs/adopters/WORKFLOWS',
+      'Three auditor CLIs (e.g. claude, copilot, gemini) read the same prompt and audit a closed Charter independently. A calibrator deduplicates, reclassifies severity, and merges signed evidence into telemetry.',
+    to: '/features/multi-model-audit',
   },
   {
     titleId: 'features.eod.title',
@@ -82,7 +82,7 @@ const FEATURES: Feature[] = [
     bodyId: 'features.eod.body',
     bodyDefault:
       'Mandatory cross-references between documents let the agent spot stale specs and inter-charter drift on its own. Cognitive discipline raises the floor without tightening the prompt.',
-    to: '/blog/emergent-observation-design',
+    to: '/features/emergent-observation',
   },
 ];
 

--- a/website/src/components/FeaturesLayout/index.tsx
+++ b/website/src/components/FeaturesLayout/index.tsx
@@ -1,0 +1,113 @@
+import type {ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+import {useLocation} from '@docusaurus/router';
+import {translate} from '@docusaurus/Translate';
+import TOC from '@theme/TOC';
+import styles from './styles.module.css';
+
+type TocItem = {
+  id: string;
+  level: number;
+  value: string;
+};
+
+type Props = {
+  children: ReactNode;
+  toc?: TocItem[];
+};
+
+type FeatureLink = {
+  slug: string;
+  titleId: string;
+  titleDefault: string;
+};
+
+const FEATURES: FeatureLink[] = [
+  {
+    slug: 'cognitive-discipline',
+    titleId: 'features.discipline.title',
+    titleDefault: 'Structured cognitive discipline',
+  },
+  {
+    slug: 'repo-native',
+    titleId: 'features.repo.title',
+    titleDefault: 'Repo-native by design',
+  },
+  {
+    slug: 'agent-governance',
+    titleId: 'features.agents.title',
+    titleDefault: 'Declarative agent governance',
+  },
+  {
+    slug: 'evidence-byproduct',
+    titleId: 'features.evidence.title',
+    titleDefault: 'Evidence as a byproduct',
+  },
+  {slug: 'cli', titleId: 'features.cli.title', titleDefault: 'A CLI that does the work'},
+  {slug: 'tde', titleId: 'features.tde.title', titleDefault: 'TDE: drift detection'},
+  {
+    slug: 'skills',
+    titleId: 'features.skills.title',
+    titleDefault: 'Skills for AI agents',
+  },
+  {
+    slug: 'multi-model-audit',
+    titleId: 'features.audit.title',
+    titleDefault: 'Multi-model external audit',
+  },
+  {
+    slug: 'emergent-observation',
+    titleId: 'features.eod.title',
+    titleDefault: 'Emergent observation by design',
+  },
+];
+
+function isActive(pathname: string, slug: string): boolean {
+  const target = `/features/${slug}`;
+  return (
+    pathname.endsWith(target) ||
+    pathname.endsWith(`${target}/`) ||
+    pathname.includes(`${target}/`)
+  );
+}
+
+export default function FeaturesLayout({children, toc}: Props): ReactNode {
+  const {pathname} = useLocation();
+  const sidebarTitle = translate({
+    id: 'features.sidebar.title',
+    message: "What's in the box",
+    description: 'Title for the left sidebar shared across feature pages',
+  });
+
+  return (
+    <div className={styles.container}>
+      <aside className={styles.sidebar} aria-label={sidebarTitle}>
+        <h3 className={styles.sidebarTitle}>{sidebarTitle}</h3>
+        <ul className={styles.sidebarList}>
+          {FEATURES.map((f) => {
+            const active = isActive(pathname, f.slug);
+            return (
+              <li key={f.slug}>
+                <Link
+                  to={`/features/${f.slug}`}
+                  className={`${styles.sidebarLink} ${active ? styles.sidebarLinkActive : ''}`}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {translate({id: f.titleId, message: f.titleDefault})}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+      <main className={styles.content}>
+        <article className={styles.article}>{children}</article>
+      </main>
+      {toc && toc.length > 0 ? (
+        <aside className={styles.tocColumn} aria-label="On this page">
+          <TOC toc={toc} minHeadingLevel={2} maxHeadingLevel={3} className={styles.tocInner} />
+        </aside>
+      ) : null}
+    </div>
+  );
+}

--- a/website/src/components/FeaturesLayout/index.tsx
+++ b/website/src/components/FeaturesLayout/index.tsx
@@ -2,18 +2,10 @@ import type {ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import {useLocation} from '@docusaurus/router';
 import {translate} from '@docusaurus/Translate';
-import TOC from '@theme/TOC';
 import styles from './styles.module.css';
-
-type TocItem = {
-  id: string;
-  level: number;
-  value: string;
-};
 
 type Props = {
   children: ReactNode;
-  toc?: TocItem[];
 };
 
 type FeatureLink = {
@@ -71,7 +63,7 @@ function isActive(pathname: string, slug: string): boolean {
   );
 }
 
-export default function FeaturesLayout({children, toc}: Props): ReactNode {
+export default function FeaturesLayout({children}: Props): ReactNode {
   const {pathname} = useLocation();
   const sidebarTitle = translate({
     id: 'features.sidebar.title',
@@ -103,11 +95,6 @@ export default function FeaturesLayout({children, toc}: Props): ReactNode {
       <main className={styles.content}>
         <article className={styles.article}>{children}</article>
       </main>
-      {toc && toc.length > 0 ? (
-        <aside className={styles.tocColumn} aria-label="On this page">
-          <TOC toc={toc} minHeadingLevel={2} maxHeadingLevel={3} className={styles.tocInner} />
-        </aside>
-      ) : null}
     </div>
   );
 }

--- a/website/src/components/FeaturesLayout/styles.module.css
+++ b/website/src/components/FeaturesLayout/styles.module.css
@@ -1,0 +1,137 @@
+.container {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 220px;
+  gap: 2.5rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  align-items: start;
+}
+
+@media (max-width: 1200px) {
+  .container {
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: 2rem;
+  }
+  .tocColumn {
+    display: none;
+  }
+}
+
+@media (max-width: 996px) {
+  .container {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    padding: 1.5rem 1rem 3rem;
+  }
+  .sidebar {
+    position: static;
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-200);
+    padding-bottom: 1.5rem;
+    margin-bottom: 0.5rem;
+    max-height: none;
+  }
+}
+
+.sidebar {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height, 60px) + 1rem);
+  align-self: start;
+  padding-right: 1rem;
+  border-right: 1px solid var(--ifm-color-emphasis-200);
+  max-height: calc(100vh - var(--ifm-navbar-height, 60px) - 2rem);
+  overflow-y: auto;
+}
+
+.sidebarTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin: 0 0 0.85rem 0.4rem;
+}
+
+.sidebarList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebarList li {
+  margin: 0;
+}
+
+.sidebarLink {
+  display: block;
+  padding: 0.45rem 0.6rem;
+  margin: 0.1rem 0;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  color: var(--ifm-color-emphasis-800);
+  text-decoration: none;
+  border-radius: 6px;
+  border-left: 2px solid transparent;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.sidebarLink:hover {
+  text-decoration: none;
+  color: var(--ifm-color-emphasis-900);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.sidebarLinkActive,
+.sidebarLinkActive:hover {
+  color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+  border-left-color: var(--ifm-color-primary);
+  font-weight: 600;
+}
+
+.content {
+  min-width: 0;
+}
+
+.article {
+  max-width: 820px;
+}
+
+.article h1 {
+  font-size: 2.25rem;
+  letter-spacing: -0.01em;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.article h2 {
+  font-size: 1.4rem;
+  margin-top: 2.25rem;
+}
+
+.article h3 {
+  font-size: 1.1rem;
+  margin-top: 1.5rem;
+}
+
+.article p {
+  line-height: 1.65;
+}
+
+.article table {
+  display: table;
+  width: 100%;
+}
+
+.tocColumn {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height, 60px) + 1rem);
+  align-self: start;
+  max-height: calc(100vh - var(--ifm-navbar-height, 60px) - 2rem);
+  overflow-y: auto;
+}
+
+.tocInner {
+  font-size: 0.85rem;
+}

--- a/website/src/components/FeaturesLayout/styles.module.css
+++ b/website/src/components/FeaturesLayout/styles.module.css
@@ -1,21 +1,11 @@
 .container {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr) 220px;
+  grid-template-columns: 240px minmax(0, 1fr);
   gap: 2.5rem;
   max-width: 1400px;
   margin: 0 auto;
   padding: 2rem 1.5rem 4rem;
   align-items: start;
-}
-
-@media (max-width: 1200px) {
-  .container {
-    grid-template-columns: 220px minmax(0, 1fr);
-    gap: 2rem;
-  }
-  .tocColumn {
-    display: none;
-  }
 }
 
 @media (max-width: 996px) {
@@ -124,14 +114,3 @@
   width: 100%;
 }
 
-.tocColumn {
-  position: sticky;
-  top: calc(var(--ifm-navbar-height, 60px) + 1rem);
-  align-self: start;
-  max-height: calc(100vh - var(--ifm-navbar-height, 60px) - 2rem);
-  overflow-y: auto;
-}
-
-.tocInner {
-  font-size: 0.85rem;
-}

--- a/website/src/pages/features/agent-governance.mdx
+++ b/website/src/pages/features/agent-governance.mdx
@@ -1,0 +1,27 @@
+---
+title: Declarative agent governance
+description: Versioned rules in STRAYMARK.md and AGENT-RULES bind agent behavior at the workflow level — not at runtime, not after the fact.
+---
+
+# Declarative agent governance
+
+Runtime guardrails come too late. By the time the agent has typed a destructive command, the prompt is over and you're triaging the cleanup. StrayMark moves agent governance upstream: the rules are declared in versioned files the agent reads *before* it begins, and updates to those rules are visible in `git log`.
+
+## Why this matters
+
+- **Runtime ≠ workflow.** Most LLM guardrails are prompt-injection defenses or output filters — important, but they don't decide whether the agent should write that DB migration in the first place. Workflow-level governance does.
+- **Versioned rules are reviewable rules.** `STRAYMARK.md` is a file with PR diffs. Tightening or loosening a rule shows up in `git log` with an author, a date, and a discussion thread. That's auditable in a way runtime configs aren't.
+- **Same contract across CLIs.** The same `STRAYMARK.md` directs Claude Code, Gemini CLI, Copilot CLI, Codex CLI. One source of truth, N agents. Switching models doesn't mean rewriting the operating contract.
+
+## The contract layers
+
+1. **`STRAYMARK.md`** at the repo root (~600 lines, ~12 sections). The unified rules: hierarchies, prohibited operations, documentation policy, security stance, when to ask before acting. Agents are required to read it before any non-trivial action.
+2. **`AGENT-RULES.md`** under `.straymark/00-governance/`: stricter operational rules — when to flag drift, when to recommend a TDE, the "Be Proactive" clause that authorizes the agent to surface findings unprompted.
+3. **Skill frontmatter** augments the global rules for specific rituals. Each `/straymark-*` skill has its own preconditions, output contract, and post-conditions.
+
+When the framework version bumps, the contract bumps. `straymark update-framework` shows you the diff before applying.
+
+## Learn more
+
+- [Workflows](/docs/adopters/WORKFLOWS)
+- [STRAYMARK.md on GitHub](https://github.com/StrangeDaysTech/straymark/blob/main/dist/STRAYMARK.md)

--- a/website/src/pages/features/agent-governance.mdx
+++ b/website/src/pages/features/agent-governance.mdx
@@ -2,6 +2,9 @@
 title: Declarative agent governance
 description: Versioned rules in STRAYMARK.md and AGENT-RULES bind agent behavior at the workflow level — not at runtime, not after the fact.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Declarative agent governance
 
@@ -25,3 +28,5 @@ When the framework version bumps, the contract bumps. `straymark update-framewor
 
 - [Workflows](/docs/adopters/WORKFLOWS)
 - [STRAYMARK.md on GitHub](https://github.com/StrangeDaysTech/straymark/blob/main/dist/STRAYMARK.md)
+
+</FeaturesLayout>

--- a/website/src/pages/features/agent-governance.mdx
+++ b/website/src/pages/features/agent-governance.mdx
@@ -4,7 +4,7 @@ description: Versioned rules in STRAYMARK.md and AGENT-RULES bind agent behavior
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Declarative agent governance
 

--- a/website/src/pages/features/cli.mdx
+++ b/website/src/pages/features/cli.mdx
@@ -2,6 +2,9 @@
 title: A CLI that does the work
 description: One Rust binary, eleven commands. Deterministic, scriptable, no daemons.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # A CLI that does the work
 
@@ -47,3 +50,5 @@ straymark analyze --since HEAD~10
 ## Learn more
 
 - [CLI Reference](/docs/adopters/CLI-REFERENCE)
+
+</FeaturesLayout>

--- a/website/src/pages/features/cli.mdx
+++ b/website/src/pages/features/cli.mdx
@@ -4,7 +4,7 @@ description: One Rust binary, eleven commands. Deterministic, scriptable, no dae
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # A CLI that does the work
 

--- a/website/src/pages/features/cli.mdx
+++ b/website/src/pages/features/cli.mdx
@@ -1,0 +1,49 @@
+---
+title: A CLI that does the work
+description: One Rust binary, eleven commands. Deterministic, scriptable, no daemons.
+---
+
+# A CLI that does the work
+
+`straymark` is a single Rust binary with eleven subcommands that operate on your repo: scaffolding, validating, auditing, analyzing complexity, generating compliance reports. Deterministic outputs you can pipe to `grep`, `jq`, or CI.
+
+## Why this matters
+
+- **One install path, one upgrade path.** No language-runtime hunt, no Docker layer, no orchestration. `curl -fsSL .../install.sh | sh` puts it on `$PATH`. `straymark update-cli` keeps it current.
+- **No hidden side effects.** `straymark validate` reads files; `straymark audit` produces a markdown report. None of the subcommands call out to APIs or modify your git state without you asking. Safe to wire into pre-commit and CI.
+- **The CLI is the contract.** The same `straymark validate` runs locally, in pre-commit, and in pipelines. There isn't a "CI mode" with different rules.
+
+## The eleven commands
+
+| Command | What it does |
+|---|---|
+| `straymark init [path]` | Initialize StrayMark in a project |
+| `straymark update` | Update both framework and CLI |
+| `straymark status [path]` | Show installation health and doc stats |
+| `straymark repair [path]` | Restore missing directories and framework files |
+| `straymark validate [path] [--staged]` | Validate documents for compliance and correctness |
+| `straymark new [-t type] [--title]` | Create a new document from a template |
+| `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST, ...) |
+| `straymark metrics [path]` | Show governance metrics and documentation statistics |
+| `straymark analyze [path]` | Analyze code complexity (cognitive + cyclomatic) |
+| `straymark audit [path]` | Generate audit trail reports with timeline and traceability |
+| `straymark explore [path]` | Interactive TUI documentation browser |
+
+All commands respect `--json` where it makes sense, so output is machine-readable.
+
+## Built for piping
+
+```bash
+# Find every open TDE sorted by impact:
+straymark metrics --json | jq '.tde[] | select(.status=="identified") | .id'
+
+# Fail CI when any high-risk Charter lacks an AILOG:
+straymark validate --staged || exit 1
+
+# Diff complexity between two commits:
+straymark analyze --since HEAD~10
+```
+
+## Learn more
+
+- [CLI Reference](/docs/adopters/CLI-REFERENCE)

--- a/website/src/pages/features/cognitive-discipline.mdx
+++ b/website/src/pages/features/cognitive-discipline.mdx
@@ -2,6 +2,9 @@
 title: Structured cognitive discipline
 description: Three small artifact types that turn vague "AI-assisted work" into traceable units of thought — Charters, AILOGs, AIDECs.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Structured cognitive discipline
 
@@ -25,3 +28,5 @@ All three are plain Markdown with YAML frontmatter. They live in `.straymark/` a
 
 - [What is a Charter](/docs/contributors/WHAT-IS-A-CHARTER)
 - [Adoption Guide](/docs/adopters/ADOPTION-GUIDE)
+
+</FeaturesLayout>

--- a/website/src/pages/features/cognitive-discipline.mdx
+++ b/website/src/pages/features/cognitive-discipline.mdx
@@ -4,7 +4,7 @@ description: Three small artifact types that turn vague "AI-assisted work" into 
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Structured cognitive discipline
 

--- a/website/src/pages/features/cognitive-discipline.mdx
+++ b/website/src/pages/features/cognitive-discipline.mdx
@@ -1,0 +1,27 @@
+---
+title: Structured cognitive discipline
+description: Three small artifact types that turn vague "AI-assisted work" into traceable units of thought — Charters, AILOGs, AIDECs.
+---
+
+# Structured cognitive discipline
+
+Most AI-assisted work loses its reasoning the moment the diff lands. StrayMark fixes that with three small artifact types — **Charters**, **AILOGs**, **AIDECs** — that sit next to your code and document the intent, the action, and the trade-off behind each change.
+
+## Why this matters
+
+When an agent ships a feature, you usually get the result and lose everything that led there: the alternatives considered, the scope explicitly excluded, the risks discovered mid-flight. Six months later, the code is unrecoverable archaeology. Cognitive discipline is cheap when you have a template; it's everything when you don't.
+
+The cost of *not* having it shows up later as: undocumented decisions that nobody can defend in a review, agents drifting silently from the spec, and compliance auditors asking for evidence that doesn't exist.
+
+## What you get
+
+- **Charters** declare a bounded unit of work *before* you start: scope (in / out), files declared up-front, risks (`R1...Rn`), verification commands. The Charter cannot close if reality drifted from the declaration and the drift wasn't reconciled in the same PR.
+- **AILOGs** log the actual execution: what got done, why, what was discovered in flight, what was punted. One per commit, sequence-numbered per day, with a `risk_level` and a `confidence` field.
+- **AIDECs** capture standalone decisions: alternatives considered, trade-offs, the option chosen and the reason. The decision survives even if the original Charter is closed.
+
+All three are plain Markdown with YAML frontmatter. They live in `.straymark/` and ship with templates. The CLI scaffolds them; agents invoke them via skills.
+
+## Learn more
+
+- [What is a Charter](/docs/contributors/WHAT-IS-A-CHARTER)
+- [Adoption Guide](/docs/adopters/ADOPTION-GUIDE)

--- a/website/src/pages/features/emergent-observation.mdx
+++ b/website/src/pages/features/emergent-observation.mdx
@@ -4,7 +4,7 @@ description: When documents reference each other formally, agents start spotting
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Emergent observation by design
 

--- a/website/src/pages/features/emergent-observation.mdx
+++ b/website/src/pages/features/emergent-observation.mdx
@@ -1,0 +1,29 @@
+---
+title: Emergent observation by design
+description: When documents reference each other formally, agents start spotting drift without being asked. The property has a name — Emergent Observation. It's Principle #8.
+---
+
+# Emergent observation by design
+
+On 2026-05-16, an agent flagged a stale spec before being asked to. Nobody had prompted it; it noticed the divergence on its own. The reconstruction of that morning surfaced a design property StrayMark had been building toward without naming: **Emergent Observation**. It became Principle #8.
+
+## Why this matters
+
+Most agent governance tries to make agents more restricted: tighter prompts, stricter personas, more guardrails. Emergent Observation goes the other way — when the documents are formally linked and the cultural permission is explicit, the agent gains enough context to *notice* problems and enough authorization to *flag* them.
+
+- **The floor rises without the prompt tightening.** You don't need a longer prompt; you need a denser semantic graph between artifacts. The agent's "ability to observe" is a function of how the documents reference each other, not how restrictive the prompt is.
+- **Findings the team would have missed get surfaced early.** Stale specs, inter-charter drift, MCARDs that no longer match the deployed model. The agent finds these because the graph makes the divergence visible — not because anyone asked.
+- **It's a property, not a feature.** Every StrayMark concept (Charter→AILOG, AILOG→Risk, MCARD→DPIA, TDE→origin Charter, ...) contributes to it. Removing any one of them weakens the agent's ability to observe.
+
+## What makes it work
+
+1. **Mandatory linkage.** Every Charter must declare its files and risks. Every AILOG must reference its Charter. Every TDE must trace its origin. The forward and back-references close a graph.
+2. **Stable IDs, canonical sections.** Documents have predictable headings (`## Scope`, `## Risks`, `## Verification`, `## Status`) and stable IDs in frontmatter. The agent can dereference quickly without prose-parsing every file.
+3. **Explicit permission.** `AGENT-RULES.md §6` ("Be Proactive — Identify potential risks, Suggest improvements when evident, Alert about technical debt") tells the agent that surfacing findings is part of the job, not stepping out of line.
+
+Remove any one of those three and the property collapses. That's why the design treats them as load-bearing, not optional.
+
+## Learn more
+
+- [Blog: The day the agent saw something nobody asked it to see](/blog/emergent-observation-design)
+- [Design Principles](/docs/contributors/DESIGN-PRINCIPLES)

--- a/website/src/pages/features/emergent-observation.mdx
+++ b/website/src/pages/features/emergent-observation.mdx
@@ -2,6 +2,9 @@
 title: Emergent observation by design
 description: When documents reference each other formally, agents start spotting drift without being asked. The property has a name — Emergent Observation. It's Principle #8.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Emergent observation by design
 
@@ -27,3 +30,5 @@ Remove any one of those three and the property collapses. That's why the design 
 
 - [Blog: The day the agent saw something nobody asked it to see](/blog/emergent-observation-design)
 - [Design Principles](/docs/contributors/DESIGN-PRINCIPLES)
+
+</FeaturesLayout>

--- a/website/src/pages/features/evidence-byproduct.mdx
+++ b/website/src/pages/features/evidence-byproduct.mdx
@@ -1,0 +1,39 @@
+---
+title: Evidence as a byproduct
+description: Regulatory compliance evidence emerges from the same artifacts the team already produces. No parallel paper trail.
+---
+
+# Evidence as a byproduct
+
+Compliance shouldn't be a separate pile of documents your team maintains after the fact. StrayMark maps your existing artifacts — Charters, AILOGs, AIDECs, ETH, DPIA, MCARDs — directly to EU AI Act, ISO 42001, NIST AI RMF, GDPR, and China-region (TC260, PIPL, GB45438, CAC, CSL) controls. The artifacts *are* the evidence.
+
+## Why this matters
+
+- **You're already writing the inputs.** Auditors ask for risk registers, decision logs, model cards, incident response plans. Those map onto Charter `Risks` sections, AILOGs, AIDECs, MCARDs, SEC documents — artifacts the team produces during normal work, not in a compliance sprint at year-end.
+- **Gap reports in seconds.** `straymark compliance --standard EuAiAct` walks the repo, parses frontmatter (tags, risk_level, regional_scope), and produces a gap report. No spreadsheet, no Confluence space, no external GRC tool.
+- **Standards evolve; the engine ships with releases.** When a regulator publishes a clarification, the mapping engine updates in the next framework release. You don't re-train your team — you `straymark update-framework`.
+
+## What gets scanned
+
+```bash
+$ straymark compliance --standard EuAiAct
+[OK]   Risk management   8/8   covered by R1-R8 across 12 Charters
+[OK]   Data governance   4/4   covered by 3 DPIA documents
+[GAP]  Model cards       0/2   high-risk models in scope are missing MCARD
+[GAP]  Incident response 0/1   ETH-RESPONSE not declared
+```
+
+Supported standards out of the box:
+
+| Region | Standards |
+|---|---|
+| EU | EU AI Act, GDPR |
+| International | ISO/IEC 42001, NIST AI RMF |
+| China | TC260, PIPL, GB45438, CAC, CSL |
+
+The `regional_scope` field in `.straymark/config.yml` determines which scans run by default.
+
+## Learn more
+
+- [CLI Reference: `compliance`](/docs/adopters/CLI-REFERENCE)
+- [Adoption Guide](/docs/adopters/ADOPTION-GUIDE)

--- a/website/src/pages/features/evidence-byproduct.mdx
+++ b/website/src/pages/features/evidence-byproduct.mdx
@@ -4,7 +4,7 @@ description: Regulatory compliance evidence emerges from the same artifacts the 
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Evidence as a byproduct
 

--- a/website/src/pages/features/evidence-byproduct.mdx
+++ b/website/src/pages/features/evidence-byproduct.mdx
@@ -2,6 +2,9 @@
 title: Evidence as a byproduct
 description: Regulatory compliance evidence emerges from the same artifacts the team already produces. No parallel paper trail.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Evidence as a byproduct
 
@@ -37,3 +40,5 @@ The `regional_scope` field in `.straymark/config.yml` determines which scans run
 
 - [CLI Reference: `compliance`](/docs/adopters/CLI-REFERENCE)
 - [Adoption Guide](/docs/adopters/ADOPTION-GUIDE)
+
+</FeaturesLayout>

--- a/website/src/pages/features/multi-model-audit.mdx
+++ b/website/src/pages/features/multi-model-audit.mdx
@@ -2,6 +2,9 @@
 title: Multi-model external audit
 description: Three independent auditor CLIs review the same closed Charter; a calibrator consolidates findings into signed evidence in the Charter's telemetry.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Multi-model external audit
 
@@ -40,3 +43,5 @@ The reviewed evidence then merges into the Charter's `external_audit:` YAML bloc
 
 - [Workflows](/docs/adopters/WORKFLOWS)
 - [Blog: Charters and the external audit cycle](/blog/charters-and-the-external-audit-cycle)
+
+</FeaturesLayout>

--- a/website/src/pages/features/multi-model-audit.mdx
+++ b/website/src/pages/features/multi-model-audit.mdx
@@ -1,0 +1,42 @@
+---
+title: Multi-model external audit
+description: Three independent auditor CLIs review the same closed Charter; a calibrator consolidates findings into signed evidence in the Charter's telemetry.
+---
+
+# Multi-model external audit
+
+Once a Charter closes, StrayMark can commission an external audit — not from one agent, but from several, in parallel. Three independent auditor CLIs (for example: Claude, Copilot, Gemini) read the same prompt and audit the Charter independently. A **calibrator** then consolidates findings into a single signed evidence block in the Charter's telemetry.
+
+## Why this matters
+
+- **Single-model audits inherit their auditing model's biases.** Multi-model parallel audits surface findings any one model would miss, and let the team de-prioritize findings only one model flagged. Consensus and dissent both become data.
+- **The calibrator is the discipline layer.** It reads all reports, verifies each finding against actual code, deduplicates, reclassifies severity (was the auditor inflating or deflating?), and rates each auditor's signal quality. The result is calibrated review, not a vote.
+- **Human-in-the-loop, not LLM gateway.** StrayMark itself never calls auditor APIs. The CLI prepares a prompt; the operator runs the audit in their auditor CLI of choice; the CLI consolidates the resulting reports. This is a deliberate architectural stance (Principle #10: "not an LLM gateway").
+
+## The three-phase cycle
+
+### Phase 1 — Generate the prompt
+```bash
+/straymark-audit-prompt CHARTER-12
+```
+Writes a unified prompt at `.straymark/audits/CHARTER-12/audit-prompt.md` that embeds the Charter scope, the AILOGs, the git diff, and the discipline rules (evidence citation, severity calibration, scope gates).
+
+### Phase 2 — Run N auditors in parallel
+The operator opens auditor-side CLIs (gemini-cli, claude-cli, copilot-cli, codex-cli) and runs `/straymark-audit-execute` in each. Each auditor reads the same prompt, audits with tool use (citing `path:line`), and writes `report-<model>.md` next to the prompt.
+
+### Phase 3 — Calibrate & merge
+```bash
+/straymark-audit-review CHARTER-12
+```
+Consolidates all reports into a critical `review.md` with:
+- **Per-finding verdict** — VALID, PARTIALLY_VALID, MISATTRIBUTED, FALSE_POSITIVE, DUPLICATE.
+- **Severity reclassification** — when auditors inflated/deflated against actual config.
+- **Auditor scorecard** — scope precision, depth, bug-detection rate, false-positive rate.
+- **Remediation plan** — P0 Security → P4 Documentation.
+
+The reviewed evidence then merges into the Charter's `external_audit:` YAML block as telemetry.
+
+## Learn more
+
+- [Workflows](/docs/adopters/WORKFLOWS)
+- [Blog: Charters and the external audit cycle](/blog/charters-and-the-external-audit-cycle)

--- a/website/src/pages/features/multi-model-audit.mdx
+++ b/website/src/pages/features/multi-model-audit.mdx
@@ -4,7 +4,7 @@ description: Three independent auditor CLIs review the same closed Charter; a ca
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Multi-model external audit
 

--- a/website/src/pages/features/repo-native.mdx
+++ b/website/src/pages/features/repo-native.mdx
@@ -2,6 +2,9 @@
 title: Repo-native by design
 description: Why StrayMark's artifacts live inside your git repo instead of an external SaaS platform.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Repo-native by design
 
@@ -37,3 +40,5 @@ The CLI (`straymark validate`, `straymark audit`, `straymark compliance`) operat
 
 - [Adoption Guide](/docs/adopters/ADOPTION-GUIDE)
 - [STRAYMARK.md (canonical rules file)](https://github.com/StrangeDaysTech/straymark/blob/main/dist/STRAYMARK.md)
+
+</FeaturesLayout>

--- a/website/src/pages/features/repo-native.mdx
+++ b/website/src/pages/features/repo-native.mdx
@@ -4,7 +4,7 @@ description: Why StrayMark's artifacts live inside your git repo instead of an e
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Repo-native by design
 

--- a/website/src/pages/features/repo-native.mdx
+++ b/website/src/pages/features/repo-native.mdx
@@ -1,0 +1,39 @@
+---
+title: Repo-native by design
+description: Why StrayMark's artifacts live inside your git repo instead of an external SaaS platform.
+---
+
+# Repo-native by design
+
+StrayMark has no SaaS, no dashboard, no second source of truth. Every artifact — Charters, AILOGs, agent rules, compliance evidence — lives as a versioned file in your git repository, next to the code it governs.
+
+## Why this matters
+
+- **Reasoning travels with the code.** A `git blame` on a tricky line leads to the commit, which leads to the AILOG, which leads to the Charter, which leads to the risks declared up-front. No tool to log into, no broken link from a moved Confluence page.
+- **Diff = governance.** When `STRAYMARK.md` changes, it's a PR with reviewers and a discussion. When an AILOG is missing for a non-trivial commit, CI catches it. The same git workflow you already use is the only workflow.
+- **No vendor lock-in.** The framework is plain Markdown plus a Rust CLI. Both are MIT-licensed and self-hosted. Walking away from StrayMark is `rm -rf .straymark/` — and your history doesn't go with it.
+- **Forks are first-class.** Organizations can fork the framework, pin a version, and evolve their own rules. The CLI's `update-framework` command respects that pinning.
+
+## How it works
+
+```
+your-repo/
+├── STRAYMARK.md                  # Unified rules — first thing agents read
+├── .straymark/
+│   ├── 00-governance/            # AGENT-RULES, doc policies, quick reference
+│   ├── 01-charters/              # CHARTER-NN-slug.md
+│   ├── 02-ailogs/                # AILOG-YYYYMMDD-NN-slug.md
+│   ├── 03-decisions/             # AIDEC, ADR
+│   ├── 04-models/                # MCARD
+│   ├── 05-security/              # SEC, ETH, DPIA
+│   ├── 06-evolution/             # TDE, deprecations
+│   └── audits/CHARTER-NN/        # External audit reports
+└── src/...                       # Your actual code
+```
+
+The CLI (`straymark validate`, `straymark audit`, `straymark compliance`) operates on the filesystem, deterministically. No daemons, no background sync.
+
+## Learn more
+
+- [Adoption Guide](/docs/adopters/ADOPTION-GUIDE)
+- [STRAYMARK.md (canonical rules file)](https://github.com/StrangeDaysTech/straymark/blob/main/dist/STRAYMARK.md)

--- a/website/src/pages/features/skills.mdx
+++ b/website/src/pages/features/skills.mdx
@@ -2,6 +2,9 @@
 title: Skills for AI agents
 description: Eleven /straymark-* slash-commands that let the agent invoke the framework's rituals directly — no dictation needed.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # Skills for AI agents
 
@@ -36,3 +39,5 @@ The agent calls `/straymark-status` to see what's missing. It scaffolds a Charte
 ## Learn more
 
 - [Workflows](/docs/adopters/WORKFLOWS)
+
+</FeaturesLayout>

--- a/website/src/pages/features/skills.mdx
+++ b/website/src/pages/features/skills.mdx
@@ -4,7 +4,7 @@ description: Eleven /straymark-* slash-commands that let the agent invoke the fr
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # Skills for AI agents
 

--- a/website/src/pages/features/skills.mdx
+++ b/website/src/pages/features/skills.mdx
@@ -1,0 +1,38 @@
+---
+title: Skills for AI agents
+description: Eleven /straymark-* slash-commands that let the agent invoke the framework's rituals directly — no dictation needed.
+---
+
+# Skills for AI agents
+
+The CLI is for humans and CI. Skills are for agents. Eleven `/straymark-*` slash-commands ship with the framework so Claude Code, Gemini CLI, Copilot CLI and others can invoke Charter scaffolding, AILOG creation, audit cycles, status checks and security assessments without you having to dictate the steps.
+
+## Why this matters
+
+- **Rituals you have to dictate are rituals nobody performs.** A team that says "remember to write an AILOG before committing" produces zero AILOGs after week two. Skills make the rituals discoverable from inside the agent: `/straymark-status` shows where the team is, `/straymark-charter-new` scaffolds the right document type with prompts for scope.
+- **One source of truth for both manual and agent flows.** The CLI command `straymark new -t AILOG` and the skill `/straymark-ailog` produce the same document; only the entry point differs. Maintainers don't keep two implementations in sync.
+- **New rituals ship as new skills.** When the framework adds a new ritual (e.g. the three-skill audit cycle), it ships as new slash commands the agent discovers after `straymark update-framework`. No retraining.
+
+## The eleven skills
+
+| Skill | Purpose |
+|---|---|
+| `/straymark-status` | Documentation status & compliance check |
+| `/straymark-new` | Create any StrayMark document type (interactive) |
+| `/straymark-charter-new` | Scaffold a Charter — the bounded unit of work |
+| `/straymark-ailog` | Quick AILOG creation for the current commit |
+| `/straymark-aidec` | Record a standalone decision with alternatives & trade-offs |
+| `/straymark-adr` | Create an Architecture Decision Record |
+| `/straymark-mcard` | Model Card (interactive multi-step flow) |
+| `/straymark-sec` | Security Assessment (interactive, OWASP ASVS-aware) |
+| `/straymark-audit-prompt CHARTER-XX` | Generate the multi-model audit prompt |
+| `/straymark-audit-execute [CHARTER-XX]` | Run an audit inside an auditor-side CLI |
+| `/straymark-audit-review CHARTER-XX` | Consolidate audit reports into a calibrated review |
+
+## How they fit together
+
+The agent calls `/straymark-status` to see what's missing. It scaffolds a Charter with `/straymark-charter-new`, declares scope and risks, ships the work, runs `/straymark-ailog` to log execution, and `/straymark-audit-prompt` to commission an external audit. Each skill is small; the discipline emerges from their composition.
+
+## Learn more
+
+- [Workflows](/docs/adopters/WORKFLOWS)

--- a/website/src/pages/features/tde.mdx
+++ b/website/src/pages/features/tde.mdx
@@ -1,0 +1,43 @@
+---
+title: TDE — Transversal Debt Entries
+description: When technical debt outgrows a single Charter — heritage, multi-module, needs its own remediation — it becomes a tracked, scored TDE.
+---
+
+# TDE — drift detection that survives the Charter
+
+Every Charter has a `Risks` section for things that might go wrong inside its scope. But some debt is bigger than any one Charter: heritage from a previous decision, propagation across modules, debt that needs a dedicated Charter to fix. That's a **TDE (Transversal Debt Entry)**.
+
+## Why this matters
+
+- **"Everything is a risk" defeats the risk list.** Without a higher-order category, important transversal issues drown in per-Charter `R<N>` noise. TDE rescues them with explicit eligibility criteria.
+- **Debt has to outlive the Charter that found it.** When a Charter closes, its risk list closes with it. Heritage debt needs its own document that survives across Charters and can be prioritized against other tracked debt.
+- **Scoring beats vibes.** TDEs carry an `impact × effort` matrix and a `status: identified | prioritized | resolved`. The framework helps the team decide what to fix next; resolved TDEs stay in the repo as audit history.
+
+## Eligibility — four criteria
+
+A debt entry becomes a TDE if **any** of these apply:
+
+1. **Heritage** — it propagates from a prior Charter (strict pattern or implicit pattern reuse).
+2. **Cross-module** — it crosses code modules OR crosses Charter execution boundaries.
+3. **Needs its own Charter** — remediation is non-trivial enough to require a dedicated future Charter.
+4. **Needs human prioritization** — the team has to decide whether/when to fix it; the agent shouldn't decide unilaterally.
+
+If none apply, it stays as a per-Charter `R<N>` risk. The `/straymark-new TDE` skill walks through this check.
+
+## How it works
+
+```
+.straymark/06-evolution/technical-debt/
+├── TDE-001-config-loader-coupling.md     status: prioritized
+├── TDE-002-i18n-fallback-incoherence.md  status: identified
+└── TDE-003-stale-validators.md           status: resolved (2026-04-30)
+```
+
+Each document has frontmatter (`tde_id`, `status`, `impact`, `effort`, `created_at`, `resolved_at`), a description of the debt, the criteria it meets, and — once prioritized — the planned Charter or remediation path.
+
+`straymark metrics` surfaces open TDEs by impact and age. CI can fail when a high-impact TDE has been `identified` for more than N days without prioritization.
+
+## Learn more
+
+- [Design Principles](/docs/contributors/DESIGN-PRINCIPLES)
+- [Blog: TDE and transversal debt](/blog/tde-and-transversal-debt)

--- a/website/src/pages/features/tde.mdx
+++ b/website/src/pages/features/tde.mdx
@@ -2,6 +2,9 @@
 title: TDE — Transversal Debt Entries
 description: When technical debt outgrows a single Charter — heritage, multi-module, needs its own remediation — it becomes a tracked, scored TDE.
 ---
+import FeaturesLayout from '@site/src/components/FeaturesLayout';
+
+<FeaturesLayout toc={toc}>
 
 # TDE — drift detection that survives the Charter
 
@@ -41,3 +44,5 @@ Each document has frontmatter (`tde_id`, `status`, `impact`, `effort`, `created_
 
 - [Design Principles](/docs/contributors/DESIGN-PRINCIPLES)
 - [Blog: TDE and transversal debt](/blog/tde-and-transversal-debt)
+
+</FeaturesLayout>

--- a/website/src/pages/features/tde.mdx
+++ b/website/src/pages/features/tde.mdx
@@ -4,7 +4,7 @@ description: When technical debt outgrows a single Charter — heritage, multi-m
 ---
 import FeaturesLayout from '@site/src/components/FeaturesLayout';
 
-<FeaturesLayout toc={toc}>
+<FeaturesLayout>
 
 # TDE — drift detection that survives the Charter
 


### PR DESCRIPTION
## Summary

Two-part expansion of the "What's in the box" section on the landing:

### 1. Three new cards (6 → 9, fills a 3×3 grid on desktop)

- **Skills for AI agents** — the eleven `/straymark-*` slash-commands that let the agent invoke rituals directly. Makes it clear StrayMark isn't just a CLI for humans.
- **Multi-model external audit** — three independent auditor CLIs read the same prompt; a calibrator consolidates findings into signed evidence in telemetry. Previously only visible inside the workflow diagram.
- **Emergent observation by design** — Principle #8: the meta-property that lets agents surface cross-charter drift unprompted when documents are formally linked.

The CLI card is unchanged — skills get their own card so neither concept is shortchanged. Audit card body uses an illustrative model list (`e.g. claude, copilot, gemini` / `ej.` / `如`) with Claude first.

### 2. Nine intermediate-depth landing pages

Each card now links to a focused MDX page at `/features/<slug>/` instead of a deep docs page:

| Card | Page |
|---|---|
| Structured cognitive discipline | `/features/cognitive-discipline` |
| Repo-native by design | `/features/repo-native` |
| Declarative agent governance | `/features/agent-governance` |
| Evidence as a byproduct | `/features/evidence-byproduct` |
| A CLI that does the work | `/features/cli` |
| TDE: drift detection | `/features/tde` |
| Skills for AI agents | `/features/skills` |
| Multi-model external audit | `/features/multi-model-audit` |
| Emergent observation by design | `/features/emergent-observation` |

Same shape across all nine: lede paragraph, "why this matters", "how it works" / "what you get" with concrete file paths and command examples, and a "learn more" footer linking to deeper docs. Targets the visitor who clicked because the card caught their attention but isn't ready to read full contributor docs or a historical blog post — the in-between reader.

## Why

- The 6-card grid was hiding three real capabilities (skills, multi-model audit, EOD).
- Linking cards straight to `/docs/contributors/WHAT-IS-A-CHARTER` or a blog post was too steep a jump for a curious-but-not-committed visitor. The new pages bridge landing → docs.
- The audit card's model list was being read as definitive rather than illustrative; rewording fixes that and matches the reference auditor flow (Claude first).

## i18n

The MDX pages are English-only in this PR. Docusaurus falls back gracefully under `/es/features/*` and `/zh-CN/features/*` (visitor sees English content within their localized chrome — better than 404). Translating the 9 pages is a deliberate follow-up; the audit card body and the 6 strings for the new cards ARE translated to `es` and `zh-CN` in this PR.

## Test plan

- [ ] `npm run build` succeeds for all 3 locales (verified — `build/{features,es/features,zh-CN/features}/` each contain 9 HTML pages).
- [ ] On `/`, `/es/`, `/zh-CN/`: 9 cards in 3 rows of 3 on desktop; each links to `/features/<slug>/`.
- [ ] Clicking each card lands on a focused page with the same template; "learn more" links reach reachable docs/blog.
- [ ] Multi-model audit card body reads "(e.g. claude, copilot, gemini)" in EN, "(ej. claude, copilot, gemini)" in ES, "(如 claude、copilot、gemini)" in zh-CN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)