### PR TITLE
feat(website): GA4 + cookie consent (Consent Mode v2) + /privacy

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -129,6 +129,10 @@ const config: Config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        gtag: {
+          trackingID: 'G-M8NW21WY2M',
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -59,6 +59,28 @@ const config: Config = {
         content: '#0E0E10',
       },
     },
+    // Google Consent Mode v2 defaults — MUST run before gtag.js loads so the
+    // first measurement event arrives already gated. Tracking stays denied
+    // until the user accepts in the cookie banner (vanilla-cookieconsent
+    // calls gtag('consent', 'update', ...) on acceptance). See
+    // src/clientModules/cookie-consent.ts for the runtime side.
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          analytics_storage: 'denied',
+          functionality_storage: 'granted',
+          security_storage: 'granted',
+          wait_for_update: 500
+        });
+      `.trim(),
+    },
   ],
 
   future: {
@@ -83,6 +105,8 @@ const config: Config = {
   },
 
   themes: ['@docusaurus/theme-mermaid'],
+
+  clientModules: ['./src/clientModules/cookie-consent.ts'],
 
   i18n: {
     defaultLocale: 'en',
@@ -202,6 +226,18 @@ const config: Config = {
           title: 'Strange Days Tech',
           items: [
             {label: 'Organization', href: 'https://github.com/StrangeDaysTech'},
+          ],
+        },
+        {
+          title: 'Legal',
+          items: [
+            {label: 'Privacy', to: '/privacy'},
+            // Intercepted by the cookie-consent client module
+            // (src/clientModules/cookie-consent.ts) — it reads the
+            // ?cookies=open query param on mount AND on click, opening the
+            // preferences panel. Without JS, the user simply lands on
+            // /privacy, which already explains how to opt out.
+            {label: 'Cookie preferences', to: '/privacy?cookies=open'},
           ],
         },
       ],

--- a/website/i18n/es/docusaurus-plugin-content-pages/privacy.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-pages/privacy.mdx
@@ -1,0 +1,48 @@
+---
+title: Aviso de privacidad
+description: Qué recopila StrayMark.dev, por qué, y cómo optar por no participar.
+---
+
+# Aviso de privacidad
+
+StrayMark es código abierto y el sitio del proyecto (`straymark.dev`) es un sitio estático publicado desde un repositorio Git — no hay backend de aplicación, no hay cuentas de usuario, y no hay envíos de formularios. Los únicos datos personales que el sitio procesa son los que tu navegador envía al visitar cualquier página, más lo que una herramienta de analíticas opt-in recopila cuando la autorizas.
+
+Este aviso cubre `https://straymark.dev` y sus subpaths localizados (`/es/...`, `/zh-CN/...`).
+
+## Qué recopilamos
+
+Cuando visitas el sitio y **aceptas analíticas** en el banner de cookies, [Google Analytics 4](https://support.google.com/analytics/answer/10089681) registra:
+
+- **IP anonimizada** — Google trunca el último octeto de tu IP antes de almacenarla (`anonymizeIP: true`).
+- **Páginas vistas**, tiempo en página, profundidad de scroll, geografía amplia (país/región), dispositivo, navegador, idioma.
+- **Cookies de sesión** con prefijo `_ga*`, que GA usa para agrupar requests en sesiones.
+
+Lo que **no** recopilamos:
+
+- Tu nombre, email, cuenta, ni ninguna credencial de inicio de sesión.
+- Datos de formularios — no hay formularios.
+- Identificadores personales de trackers de terceros o pixeles de marketing.
+
+## Por qué lo recopilamos
+
+Para aprender qué secciones de la documentación se leen y cuáles se ignoran. Esa retroalimentación informa decisiones editoriales (qué reescribir, qué deprecar) y orienta el roadmap del framework. No usamos los datos para marketing, publicidad, ni venta a terceros.
+
+## Tu control
+
+- **Rechaza en la primera visita.** Si eliges **Rechazar** en el banner, no se establecen cookies de analíticas y Google Analytics no recibe eventos de tu sesión.
+- **Cambia de opinión después.** Haz clic en **Preferencias de cookies** en el pie de página para reabrir el panel en cualquier momento.
+- **Controles a nivel de navegador.** Las configuraciones del navegador, `Do Not Track`, y extensiones como uBlock Origin funcionan independientemente de nuestro banner.
+
+## Base legal y dónde viven los datos
+
+- El consentimiento de analíticas se recopila bajo la base de "consentimiento" del GDPR de la UE (Art. 6(1)(a)). Sin tu opt-in explícito, Google Analytics permanece en modo default-deny vía [Consent Mode v2](https://developers.google.com/tag-platform/security/guides/consent) de Google.
+- Los datos procesados por Google Analytics se almacenan en la infraestructura de Google y se retienen por **14 meses** (default de GA4). Ver la [política de privacidad de Google](https://policies.google.com/privacy) para sus prácticas globales.
+- El sitio mismo se sirve desde GitHub Pages, que registra metadata de requests a nivel de CDN (logs de acceso web estándar).
+
+## Cambios a este aviso
+
+Cambios materiales en lo que recopilamos o cómo se procesa se publican como un commit en este archivo en [el repositorio de StrayMark](https://github.com/StrangeDaysTech/straymark/blob/main/website/i18n/es/docusaurus-plugin-content-pages/privacy.mdx). La historia de Git es el registro canónico.
+
+## Contacto
+
+Para preguntas o solicitudes sobre este aviso, abre un issue en [GitHub](https://github.com/StrangeDaysTech/straymark/issues). Para asuntos que requieran email, escribe a `legal@strangedays.tech`.

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -43,6 +43,18 @@
     "message": "Organización",
     "description": "The label of footer link with label=Organization linking to https://github.com/StrangeDaysTech"
   },
+  "link.title.Legal": {
+    "message": "Legal",
+    "description": "The title of the footer links column with title=Legal in the footer"
+  },
+  "link.item.label.Privacy": {
+    "message": "Privacidad",
+    "description": "The label of footer link with label=Privacy linking to /privacy"
+  },
+  "link.item.label.Cookie preferences": {
+    "message": "Preferencias de cookies",
+    "description": "The label of footer link that reopens the cookie consent panel (href=#cookie-preferences, intercepted by client module)"
+  },
   "copyright": {
     "message": "Copyright © 2026 Strange Days Tech. Hecho con Docusaurus.",
     "description": "The footer copyright"

--- a/website/i18n/zh-CN/docusaurus-plugin-content-pages/privacy.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-pages/privacy.mdx
@@ -1,0 +1,48 @@
+---
+title: 隐私声明
+description: StrayMark.dev 收集什么、为什么、以及如何选择退出。
+---
+
+# 隐私声明
+
+StrayMark 是开源项目，项目网站（`straymark.dev`）是一个从 Git 仓库发布的静态站点 —— 没有应用后端、没有用户账号、也没有表单提交。本站点处理的唯一个人数据，是你的浏览器访问任何页面时发送的内容，加上一个 opt-in 分析工具在你允许时收集的内容。
+
+本声明覆盖 `https://straymark.dev` 及其本地化子路径（`/es/...`、`/zh-CN/...`）。
+
+## 我们收集什么
+
+当你访问站点并在 cookie 横幅中**接受分析**时，[Google Analytics 4](https://support.google.com/analytics/answer/10089681) 会记录：
+
+- **匿名化 IP** —— Google 在存储前会截断你 IP 的最后一段（`anonymizeIP: true`）。
+- **浏览的页面**、停留时间、滚动深度、宽泛地理位置（国家/地区）、设备、浏览器、语言。
+- **会话级 cookies**，前缀为 `_ga*`，GA 用来把请求分组为会话。
+
+我们**不**收集：
+
+- 你的姓名、邮箱、账号或任何登录凭证。
+- 表单数据 —— 没有表单。
+- 来自第三方追踪器或营销像素的个人标识符。
+
+## 我们为什么收集
+
+为了了解文档的哪些章节被阅读、哪些被忽略。这些反馈用于编辑决策（重写什么、弃用什么），并指引框架的路线图。我们不把这些数据用于营销、广告或任何向第三方的出售。
+
+## 你的控制
+
+- **首次访问时拒绝。** 如果你在横幅中选择**拒绝**，则不会设置分析 cookies，Google Analytics 也不会从你的会话收到任何事件。
+- **之后改变主意。** 点击页脚的 **Cookie 偏好** 随时重新打开面板。
+- **浏览器级别的控制。** 浏览器设置、`Do Not Track` 以及 uBlock Origin 等扩展都独立于我们的横幅工作。
+
+## 法律依据与数据存放位置
+
+- 分析同意以欧盟 GDPR 的"同意"基础收集（第 6(1)(a) 条）。在你明确 opt-in 之前，Google Analytics 通过 Google 的 [Consent Mode v2](https://developers.google.com/tag-platform/security/guides/consent) 保持 default-deny 模式。
+- 由 Google Analytics 处理的数据存储在 Google 的基础设施上，保留 **14 个月**（GA4 默认）。详见 [Google 的隐私政策](https://policies.google.com/privacy)。
+- 站点本身由 GitHub Pages 提供服务，它在 CDN 层记录请求元数据（标准 Web 服务器访问日志）。
+
+## 本声明的变更
+
+对于我们收集什么或如何处理的实质变更，会作为对 [StrayMark 仓库](https://github.com/StrangeDaysTech/straymark/blob/main/website/i18n/zh-CN/docusaurus-plugin-content-pages/privacy.mdx) 中本文件的一次 commit 发布。Git 历史是规范记录。
+
+## 联系
+
+关于本声明的问题或请求，请在 [GitHub](https://github.com/StrangeDaysTech/straymark/issues) 上开 issue。对需要邮件的事项，请写信到 `legal@strangedays.tech`。

--- a/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -43,6 +43,18 @@
     "message": "组织",
     "description": "The label of footer link with label=Organization linking to https://github.com/StrangeDaysTech"
   },
+  "link.title.Legal": {
+    "message": "法律",
+    "description": "The title of the footer links column with title=Legal in the footer"
+  },
+  "link.item.label.Privacy": {
+    "message": "隐私",
+    "description": "The label of footer link with label=Privacy linking to /privacy"
+  },
+  "link.item.label.Cookie preferences": {
+    "message": "Cookie 偏好",
+    "description": "The label of footer link that reopens the cookie consent panel (href=#cookie-preferences, intercepted by client module)"
+  },
   "copyright": {
     "message": "版权所有 © 2026 Strange Days Tech。基于 Docusaurus 构建。",
     "description": "The footer copyright"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,8 @@
         "plugin-image-zoom": "^1.2.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "vanilla-cookieconsent": "^3.1.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -18058,6 +18059,12 @@
     },
     "node_modules/value-equal": {
       "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/vanilla-cookieconsent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+      "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
       "license": "MIT"
     },
     "node_modules/vary": {

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,8 @@
     "plugin-image-zoom": "^1.2.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",

--- a/website/src/clientModules/cookie-consent.ts
+++ b/website/src/clientModules/cookie-consent.ts
@@ -1,0 +1,219 @@
+/**
+ * Cookie consent + Google Consent Mode v2 bridge.
+ *
+ * Runs only in the browser. Initialises vanilla-cookieconsent v3, and on
+ * accept/reject calls gtag('consent', 'update', ...) so GA respects the
+ * decision. The default-deny gtag('consent', 'default', ...) call lives in
+ * docusaurus.config.ts > headTags and runs before gtag.js loads.
+ *
+ * Public API:
+ *   window.openCookieConsent()  - reopen the preferences panel
+ *                                 (wired into the footer "Privacy settings"
+ *                                 link via theme-classic footer JS).
+ */
+
+import type {} from 'vanilla-cookieconsent';
+
+// Declare gtag on window for TS.
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+    openCookieConsent?: () => void;
+  }
+}
+
+// Strings shared across locales. Docusaurus's i18n doesn't reach this far
+// (clientModules run outside the React tree), so we read the active locale
+// from the <html lang> attribute and pick the matching copy ourselves.
+const COPY = {
+  en: {
+    title: 'We use anonymous analytics',
+    description:
+      'StrayMark uses Google Analytics (with IP anonymisation) to understand which docs are most useful. Nothing personal is collected. You can change your mind any time from the footer.',
+    acceptAll: 'Accept',
+    acceptNecessary: 'Reject',
+    showPreferences: 'Manage preferences',
+    preferencesTitle: 'Cookie preferences',
+    necessaryTitle: 'Strictly necessary',
+    necessaryDescription:
+      'Required for the site to function (locale switcher, theme preference). Always on.',
+    analyticsTitle: 'Analytics',
+    analyticsDescription:
+      'Anonymous page-view stats via Google Analytics. Used to learn which sections of the docs are read and which are ignored.',
+    savePreferences: 'Save preferences',
+    close: 'Close',
+    learnMore: 'Read the full privacy notice',
+    learnMoreHref: '/privacy',
+  },
+  es: {
+    title: 'Usamos analíticas anónimas',
+    description:
+      'StrayMark usa Google Analytics (con IP anonimizada) para entender qué documentos resultan más útiles. No se recopila nada personal. Puedes cambiar de opinión en cualquier momento desde el pie de página.',
+    acceptAll: 'Aceptar',
+    acceptNecessary: 'Rechazar',
+    showPreferences: 'Gestionar preferencias',
+    preferencesTitle: 'Preferencias de cookies',
+    necessaryTitle: 'Estrictamente necesarias',
+    necessaryDescription:
+      'Requeridas para que el sitio funcione (selector de idioma, preferencia de tema). Siempre activas.',
+    analyticsTitle: 'Analíticas',
+    analyticsDescription:
+      'Estadísticas anónimas de vistas de página vía Google Analytics. Sirven para aprender qué secciones de la documentación se leen y cuáles se ignoran.',
+    savePreferences: 'Guardar preferencias',
+    close: 'Cerrar',
+    learnMore: 'Leer el aviso de privacidad completo',
+    learnMoreHref: '/privacy',
+  },
+  'zh-CN': {
+    title: '我们使用匿名分析',
+    description:
+      'StrayMark 使用 Google Analytics（已匿名化 IP）来了解哪些文档最有用。不会收集任何个人信息。你随时可以从页脚改变主意。',
+    acceptAll: '接受',
+    acceptNecessary: '拒绝',
+    showPreferences: '管理偏好',
+    preferencesTitle: 'Cookie 偏好',
+    necessaryTitle: '严格必需',
+    necessaryDescription:
+      '站点正常运行所需（语言切换器、主题偏好）。始终开启。',
+    analyticsTitle: '分析',
+    analyticsDescription:
+      '通过 Google Analytics 收集匿名页面浏览统计。用于了解文档的哪些部分被阅读、哪些被忽略。',
+    savePreferences: '保存偏好',
+    close: '关闭',
+    learnMore: '阅读完整的隐私声明',
+    learnMoreHref: '/privacy',
+  },
+} as const;
+
+type LocaleKey = keyof typeof COPY;
+
+function detectLocale(): LocaleKey {
+  if (typeof document === 'undefined') return 'en';
+  const lang = document.documentElement.lang || 'en';
+  if (lang.startsWith('zh')) return 'zh-CN';
+  if (lang.startsWith('es')) return 'es';
+  return 'en';
+}
+
+function updateGtagConsent(granted: boolean) {
+  // gtag is defined in the inline headTag script that initialises dataLayer.
+  // Call it through window so we don't depend on the closure.
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    // dataLayer-only fallback: push directly.
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push([
+      'consent',
+      'update',
+      {analytics_storage: granted ? 'granted' : 'denied'},
+    ]);
+    return;
+  }
+  window.gtag('consent', 'update', {
+    analytics_storage: granted ? 'granted' : 'denied',
+  });
+}
+
+export default (async function cookieConsentClientModule() {
+  if (typeof window === 'undefined') return;
+
+  // vanilla-cookieconsent injects its own CSS; we import it explicitly so
+  // webpack bundles it. The CSS file path is stable since v3.
+  await import('vanilla-cookieconsent/dist/cookieconsent.css');
+  const CookieConsent = await import('vanilla-cookieconsent');
+
+  const lc = detectLocale();
+  const t = COPY[lc];
+
+  CookieConsent.run({
+    guiOptions: {
+      consentModal: {
+        layout: 'box inline',
+        position: 'bottom right',
+        equalWeightButtons: true,
+        flipButtons: false,
+      },
+      preferencesModal: {
+        layout: 'box',
+        position: 'right',
+        equalWeightButtons: true,
+        flipButtons: false,
+      },
+    },
+    categories: {
+      necessary: {readOnly: true, enabled: true},
+      analytics: {},
+    },
+    language: {
+      default: lc,
+      translations: {
+        [lc]: {
+          consentModal: {
+            title: t.title,
+            description: `${t.description} <a href="${t.learnMoreHref}">${t.learnMore}</a>.`,
+            acceptAllBtn: t.acceptAll,
+            acceptNecessaryBtn: t.acceptNecessary,
+            showPreferencesBtn: t.showPreferences,
+          },
+          preferencesModal: {
+            title: t.preferencesTitle,
+            acceptAllBtn: t.acceptAll,
+            acceptNecessaryBtn: t.acceptNecessary,
+            savePreferencesBtn: t.savePreferences,
+            closeIconLabel: t.close,
+            sections: [
+              {
+                title: t.necessaryTitle,
+                description: t.necessaryDescription,
+                linkedCategory: 'necessary',
+              },
+              {
+                title: t.analyticsTitle,
+                description: t.analyticsDescription,
+                linkedCategory: 'analytics',
+              },
+            ],
+          },
+        },
+      },
+    },
+    onConsent: ({cookie}) => {
+      updateGtagConsent(cookie.categories?.includes('analytics') ?? false);
+    },
+    onChange: ({cookie}) => {
+      updateGtagConsent(cookie.categories?.includes('analytics') ?? false);
+    },
+  });
+
+  // Expose a reopen handle for footer links / external triggers.
+  window.openCookieConsent = () => {
+    CookieConsent.showPreferences();
+  };
+
+  // Intercept clicks on any link whose href contains ?cookies=open — the
+  // footer "Cookie preferences" link uses that query so the URL works without
+  // JS (it just lands on /privacy). With JS we hijack the click and open the
+  // panel inline. One listener on document survives client-side navigation.
+  document.addEventListener('click', (e) => {
+    const target = (e.target as HTMLElement | null)?.closest?.(
+      'a[href*="cookies=open"]',
+    );
+    if (target) {
+      e.preventDefault();
+      CookieConsent.showPreferences();
+    }
+  });
+
+  // If the user landed via a deep-link like /privacy?cookies=open (no JS at
+  // click time, or shared URL), open the panel after mount and clean the URL.
+  if (
+    typeof URLSearchParams !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('cookies') === 'open'
+  ) {
+    CookieConsent.showPreferences();
+    const cleanUrl =
+      window.location.pathname +
+      window.location.hash;
+    window.history.replaceState({}, '', cleanUrl);
+  }
+})();

--- a/website/src/pages/privacy.mdx
+++ b/website/src/pages/privacy.mdx
@@ -1,0 +1,48 @@
+---
+title: Privacy notice
+description: What StrayMark.dev collects, why, and how to opt out.
+---
+
+# Privacy notice
+
+StrayMark is open source and the project's website (`straymark.dev`) is a static site published from a Git repository — there is no application backend, no user accounts, and no form submission. The only personal data the site processes is what your browser sends when you visit any page, plus what an opt-in analytics tool collects when you allow it.
+
+This notice covers `https://straymark.dev` and its localised subpaths (`/es/...`, `/zh-CN/...`).
+
+## What we collect
+
+When you visit the site and **accept analytics** in the cookie banner, [Google Analytics 4](https://support.google.com/analytics/answer/10089681) records:
+
+- **Anonymised IP** — the last octet of your IP is truncated by Google before storage (`anonymizeIP: true`).
+- **Pages viewed**, time on page, scroll depth, broad geography (country/region), device, browser, language.
+- **Session-scoped cookies** under the `_ga*` prefix, used by GA to group requests into sessions.
+
+What we do **not** collect:
+
+- Your name, email, account, or any login credential.
+- Form data — there are no forms.
+- Personal identifiers from third-party trackers or marketing pixels.
+
+## Why we collect it
+
+To learn which sections of the documentation are read and which are ignored. That feedback shapes editorial decisions (what to rewrite, what to deprecate) and informs the framework's roadmap. We do not use the data for marketing, advertising, or any sale to third parties.
+
+## Your control
+
+- **Decline at first visit.** If you choose **Reject** in the banner, no analytics cookies are set and Google Analytics receives no events from your session.
+- **Change your mind later.** Click **Cookie preferences** in the footer to reopen the panel at any time.
+- **Browser-level controls.** Browser settings, `Do Not Track`, and extensions like uBlock Origin will all work independently of our banner.
+
+## Legal basis and where the data lives
+
+- Analytics consent is collected under the EU GDPR's "consent" basis (Art. 6(1)(a)). Without your explicit opt-in, Google Analytics remains in default-deny mode via Google's [Consent Mode v2](https://developers.google.com/tag-platform/security/guides/consent).
+- Data processed by Google Analytics is stored on Google's infrastructure and retained for **14 months** (GA4 default). See [Google's privacy policy](https://policies.google.com/privacy) for their global practices.
+- The site itself is served from GitHub Pages, which logs request metadata at the CDN level (standard web-server access logs).
+
+## Changes to this notice
+
+Material changes to what we collect or how it is processed will be published as a commit on this file in [the StrayMark repository](https://github.com/StrangeDaysTech/straymark/blob/main/website/src/pages/privacy.mdx). The Git history is the canonical record.
+
+## Contact
+
+For questions or requests about this notice, open an issue on [GitHub](https://github.com/StrangeDaysTech/straymark/issues). For matters that require email, write to `legal@strangedays.tech`.


### PR DESCRIPTION
## Summary

Enables Google Analytics 4 on straymark.dev with **full GDPR-compliant consent gating** via Google Consent Mode v2.

### Commits

1. **`feat(website): wire Google Analytics 4 via plugin-google-gtag`** — adds `@docusaurus/plugin-google-gtag` to the preset with `trackingID: G-M8NW21WY2M` and `anonymizeIP: true`. No new dep (plugin ships with `preset-classic`).

2. **`feat(website): cookie consent with Consent Mode v2 default-deny + /privacy`** — adds the consent layer, banner UI, `/privacy` page, and footer "Legal" column.

### How it works

- **Default-deny on page load.** An inline `<script>` in `headTags` initialises Google Consent Mode v2 (`analytics_storage: 'denied'`, etc.) **before** `gtag.js` loads. The first GA call is already gated.
- **Banner via `vanilla-cookieconsent` v3** (~50KB). Two categories: "Necessary" (always on, no cookies) and "Analytics" (off by default). Translated inline in en/es/zh-CN (the consent library runs outside the React tree, so Docusaurus's `<Translate>` isn't available — locale read from `<html lang>`).
- **Accept/reject flips Consent Mode.** `gtag('consent', 'update', {analytics_storage: 'granted' | 'denied'})` on every change.
- **Footer "Legal" column** with `Privacy` → `/privacy` and `Cookie preferences` → `/privacy?cookies=open`. The query-string sentinel is intercepted by the client module to open the panel inline; with JS off, the user lands on `/privacy` which already explains how to opt out.
- **`/privacy` page** (~300 words) in en/es/zh-CN: what GA collects, why, retention (14 months), opt-out path, GDPR Art. 6(1)(a) basis. Lives in `src/pages/privacy.mdx` and the i18n mirrors.

### Design notes

- **Query string instead of `#anchor`**: MDX 2+ parses `{#id}` as JSX expression, and JSX `<h2 id>` anchors aren't picked up by Docusaurus's broken-anchor checker. The `?cookies=open` approach avoids 200+ false-positive warnings on every page rendering the footer.
- **Detection on direct deep-link**: if a user shares `/privacy?cookies=open`, the client module reads the query on mount and opens the panel, then cleans the URL via `history.replaceState`.
- **Cookie consent decisions, persisted by the library**, live in `cc_cookie` (one cookie, ~6 months default). No personal data inside.

## Test plan

### Local (production build)
- [x] `npm run build` succeeds for all three locales with **zero** warnings
- [x] `index.html` (all locales) contains `analytics_storage:'denied'` in the head
- [x] `index.html` references `https://www.googletagmanager.com/gtag/js?id=G-M8NW21WY2M`
- [x] `/privacy`, `/es/privacy`, `/zh-CN/privacy` all built
- [x] cookieconsent bundle present in `assets/js/`

### Post-deploy
- [ ] On first visit to https://straymark.dev/ the banner appears bottom-right
- [ ] **Reject** → no `_ga*` cookies set, no requests to `*.google-analytics.com` in DevTools Network
- [ ] **Accept** → `_ga` and `_ga_M8NW21WY2M` cookies appear, GA4 Realtime view receives the hit
- [ ] Footer "Cookie preferences" reopens the panel
- [ ] `/privacy?cookies=open` opens the panel on landing and cleans the URL
- [ ] Banner copy reads naturally in each of en/es/zh-CN (locale switcher should refresh the consent UI on next visit)
- [ ] GA4 DebugView (with Tag Assistant extension) confirms events when consent is granted
- [ ] LinkedIn / Twitter share preview still works (no consent regressions there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)