### PR TITLE
fix(website): Consent Mode v2 must fire before gtag.js writes cookies

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,6 +11,69 @@ const config: Config = {
   favicon: 'favicon.ico',
 
   headTags: [
+    // ── Google Analytics 4 + Consent Mode v2 ─────────────────────────────────
+    // Critical: these five tags must appear in this exact order. They sit at
+    // the top of headTags so they precede everything else Docusaurus injects.
+    //
+    // 1. Bootstrap dataLayer + gtag, push consent defaults to DENY analytics
+    //    storage. gtag.js will read these from dataLayer when it boots and
+    //    refuse to write cookies / fire hits until consent is updated.
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          analytics_storage: 'denied',
+          functionality_storage: 'granted',
+          security_storage: 'granted',
+          wait_for_update: 500
+        });
+      `.trim(),
+    },
+    // 2-3. Preconnect to Google's endpoints to save a round-trip when gtag.js
+    //      loads. Cheap and standard.
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://www.googletagmanager.com',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://www.google-analytics.com',
+      },
+    },
+    // 4. Load gtag.js async. When it executes, it reads the dataLayer queue
+    //    above (consent default first, then config below) and applies
+    //    consent BEFORE attempting to write cookies or fire events.
+    {
+      tagName: 'script',
+      attributes: {
+        async: 'true',
+        src: 'https://www.googletagmanager.com/gtag/js?id=G-M8NW21WY2M',
+      },
+    },
+    // 5. Initialise the GA tracker. anonymize_ip truncates the last octet of
+    //    visitor IPs before transmission. Cookies are still gated by consent
+    //    default above.
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `
+        gtag('js', new Date());
+        gtag('config', 'G-M8NW21WY2M', {anonymize_ip: true});
+      `.trim(),
+    },
+    // ── End GA setup ────────────────────────────────────────────────────────
+
     {
       tagName: 'link',
       attributes: {
@@ -58,28 +121,6 @@ const config: Config = {
         name: 'theme-color',
         content: '#0E0E10',
       },
-    },
-    // Google Consent Mode v2 defaults — MUST run before gtag.js loads so the
-    // first measurement event arrives already gated. Tracking stays denied
-    // until the user accepts in the cookie banner (vanilla-cookieconsent
-    // calls gtag('consent', 'update', ...) on acceptance). See
-    // src/clientModules/cookie-consent.ts for the runtime side.
-    {
-      tagName: 'script',
-      attributes: {},
-      innerHTML: `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('consent', 'default', {
-          ad_storage: 'denied',
-          ad_user_data: 'denied',
-          ad_personalization: 'denied',
-          analytics_storage: 'denied',
-          functionality_storage: 'granted',
-          security_storage: 'granted',
-          wait_for_update: 500
-        });
-      `.trim(),
     },
   ],
 
@@ -153,10 +194,13 @@ const config: Config = {
         theme: {
           customCss: './src/css/custom.css',
         },
-        gtag: {
-          trackingID: 'G-M8NW21WY2M',
-          anonymizeIP: true,
-        },
+        // Note: we do NOT use the preset's `gtag` option. The plugin injects
+        // gtag.js + `gtag('config', ...)` BEFORE user-config headTags render,
+        // which means `gtag('consent', 'default', 'denied')` arrives after
+        // config — too late to gate the initial cookie writes. We replicate
+        // the plugin's behaviour manually in `headTags` (further down) so we
+        // control the order, and re-implement SPA route tracking in the
+        // cookie-consent client module via `onRouteUpdate`.
       } satisfies Preset.Options,
     ],
   ],

--- a/website/src/clientModules/cookie-consent.ts
+++ b/website/src/clientModules/cookie-consent.ts
@@ -114,7 +114,7 @@ function updateGtagConsent(granted: boolean) {
   });
 }
 
-export default (async function cookieConsentClientModule() {
+async function initConsentUI() {
   if (typeof window === 'undefined') return;
 
   // vanilla-cookieconsent injects its own CSS; we import it explicitly so
@@ -216,4 +216,35 @@ export default (async function cookieConsentClientModule() {
       window.location.hash;
     window.history.replaceState({}, '', cleanUrl);
   }
-})();
+}
+
+// Fire-and-forget on module load. Docusaurus imports client modules during
+// hydration and we want the banner mounted as soon as possible.
+initConsentUI();
+
+type RouteUpdateArgs = {
+  location: {pathname: string};
+  previousLocation: {pathname: string} | null;
+};
+
+// Docusaurus calls this on every SPA route change. Replaces the page-view
+// tracking that the @docusaurus/plugin-google-gtag client module would do —
+// we removed the gtag preset option because its scripts injected before our
+// consent default, defeating Consent Mode v2. See docusaurus.config.ts.
+export default {
+  onRouteUpdate({location, previousLocation}: RouteUpdateArgs) {
+    if (typeof window === 'undefined') return;
+    if (!previousLocation || location.pathname === previousLocation.pathname) return;
+    if (typeof window.gtag !== 'function') return;
+    // gtag respects the current consent state — if analytics_storage is still
+    // 'denied', this becomes a no-op (or a cookieless ping under Consent Mode
+    // v2). When the user has accepted, a normal page_view event fires.
+    setTimeout(() => {
+      window.gtag!('event', 'page_view', {
+        page_title: document.title,
+        page_location: window.location.href,
+        page_path: location.pathname,
+      });
+    }, 50);
+  },
+};


### PR DESCRIPTION
## Summary

Hotfix for #190. The Consent Mode v2 default-deny gate was set up in `headTags`, but **the @docusaurus/plugin-google-gtag from the preset injects its scripts BEFORE user-config `headTags`** — so the rendered `<head>` order was:

```
<script async src=gtag.js>                                    ← plugin
<script>gtag("config","G-M8NW21WY2M",{anonymize_ip:true})</script>  ← plugin
<script>gtag("consent","default",{analytics_storage:"denied"})</script>  ← mine, too late
```

When `gtag.js` finished loading and processed `dataLayer`, it saw `config` **before** the consent default → initialised the tracker → wrote `_ga` and `_ga_M8NW21WY2M` cookies with 2-year expiry **before any banner interaction**.

The user reported this by opening an incognito tab → DevTools → Application → Cookies and finding both already set:

![incognito-cookies-pre-consent](will-fill-from-context)

## Fix

Stopped using the preset's `gtag` shortcut. Replicated the plugin's behaviour by hand in `headTags`, in the correct order:

```
1. <script>gtag("consent","default","denied")</script>  ← now first
2. <link rel=preconnect googletagmanager>
3. <link rel=preconnect google-analytics>
4. <script async src=gtag.js>
5. <script>gtag("js",…); gtag("config",…,anonymize_ip:true)</script>
```

`dataLayer` is now seeded with the denied consent default before any `config` call. When `gtag.js` boots, the gate is already applied — no cookies, no hits, until the user clicks **Accept**.

### SPA pageview tracking

The preset's plugin-google-gtag also handled SPA route changes via `onRouteUpdate` (firing `gtag('event','page_view',...)` on navigation). Ported that into the existing cookie-consent client module so route changes still report — gated by the current consent state, of course.

## Test plan

Local build was verified by extracting the rendered `<head>` and confirming the new order. After deploy, in a fresh incognito tab:

- [ ] Open https://straymark.dev/, DevTools → Application → Cookies → **`_ga*` cookies should NOT exist**.
- [ ] DevTools → Network filter `collect` → no requests to `*.google-analytics.com/g/collect`.
- [ ] Click **Accept** in the banner → `_ga` and `_ga_M8NW21WY2M` cookies appear, `collect` requests start, GA4 Realtime shows the visit.
- [ ] Click **Reject** in a new incognito → cookies stay absent, `collect` requests never fire.
- [ ] Navigate between pages after Accept → DevTools shows new `collect` requests with `page_path` matching each route (SPA pageview tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)