### PR TITLE
fix(website): workflow carousel dots — visible on mobile, hidden on desktop

### DIFF
--- a/website/src/components/WorkflowDiagram/styles.module.css
+++ b/website/src/components/WorkflowDiagram/styles.module.css
@@ -333,16 +333,29 @@
   cursor: not-allowed;
 }
 
+/* Dots are only navigation on mobile; on desktop the named tablist
+   (Charter / AILOG / TDE / …) handles selection, so the dots are redundant
+   and hidden. Avoids visual noise + duplicate `role="tablist"` controls. */
 .dots {
-  display: inline-flex;
+  display: none;
   gap: 0.2rem;
 }
 
-/* WCAG 2.2 minimum touch target is 24×24px. We keep the visible dot at 8px
-   for design density but expand the clickable hit area to 24×24 via padding
-   and box-sizing tricks: the button itself is 24×24, its content (the dot)
-   is rendered via box-shadow so visual size stays compact. */
+@media (max-width: 767px) {
+  .dots {
+    display: inline-flex;
+  }
+}
+
+/* WCAG 2.2 minimum touch target is 24×24px. The button itself is 24×24
+   (the full hit area) and the visible 8px circle is drawn as a centered
+   pseudo-element. `display: inline-flex` + `appearance: none` are
+   essential — Chromium needs both for `::before` to render reliably on
+   `<button>`. */
 .dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 24px;
   height: 24px;
   border: none;
@@ -350,20 +363,19 @@
   background: transparent;
   padding: 0;
   cursor: pointer;
-  position: relative;
+  appearance: none;
+  -webkit-appearance: none;
 }
 
 .dot::before {
   content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
+  display: block;
   width: 8px;
   height: 8px;
   border-radius: 50%;
   border: 1px solid var(--ifm-color-emphasis-400);
   background: transparent;
-  transform: translate(-50%, -50%);
+  box-sizing: border-box;
   transition: background 0.12s ease, border-color 0.12s ease;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #197. Two corrections:

1. **The dots disappeared visually after #197.** Root cause: my previous fix used a `::before` pseudo-element on `<button>` with `position: absolute` to draw the 8px visible circle inside a 24×24 hit area, but Chromium does not reliably render pseudo-elements on `<button>` without `display: inline-flex` + `appearance: none`. Fixed by switching to flex centering and adding `appearance: none`.

2. **The dots were redundant on desktop.** The named tablist (Charter / AILOG / TDE / Compliance / Audit) already provides navigation with `role=\"tablist\"`. The dots had the same role and controlled the same carousel — duplicate UI. On mobile (<768px) the named tablist is hidden by an existing media query, so the dots remain there as the only navigation.

Net: cleaner desktop (no redundant indicator strip below the named tabs), correct mobile (visible 8px dot with WCAG 2.2-compliant 24×24 touch target).

## Test plan

- [ ] **Desktop** (≥768px): named tablist visible above carousel, no dots strip below. Click each tab title → carousel advances.
- [ ] **Mobile** (<768px, via DevTools device toolbar): named tablist hidden, dots strip visible below the carousel. Each dot is 24×24 to the touch but visually shows an 8×8 circle. Selected dot is filled with the accent color.
- [ ] Lighthouse mobile run on `/`: `target-size` audit still passes (24×24 hit area is preserved on mobile where dots render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)