### PR TITLE
docs(website): blog post for fw-4.18.0 — "What the binary couldn't hide"

### DIFF
--- a/website/blog/2026-05-23-what-the-binary-couldnt-hide.md
+++ b/website/blog/2026-05-23-what-the-binary-couldnt-hide.md
@@ -1,0 +1,101 @@
+---
+slug: what-the-binary-couldnt-hide
+title: What the binary couldn't hide
+authors:
+  - jose
+tags:
+  - straymark
+  - charters
+  - governance
+  - polish-charter
+  - sentinel
+  - anti-pattern
+date: 2026-05-23T00:00:00.000Z
+description: Ten latent gaps surfaced in a single polish Charter, and the anti-pattern that earned a name
+---
+*A polish Charter that was supposed to be cosmetic cleanup surfaced ten production gaps in six hours — including two features that had shipped to `main` and never functionally worked for ten days. The anti-pattern got named, the pattern got documented as `fw-4.18.0`, and the CLI helper got deferred on purpose.*
+
+<!-- truncate -->
+
+> *"The first thing the polish Charter tried — booting `./sentinel` from `main` to run the §5 smoke — failed with two distinct panics."*
+
+That sentence opened Issue [#199](https://github.com/StrangeDaysTech/straymark/issues/199) on May 22, filed by the Sentinel adopter as an RFC. By the time the thread closed five comment-updates later, the count had grown from two to ten. The polish Charter — the closing Charter of Etapa 2, planned as a docket of WCAG audits and quickstart verification — had spent six hours doing something else: catching a class of latent regression that none of the per-Charter test suites of the eight previous Charters had caught, and that none of them *could* have caught given how they were written.
+
+This post is the reconstruction of why that happened, what the recurring shape underneath it turned out to be, and the deliberate decision in PR [#200](https://github.com/StrangeDaysTech/straymark/pull/200) to **name the anti-pattern but not yet tool for it**. The cycle is familiar to readers who followed the previous posts on [emergent observation](emergent-observation-design) and [chain evolution](pattern-1-and-pattern-2-chain-evolution) — this is the third pattern in two weeks to crystallize via the same arc: surface in N=1, name the meta, defer the cross-project tooling until N=2 validates.
+
+## The two cases that mattered
+
+Of the ten gaps the polish session surfaced, eight were either dependency rot (a `huma` upgrade introduced a panic on `*string` parameters; Go 1.22 tightened `http.ServeMux` wildcard semantics) or runbook drift (env vars missing from §boot, smoke recipes that mixed mutually-exclusive modes, claims about a fake provider's stdout that the fake never wrote to). Each one merits a fix. None of them rewrites the playbook.
+
+The two that did rewrite the playbook are different. They share a shape.
+
+**US3 Preference Center, shipped May 12.** When recipients of a Sentinel-sent email click the unsubscribe-style footer link, they land on a JWT-in-path URL like `/preferences/<token>`. The handler is intentionally public-by-contract: the JWT *is* the auth; no `Authorization` header is expected. The handler's doc-comment said so. The integration test, written in `humatest`, mounted the handler directly through the testing adapter and confirmed: given a valid JWT in the path, the handler returns the right HTML. CI passed. The feature shipped to `main`.
+
+What never happened: anything that exercised the production middleware chain in front of that handler. `internal/core/middleware/auth.go` has a `publicPrefixes` list of route prefixes that bypass the `Authorization` check. `/preferences/` was not in it. For ten days, every recipient who clicked an unsubscribe link got a `401 missing authorization header` from the middleware before the request ever reached the handler that knew not to expect one. The Preference Center was reachable in tests, unreachable in production.
+
+**OTel observability instruments for the send pipeline, shipped the same week.** Eight metric instruments — counters, histograms, gauges — declared in `internal/core/metrics/commshub.go`, registered with the OpenTelemetry meter at boot. The Charter's `Constitution Check §IV` formally declared the FR-039..042 observability gate satisfied: the API layer was correct, the registrations went through, dashboards were planned. Seven of those eight instruments had **zero `.Add()` / `.Record()` call sites in the entire commshub module**. Declared, registered, never invoked. The dashboards that ops built on top of those series had been receiving zero data for ten days. The polish Charter's manual smoke — boot an OTel Collector, generate a few sends, grep collector output for the FR-039..042 names — surfaced this instantly.
+
+Neither case is exotic. Neither case is a hard bug. They are both instances of the same mechanical mistake: an artifact got declared in one place, and the implementation that was supposed to wire it lived in another place, and nothing in the codebase or in CI correlated the two.
+
+## The name the anti-pattern wanted
+
+A name matters when the same shape shows up enough times to deserve one. By the third comment update on #199, the Sentinel author had counted four sub-classes of the same underlying mistake:
+
+| Declaration site | Wiring site | Mechanical check |
+|---|---|---|
+| env var documented in the operator runbook | `os.Getenv(...)` (or stack equivalent) in code | each documented env var has at least one consumer |
+| metric instrument declared in a metrics package | `.Record()` / `.Add()` call site in handler or worker code | each declared instrument is recorded at least once |
+| URL referenced from rendered/embedded HTML (`<script src=...>`, `<link href=...>`) | route registered on the same API surface | each `src=`/`href=` in served HTML resolves to a registered route |
+| route marked public-by-contract (doc-comment, dedicated marker) | entry in the auth middleware's public-prefix list | each public-by-contract handler has a matching prefix entry |
+
+The unifier — the one-liner that the new governance doc opens with — is:
+
+> *Every declared surface artifact has at least one wiring site reachable from a real request.*
+
+The anti-pattern's name, which lands canonically in `dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md`, is **Surface declaration without wiring.** That is the deliverable. The polish Charter is the discovery vehicle, not the thesis.
+
+## Why integration tests systematically miss this
+
+This part is worth dwelling on because it shapes the rest of the post. The common failure mode across all four sub-classes is that the standard integration-test harness — `humatest.NewTestAdapter` in Go, the equivalent in TypeScript, Python, Rust — mounts handlers *directly* via the testing API. The handler under test is wired correctly by the fixture. The production composition step — where the route registration meets the middleware chain meets the env-var inventory meets the embedded asset table — is what's broken. CI's green light is genuine for what it claims: the handler returns the right response given the right request. It says nothing about whether the request can reach the handler in production, or whether the artifact the handler depends on was ever wired to the runtime.
+
+There's a temptation to read this as a critique of `humatest`. It isn't. `humatest` (and its equivalents) is doing exactly what it was designed to do: let you test handler logic in isolation, fast, without standing up the whole composition tree. That isolation is a feature. The cost of the isolation is what we just named — and the cost only becomes visible when something outside the isolation surfaces a divergence. The polish Charter is the cheapest method to surface that divergence, because it does what no test fixture does: it boots the actual binary and runs the actual documented operator recipe against it.
+
+This is the load-bearing claim of the new pattern doc. Not that polish Charters are valuable for cosmetic reasons. That they are **the only place** where the production composition gets exercised end-to-end against an externally-readable specification (the operator runbook). If you treat the polish Charter as cosmetic cleanup, you also treat that surfacing capacity as cosmetic. Sentinel's data argues the opposite.
+
+## The decision: B′, not B
+
+The RFC proposed three options. The decision in PR #200 was none of them as stated — call it B′. Worth saying why, because the structural choice matters more than it looks.
+
+**The RFC's Option B** asked for a pattern doc under `docs/patterns/`. That directory does not exist in StrayMark today, and creating it would have split the project's documentation convention. The empirical patterns that already live in the canon — `FOLLOW-UPS-BACKLOG-PATTERN.md`, `CHARTER-CHAIN-EVOLUTION.md`, `EMERGENT-OBSERVATION-DESIGN.md`, `SPECKIT-CHARTER-BRIDGE.md` — all live in `dist/.straymark/00-governance/`. They share an i18n mirror infrastructure (every governance doc has English, Spanish, and Simplified Chinese siblings). Adding a third documentation surface would have multiplied the i18n overhead and pulled the project's patterns across two homes. Keeping the new doc inside `00-governance/` reused the existing infrastructure with zero marginal cost.
+
+**The RFC's Option C** asked for a `straymark charter polish-checklist` or `straymark analyze declared-vs-wired` CLI helper. The Sentinel author had already prototyped one (CHARTERs 25/26/27, the three preparatory CI guards) and offered to seed it upstream. The decision here was conservative: defer. Not because the prototype isn't valuable — it is — but because Sentinel is N=1. The four sub-classes were the ones *one adopter, one stack* surfaced. The fifth, sixth, and seventh sub-classes that the framework would have to anticipate to ship a useful cross-project CLI don't exist yet, because no second adopter has pushed them. We've been down this road before. [`FOLLOW-UPS-BACKLOG-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md) shipped as v0 in `fw-4.10.0` and has lived there for a month and a half, waiting for a second adopter to validate before graduating to a `straymark followups` subcommand. The same gate applies here. The new doc's `## Open questions` says so explicitly: "Crystallization as `straymark analyze declared-vs-wired` CLI subcommand … Gate: N=2 adopters."
+
+**B′ is what landed.** A new governance pattern doc in the canonical location, in three languages. A seventh `Format conventions` bullet in the Charter template pointing authors at it when closing an Etapa or SpecKit `Polish` Phase. A row in the QUICK-REFERENCE `## Patterns` table. A `fw-4.18.0` bump with the footer cascade across thirty-some docs. No CLI subcommand. No new frontmatter field. No schema change. The anti-pattern has a name; the discovery ritual has a doc; the tooling waits.
+
+## The arc that keeps repeating
+
+Three weeks ago, the follow-ups backlog pattern crystallized via the same arc: an adopter surfaced a need, the pattern got named at v0, the CLI helper was deferred. Two weeks ago, the chain-evolution patterns crystallized: Pattern 1 (pre-declare SpecKit refresh) and Pattern 2 (post-close audit-driven Batch N.4), surfaced from the same Sentinel adopter, named in `fw-4.16.0`, with `straymark charter refresh-suggest` as a soft helper rather than a hard gate. One week ago, the meta — `EMERGENT-OBSERVATION-DESIGN.md` — codified what made any of those observations possible in the first place: formal cross-referencing plus cultural permission. This week, this pattern.
+
+That's four crystallizations in a month, all from the same adopter, all following the same shape: **surface in N=1 → name the meta → tool only after N=2**. The temptation when a pattern surfaces vividly — and ten production gaps in six hours is vivid — is to skip the name and go straight to the tool. The discipline is the opposite. The name does most of the work. The tool, when it comes, is parameterized by what at least two adopters have surfaced; built on N=1, it's an extrapolation from one stack and one team's failure modes, and it tends to ossify those choices into framework defaults that don't generalize.
+
+There is one piece of this iteration that is genuinely new and worth flagging. The new pattern doc names a falsifiable prediction the Sentinel author already committed to publishing: the next Etapa's polish Charter, executed against the three preparatory CI guards that just landed in Sentinel CHARTERs 25/26/27, should surface roughly 80% fewer gaps. If that prediction holds, the case for graduating Option C from "open question" to "CLI subcommand" gets quantitative backing. If it fails — if the next polish Charter still surfaces ten gaps but in a fifth, unanticipated sub-class — the failure itself is the next data point, and reshapes the spec before tooling is built. Either result is useful. Neither result has been observed yet. We wait.
+
+## A note on what was deliberately not done
+
+There is no `phase: polish` field in the Charter frontmatter. There is no `straymark charter polish-checklist <ID>`. There is no automated analyzer scanning Go (or any other language) code for declared-but-unwired symbols. The pattern doc lists each of those as a candidate evolution, gated explicitly on N=2 or on the post-Etapa-3 retrospective. None of them are present in `fw-4.18.0`.
+
+This is intentional and worth saying out loud, because the natural reaction to a vivid finding is to over-build the response. Each one of those deferrals trades short-term thoroughness for long-term portability. A frontmatter field commits the framework to a vocabulary the next adopter may not share. A CLI helper commits the framework to a runtime that mirrors one specific stack's failure modes. An analyzer commits the framework to scanning a language whose conventions may diverge from the next adopter's. None of those commitments should be made on a single domain's signal, however clean the signal is. The pattern doc itself can be revised; a CLI subcommand cannot be unshipped without breaking adopters.
+
+## What I'd suggest you look at, if you've read this far
+
+If you operate a codebase with mock-adapter integration tests — which is most codebases — you can run a useful internal exercise without adopting anything from StrayMark at all. Pick the most recent feature your team shipped that has both (a) a docs-side declaration (env vars, OpenAPI specs, embedded HTML, metric instruments) and (b) a wiring site that lives in a different file. Boot the binary from a clean shell. Run the operator-facing recipe from the runbook end-to-end. If it works on the first try, your codebase doesn't yet have the latent debt this pattern catches — or it does and you got lucky on this one. If it doesn't, count the gaps. The number is the calibration you need for whether the polish-Charter-as-debt-detection ritual would be worth its overhead in your project.
+
+If you've adopted StrayMark and you're closing an Etapa with handlers tested through `humatest`-style adapters, the new pattern doc has the four sub-class checks scoped for you. Budget the polish Charter as L, not XS or S. Expect emergent follow-on Charters, not residual cleanup scope creep. Read [`POLISH-CHARTER-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md) before scoping the work, not after.
+
+And if you're an adopter on a stack other than Go — TypeScript, Python, Rust, Elixir — the four sub-classes are language-agnostic, but the concrete check shape is not. Surfacing a fifth or sixth sub-class in your stack is exactly the second-adopter signal the pattern needs to graduate from v0. The path from "interesting observation in your project" to "named in the StrayMark canon" runs through the same channel #199 went through: open an issue. The cost of opening it is low; the cost of leaving the pattern under-validated is real.
+
+---
+
+*StrayMark `fw-4.18.0` — Issue [#199](https://github.com/StrangeDaysTech/straymark/issues/199) · PR [#200](https://github.com/StrangeDaysTech/straymark/pull/200) · tag [`fw-4.18.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.18.0). Sentinel anchors: [`AIDEC-2026-05-22-001`](https://github.com/StrangeDaysTech/sentinel/pull/93) · [CHARTERs 25/26/27 PR](https://github.com/StrangeDaysTech/sentinel/pull/94).*
+
+*This document was produced with assistance from generative AI tools (Claude 4.7); all responsibility for the content rests with the human author.*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-23-what-the-binary-couldnt-hide.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-23-what-the-binary-couldnt-hide.md
@@ -1,0 +1,101 @@
+---
+slug: what-the-binary-couldnt-hide
+title: Lo que el binario no pudo esconder
+authors:
+  - jose
+tags:
+  - straymark
+  - charters
+  - governance
+  - polish-charter
+  - sentinel
+  - anti-patron
+date: 2026-05-23T00:00:00.000Z
+description: Diez gaps latentes aflorados en un solo polish Charter, y el anti-patrón que se ganó un nombre
+---
+*Un polish Charter que iba a ser limpieza cosmética afloró diez gaps de producción en seis horas — incluyendo dos features que estaban shippeadas a `main` y nunca habían funcionado durante diez días. El anti-patrón obtuvo nombre, el patrón se documentó como `fw-4.18.0`, y el helper de CLI se difirió a propósito.*
+
+<!-- truncate -->
+
+> *"Lo primero que el polish Charter intentó — bootear `./sentinel` desde `main` para correr el smoke de §5 — falló con dos panics distintos."*
+
+Así abrió el Issue [#199](https://github.com/StrangeDaysTech/straymark/issues/199) el 22 de mayo, presentado por el adopter Sentinel como RFC. Para cuando el thread cerró cinco actualizaciones de comentario después, la cuenta había crecido de dos a diez. El polish Charter — el Charter de cierre de Etapa 2, planeado como un docket de auditorías WCAG y verificación del quickstart — había pasado seis horas haciendo otra cosa: cazando una clase de regresión latente que ninguna de las suites de tests per-Charter de los ocho Charters previos había cazado, y que ninguna de ellas *podía* haber cazado dado cómo estaban escritas.
+
+Este post es la reconstrucción de por qué ocurrió, qué forma recurrente terminó habiendo debajo, y la decisión deliberada en el PR [#200](https://github.com/StrangeDaysTech/straymark/pull/200) de **nombrar el anti-patrón pero todavía no fabricar tooling para él**. El ciclo le es familiar a quien siguió los posts previos sobre [observación emergente](emergent-observation-design) y [evolución de cadenas](pattern-1-and-pattern-2-chain-evolution) — este es el tercer patrón en dos semanas que cristaliza vía el mismo arco: aflorar en N=1, nombrar el meta, diferir el tooling cross-proyecto hasta que N=2 lo valide.
+
+## Los dos casos que pesaron
+
+De los diez gaps que la sesión de polish afloró, ocho eran o bien deterioro ambiental de dependencias (un upgrade de `huma` introdujo un panic en parámetros `*string`; Go 1.22 endureció la semántica de wildcards de `http.ServeMux`) o bien drift del runbook (env vars faltantes en §boot, recetas de smoke que mezclaban modos mutuamente excluyentes, afirmaciones sobre el stdout de un fake provider que el fake nunca escribió). Cada uno merece un fix. Ninguno reescribe el manual.
+
+Los dos que sí reescribieron el manual son distintos. Comparten forma.
+
+**US3 Preference Center, shippeado el 12 de mayo.** Cuando los recipients de un correo enviado por Sentinel hacen click en el link tipo unsubscribe del footer, aterrizan en una URL JWT-in-path como `/preferences/<token>`. El handler es público-por-contrato a propósito: el JWT *es* la auth; no se espera un header `Authorization`. El doc-comment del handler lo decía. El test de integración, escrito en `humatest`, montaba el handler directamente a través del adapter de testing y confirmaba: dado un JWT válido en el path, el handler devuelve el HTML correcto. CI pasó. La feature se shipeó a `main`.
+
+Lo que nunca pasó: nada que ejerciera la cadena de middleware de producción enfrente de ese handler. `internal/core/middleware/auth.go` tiene una lista `publicPrefixes` de prefijos de ruta que evaden el check de `Authorization`. `/preferences/` no estaba en ella. Durante diez días, cada recipient que hizo click en un link de unsubscribe recibió un `401 missing authorization header` del middleware antes de que el request alcanzara nunca al handler que sabía que no debía esperarlo. El Preference Center era alcanzable en tests, inalcanzable en producción.
+
+**Instrumentos de observabilidad OTel del pipeline de envío, shippeados la misma semana.** Ocho metric instruments — counters, histograms, gauges — declarados en `internal/core/metrics/commshub.go`, registrados con el meter de OpenTelemetry al boot. El `Constitution Check §IV` del Charter declaró formalmente satisfecha la compuerta de observabilidad FR-039..042: la capa de API era correcta, los registros pasaban, los dashboards estaban planeados. Siete de esos ocho instrumentos tenían **cero call sites de `.Add()` / `.Record()` en todo el módulo commshub**. Declarados, registrados, nunca invocados. Los dashboards que ops construyó encima de esas series llevaban diez días recibiendo cero datos. El smoke manual del polish Charter — bootear un OTel Collector, generar unos cuantos sends, grep del output del collector buscando los nombres FR-039..042 — afloró esto al instante.
+
+Ninguno de los dos casos es exótico. Ninguno es un bug duro. Ambos son instancias del mismo error mecánico: un artefacto se declaró en un lugar, y la implementación que se suponía que lo cableara vivía en otro lugar, y nada en el codebase ni en CI correlacionaba los dos.
+
+## El nombre que el anti-patrón pedía
+
+Un nombre importa cuando la misma forma aparece suficientes veces como para merecer uno. Para la tercera actualización del comentario en #199, el autor de Sentinel había contado cuatro subclases del mismo error subyacente:
+
+| Sitio de declaración | Sitio de cableado | Verificación mecánica |
+|---|---|---|
+| env var documentada en el runbook operativo | `os.Getenv(...)` (o equivalente del stack) en código | cada env var documentada tiene al menos un consumidor |
+| metric instrument declarado en un paquete de métricas | call site `.Record()` / `.Add()` en código de handler o worker | cada instrument declarado se registra al menos una vez |
+| URL referenciada desde HTML renderizado/embebido (`<script src=...>`, `<link href=...>`) | ruta registrada en la misma superficie de API | cada `src=`/`href=` en HTML servido resuelve a una ruta registrada |
+| ruta marcada pública-por-contrato (doc-comment, marker dedicado) | entrada en la lista de prefijos públicos del middleware de auth | cada handler público-por-contrato tiene una entrada de prefijo equivalente |
+
+El unificador — el one-liner con el que abre el nuevo doc de gobernanza — es:
+
+> *Cada artefacto de superficie declarado tiene al menos un sitio de cableado alcanzable desde un request real.*
+
+El nombre del anti-patrón, que aterriza canónicamente en `dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md`, es **Declaración de superficie sin cableado.** Ese es el deliverable. El polish Charter es el vehículo de descubrimiento, no la tesis.
+
+## Por qué los tests de integración omiten esto sistemáticamente
+
+Esta parte vale la pena trabajarla porque le da forma al resto del post. El modo de falla común a las cuatro subclases es que el harness estándar de tests de integración — `humatest.NewTestAdapter` en Go, el equivalente en TypeScript, Python, Rust — monta los handlers *directamente* vía la API de testing. El handler bajo prueba está correctamente cableado por el fixture. El paso de composición de producción — donde el registro de rutas se encuentra con la cadena de middleware se encuentra con el inventario de env vars se encuentra con la tabla de assets embebidos — es lo que está roto. La luz verde de CI es genuina respecto a lo que afirma: el handler devuelve la respuesta correcta dado el request correcto. No dice nada sobre si el request puede alcanzar el handler en producción, o sobre si el artefacto del que el handler depende fue alguna vez cableado al runtime.
+
+Hay una tentación de leer esto como una crítica a `humatest`. No lo es. `humatest` (y sus equivalentes) está haciendo exactamente lo que fue diseñado para hacer: dejar que pruebes la lógica del handler en aislamiento, rápido, sin parar todo el árbol de composición. Ese aislamiento es una feature. El costo del aislamiento es lo que acabamos de nombrar — y el costo solo se vuelve visible cuando algo fuera del aislamiento aflora una divergencia. El polish Charter es el método más barato para aflorar esa divergencia, porque hace lo que ningún fixture de test hace: bootea el binario real y corre la receta operativa documentada real contra él.
+
+Esta es la afirmación load-bearing del nuevo pattern doc. No que los polish Charters sean valiosos por razones cosméticas. Que son **el único lugar** donde la composición de producción se ejerce end-to-end contra una especificación externamente legible (el runbook operativo). Si tratas el polish Charter como limpieza cosmética, también tratas esa capacidad de aflorar como cosmética. Los datos de Sentinel argumentan lo opuesto.
+
+## La decisión: B′, no B
+
+El RFC proponía tres opciones. La decisión en el PR #200 fue ninguna de ellas tal como estaban formuladas — llamémosla B′. Vale la pena decir por qué, porque la decisión estructural pesa más de lo que parece.
+
+**La Option B del RFC** pedía un pattern doc bajo `docs/patterns/`. Ese directorio no existe en StrayMark hoy, y crearlo habría partido la convención de documentación del proyecto. Los patterns empíricos que ya viven en el canon — `FOLLOW-UPS-BACKLOG-PATTERN.md`, `CHARTER-CHAIN-EVOLUTION.md`, `EMERGENT-OBSERVATION-DESIGN.md`, `SPECKIT-CHARTER-BRIDGE.md` — todos viven en `dist/.straymark/00-governance/`. Comparten una infraestructura de mirror i18n (cada doc de gobernanza tiene hermanos en inglés, español y chino simplificado). Agregar una tercera superficie de documentación habría multiplicado el overhead de i18n y desparramado los patterns del proyecto entre dos hogares. Mantener el nuevo doc dentro de `00-governance/` reusaba la infraestructura existente con costo marginal cero.
+
+**La Option C del RFC** pedía un helper CLI `straymark charter polish-checklist` o `straymark analyze declared-vs-wired`. El autor de Sentinel ya había prototipado uno (CHARTERs 25/26/27, los tres guards preparatorios de CI) y ofrecido sembrarlo upstream. La decisión aquí fue conservadora: diferir. No porque el prototipo no sea valioso — lo es — sino porque Sentinel es N=1. Las cuatro subclases fueron las que *un adopter, un stack* afloró. La quinta, sexta y séptima subclase que el framework tendría que anticipar para shippear un CLI cross-proyecto útil aún no existen, porque ningún segundo adopter las ha empujado. Ya hemos recorrido este camino. [`FOLLOW-UPS-BACKLOG-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md) shippeó como v0 en `fw-4.10.0` y vive ahí desde hace mes y medio, esperando que un segundo adopter lo valide antes de graduarse a un subcomando `straymark followups`. La misma compuerta aplica aquí. Las `## Open questions` del nuevo doc lo dicen explícitamente: "Cristalización como subcomando CLI `straymark analyze declared-vs-wired` … Gate: N=2 adopters."
+
+**B′ es lo que aterrizó.** Un nuevo governance pattern doc en la ubicación canónica, en tres idiomas. Un séptimo bullet de `Format conventions` en el template de Charter apuntando a los autores hacia él cuando cierran una Etapa o Fase `Polish` de SpecKit. Una fila en la tabla `## Patterns` del QUICK-REFERENCE. Un bump `fw-4.18.0` con la cascada de footers a través de unos treinta docs. Ningún subcomando CLI. Ningún nuevo campo de frontmatter. Ningún cambio de schema. El anti-patrón tiene un nombre; el ritual de descubrimiento tiene un doc; el tooling espera.
+
+## El arco que se repite
+
+Hace tres semanas, el patrón de backlog de follow-ups cristalizó vía el mismo arco: un adopter afloró una necesidad, el patrón se nombró en v0, el helper CLI se difirió. Hace dos semanas, los patrones de evolución de cadena cristalizaron: Pattern 1 (pre-declare SpecKit refresh) y Pattern 2 (post-close audit-driven Batch N.4), aflorados desde el mismo adopter Sentinel, nombrados en `fw-4.16.0`, con `straymark charter refresh-suggest` como helper blando en vez de gate duro. Hace una semana, el meta — `EMERGENT-OBSERVATION-DESIGN.md` — codificó qué hacía posibles esas observaciones de entrada: cross-referencing formal más permiso cultural. Esta semana, este patrón.
+
+Son cuatro cristalizaciones en un mes, todas desde el mismo adopter, todas siguiendo la misma forma: **aflorar en N=1 → nombrar el meta → fabricar tooling solo después de N=2**. La tentación cuando un patrón aflora vívidamente — y diez gaps de producción en seis horas es vívido — es saltearse el nombre e ir directo al tooling. La disciplina es lo opuesto. El nombre hace la mayor parte del trabajo. El tooling, cuando llega, está parametrizado por lo que al menos dos adopters han aflorado; construido sobre N=1, es una extrapolación de un stack y los modos de falla de un equipo, y tiende a osificar esas elecciones como defaults del framework que no generalizan.
+
+Hay una pieza de esta iteración que sí es genuinamente nueva y vale la pena destacar. El nuevo pattern doc nombra una predicción falsable que el autor de Sentinel ya se comprometió a publicar: el polish Charter de la próxima Etapa, ejecutado contra los tres guards preparatorios de CI que acaban de aterrizar en CHARTERs 25/26/27 de Sentinel, debería aflorar aproximadamente 80% menos gaps. Si esa predicción se sostiene, el caso para graduar la Option C de "open question" a "subcomando CLI" obtiene respaldo cuantitativo. Si falla — si el siguiente polish Charter sigue aflorando diez gaps pero en una quinta subclase no anticipada — la falla en sí misma es el siguiente data point, y reescribe el spec antes de fabricar tooling. Cualquiera de los dos resultados es útil. Ninguno se ha observado aún. Esperamos.
+
+## Una nota sobre lo que deliberadamente no se hizo
+
+No hay campo `phase: polish` en el frontmatter de Charter. No hay `straymark charter polish-checklist <ID>`. No hay analyzer automatizado escaneando código Go (ni de ningún otro lenguaje) por símbolos declarados-pero-no-cableados. El pattern doc lista cada una de esas como candidata de evolución, gated explícitamente en N=2 o en el retrospectivo post-Etapa-3. Ninguna está presente en `fw-4.18.0`.
+
+Esto es intencional y vale la pena decirlo en voz alta, porque la reacción natural ante un hallazgo vívido es sobre-construir la respuesta. Cada una de esas postergaciones intercambia exhaustividad de corto plazo por portabilidad de largo plazo. Un campo de frontmatter compromete al framework con un vocabulario que el próximo adopter puede no compartir. Un helper CLI compromete al framework con un runtime que refleja los modos de falla de un stack específico. Un analyzer compromete al framework con escanear un lenguaje cuyas convenciones pueden divergir de las del próximo adopter. Ninguno de esos compromisos debería hacerse con la señal de un solo dominio, por más limpia que sea la señal. El pattern doc en sí mismo puede revisarse; un subcomando CLI no puede desshipearse sin romper a los adopters.
+
+## Qué te sugeriría mirar, si llegaste hasta acá
+
+Si operás un codebase con tests de integración basados en mock adapter — que es la mayoría de los codebases — podés correr un ejercicio interno útil sin adoptar nada de StrayMark. Elegí la feature más reciente que tu equipo shipeó que tenga tanto (a) una declaración del lado de docs (env vars, specs OpenAPI, HTML embebido, metric instruments) como (b) un sitio de cableado que viva en un archivo distinto. Booteá el binario desde una shell limpia. Corré la receta operativa del runbook end-to-end. Si funciona al primer intento, tu codebase aún no tiene la deuda latente que este patrón caza — o sí la tiene y tuviste suerte en este caso. Si no funciona, contá los gaps. El número es la calibración que necesitás para saber si el ritual de polish-Charter-como-detección-de-deuda valdría su overhead en tu proyecto.
+
+Si adoptaste StrayMark y estás cerrando una Etapa con handlers testeados a través de adapters estilo `humatest`, el nuevo pattern doc tiene las cuatro verificaciones de subclase scoped para vos. Presupuestá el polish Charter como L, no XS o S. Esperá Charters emergentes de follow-on, no scope creep de limpieza residual. Leé [`POLISH-CHARTER-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md) antes de scopear el trabajo, no después.
+
+Y si sos adopter en un stack distinto a Go — TypeScript, Python, Rust, Elixir — las cuatro subclases son agnósticas de lenguaje, pero la forma concreta de verificación no lo es. Aflorar una quinta o sexta subclase en tu stack es exactamente la señal de segundo-adopter que el patrón necesita para graduarse de v0. El camino de "observación interesante en tu proyecto" a "nombrada en el canon de StrayMark" corre por el mismo canal por donde corrió #199: abrir un issue. El costo de abrirlo es bajo; el costo de dejar el patrón subvalidado es real.
+
+---
+
+*StrayMark `fw-4.18.0` — Issue [#199](https://github.com/StrangeDaysTech/straymark/issues/199) · PR [#200](https://github.com/StrangeDaysTech/straymark/pull/200) · tag [`fw-4.18.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.18.0). Anclas de Sentinel: [`AIDEC-2026-05-22-001`](https://github.com/StrangeDaysTech/sentinel/pull/93) · [PR de CHARTERs 25/26/27](https://github.com/StrangeDaysTech/sentinel/pull/94).*
+
+*Este documento fue elaborado con asistencia de herramientas de IA generativa (Claude 4.7); toda la responsabilidad del contenido recae en el autor humano.*

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-05-23-what-the-binary-couldnt-hide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-05-23-what-the-binary-couldnt-hide.md
@@ -1,0 +1,95 @@
+---
+slug: what-the-binary-couldnt-hide
+title: 二进制藏不住的东西
+authors:
+  - jose
+tags: [straymark, charters, governance, polish-charter, sentinel, anti-pattern]
+date: 2026-05-23
+description: 一次 polish Charter 浮现了十个潜伏 gap，以及一个终于得到命名的反模式
+---
+*一次本应是美容清理的 polish Charter，在六个小时内浮现了十个生产 gap —— 其中两个已经交付到 `main` 并且整整十天从未真正工作过。反模式获得了名字，模式作为 `fw-4.18.0` 被写入文档，而 CLI helper 被有意推迟。*
+
+<!-- truncate -->
+
+> *"polish Charter 尝试做的第一件事 —— 从 `main` 启动 `./sentinel` 来执行 §5 的 smoke —— 以两个不同的 panic 失败了。"*
+
+5 月 22 日，Sentinel adopter 以 RFC 形式提交了 Issue [#199](https://github.com/StrangeDaysTech/straymark/issues/199)，正是这样开头。当 thread 在五条评论更新后收尾时，计数已经从两个增长到十个。polish Charter —— Etapa 2 的关闭 Charter，原本被规划为一份 WCAG 审计与 quickstart 验证的清单 —— 用六个小时做了另外一件事：捕获了一类潜伏回归，而之前八个 Charter 的所有 per-Charter 测试套件都没能抓住它，*也*不可能抓住它，因为它们的写法决定了这一点。
+
+这篇文章是对那个早晨为何发生的重建，对底层那个反复出现的形状是什么的追问，以及在 PR [#200](https://github.com/StrangeDaysTech/straymark/pull/200) 中所做的深思熟虑的决定：**为反模式命名，但暂时不为它打造工具**。这个循环对追读过前几篇 —— 关于[涌现观察](emergent-observation-design)与[链条演化](pattern-1-and-pattern-2-chain-evolution) —— 的读者来说很熟悉：这是两周内第三个沿着同一弧线结晶的模式：在 N=1 中浮现 → 为元模式命名 → 在 N=2 验证之前，推迟跨项目工具化。
+
+## 真正分量重的两个案例
+
+在 polish 会话浮现的十个 gap 中，八个或者是环境依赖腐烂（`huma` 升级在 `*string` 参数上引入了 panic；Go 1.22 收紧了 `http.ServeMux` 的 wildcard 语义），或者是 runbook 漂移（§boot 中缺失的 env vars、混淆了互斥模式的 smoke 配方、关于 fake provider 标准输出的声明而 fake 实际上从未写过任何东西）。每个都值得修。没有哪个改写了规则手册。
+
+真正改写了规则手册的那两个不一样。它们共享一个形状。
+
+**US3 Preference Center，5 月 12 日交付。** 当 Sentinel 发送邮件的 recipients 点击 footer 中类似 unsubscribe 的链接时，他们落在一个 JWT-in-path 的 URL 上，形如 `/preferences/<token>`。handler 是有意公共-按-合约的：JWT *就是* auth；不期望 `Authorization` header。handler 的 doc-comment 这样写着。集成测试用 `humatest` 写成，通过测试 adapter 直接挂载 handler 并确认：给定 path 中一个合法的 JWT，handler 返回正确的 HTML。CI 通过。feature 被交付到 `main`。
+
+从未发生的事：任何在那个 handler 前面执行生产 middleware 链的事情。`internal/core/middleware/auth.go` 有一个 `publicPrefixes` 列表，列出绕过 `Authorization` 检查的路由前缀。`/preferences/` 不在这个列表里。整整十天，每个点击 unsubscribe 链接的 recipient 都从 middleware 那里收到一个 `401 missing authorization header`，请求甚至没有触达那个本来知道不该期望 Authorization 的 handler。Preference Center 在测试中可达，在生产中不可达。
+
+**发送 pipeline 的 OTel 可观测性 instruments，同一周交付。** 八个 metric instruments —— counters、histograms、gauges —— 在 `internal/core/metrics/commshub.go` 中声明，在启动时与 OpenTelemetry meter 注册。Charter 的 `Constitution Check §IV` 正式宣布 FR-039..042 可观测性门已满足：API 层是正确的，注册都通过了，dashboards 已经规划好。这八个 instruments 中有七个在**整个 commshub 模块中拥有零个 `.Add()` / `.Record()` 调用位置**。声明了，注册了，从未被调用。ops 在这些 series 之上构建的 dashboards 已经收了十天的零数据。polish Charter 的手动 smoke —— 启动一个 OTel Collector，生成几个 sends，grep collector 输出查找 FR-039..042 名称 —— 立即浮现了这一点。
+
+两个案例都不奇特。两个都不是硬 bug。两个都是同一个机械错误的实例：一个 artifact 在一处被声明，而本应连线它的实现住在另一处，并且代码库或 CI 里没有任何东西在关联两者。
+
+## 反模式想要的那个名字
+
+当同一个形状出现得足够多以至于值得一个名字时，名字就重要起来。在 #199 的第三条评论更新时，Sentinel 作者已经数出了同一个底层错误的四个子类：
+
+| 声明位置 | 连线位置 | 机械检查 |
+|---|---|---|
+| operator runbook 中记录的 env var | 代码中的 `os.Getenv(...)`（或对应 stack 的等价物） | 每个记录的 env var 都至少有一个消费者 |
+| metrics 包中声明的 metric instrument | handler 或 worker 代码中的 `.Record()` / `.Add()` 调用位置 | 每个声明的 instrument 至少被记录一次 |
+| 渲染/嵌入 HTML 中引用的 URL（`<script src=...>`、`<link href=...>`） | 注册在同一 API surface 上的路由 | 被服务的 HTML 中的每个 `src=`/`href=` 都解析到一个已注册的路由 |
+| 标记为公共-按-合约的路由（doc-comment、专用标记） | auth middleware 的公共前缀列表中的条目 | 每个公共-按-合约的 handler 都有匹配的前缀条目 |
+
+那个一句话的统一者 —— 新治理文档以此开篇的那一句 —— 是：
+
+> *每个被声明的 surface artifact 都至少有一个可从真实 request 触达的连线位置。*
+
+这个反模式的名字 —— 它在 `dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md` 中作为典范落地 —— 是**声明了表层但未连线**（Surface declaration without wiring）。那才是交付物。polish Charter 是发现工具，不是论点本身。
+
+## 为什么集成测试会系统性地漏掉这些
+
+这一节值得展开，因为它塑造了这篇文章其余部分的形状。四个子类共有的失败模式是：标准集成测试 harness —— Go 中的 `humatest.NewTestAdapter`、TypeScript、Python、Rust 中的对应物 —— *直接*通过测试 API 挂载 handler。被测的 handler 由 fixture 正确连线了。生产组合的那一步 —— 路由注册在那里与 middleware 链相遇，与 env-var 清单相遇，与嵌入资源表相遇 —— 才是坏掉的那一步。CI 的绿灯对它声明的内容是诚实的：handler 在正确的 request 下返回正确的响应。它对以下事情什么也没说：request 在生产中是否能触达 handler，以及 handler 所依赖的 artifact 是否曾经被连线到 runtime。
+
+把这件事读成对 `humatest` 的批评是诱人的。它不是。`humatest`（以及它的等价物）正在做它被设计来做的事：让你以隔离方式、快速地、不需要立起整棵组合树就测试 handler 逻辑。那种隔离是一个 feature。隔离的代价就是我们刚刚命名的那个 —— 而代价只在隔离之外的某些事浮现出分歧时才变得可见。polish Charter 是浮现那种分歧最便宜的方法，因为它做了没有任何 test fixture 在做的事：它启动真实的 binary，对它执行真实的、已记录的 operator 配方。
+
+这是新 pattern doc 那项承重的主张。不是说 polish Charter 出于美容原因而有价值。而是说它是**唯一**让生产组合在外部可读的规范（operator runbook）面前被 end-to-end 执行的地方。如果你把 polish Charter 当作美容清理，你也就把那种浮现能力当作美容。Sentinel 的数据论证了相反的方向。
+
+## 决定：B′，不是 B
+
+RFC 提出了三个选项。PR #200 中的决定是它们都不照原样采纳 —— 称之为 B′。值得说出原因，因为结构性的决定比表面看上去更重要。
+
+**RFC 的 Option B** 要求一个 pattern doc 放在 `docs/patterns/` 之下。那个目录今天在 StrayMark 中并不存在，创建它会分裂项目的文档约定。已经住在正典里的经验模式 —— `FOLLOW-UPS-BACKLOG-PATTERN.md`、`CHARTER-CHAIN-EVOLUTION.md`、`EMERGENT-OBSERVATION-DESIGN.md`、`SPECKIT-CHARTER-BRIDGE.md` —— 都住在 `dist/.straymark/00-governance/`。它们共享一个 i18n 镜像基础设施（每个治理 doc 都有英文、西班牙文、简体中文的兄弟版本）。增加第三个文档 surface 会成倍放大 i18n 开销，并把项目的模式撒在两个家之间。把新 doc 留在 `00-governance/` 内部以零边际成本复用了既有基础设施。
+
+**RFC 的 Option C** 要求一个 `straymark charter polish-checklist` 或 `straymark analyze declared-vs-wired` 的 CLI helper。Sentinel 作者已经原型化了一个（CHARTERs 25/26/27，三个预备性 CI 守卫），并愿意把它种到 upstream。这里的决定是保守的：推迟。不是因为原型没有价值 —— 它有 —— 而是因为 Sentinel 是 N=1。那四个子类是*一个 adopter、一个 stack* 所浮现的。framework 必须预先考虑才能交付一个有用的跨项目 CLI 的第五、第六、第七个子类，目前还不存在，因为没有第二个 adopter 把它们推上来。我们走过这条路。[`FOLLOW-UPS-BACKLOG-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md) 作为 v0 在 `fw-4.10.0` 中交付，并在那里住了一个半月，等待第二个 adopter 在它毕业为 `straymark followups` 子命令之前完成验证。同一道闸门在这里适用。新 doc 的 `## Open questions` 明确说了：「结晶为 `straymark analyze declared-vs-wired` CLI 子命令 …… 闸门：N=2 adopters。」
+
+**B′ 是落地的版本。** 一个新的治理 pattern doc 放在典范位置，以三种语言。Charter 模板里的第七个 `Format conventions` 项目符号，当作者关闭一个 Etapa 或 SpecKit `Polish` 阶段时把他们指向它。QUICK-REFERENCE `## Patterns` 表格里的一行。一个 `fw-4.18.0` 版本号 bump，附带在三十几份文档间的页脚级联。没有 CLI 子命令。没有新的 frontmatter 字段。没有 schema 变更。反模式有了名字；发现仪式有了一份文档；工具化在等。
+
+## 反复重演的弧线
+
+三周前，follow-ups backlog 模式沿同一弧线结晶：一个 adopter 浮现了一个需求，模式在 v0 被命名，CLI helper 被推迟。两周前，链条演化的两个模式结晶：Pattern 1（pre-declare SpecKit refresh）和 Pattern 2（post-close audit-driven Batch N.4），由同一个 Sentinel adopter 浮现，在 `fw-4.16.0` 中被命名，并以 `straymark charter refresh-suggest` 作为软 helper 而非硬闸门。一周前，元模式 —— `EMERGENT-OBSERVATION-DESIGN.md` —— 编码了让上述所有观察首先成为可能的东西：形式化的交叉引用加上文化上的许可。这周，这个模式。
+
+这是一个月里的四次结晶，全都来自同一个 adopter，全都遵循同一个形状：**在 N=1 中浮现 → 为元模式命名 → 只在 N=2 之后才工具化**。当一个模式以鲜明的方式浮现 —— 六小时里十个生产 gap 就是鲜明的 —— 的诱惑是跳过命名，直接去做工具。纪律恰好相反。名字承担了大部分工作。工具化在到来时，是被至少两个 adopter 所浮现的内容参数化的；建造在 N=1 之上时，它是对一个 stack 与一个团队失败模式的外推，并倾向于把那些选择固化成不通用的 framework 默认值。
+
+这一轮迭代里有一个真正新的、值得标出来的东西。新 pattern doc 命名了一个 Sentinel 作者已经承诺要发表的可证伪预测：下一个 Etapa 的 polish Charter，在刚刚在 Sentinel CHARTERs 25/26/27 中落地的三个预备性 CI 守卫的对照下执行，应该浮现大约少 80% 的 gap。如果那个预测成立，把 Option C 从「open question」升级为「CLI 子命令」就获得了定量支撑。如果它失败 —— 如果下一个 polish Charter 仍然浮现十个 gap 但落在没被预料到的第五个子类里 —— 失败本身就是下一个数据点，并会在打造工具之前重塑规范。任何一种结果都有用。两种都还没被观察到。我们在等。
+
+## 关于刻意没有做的事的一则说明
+
+Charter frontmatter 里没有 `phase: polish` 字段。没有 `straymark charter polish-checklist <ID>`。没有自动化 analyzer 在扫描 Go（或任何其他语言）代码中已声明但未连线的符号。pattern doc 把上述每一项都列为候选演化，明确以 N=2 或 Etapa-3 之后的回顾为闸门。在 `fw-4.18.0` 中它们一个都不存在。
+
+这是有意的，而且值得公开说出来，因为对一个鲜明发现的自然反应是过度建造响应。每一项推迟都是用短期完备性换长期可移植性。一个 frontmatter 字段把 framework 锁定到下一个 adopter 可能不共享的词汇上。一个 CLI helper 把 framework 锁定到一个映射某个具体 stack 失败模式的 runtime 上。一个 analyzer 把 framework 锁定到扫描一种语言，而它的约定可能与下一个 adopter 的截然不同。任何这样的承诺都不应基于一个领域的信号来做，无论信号多干净。pattern doc 本身可以被修订；一个 CLI 子命令不能在不破坏 adopters 的情况下被收回。
+
+## 如果你读到这里，我会建议你看什么
+
+如果你运营一个有基于 mock-adapter 的集成测试的代码库 —— 大多数代码库都是 —— 你可以做一项有用的内部练习，完全不需要采纳 StrayMark 的任何东西。挑你的团队最近交付的、同时具有（a）docs 一侧声明（env vars、OpenAPI specs、嵌入式 HTML、metric instruments）与（b）住在另一份文件里的连线位置的最新 feature。在一个干净的 shell 里启动 binary。把 runbook 中面向 operator 的配方端到端跑一遍。如果第一次就跑通了，你的代码库还没有这个模式所捕获的潜伏债务 —— 或者它有但你这次走运。如果跑不通，数一下 gap。这个数字就是你需要的校准，用来判断 polish-Charter-作为债务检测的仪式在你的项目里是否值得它的开销。
+
+如果你已经采纳了 StrayMark 并且正在关闭一个用 `humatest` 风格 adapter 测试 handler 的 Etapa，新 pattern doc 已经为你 scoped 好四个子类检查。把 polish Charter 预算为 L，不是 XS 或 S。预期会有 emergent 的 follow-on Charter，而不是残余清理 scope creep。在 scoped 工作之前去读 [`POLISH-CHARTER-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md)，而不是在之后。
+
+而如果你是 Go 之外某个 stack —— TypeScript、Python、Rust、Elixir —— 上的 adopter，那四个子类是与语言无关的，但具体的检查形态不是。在你的 stack 里浮现一个第五或第六子类正是模式要从 v0 毕业所需要的第二-adopter 信号。从「在你的项目里一个有趣的观察」到「在 StrayMark 正典中被命名」的路径与 #199 走过的是同一条：开一个 issue。开它的成本很低；让模式处于欠验证状态的成本是真实的。
+
+---
+
+*StrayMark `fw-4.18.0` —— Issue [#199](https://github.com/StrangeDaysTech/straymark/issues/199) · PR [#200](https://github.com/StrangeDaysTech/straymark/pull/200) · tag [`fw-4.18.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.18.0)。Sentinel 锚点：[`AIDEC-2026-05-22-001`](https://github.com/StrangeDaysTech/sentinel/pull/93) · [CHARTERs 25/26/27 PR](https://github.com/StrangeDaysTech/sentinel/pull/94)。*
+
+*本文档在生成式 AI 工具（Claude 4.7）的协助下撰写；内容的全部责任由人类作者承担。*


### PR DESCRIPTION
## Summary

- New blog post for straymark.dev covering the **Polish Charter as debt-detection pattern** that landed as \`fw-4.18.0\` (PR #200, closes #199).
- ~2,400 words, EN canonical + ES + zh-CN translations following the established per-locale conventions observed across the 14 prior posts.
- Author approved the EN draft 2026-05-23 before translations were produced.

## Content shape

- Italicized one-line opener + \`<!-- truncate -->\` (matches the established pattern from \`2026-05-16-emergent-observation-design\`, \`2026-05-16-pattern-1-and-pattern-2-chain-evolution\`, etc.).
- Narrative-first, 8 sections: the two production cases (US3 Preference Center 401-loop for 10 days; OTel instruments never recorded for 10 days), the named anti-pattern table with the four sub-classes, why integration tests miss them, the B' decision rationale, the recurring N=1 → name-the-meta → defer-tooling arc, what was deliberately not done, and three concrete invitations for readers depending on their stack/adopter status.
- Footer with anchor line (Issue #199, PR #200, tag fw-4.18.0, Sentinel AIDEC + CHARTERs 25/26/27 PR) + standard AI-assistance disclaimer.

## i18n conventions honored

| Locale | Date format | Tags format | Title/description |
|---|---|---|---|
| EN | \`2026-05-23T00:00:00.000Z\` | block list | original |
| ES | \`2026-05-23T00:00:00.000Z\` | block list, technical tags kept in English, \`anti-pattern\` → \`anti-patron\` | translated |
| zh-CN | \`2026-05-23\` (short) | inline array, English retained | translated |

\`authors.yml\` already has \`jose\` in both locale mirrors — no changes needed.

## Test plan

- [x] \`npm run typecheck\` clean (no TS errors introduced)
- [ ] Once merged, the deploy-website.yml workflow builds against the new post (the workflow triggers on \`website/**\` changes per the configured paths filter).
- [ ] Verify on https://straymark.dev/blog/ that the post appears at the top of the feed in all three locales after the Pages deploy finishes.
- [ ] Spot-check internal links: \`emergent-observation-design\`, \`pattern-1-and-pattern-2-chain-evolution\`, and the GitHub anchors in the footer resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)