### PR TITLE
fix(website): /features/* sidebar overlapping article in compact view

### DIFF
--- a/website/src/components/FeaturesLayout/styles.module.css
+++ b/website/src/components/FeaturesLayout/styles.module.css
@@ -1,3 +1,5 @@
+/* ---- Base (desktop-first) ---- */
+
 .container {
   display: grid;
   grid-template-columns: 240px minmax(0, 1fr);
@@ -8,22 +10,6 @@
   align-items: start;
 }
 
-@media (max-width: 996px) {
-  .container {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-    padding: 1.5rem 1rem 3rem;
-  }
-  .sidebar {
-    position: static;
-    border-right: none;
-    border-bottom: 1px solid var(--ifm-color-emphasis-200);
-    padding-bottom: 1.5rem;
-    margin-bottom: 0.5rem;
-    max-height: none;
-  }
-}
-
 .sidebar {
   position: sticky;
   top: calc(var(--ifm-navbar-height, 60px) + 1rem);
@@ -32,6 +18,10 @@
   border-right: 1px solid var(--ifm-color-emphasis-200);
   max-height: calc(100vh - var(--ifm-navbar-height, 60px) - 2rem);
   overflow-y: auto;
+  /* Opaque background so a scrolling article doesn't bleed through when
+     the sidebar is sticky. */
+  background: var(--ifm-background-color);
+  z-index: 1;
 }
 
 .sidebarTitle {
@@ -63,7 +53,10 @@
   text-decoration: none;
   border-radius: 6px;
   border-left: 2px solid transparent;
-  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
 }
 
 .sidebarLink:hover {
@@ -114,3 +107,47 @@
   width: 100%;
 }
 
+/* ---- Tablet / compact desktop: stack sidebar above content ----
+   Must come AFTER the base rules so the overrides actually win on cascade.
+*/
+@media (max-width: 996px) {
+  .container {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .sidebar {
+    position: static;
+    top: auto;
+    max-height: none;
+    overflow-y: visible;
+    align-self: stretch;
+    padding-right: 0;
+    padding-bottom: 1.25rem;
+    margin-bottom: 0.25rem;
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-200);
+    /* No need for the z-index/background trick here — it's a normal block. */
+    z-index: auto;
+  }
+}
+
+/* ---- True mobile: drop the sidebar entirely.
+   At narrow widths the 9-entry list would push the article half a screen
+   down before the user sees any content; cleaner to send mobile visitors
+   straight to the article. They can return to /#features-grid (the home
+   grid) for navigation. */
+@media (max-width: 640px) {
+  .sidebar {
+    display: none;
+  }
+
+  .container {
+    padding: 1rem 0.85rem 2.5rem;
+  }
+
+  .article h1 {
+    font-size: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Summary

Three related fixes in `website/src/components/FeaturesLayout/styles.module.css` that resolve the overlapping sidebar / article visible at compact-to-mobile widths.

### Root cause: CSS source-order bug

The base `.sidebar` rule sets `position: sticky`. The `@media (max-width: 996px)` block resets it to `position: static`. But in the source, the media query came **before** the base rule — so the cascade (later rule wins at same specificity) put `position: sticky` back on top. **Result: the sidebar stayed sticky at every viewport width**, and once the article scrolled past it, the article bled through the transparent sticky element.

Fix: move both media queries to the bottom of the file so the mobile overrides actually apply.

### Defensive: opaque background on the sticky sidebar

Added `background: var(--ifm-background-color); z-index: 1;` to the desktop `.sidebar`. Even on wide viewports, if something else ever scrolls beneath, it won't bleed through. Belt-and-suspenders against the kind of bug we just hit.

### True mobile: hide the sidebar entirely (<640px)

At narrow widths, the 9-entry list was pushing the article half a screen down before the user could read any content. Cleaner to send phone-sized visitors straight to the article. Tablet range (640–996px) keeps the stacked-above behavior the user already saw working in their first screenshot.

## What each breakpoint looks like now

| Viewport | Layout |
|---|---|
| `>996px` (desktop) | Two columns. Sidebar 240px, sticky, opaque background. |
| `640–996px` (tablet) | Single column. Sidebar block stacks above the article. |
| `<640px` (mobile) | Single column. Sidebar hidden; article tightened a touch (`h1` to 1.75rem, padding tightened). |

## Test plan

- [ ] `npm run build` succeeds for all three locales (verified locally).
- [ ] DevTools width 1200px → two columns, sidebar sticky at the top while scrolling. Scrolling the article does not bleed through.
- [ ] DevTools width 800px → single column, "What's in the box" block stacks above the article. No overlap on scroll.
- [ ] DevTools width 400px → sidebar gone; article takes the full width; `h1` smaller; padding tighter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)