### PR TITLE
fix(website): Lighthouse accessibility + CLS fixes

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -232,6 +232,10 @@ const config: Config = {
         alt: 'StrayMark',
         src: 'img/logo.svg',
         srcDark: 'img/logo-dark.svg',
+        // Explicit dimensions prevent a navbar reflow before the SVG loads
+        // (Lighthouse `unsized-images`).
+        width: 32,
+        height: 32,
       },
       items: [
         {

--- a/website/src/components/GettingStarted/styles.module.css
+++ b/website/src/components/GettingStarted/styles.module.css
@@ -32,7 +32,9 @@
 .meta {
   margin: 1.5rem 0 0;
   font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-600);
+  /* emphasis-600 (#8d949e on white) is 3.06:1 — below WCAG AA. emphasis-700
+     (~#606770) clears 4.5:1 for normal text. */
+  color: var(--ifm-color-emphasis-700);
 }
 
 .meta a {

--- a/website/src/components/Hero/index.tsx
+++ b/website/src/components/Hero/index.tsx
@@ -14,6 +14,8 @@ export default function Hero(): ReactNode {
         <ThemedImage
           className={styles.banner}
           alt="StrayMark — by Strange Days Tech"
+          width={600}
+          height={140}
           sources={{
             light: '/img/straymark-banner-light.svg',
             dark: '/img/straymark-banner-dark.svg',

--- a/website/src/components/WorkflowDiagram/styles.module.css
+++ b/website/src/components/WorkflowDiagram/styles.module.css
@@ -227,6 +227,10 @@
   display: block;
   width: 100%;
   height: auto;
+  /* viewBox is 900×380 — reserve the layout space up-front so the section
+     doesn't grow as the SVG renders (Lighthouse `cumulative-layout-shift`
+     was 0.087, almost entirely from this section). */
+  aspect-ratio: 900 / 380;
 }
 
 .node {
@@ -331,20 +335,39 @@
 
 .dots {
   display: inline-flex;
-  gap: 0.4rem;
+  gap: 0.2rem;
 }
 
+/* WCAG 2.2 minimum touch target is 24×24px. We keep the visible dot at 8px
+   for design density but expand the clickable hit area to 24×24 via padding
+   and box-sizing tricks: the button itself is 24×24, its content (the dot)
+   is rendered via box-shadow so visual size stays compact. */
 .dot {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+}
+
+.dot::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
   width: 8px;
   height: 8px;
   border-radius: 50%;
   border: 1px solid var(--ifm-color-emphasis-400);
   background: transparent;
-  padding: 0;
-  cursor: pointer;
+  transform: translate(-50%, -50%);
+  transition: background 0.12s ease, border-color 0.12s ease;
 }
 
-.dot[aria-selected='true'] {
+.dot[aria-selected='true']::before {
   background: var(--bp-accent);
   border-color: var(--bp-accent);
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -30,12 +30,18 @@ export default function Home(): ReactNode {
   });
   return (
     <Layout title={metaTitle} description={metaDescription}>
-      <Hero />
-      <WorkflowDiagram />
-      <AsciinemaDemo />
-      <WhyExists />
-      <FeatureGrid />
-      <GettingStarted />
+      {/* Lighthouse flagged the homepage as missing a <main> landmark — the
+          Docusaurus Layout wraps children in a generic <div>. Wrap our
+          sections in <main> so screen readers and search engines can locate
+          primary content. */}
+      <main>
+        <Hero />
+        <WorkflowDiagram />
+        <AsciinemaDemo />
+        <WhyExists />
+        <FeatureGrid />
+        <GettingStarted />
+      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary

Targets the actionable findings from the Lighthouse audit on `https://straymark.dev/` (Performance 98 / **A11y 89** / Best Practices 100 / SEO 100). After deploy, expected: **A11y → ~96-98**, **CLS 0.088 → ~0**.

## Fixes

| # | Issue | Where | Fix |
|---|---|---|---|
| 1 | `landmark-one-main` (score 0) | Homepage `<Layout>` wraps content in a plain `<div>` | `src/pages/index.tsx` — wrap sections in `<main>` |
| 2 | `color-contrast` 3.06:1 on "Open source · MIT-licensed · source on GitHub →" | `GettingStarted/styles.module.css` `.meta` | `--ifm-color-emphasis-600` (#8d949e) → `-700` (~#606770, ≥4.5:1) |
| 3 | `target-size` — 8×8px touch targets (WCAG 2.2 needs 24×24) | Workflow carousel dots in `WorkflowDiagram/styles.module.css` | Button hit-area expanded to 24×24, visible dot kept at 8px via `::before` |
| 4 | `unsized-images` — 3 images | Hero banner + navbar logo (×2 themed variants) | Explicit `width`/`height` from SVG viewBox (banner 600×140, logo 32×32) |
| 5 | **CLS 0.088** — almost entirely from "Five workflows, one repo" section | Workflow diagram SVG had `height:auto` so no space reserved before paint | `aspect-ratio: 900 / 380` on `.svg` (matches viewBox) |

## Intentionally NOT fixed (documented trade-offs)

| Finding | Why deferred |
|---|---|
| `color-contrast` on Prism syntax highlighting (`curl`, `-fsSL`, `sh` tokens) | Theme-wide change affecting every code block on the site |
| `aria-input-field-name` on `.ap-timer` | Coming from `asciinema-player` upstream — needs PR or aggressive swizzle |
| `cache-insight` (251 KiB est savings on repeat) | GitHub Pages caps TTL at 10 min, non-configurable. Would need migration to Cloudflare/Netlify |
| `unused-javascript` (122 KiB) | 63KB Google Tag Manager (third-party), 33KB Docusaurus core, 28KB Chrome extension (false signal) |
| `render-blocking-insight` (80 ms FCP savings) | Docusaurus-generated CSS, would require build pipeline customization |

## Test plan

After deploy, re-run Lighthouse on `https://straymark.dev/` and check:

- [ ] **Accessibility score** climbs from 89 to ≥96
- [ ] `landmark-one-main`, `target-size`, color-contrast on the OSS line, and unsized-images are all green
- [ ] **CLS** drops from 0.088 to <0.01
- [ ] Performance still ≥97 (no regressions from the changes)
- [ ] Visual smoke test: workflow carousel dots are still small visually but easier to click; nothing else looks different

🤖 Generated with [Claude Code](https://claude.com/claude-code)