### PR TITLE
feat(website): SEO-optimal landing title + description for share previews

### DIFF
--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -51,6 +51,14 @@
     "message": "Código abierto · licencia MIT · código en {github}",
     "description": "OSS/MIT mention under the bottom CTA, with {github} interpolating to a link to the repo"
   },
+  "meta.landing.title": {
+    "message": "Disciplina cognitiva para ingeniería asistida por IA",
+    "description": "OG/Twitter title and browser tab for the landing page (the \" | StrayMark\" suffix is appended by Docusaurus automatically)"
+  },
+  "meta.landing.description": {
+    "message": "Framework open source + CLI en Rust para externalizar alcance, decisiones y riesgos, manteniendo a los agentes de IA coherentes entre turnos. Mapea a ISO 42001, EU AI Act, NIST AI RMF.",
+    "description": "OG/Twitter description and meta description for the landing page"
+  },
   "asciinema.title": {
     "message": "De una terminal vacía a tu primer Charter",
     "description": "Asciinema section title"

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -131,6 +131,14 @@
     "message": "开源 · MIT 许可 · 源代码在 {github}",
     "description": "OSS/MIT mention under the bottom CTA, with {github} interpolating to a link to the repo"
   },
+  "meta.landing.title": {
+    "message": "面向 AI 辅助工程的认知纪律",
+    "description": "OG/Twitter title and browser tab for the landing page (the \" | StrayMark\" suffix is appended by Docusaurus automatically)"
+  },
+  "meta.landing.description": {
+    "message": "开源框架 + Rust CLI，将范围、决策与风险外部化，让 AI Agent 在多轮对话中保持连贯。原生映射 ISO 42001、EU AI Act、NIST AI RMF。",
+    "description": "OG/Twitter description and meta description for the landing page"
+  },
   "asciinema.title": {
     "message": "从空白终端到你的第一个 Charter",
     "description": "Asciinema section title"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -9,13 +9,27 @@ import FeatureGrid from '@site/src/components/FeatureGrid';
 import GettingStarted from '@site/src/components/GettingStarted';
 
 export default function Home(): ReactNode {
-  const description = translate({
-    id: 'hero.tagline',
+  // SEO/Open-Graph title and description for the landing page. Kept separate
+  // from the H1/hero copy (which stays short and punchy) because share
+  // previews and search engines reward longer, keyword-rich strings — the
+  // ~50-60 char title and ~110-160 char description ranges are the
+  // generally-accepted sweet spot.
+  // Docusaurus auto-appends ` | ${siteTitle}` to any Layout title, so we
+  // only provide the tagline portion — final rendered title becomes
+  // "Cognitive discipline for AI-assisted engineering | StrayMark".
+  const metaTitle = translate({
+    id: 'meta.landing.title',
     message: 'Cognitive discipline for AI-assisted engineering',
-    description: 'Hero tagline (H1 on the landing)',
+    description: 'OG/Twitter title and browser tab for the landing page (the " | StrayMark" suffix is appended by Docusaurus automatically)',
+  });
+  const metaDescription = translate({
+    id: 'meta.landing.description',
+    message:
+      'Open-source framework + Rust CLI to externalize scope, decisions, and risks so AI agents stay coherent across turns. Maps to ISO 42001, EU AI Act, NIST AI RMF.',
+    description: 'OG/Twitter description and meta description for the landing page',
   });
   return (
-    <Layout description={description}>
+    <Layout title={metaTitle} description={metaDescription}>
       <Hero />
       <WorkflowDiagram />
       <AsciinemaDemo />


### PR DESCRIPTION
## Summary

Follow-up to #193 (branded OG card). [opengraph.xyz](https://www.opengraph.xyz/) flagged two warnings on the landing page after that PR shipped:

- **Title is short (9 chars).** Optimal: 50-60. Was just `StrayMark` because the page fell back to the site title.
- **Description is short (48 chars).** Optimal: 110-160. Was the hero tagline doing double duty.

This PR fixes both by passing explicit `title` and `description` props on the landing page's `<Layout>`, with separate translate keys so the H1 and hero copy stay short and punchy. Docusaurus auto-appends ` | StrayMark` to the Layout title, so the message strings are the tagline portion only.

## Rendered titles after this change

| Locale | Title | Length |
|---|---|---|
| EN | `Cognitive discipline for AI-assisted engineering \| StrayMark` | 60 ✅ |
| ES | `Disciplina cognitiva para ingeniería asistida por IA \| StrayMark` | 65 ✅ |
| zh-CN | `面向 AI 辅助工程的认知纪律 \| StrayMark` | 49 ✅ |

Descriptions land at ~157 / ~187 / ~71 chars respectively — comfortably inside the 110-160 SEO sweet spot for EN, slightly above for ES (acceptable for the longer phrasing), zh-CN dense by nature.

## What's intentionally NOT addressed

opengraph.xyz also warned "Missing call-to-action in your image." Skipped on purpose:

- The card's design is restrained to match the brand voice.
- The `straymark.dev` URL on the card already serves as a soft CTA.
- Top brands with similar positioning (Stripe, Linear, Vercel) all omit imperative CTAs from their OG cards.

## Test plan

After deploy:

- [ ] [opengraph.xyz](https://www.opengraph.xyz/url/https%3A%2F%2Fstraymark.dev/) — title shows 60 chars, description ~160 chars, **no** "short" warnings (CTA warning is expected and ignored)
- [ ] Browser tab on landing shows the longer descriptive title
- [ ] Internal pages (`/quickstart`, `/features/cli`, …) still get their own page titles unchanged
- [ ] Locale switcher: `/es/` and `/zh-CN/` show the localised meta strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)