### PR TITLE
fix(website): wait for Docusaurus hydration before mounting consent UI

### DIFF
--- a/website/src/clientModules/cookie-consent.ts
+++ b/website/src/clientModules/cookie-consent.ts
@@ -114,8 +114,48 @@ function updateGtagConsent(granted: boolean) {
   });
 }
 
+/**
+ * Wait for Docusaurus's React hydration to finish before mounting the consent
+ * UI. vanilla-cookieconsent v3 adds visibility classes (e.g. `show--consent`)
+ * directly to <html> to show the banner, but Docusaurus uses React Helmet to
+ * reconcile <html>'s className during hydration — which wipes anything an
+ * external library added before hydration completes. The visible symptom is
+ * the banner flashing for a frame and then vanishing.
+ *
+ * Docusaurus flips data-has-hydrated="true" on <html> after hydration. We
+ * watch for that attribute and resolve once it lands. If it's already true
+ * (e.g. on slow client-side navigation that re-evaluates the module), we
+ * resolve immediately.
+ */
+function whenHydrated(): Promise<void> {
+  return new Promise((resolve) => {
+    const html = document.documentElement;
+    if (html.getAttribute('data-has-hydrated') === 'true') {
+      resolve();
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      if (html.getAttribute('data-has-hydrated') === 'true') {
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe(html, {
+      attributes: true,
+      attributeFilter: ['data-has-hydrated'],
+    });
+    // Safety net: resolve after 3s no matter what, so a regression in
+    // Docusaurus's hydration signal doesn't permanently hide the banner.
+    setTimeout(() => {
+      observer.disconnect();
+      resolve();
+    }, 3000);
+  });
+}
+
 async function initConsentUI() {
   if (typeof window === 'undefined') return;
+  await whenHydrated();
 
   // vanilla-cookieconsent injects its own CSS; we import it explicitly so
   // webpack bundles it. The CSS file path is stable since v3.


### PR DESCRIPTION
## Summary

Recovers a commit that was lost during the merge of #191. Originally pushed there as a second commit, but a race between my push and the user's merge meant only the first commit (`aec6104`) ended up in the squash on main. Subsequent branch deletion garbage-collected the orphaned commit on the remote. I recovered it from the local reflog.

## What this fixes

After #191 shipped, the consent banner **flashed for a frame and then vanished** on first visit. No banner = no Accept button = no way for the user to grant consent. With Consent Mode v2 default-deny in place, this meant GA was permanently silent.

### Root cause

`vanilla-cookieconsent` v3 toggles modal visibility by adding classes (`show--consent`, `show--preferences`) directly to `<html>` — see the library source:

```
t.ye = p.documentElement;  // hardcoded to <html>
...
j(t.ye, 'show--consent');  // adds the class
```

Docusaurus uses React Helmet to reconcile `<html>`'s `className` during hydration. The library's class was added before hydration completed, and Helmet wiped it on its next reconciliation pass — banner gone.

### Fix

A `whenHydrated()` helper that waits for Docusaurus's `data-has-hydrated="true"` attribute on `<html>` via `MutationObserver` before calling `CookieConsent.run()`. Resolves immediately if hydration already finished (e.g. SPA navigation re-evaluates the module). 3-second safety timeout so a hypothetical regression in Docusaurus's hydration signal can't permanently hide the banner.

## Test plan

After deploy, in a fresh incognito tab:

- [ ] Banner appears bottom-right and **stays visible** (does not flash/disappear)
- [ ] DevTools → Application → Cookies: no `_ga*` cookies before clicking Accept
- [ ] Click **Accept** → `_ga` and `_ga_M8NW21WY2M` cookies appear, `collect` requests start, GA4 Realtime shows the visit
- [ ] Click **Reject** in a different incognito → cookies stay absent permanently
- [ ] Footer "Cookie preferences" reopens the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)