### PR TITLE
feat(website): /features index + multilingual sitemap (hreflang + lastmod + sitemap-index + robots.txt)

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,5 +1,5 @@
 import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
+import type {Config, I18n} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const GITHUB_REPO = 'https://github.com/StrangeDaysTech/straymark';
@@ -126,6 +126,12 @@ const config: Config = {
 
   future: {
     v4: true,
+    // Required for sitemap <lastmod> to be populated from git: the sitemap
+    // plugin reads each route's last update timestamp via this VCS layer.
+    // 'git-eager' pre-reads the whole repo once at build start, then answers
+    // per-file queries in memory — faster than 'git-ad-hoc' for a build that
+    // covers ~80 routes × 3 locales. See VcsPreset in @docusaurus/types.
+    experimental_vcs: 'git-eager',
   },
 
   url: 'https://straymark.dev',
@@ -169,6 +175,9 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           include: ['intro.md', 'adopters/**', 'contributors/**'],
           exclude: ['**/i18n/**', '**/proposals/**', '**/decisions/**'],
+          // Populates each route's metadata.lastUpdatedAt from git so the
+          // sitemap plugin can emit <lastmod> per doc URL.
+          showLastUpdateTime: true,
         },
         blog: {
           path: 'blog',
@@ -178,6 +187,10 @@ const config: Config = {
           blogSidebarCount: 'ALL',
           blogSidebarTitle: 'All posts',
           showReadingTime: true,
+          // Populates metadata.lastUpdatedAt from git for every post so the
+          // sitemap plugin can emit <lastmod> per post URL. Same lever the
+          // docs plugin uses above.
+          showLastUpdateTime: true,
           feedOptions: {
             type: ['rss', 'atom'],
             title: 'StrayMark Blog',
@@ -193,6 +206,79 @@ const config: Config = {
         },
         theme: {
           customCss: './src/css/custom.css',
+        },
+        // Sitemap config. The classic preset bundles @docusaurus/plugin-sitemap;
+        // by default it emits one sitemap.xml per locale build (en at root,
+        // /es/sitemap.xml, /zh-CN/sitemap.xml) with no lastmod and no
+        // hreflang alternates — meaning search engines treat each locale's
+        // copy of the same content as unrelated documents.
+        //
+        // We enrich the default emitter via createSitemapItems:
+        //   - `lastmod: 'date'` makes the plugin attach <lastmod> per URL,
+        //     pulled from git for files with a known sourceFilePath.
+        //   - createSitemapItems wraps defaultCreateSitemapItems and adds an
+        //     `xhtml:link rel="alternate" hreflang="..."` entry per item for
+        //     every locale we ship, plus an x-default pointing at the EN
+        //     canonical. Google uses this to cluster the per-locale URLs as
+        //     translations of the same page rather than as duplicates.
+        //
+        // The static counterparts (/sitemap-index.xml that aggregates the
+        // three per-locale sitemaps, and /robots.txt that points crawlers at
+        // the index) live under website/static/ — Docusaurus copies them
+        // verbatim to the build root.
+        sitemap: {
+          lastmod: 'date',
+          createSitemapItems: async (params) => {
+            const {defaultCreateSitemapItems, ...rest} = params;
+            const items = await defaultCreateSitemapItems(rest);
+            const {siteConfig} = params;
+            const siteUrl = siteConfig.url;
+            // Docusaurus types `siteConfig.i18n` as I18nConfig (the input
+            // shape), but at build time the loader hydrates it into the full
+            // I18n shape, which carries `currentLocale`. Cast accordingly.
+            const i18n = siteConfig.i18n as unknown as I18n;
+            const {defaultLocale, locales, currentLocale} = i18n;
+
+            // URL prefix for the current build. Default locale has no prefix
+            // (URLs live at root); other locales are namespaced as
+            // /<locale>/... — matches Docusaurus's i18n routing.
+            const prefixFor = (locale: string): string =>
+              locale === defaultLocale ? '' : `/${locale}`;
+            const currentPrefix = prefixFor(currentLocale);
+
+            // Strip the current-locale prefix from a path to recover the
+            // locale-agnostic canonical path. Used to build the per-locale
+            // alternate URLs below.
+            const stripCurrentPrefix = (path: string): string => {
+              if (!currentPrefix) return path;
+              if (path === currentPrefix) return '/';
+              if (path.startsWith(`${currentPrefix}/`)) {
+                return path.slice(currentPrefix.length);
+              }
+              return path;
+            };
+
+            return items.map((item) => {
+              const path = item.url.replace(siteUrl, '');
+              const canonicalPath = stripCurrentPrefix(path) || '/';
+
+              // One hreflang entry per shipped locale + x-default. The lib
+              // (sitemap@7.x) emits each as
+              //   <xhtml:link rel="alternate" hreflang="<lang>" href="<url>" />
+              const links = [
+                ...locales.map((locale) => ({
+                  lang: locale,
+                  url: `${siteUrl}${prefixFor(locale)}${canonicalPath}`,
+                })),
+                {
+                  lang: 'x-default',
+                  url: `${siteUrl}${canonicalPath}`,
+                },
+              ];
+
+              return {...item, links};
+            });
+          },
         },
         // Note: we do NOT use the preset's `gtag` option. The plugin injects
         // gtag.js + `gtag('config', ...)` BEFORE user-config headTags render,

--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -83,6 +83,30 @@
     "message": "Qué trae StrayMark",
     "description": "Title for the left sidebar shared across feature pages"
   },
+  "features.sidebar.overview": {
+    "message": "Resumen",
+    "description": "Sidebar link back to the /features index page from any feature subpage"
+  },
+  "features.index.eyebrow": {
+    "message": "Características",
+    "description": "Small eyebrow label above the /features H1"
+  },
+  "features.index.title": {
+    "message": "Qué trae StrayMark",
+    "description": "H1 of the /features index page"
+  },
+  "features.index.intro": {
+    "message": "Nueve capacidades que componen StrayMark — desde la disciplina cognitiva y la gobernanza repo-native hasta la auditoría multi-modelo y la observación emergente. Elegí la que mapea al problema que estás resolviendo; cada una enlaza a una página dedicada.",
+    "description": "Intro paragraph above the FeatureGrid on the /features index page"
+  },
+  "meta.features.title": {
+    "message": "Qué trae StrayMark — todas las características",
+    "description": "OG/Twitter title and browser tab for the /features index (the \" | StrayMark\" suffix is appended by Docusaurus automatically)"
+  },
+  "meta.features.description": {
+    "message": "Todas las capacidades de StrayMark en una página: charters, gobernanza, auditoría multi-modelo, detección de drift TDE, el CLI, skills para agentes y observación emergente.",
+    "description": "OG/Twitter description and meta description for the /features index"
+  },
   "features.discipline.title": {
     "message": "Disciplina cognitiva estructurada",
     "description": "Feature: structured cognitive discipline (title)"

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -11,6 +11,30 @@
     "message": "StrayMark 提供什么",
     "description": "Title for the left sidebar shared across feature pages"
   },
+  "features.sidebar.overview": {
+    "message": "概览",
+    "description": "Sidebar link back to the /features index page from any feature subpage"
+  },
+  "features.index.eyebrow": {
+    "message": "功能",
+    "description": "Small eyebrow label above the /features H1"
+  },
+  "features.index.title": {
+    "message": "StrayMark 提供什么",
+    "description": "H1 of the /features index page"
+  },
+  "features.index.intro": {
+    "message": "构成 StrayMark 的九项能力 —— 从认知纪律与原生于仓库的治理，到多模型审计与涌现观察。选择映射到你正在解决的问题的那一项；每一项都链接到一个专门的页面。",
+    "description": "Intro paragraph above the FeatureGrid on the /features index page"
+  },
+  "meta.features.title": {
+    "message": "StrayMark 提供什么 —— 全部功能一览",
+    "description": "OG/Twitter title and browser tab for the /features index (the \" | StrayMark\" suffix is appended by Docusaurus automatically)"
+  },
+  "meta.features.description": {
+    "message": "StrayMark 的所有能力汇集在一页：charters、治理、多模型审计、TDE 漂移检测、CLI、智能体 skills 与涌现观察。",
+    "description": "OG/Twitter description and meta description for the /features index"
+  },
   "features.discipline.title": {
     "message": "结构化的认知纪律",
     "description": "Feature: structured cognitive discipline (title)"

--- a/website/src/components/FeaturesLayout/index.tsx
+++ b/website/src/components/FeaturesLayout/index.tsx
@@ -63,6 +63,11 @@ function isActive(pathname: string, slug: string): boolean {
   );
 }
 
+function isOverviewActive(pathname: string): boolean {
+  // True only on the /features index — must NOT match /features/<slug>.
+  return /\/features\/?$/.test(pathname);
+}
+
 export default function FeaturesLayout({children}: Props): ReactNode {
   const {pathname} = useLocation();
   const sidebarTitle = translate({
@@ -70,12 +75,27 @@ export default function FeaturesLayout({children}: Props): ReactNode {
     message: "What's in the box",
     description: 'Title for the left sidebar shared across feature pages',
   });
+  const overviewLabel = translate({
+    id: 'features.sidebar.overview',
+    message: 'Overview',
+    description: 'Sidebar link back to the /features index page from any feature subpage',
+  });
+  const overviewActive = isOverviewActive(pathname);
 
   return (
     <div className={styles.container}>
       <aside className={styles.sidebar} aria-label={sidebarTitle}>
         <h3 className={styles.sidebarTitle}>{sidebarTitle}</h3>
         <ul className={styles.sidebarList}>
+          <li>
+            <Link
+              to="/features"
+              className={`${styles.sidebarLink} ${overviewActive ? styles.sidebarLinkActive : ''}`}
+              aria-current={overviewActive ? 'page' : undefined}
+            >
+              {overviewLabel}
+            </Link>
+          </li>
           {FEATURES.map((f) => {
             const active = isActive(pathname, f.slug);
             return (

--- a/website/src/pages/features/index.module.css
+++ b/website/src/pages/features/index.module.css
@@ -1,0 +1,33 @@
+.header {
+  padding: 4rem 0 2rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.headerInner {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+.title {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 4vw + 1rem, 3rem);
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.intro {
+  margin: 0;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/website/src/pages/features/index.tsx
+++ b/website/src/pages/features/index.tsx
@@ -1,0 +1,59 @@
+import type {ReactNode} from 'react';
+import Layout from '@theme/Layout';
+import Translate, {translate} from '@docusaurus/Translate';
+import FeatureGrid from '@site/src/components/FeatureGrid';
+import styles from './index.module.css';
+
+export default function FeaturesIndex(): ReactNode {
+  const metaTitle = translate({
+    id: 'meta.features.title',
+    message: "What's in the box — all StrayMark features",
+    description:
+      'OG/Twitter title and browser tab for the /features index (the " | StrayMark" suffix is appended by Docusaurus automatically)',
+  });
+  const metaDescription = translate({
+    id: 'meta.features.description',
+    message:
+      'Every StrayMark capability on one page: charters, governance, multi-model audit, TDE drift detection, the CLI, agent skills, and emergent observation.',
+    description: 'OG/Twitter description and meta description for the /features index',
+  });
+
+  return (
+    <Layout title={metaTitle} description={metaDescription}>
+      <main>
+        <header className={styles.header}>
+          <div className={styles.headerInner}>
+            <p className={styles.eyebrow}>
+              <Translate
+                id="features.index.eyebrow"
+                description="Small eyebrow label above the /features H1"
+              >
+                Features
+              </Translate>
+            </p>
+            <h1 className={styles.title}>
+              <Translate
+                id="features.index.title"
+                description="H1 of the /features index page"
+              >
+                What's in the box
+              </Translate>
+            </h1>
+            <p className={styles.intro}>
+              <Translate
+                id="features.index.intro"
+                description="Intro paragraph above the FeatureGrid on the /features index page"
+              >
+                Nine capabilities that compose StrayMark — from cognitive
+                discipline and repo-native governance to multi-model audit
+                and emergent observation. Pick the one that maps to the
+                problem you're solving; each links to a focused page.
+              </Translate>
+            </p>
+          </div>
+        </header>
+        <FeatureGrid />
+      </main>
+    </Layout>
+  );
+}

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,9 @@
+# StrayMark robots.txt
+# Crawl policy: open. The site is public marketing + docs + blog.
+# Sitemap directive points crawlers at the locale-aware index, which
+# in turn references the three per-locale sitemaps (en, es, zh-CN).
+
+User-agent: *
+Allow: /
+
+Sitemap: https://straymark.dev/sitemap-index.xml

--- a/website/static/sitemap-index.xml
+++ b/website/static/sitemap-index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://straymark.dev/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://straymark.dev/es/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://straymark.dev/zh-CN/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
## Summary

SEO improvement so crawlers (Google + friends) understand the site's information tree (**features / docs / blog**) and how each section's content branches into the three shipped locales (**en / es / zh-CN**).

The trigger: the sitemap analysis from the previous turn showed three gaps — no \`/features\` aggregator page (asymmetric with \`/blog\` and \`/docs\`), no hreflang annotations relating the per-locale URLs, and no \`robots.txt\` to make the three per-locale sitemaps discoverable from a single entry point.

## What changed

### 1. \`/features\` index page (consistency with /blog and /docs)
- **\`website/src/pages/features/{index.tsx, index.module.css}\`** — new aggregator page that renders \`FeatureGrid\` wrapped in a small header (eyebrow + H1 + intro). The nine \`/features/<slug>\` pages now have a parent index, matching the pattern \`/blog\` and \`/docs\` already had.
- **\`website/src/components/FeaturesLayout/index.tsx\`** gains a sidebar "Overview" link back to the new \`/features\` index, with active-state detection that doesn't false-match on \`/features/<slug>\`.
- **i18n** — six new keys per locale (\`features.index.eyebrow\`, \`features.index.title\`, \`features.index.intro\`, \`features.sidebar.overview\`, \`meta.features.title\`, \`meta.features.description\`) in \`website/i18n/{es,zh-CN}/code.json\`.

### 2. Sitemap plugin: hreflang + lastmod
- **\`docusaurus.config.ts\` preset.classic.sitemap** — new \`createSitemapItems\` that wraps the default emitter and adds \`xhtml:link rel="alternate" hreflang="..."\` per URL for all three locales + \`x-default\`. Google uses these to cluster per-locale URLs as translations (not duplicates).
- **\`lastmod: 'date'\`** + **\`showLastUpdateTime: true\`** on the docs and blog plugins + **\`future.experimental_vcs: 'git-eager'\`** so the sitemap plugin can read git history per file efficiently.

### 3. Static SEO files
- **\`website/static/sitemap-index.xml\`** — aggregates the three per-locale sitemaps (\`/sitemap.xml\`, \`/es/sitemap.xml\`, \`/zh-CN/sitemap.xml\`) so crawlers discover all locales from one entry point.
- **\`website/static/robots.txt\`** — declares \`Sitemap: https://straymark.dev/sitemap-index.xml\`. Without this, the multi-sitemap setup is not auto-discoverable (Google would only crawl the canonical \`/sitemap.xml\` and miss \`/es\` + \`/zh-CN\` unless submitted manually to Search Console).

## Local build verification

After \`npm run build\`:

| Sitemap | URLs | hreflang links | lastmod | Notes |
|---|---|---|---|---|
| \`build/sitemap.xml\` | 80 | 320 | 23 | EN canonical |
| \`build/es/sitemap.xml\` | 80 | 320 | 16 | ES |
| \`build/zh-CN/sitemap.xml\` | 80 | 320 | 16 | zh-CN |

- **80 URLs per locale** (was 79; +1 for the new \`/features\` index).
- **320 hreflang annotations per sitemap** = 80 URLs × 4 alternates (en + es + zh-CN + x-default). 960 total across the three sitemaps.
- **lastmod populated** on all content pages (docs + blog). Aggregator pages (\`/blog\`, \`/blog/tags/*\`, \`/blog/archive\`, etc.) correctly have no lastmod — they don't map to a single source file.
- **\`build/{sitemap-index.xml, robots.txt}\`** present at root.
- **\`/features\` renders correctly** in all three locales: title, H1, and eyebrow translated.

Sample \`<url>\` entry (the new \`/features\`):

\`\`\`xml
<url>
  <loc>https://straymark.dev/features</loc>
  <changefreq>weekly</changefreq>
  <priority>0.5</priority>
  <xhtml:link rel="alternate" hreflang="en" href="https://straymark.dev/features"/>
  <xhtml:link rel="alternate" hreflang="es" href="https://straymark.dev/es/features"/>
  <xhtml:link rel="alternate" hreflang="zh-CN" href="https://straymark.dev/zh-CN/features"/>
  <xhtml:link rel="alternate" hreflang="x-default" href="https://straymark.dev/features"/>
</url>
\`\`\`

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean for all three locales
- [x] Sitemap output verified locally (counts above)
- [x] \`/features\` index renders with translated metadata in en/es/zh-CN
- [ ] After merge + deploy: verify \`curl -sI https://straymark.dev/{robots.txt, sitemap-index.xml, features}\` all return 200
- [ ] After merge + deploy: submit \`sitemap-index.xml\` to Search Console (optional accelerator; robots.txt makes it crawl-discoverable automatically over time)

## Known limitations (acceptable for v1)

- **lastmod on static pages** (\`src/pages/*\`: \`/features\`, \`/quickstart\`, \`/privacy\`, \`/\`) is not populated. The pages plugin doesn't propagate \`metadata.lastUpdatedAt\`. Low SEO impact (Google ignores lastmod when not trusted; pages change rarely anyway). Can be added in a follow-up if needed.
- **lastmod on translated docs** is partial — the docs plugin reads from the synced location (\`website/i18n/{locale}/.../current/\`) which is gitignored, so git lookup returns no timestamp. Fixing this would require either modifying \`scripts/sync-docs-i18n.ts\` to preserve the canonical source's git timestamp on the synced file, or pointing the sitemap to the canonical source. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)