### PR TITLE
feat(repo): adopter intake — Adopters discussions/issue templates + ADOPTERS.md registry + feedback guide

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/adopters.yml
+++ b/.github/DISCUSSION_TEMPLATE/adopters.yml
@@ -1,0 +1,127 @@
+title: "[Adopter] <project name>"
+labels: ["adopter"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## You're adopting StrayMark — welcome.
+
+        This category is for **adoption announcements with a feedback commitment**, not casual
+        hellos. Posting here means your project intends to send **telemetry and findings** upstream
+        (the way [Sentinel](https://github.com/StrangeDaysTech/sentinel) has), so the framework can
+        evolve on real evidence instead of one maintainer's intuition.
+
+        **Why this matters:** StrayMark crystallizes patterns by adopter count. A pattern observed in
+        one project/domain (N=1) is documented but stays manual; a second independent validation
+        (N=2) is the gate that justifies automating it in the CLI. Your announcement is how we know an
+        N=2 signal is coming — and from which domain.
+
+        Before filling this out, skim the
+        [Adoption Guide](https://straymark.dev/docs/adopters/adoption-guide) and the
+        [Adopter Feedback guide](https://straymark.dev/docs/adopters/adopter-feedback).
+
+  - type: input
+    id: project
+    attributes:
+      label: Project name & repository
+      description: The project adopting StrayMark, with a link if public.
+      placeholder: "lnxdrive — https://github.com/owner/lnxdrive"
+    validations:
+      required: true
+
+  - type: input
+    id: maintainer
+    attributes:
+      label: Organization / responsible maintainer
+      description: Who owns the adoption and will be the contact for upstream feedback.
+      placeholder: "Strange Days Tech / @handle"
+    validations:
+      required: true
+
+  - type: textarea
+    id: stack
+    attributes:
+      label: Stack & domain
+      description: >
+        Language(s), runtime, and what the project actually is (CLI, backend service, desktop app,
+        library…). Be specific about the domain — crystallization needs a *second domain*, not just a
+        second repo, so a Rust desktop sync tool validating a pattern first seen in a Go backend is
+        a much stronger N=2 than another Go backend.
+      placeholder: "Rust + GTK desktop app; cloud-drive sync client for Linux."
+    validations:
+      required: true
+
+  - type: input
+    id: versions
+    attributes:
+      label: Versions adopted
+      description: Framework and CLI versions you're starting from.
+      placeholder: "fw-4.19.0 / cli-3.16.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: adoption-path
+    attributes:
+      label: Adoption path
+      description: See the Adoption Guide for what A vs B means.
+      options:
+        - "Path A — new project (StrayMark from day one)"
+        - "Path B — existing project (retrofitting StrayMark)"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: commitment
+    attributes:
+      label: What feedback do you commit to send?
+      description: Check everything you realistically plan to contribute. Honesty beats ambition here.
+      options:
+        - label: "Charter telemetry (`.straymark/charters/CHARTER-NN.telemetry.yaml` at close)"
+        - label: "External audit results (the `external_audit` array — dual/multi-model calibration)"
+        - label: "Pattern candidates (anti-patterns or disciplines you discover during execution)"
+        - label: "Format friction (where the Charter / document templates got in your way)"
+        - label: "CLI bugs and documentation gaps"
+
+  - type: textarea
+    id: n-context
+    attributes:
+      label: N-context — are you validating an existing pattern?
+      description: >
+        If your adoption is, in part, a second validation of a pattern already documented at N=1
+        (e.g. the Polish Charter debt-detection pattern, the Charter-chain evolution patterns), name
+        it here and note whether your domain differs from the original. This is the field that turns
+        an announcement into a crystallization signal. Leave blank if you're starting fresh.
+      placeholder: "Likely N=2 for the Polish Charter pattern (Sentinel was N=1, Go backend; we're a Rust desktop app)."
+    validations:
+      required: false
+
+  - type: input
+    id: cadence
+    attributes:
+      label: Expected feedback cadence
+      description: Roughly how often you'll surface findings — per Charter close, monthly, ad-hoc.
+      placeholder: "Per Charter close (~every 1–2 weeks)."
+    validations:
+      required: false
+
+  - type: textarea
+    id: cross-link
+    attributes:
+      label: How you'll cross-link findings
+      description: >
+        Actionable findings belong in **Issues** (use the *Adopter feedback / upstream finding*
+        template), each linking back to this discussion. Note here how you'll keep that thread.
+      placeholder: "I'll reference this discussion # in every adopter-feedback Issue."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: "I've read the Adoption Guide and the Adopter Feedback guide."
+          required: true
+        - label: "I understand telemetry stays in my repo by default — sharing is manual, and I'll anonymize anything sensitive before posting it upstream."
+          required: true

--- a/.github/ISSUE_TEMPLATE/adopter-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/adopter-feedback.yml
@@ -1,0 +1,94 @@
+name: "Adopter feedback / upstream finding"
+description: "Report a finding from a real StrayMark adoption — telemetry-backed friction, gap, or pattern candidate."
+title: "[adopter] <short finding summary>"
+labels: ["adopter-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For findings that come out of **using StrayMark on a real project** — not generic bug reports
+        (use a blank issue for those). If you haven't announced your adoption yet, please open an
+        [Adopters discussion](https://github.com/StrangeDaysTech/straymark/discussions) first and link
+        it below.
+
+  - type: input
+    id: adopter
+    attributes:
+      label: Adopter project
+      description: The project this finding comes from.
+      placeholder: "lnxdrive"
+    validations:
+      required: true
+
+  - type: input
+    id: discussion
+    attributes:
+      label: Adoption discussion link
+      description: The Adopters discussion that announced this project. This cross-link is what ties findings to a known adopter.
+      placeholder: "https://github.com/StrangeDaysTech/straymark/discussions/NNN"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: finding-type
+    attributes:
+      label: Finding type
+      description: >
+        Vocabulary aligned with the Charter telemetry schema (IG = implementation gap,
+        FP = false positive).
+      options:
+        - "Implementation gap (IG) — declared but not wired"
+        - "False positive (FP) — flagged but not a real problem"
+        - "Format friction — a template/workflow got in the way"
+        - "Pattern candidate — recurring anti-pattern or discipline worth documenting"
+        - "CLI bug"
+        - "Documentation gap"
+    validations:
+      required: true
+
+  - type: input
+    id: charter-ref
+    attributes:
+      label: Charter / telemetry reference
+      description: The Charter this surfaced from, if any.
+      placeholder: "CHARTER-04"
+    validations:
+      required: false
+
+  - type: input
+    id: n-context
+    attributes:
+      label: N-context
+      description: >
+        Is this the second independent validation (N=2) of a pattern already documented at N=1? If so,
+        name the pattern — that's the signal that justifies crystallizing it into the CLI.
+      placeholder: "N=2 for the Polish Charter pattern (Sentinel = N=1)."
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, what you expected, and what you actually got.
+    validations:
+      required: true
+
+  - type: textarea
+    id: telemetry
+    attributes:
+      label: Telemetry excerpt (optional)
+      description: >
+        The relevant block from your `charter_telemetry:` YAML, if it supports the finding. Schema:
+        `dist/.straymark/schemas/charter-telemetry.schema.v0.json`. Anonymize anything sensitive.
+      render: yaml
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed upstream change
+      description: What you think StrayMark should do about it — even a rough direction helps.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📣 Announce an adoption
+    url: https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters
+    about: Adopting StrayMark and committing to send telemetry/feedback? Announce it in the Adopters category first, then file findings as issues.
+  - name: 💬 Questions & general discussion
+    url: https://github.com/StrangeDaysTech/straymark/discussions
+    about: For questions, ideas, and anything that isn't a specific bug or feature.

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,52 @@
+# StrayMark Adopters
+
+This is the living registry of projects that have adopted StrayMark **and committed to sending
+telemetry and findings upstream**. It's deliberately not a popularity list — being here means a
+project feeds real evidence back into the framework's evolution.
+
+> Guides live in [`docs/adopters/`](docs/adopters/). This file is the *registry*; the
+> [Adopter Feedback guide](docs/adopters/ADOPTER-FEEDBACK.md) explains the intake flow.
+
+## Registry
+
+| Project | Org | Domain / Stack | Since | Telemetry shared | Adoption discussion | N-status |
+|---------|-----|----------------|-------|------------------|---------------------|----------|
+| [Sentinel](https://github.com/StrangeDaysTech/sentinel) | Strange Days Tech | Go backend service | fw-2.x | Charter telemetry, dual external audits, pattern candidates | — (pre-dates this registry) | **N=1** — reference adopter |
+
+*Want to be listed? See [How to get listed](#how-to-get-listed).*
+
+## How the N-status works
+
+StrayMark crystallizes patterns by **independent validation count**, not by intuition:
+
+- **N=1** — a pattern observed in a single project/domain. It gets *documented* (in
+  `dist/.straymark/00-governance/<NAME>.md` once accepted upstream, or as a local RFC), but stays
+  **manual**. Sentinel is the N=1 reference: most of the patterns shipped between fw-4.13 and fw-4.19
+  (Polish Charter, Charter-chain evolution, surface-declaration-without-wiring) originated there.
+- **N=2** — a *second, independent* validation, ideally in a **different domain** (a Rust desktop app
+  validating a pattern first seen in a Go backend is far stronger than another Go backend). N=2 is the
+  gate that justifies **automating** the pattern in the CLI.
+
+This is why the registry tracks domain and N-status: an adopter announcing they'll validate an
+existing N=1 pattern in a new domain is the most valuable signal the project receives.
+
+## How to get listed
+
+1. **Announce** — open a discussion in the **Adopters** category
+   ([new discussion](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters)).
+   The form captures your stack, the versions you adopted, what feedback you commit to, and any
+   N-context (a pattern you'll be validating).
+2. **A maintainer adds your row** here, linking back to that discussion.
+3. **Send findings** as you go — actionable ones as Issues using the *Adopter feedback / upstream
+   finding* template, each cross-linked to your adoption discussion. See the
+   [Adopter Feedback guide](docs/adopters/ADOPTER-FEEDBACK.md).
+
+> **On privacy:** telemetry (`.straymark/charters/CHARTER-NN.telemetry.yaml`) stays in *your* repo by
+> default. Nothing is collected automatically. Sharing is always your explicit, manual act — anonymize
+> anything sensitive before posting it upstream.
+
+---
+
+*StrayMark — Because every change tells a story.*
+
+[Strange Days Tech](https://strangedays.tech)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,6 +339,14 @@ If you have questions about contributing:
 3. Open a new Discussion for general questions
 4. Open an Issue for specific bugs or features
 
+### Adopting StrayMark?
+
+If you're using StrayMark on a real project and want to send telemetry and findings upstream:
+
+1. **Announce it** in the [Adopters discussion category](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters) — this records your adoption and what you commit to share.
+2. **File findings** as Issues using the *Adopter feedback / upstream finding* template, cross-linked to your adoption discussion.
+3. See the [Adopter Feedback guide](docs/adopters/ADOPTER-FEEDBACK.md) for the full flow and the [adopters registry](ADOPTERS.md).
+
 ---
 
 ## Recognition

--- a/docs/adopters/ADOPTER-FEEDBACK.md
+++ b/docs/adopters/ADOPTER-FEEDBACK.md
@@ -1,0 +1,97 @@
+# StrayMark - Adopter Feedback
+
+**How to announce your adoption and send telemetry and findings upstream.**
+
+[![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
+
+
+---
+
+## Table of Contents
+
+1. [Why feedback matters](#why-feedback-matters)
+2. [Two channels](#two-channels)
+3. [What telemetry is — and where it lives](#what-telemetry-is-and-where-it-lives)
+4. [How to share it](#how-to-share-it)
+5. [The N=1 → N=2 gate](#the-n1--n2-gate)
+6. [Quick reference](#quick-reference)
+
+---
+
+## Why feedback matters {#why-feedback-matters}
+
+StrayMark does not collect anything automatically. There is no remote endpoint, no opt-in beacon, no
+adoption dashboard. The framework evolves on **evidence that adopters choose to send** — which means
+the quality of the next release is a direct function of what real projects report back.
+
+Most of the patterns shipped between fw-4.13 and fw-4.19 came from a single adopter
+([Sentinel](https://github.com/StrangeDaysTech/sentinel)) feeding findings upstream over many
+Charters. The framework gets better when more projects do the same, from more domains.
+
+## Two channels {#two-channels}
+
+Feedback has two distinct natures, so it has two homes:
+
+| | **Announcement** | **Findings** |
+|---|---|---|
+| **Where** | Discussions → **Adopters** category | **Issues** (`Adopter feedback / upstream finding` template) |
+| **When** | Once, when you adopt | Ongoing, as you discover things |
+| **What** | Your project, stack, versions, what you commit to send | A specific gap, friction, bug, or pattern candidate — telemetry-backed |
+| **Lifecycle** | Stays open as your adoption record | Closed when addressed |
+
+Open the [Adopters discussion](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters)
+first; then **cross-link** every finding Issue back to it. That link is what ties a finding to a known
+adopter and its N-context.
+
+## What telemetry is — and where it lives {#what-telemetry-is-and-where-it-lives}
+
+When you close a Charter (`straymark charter close`), StrayMark records structured telemetry to
+`.straymark/charters/CHARTER-NN.telemetry.yaml` — estimation accuracy (time, not line-count), agent
+behavior, external-audit results, scope changes, and qualitative wins/frictions. The shape is defined
+by [`charter-telemetry.schema.v0.json`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/schemas/charter-telemetry.schema.v0.json).
+
+**This file stays in your repository.** It is not transmitted anywhere. Sharing it upstream is always
+a deliberate, manual act on your part.
+
+## How to share it {#how-to-share-it}
+
+1. **Decide what's relevant.** A whole telemetry file is rarely needed — the useful part is usually a
+   block (an `effort` drift, an `external_audit` delta, a `qualitative.friction_points` list) that
+   backs a specific claim.
+2. **Anonymize.** Strip anything sensitive — internal names, secrets, private repo paths — before it
+   leaves your repo.
+3. **Attach it to a finding.** Paste the excerpt into the *Adopter feedback / upstream finding* Issue,
+   in the telemetry field (rendered as YAML), and link your adoption discussion.
+
+The maintainer may, with your consent, anonymize and aggregate findings across projects into blog
+posts or documentation — but only what you've chosen to publish.
+
+## The N=1 → N=2 gate {#the-n1--n2-gate}
+
+StrayMark crystallizes patterns by **independent validation count**:
+
+- **N=1** — a pattern seen in one project/domain. Documented, but kept **manual**.
+- **N=2** — a second, independent validation, ideally in a **different domain**. This is the gate that
+  justifies **automating** the pattern in the CLI.
+
+A Rust desktop app validating a pattern first observed in a Go backend is a far stronger N=2 than
+another Go backend. So when you announce — and when you file findings — say whether you're validating
+an existing pattern, and from which domain. That single piece of context is often the most valuable
+thing an adopter contributes.
+
+## Quick reference {#quick-reference}
+
+| You want to… | Do this |
+|---|---|
+| Announce your adoption | Open an [Adopters discussion](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters) |
+| Report a gap / friction / pattern | Open an Issue with the *Adopter feedback / upstream finding* template |
+| Back a finding with data | Paste an anonymized `charter_telemetry:` excerpt into the Issue |
+| Get into the registry | Announce first; a maintainer adds you to [`ADOPTERS.md`](https://github.com/StrangeDaysTech/straymark/blob/main/ADOPTERS.md) |
+
+See also: [Adoption Guide](ADOPTION-GUIDE.md) · [Recommended Workflows](WORKFLOWS.md) · [CLI Reference](CLI-REFERENCE.md)
+
+---
+
+*StrayMark — Because every change tells a story.*
+
+[Strange Days Tech](https://strangedays.tech)

--- a/docs/adopters/ADOPTION-GUIDE.md
+++ b/docs/adopters/ADOPTION-GUIDE.md
@@ -577,6 +577,11 @@ A: StrayMark rules are instructions, not enforcement. If an AI assistant creates
 
 - **CLI Reference**: [CLI-REFERENCE.md](CLI-REFERENCE.md) — detailed command reference
 - **Workflows**: [WORKFLOWS.md](WORKFLOWS.md) — recommended daily usage patterns
+- **Adopter Feedback**: [ADOPTER-FEEDBACK.md](ADOPTER-FEEDBACK.md) — how to announce your adoption and send telemetry/findings upstream
 - **Issues**: [GitHub Issues](https://github.com/StrangeDaysTech/straymark/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/StrangeDaysTech/straymark/discussions)
 - **Contributing**: See [CONTRIBUTING.md](https://github.com/StrangeDaysTech/straymark/blob/main/CONTRIBUTING.md)
+
+> **Using StrayMark in a real project?** Consider becoming a registered adopter — see
+> [`ADOPTERS.md`](https://github.com/StrangeDaysTech/straymark/blob/main/ADOPTERS.md). Adopters who
+> feed telemetry and findings back are how the framework evolves on real evidence.

--- a/docs/i18n/es/adopters/ADOPTER-FEEDBACK.md
+++ b/docs/i18n/es/adopters/ADOPTER-FEEDBACK.md
@@ -1,0 +1,99 @@
+# StrayMark - Retroalimentación de Adoptantes
+
+**Cómo anunciar tu adopción y enviar telemetría y hallazgos al proyecto upstream.**
+
+[![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
+
+
+---
+
+## Tabla de Contenidos
+
+1. [Por qué importa la retroalimentación](#por-que-importa-la-retroalimentacion)
+2. [Dos canales](#dos-canales)
+3. [Qué es la telemetría — y dónde vive](#que-es-la-telemetria-y-donde-vive)
+4. [Cómo compartirla](#como-compartirla)
+5. [La puerta N=1 → N=2](#la-puerta-n1--n2)
+6. [Referencia rápida](#referencia-rapida)
+
+---
+
+## Por qué importa la retroalimentación {#por-que-importa-la-retroalimentacion}
+
+StrayMark no recolecta nada automáticamente. No hay endpoint remoto, ni baliza opt-in, ni tablero de
+adopción. El framework evoluciona con la **evidencia que los adoptantes deciden enviar** — lo que
+significa que la calidad del siguiente release es función directa de lo que reportan los proyectos
+reales.
+
+La mayoría de los patrones publicados entre fw-4.13 y fw-4.19 surgieron de un único adoptante
+([Sentinel](https://github.com/StrangeDaysTech/sentinel)) que alimentó hallazgos a lo largo de muchos
+Charters. El framework mejora cuando más proyectos hacen lo mismo, desde más dominios.
+
+## Dos canales {#dos-canales}
+
+La retroalimentación tiene dos naturalezas distintas, así que tiene dos hogares:
+
+| | **Anuncio** | **Hallazgos** |
+|---|---|---|
+| **Dónde** | Discussions → categoría **Adopters** | **Issues** (plantilla `Adopter feedback / upstream finding`) |
+| **Cuándo** | Una vez, al adoptar | De forma continua, conforme descubres cosas |
+| **Qué** | Tu proyecto, stack, versiones, a qué te comprometes | Una brecha, fricción, bug o candidato a patrón concreto — respaldado con telemetría |
+| **Ciclo de vida** | Queda abierto como tu registro de adopción | Se cierra cuando se atiende |
+
+Abre primero la [discusión de Adopters](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters);
+luego **cruza** cada Issue de hallazgo de vuelta a ella. Ese enlace es lo que liga un hallazgo a un
+adoptante conocido y a su contexto N.
+
+## Qué es la telemetría — y dónde vive {#que-es-la-telemetria-y-donde-vive}
+
+Cuando cierras un Charter (`straymark charter close`), StrayMark registra telemetría estructurada en
+`.straymark/charters/CHARTER-NN.telemetry.yaml` — precisión de estimación (en tiempo, no en líneas),
+comportamiento del agente, resultados de auditoría externa, cambios de alcance, y wins/fricciones
+cualitativos. La forma está definida por
+[`charter-telemetry.schema.v0.json`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/schemas/charter-telemetry.schema.v0.json).
+
+**Este archivo se queda en tu repositorio.** No se transmite a ningún lado. Compartirlo upstream es
+siempre un acto deliberado y manual de tu parte.
+
+## Cómo compartirla {#como-compartirla}
+
+1. **Decide qué es relevante.** Rara vez se necesita el archivo completo — la parte útil suele ser un
+   bloque (un drift de `effort`, una delta de `external_audit`, una lista de
+   `qualitative.friction_points`) que respalda una afirmación concreta.
+2. **Anonimiza.** Quita lo sensible — nombres internos, secretos, rutas de repos privados — antes de
+   que salga de tu repo.
+3. **Adjúntalo a un hallazgo.** Pega el extracto en el Issue *Adopter feedback / upstream finding*, en
+   el campo de telemetría (renderizado como YAML), y enlaza tu discusión de adopción.
+
+El mantenedor puede, con tu consentimiento, anonimizar y agregar hallazgos de varios proyectos en
+posts de blog o documentación — pero solo lo que tú hayas decidido publicar.
+
+## La puerta N=1 → N=2 {#la-puerta-n1--n2}
+
+StrayMark cristaliza patrones por **conteo de validaciones independientes**:
+
+- **N=1** — un patrón visto en un solo proyecto/dominio. Documentado, pero se mantiene **manual**.
+- **N=2** — una segunda validación independiente, idealmente en un **dominio distinto**. Esta es la
+  puerta que justifica **automatizar** el patrón en el CLI.
+
+Una app de escritorio en Rust validando un patrón observado primero en un backend de Go es un N=2
+mucho más fuerte que otro backend de Go. Así que cuando anuncies — y cuando reportes hallazgos — di si
+estás validando un patrón existente, y desde qué dominio. Ese único dato suele ser lo más valioso que
+aporta un adoptante.
+
+## Referencia rápida {#referencia-rapida}
+
+| Quieres… | Haz esto |
+|---|---|
+| Anunciar tu adopción | Abre una [discusión de Adopters](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters) |
+| Reportar una brecha / fricción / patrón | Abre un Issue con la plantilla *Adopter feedback / upstream finding* |
+| Respaldar un hallazgo con datos | Pega un extracto anonimizado de `charter_telemetry:` en el Issue |
+| Entrar al registro | Anuncia primero; un mantenedor te agrega a [`ADOPTERS.md`](https://github.com/StrangeDaysTech/straymark/blob/main/ADOPTERS.md) |
+
+Ver también: [Guía de Adopción](ADOPTION-GUIDE.md) · [Flujos de Trabajo Recomendados](WORKFLOWS.md) · [Referencia del CLI](CLI-REFERENCE.md)
+
+---
+
+*StrayMark — Porque cada cambio cuenta una historia.*
+
+[Strange Days Tech](https://strangedays.tech)

--- a/docs/i18n/zh-CN/adopters/ADOPTER-FEEDBACK.md
+++ b/docs/i18n/zh-CN/adopters/ADOPTER-FEEDBACK.md
@@ -1,0 +1,90 @@
+# StrayMark - 采用者反馈
+
+**如何宣告你的采用，并向上游发送遥测数据与发现。**
+
+[![Strange Days Tech](https://img.shields.io/badge/by-Strange_Days_Tech-purple.svg)](https://strangedays.tech)
+
+
+---
+
+## 目录
+
+1. [为什么反馈很重要](#为什么反馈很重要)
+2. [两个渠道](#两个渠道)
+3. [遥测数据是什么——以及它存放在哪里](#遥测数据是什么以及它存放在哪里)
+4. [如何分享](#如何分享)
+5. [N=1 → N=2 关口](#n1--n2-关口)
+6. [快速参考](#快速参考)
+
+---
+
+## 为什么反馈很重要
+
+StrayMark 不会自动收集任何数据。没有远程端点，没有 opt-in 信标，没有采用情况仪表盘。框架靠
+**采用者主动选择发送的证据**演进——这意味着下一个版本的质量，直接取决于真实项目反馈了什么。
+
+fw-4.13 到 fw-4.19 之间发布的大多数模式，都来自单一采用者
+（[Sentinel](https://github.com/StrangeDaysTech/sentinel)）在许多 Charter 中持续向上游反馈发现。
+当更多项目、来自更多领域地这样做时，框架会变得更好。
+
+## 两个渠道
+
+反馈有两种不同的性质，因此有两个归宿：
+
+| | **宣告** | **发现** |
+|---|---|---|
+| **位置** | Discussions → **Adopters** 类别 | **Issues**（`Adopter feedback / upstream finding` 模板） |
+| **时机** | 一次，在采用时 | 持续进行，随着你的发现 |
+| **内容** | 你的项目、技术栈、版本、承诺发送的内容 | 一个具体的缺口、摩擦、缺陷或模式候选——有遥测数据支撑 |
+| **生命周期** | 作为你的采用记录保持开启 | 处理完后关闭 |
+
+先开一个 [Adopters 讨论](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters)；
+然后将每个发现 Issue **交叉链接**回它。这个链接正是把一个发现与已知采用者及其 N 上下文绑定起来的纽带。
+
+## 遥测数据是什么——以及它存放在哪里
+
+当你关闭一个 Charter（`straymark charter close`）时，StrayMark 会把结构化遥测数据记录到
+`.straymark/charters/CHARTER-NN.telemetry.yaml`——估算准确度（按时间，而非代码行数）、智能体行为、
+外部审计结果、范围变更，以及定性的收获/摩擦点。其结构由
+[`charter-telemetry.schema.v0.json`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/schemas/charter-telemetry.schema.v0.json)
+定义。
+
+**这个文件留在你的仓库里。**它不会被传输到任何地方。向上游分享它，始终是你这一方刻意的、手动的行为。
+
+## 如何分享
+
+1. **决定哪些是相关的。**很少需要整个遥测文件——有用的部分通常是一个能支撑某个具体论点的代码块
+   （一个 `effort` 偏差、一个 `external_audit` 差异、一份 `qualitative.friction_points` 列表）。
+2. **匿名化。**在它离开你的仓库之前，去掉任何敏感信息——内部名称、密钥、私有仓库路径。
+3. **附到一个发现上。**把摘录粘贴到 *Adopter feedback / upstream finding* Issue 的遥测字段
+   （以 YAML 渲染），并链接你的采用讨论。
+
+经你同意，维护者可以把多个项目的发现匿名化并聚合到博客文章或文档中——但只限于你已选择公开的部分。
+
+## N=1 → N=2 关口
+
+StrayMark 按**独立验证次数**来固化模式：
+
+- **N=1**——在单一项目/领域中观察到的模式。已记录，但保持**手动**。
+- **N=2**——第二次独立验证，最好是在**不同的领域**。这是证明把该模式**自动化**进 CLI 合理性的关口。
+
+一个用 Rust 写的桌面应用，去验证一个最初在 Go 后端观察到的模式，远比另一个 Go 后端更强的 N=2。
+所以当你宣告时——以及当你提交发现时——请说明你是否在验证一个已有模式，以及来自哪个领域。这一条上下文，
+往往是采用者所能贡献的最有价值的东西。
+
+## 快速参考
+
+| 你想要… | 这样做 |
+|---|---|
+| 宣告你的采用 | 开一个 [Adopters 讨论](https://github.com/StrangeDaysTech/straymark/discussions/new?category=adopters) |
+| 报告缺口 / 摩擦 / 模式 | 用 *Adopter feedback / upstream finding* 模板开一个 Issue |
+| 用数据支撑发现 | 把匿名化的 `charter_telemetry:` 摘录粘贴进 Issue |
+| 进入注册表 | 先宣告；维护者会把你加入 [`ADOPTERS.md`](https://github.com/StrangeDaysTech/straymark/blob/main/ADOPTERS.md) |
+
+另见：[采用指南](ADOPTION-GUIDE.md) · [推荐工作流](WORKFLOWS.md) · [CLI 参考](CLI-REFERENCE.md)
+
+---
+
+*StrayMark — 因为每一次变更都讲述着一个故事。*
+
+[Strange Days Tech](https://strangedays.tech)


### PR DESCRIPTION
## Why

Adds the missing scaffolding for projects that adopt StrayMark **and commit to sending telemetry/findings upstream** (the way Sentinel does). Motivated by **lnxdrive** preparing to announce its adoption — which would be the ecosystem's **N=2**, the exact gate StrayMark's evolution policy needs to *crystallize* a documented N=1 pattern into CLI automation. Reusable for third parties going forward.

Today the repo has **no** `ADOPTERS.md`, no issue templates, and no discussion templates — only informal routing in `CONTRIBUTING.md`.

## Design (per the approved plan)

- **Channel:** a dedicated **Adopters** Discussions category is the home for the one-time announcement; recurring findings flow as cross-linked **Issues**.
- **Four reusable artifacts**, plus link wiring.

## What's in here

| Artifact | Path |
|---|---|
| Discussion form (announcement) | `.github/DISCUSSION_TEMPLATE/adopters.yml` |
| Issue form (findings) | `.github/ISSUE_TEMPLATE/adopter-feedback.yml` |
| Issue chooser config | `.github/ISSUE_TEMPLATE/config.yml` |
| Living registry | `ADOPTERS.md` (seeded with Sentinel as N=1) |
| Intake guide (EN + es + zh-CN) | `docs/adopters/ADOPTER-FEEDBACK.md` |
| Link wiring | `docs/adopters/ADOPTION-GUIDE.md`, `CONTRIBUTING.md` |

The **N=1 → N=2** crystallization gate runs through all four artifacts (announcement form, issue form, registry, guide).

## Verification

- ✅ All three template YAMLs parse.
- ✅ `has_discussions: true` on the repo.
- ✅ `npm run build` succeeds; `ADOPTER-FEEDBACK` builds in `build/`, `build/es/`, `build/zh-CN/` and auto-registers in the autogenerated **Adopters** sidebar.
- ✅ Clean rebuild — no broken anchors/links.
- No version bump (no `fw-`/`cli-` artifacts touched).

## ⚠️ Required GitHub config after merge (not doable from code)

1. Create the **Adopters** Discussions category with slug `adopters`, format **Open-ended discussion** (not *Announcement* — that would block external adopters). The discussion form only activates once `adopters.yml` is on `main` **and** the category exists.
2. Create labels `adopter` and `adopter-feedback`.
3. Issue/discussion forms only take effect from the default branch — i.e. after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)