### PR TITLE
docs(adopters): register LNXDrive as N=2 adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -12,6 +12,7 @@ project feeds real evidence back into the framework's evolution.
 | Project | Org | Domain / Stack | Since | Telemetry shared | Adoption discussion | N-status |
 |---------|-----|----------------|-------|------------------|---------------------|----------|
 | [Sentinel](https://github.com/StrangeDaysTech/sentinel) | Strange Days Tech | Go backend service | fw-2.x | Charter telemetry, dual external audits, pattern candidates | — (pre-dates this registry) | **N=1** — reference adopter |
+| [LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) | Strange Days Tech | Rust — Linux cloud-sync daemon + desktop (FUSE / D-Bus / systemd) | fw-4.19.0 | Charter telemetry, dual external audits, pattern candidates | [#205](https://github.com/StrangeDaysTech/straymark/discussions/205) | **N=2** — second domain (vs Sentinel's Go backend) |
 
 *Want to be listed? See [How to get listed](#how-to-get-listed).*
 


### PR DESCRIPTION
Adds **LNXDrive** to the adopters registry, following its adoption announcement in [discussion #205](https://github.com/StrangeDaysTech/straymark/discussions/205).

LNXDrive is a Rust cloud-storage sync client for Linux (systemd daemon + D-Bus + FUSE + native GNOME/KDE/COSMIC/GTK integrations). It's the ecosystem's **second adopter** and — the part that matters for evolution policy — a second **domain** distinct from Sentinel's Go backend, which is the gate for crystallizing N=1-documented patterns (Polish Charter, Charter-chain evolution) into CLI automation.

| Project | Org | Domain / Stack | Since | N-status |
|---|---|---|---|---|
| LNXDrive | Strange Days Tech | Rust — Linux cloud-sync daemon + desktop (FUSE/D-Bus/systemd) | fw-4.19.0 | **N=2** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)