### PR TITLE
feat: fw-4.20.0 + cli-3.17.0 — "declared but not wired" N=2; CHARTER-FILES-EXIST + recon nudge (#209, #210)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -31,6 +31,14 @@ StrayMark crystallizes patterns by **independent validation count**, not by intu
 This is why the registry tracks domain and N-status: an adopter announcing they'll validate an
 existing N=1 pattern in a new domain is the most valuable signal the project receives.
 
+**First N=2 crossing (2026-05):** LNXDrive's findings [#209](https://github.com/StrangeDaysTech/straymark/issues/209)
+and [#210](https://github.com/StrangeDaysTech/straymark/issues/210) validated the
+*surface-declaration-without-wiring* pattern in a second domain (Rust desktop vs Sentinel's Go backend),
+graduating [`POLISH-CHARTER-PATTERN.md`](dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md) from
+v0/N=1 to **v1/N=2**. That crossing seeded the `straymark analyze declared-vs-wired` subcommand and the
+`CHARTER-FILES-EXIST` validate rule — the canonical example of N=2 turning a manual convention into CLI
+automation.
+
 ## How to get listed
 
 1. **Announce** — open a discussion in the **Adopters** category

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.20.0 / CLI 3.17.0 — "declared but not wired" reaches N=2 (LNXDrive findings #209/#210)
+
+Crystallizes the *surface-declaration-without-wiring* pattern to **v1** on the strength of a second independent domain (LNXDrive, a Rust Linux daemon + GTK desktop) validating what Sentinel's Go backend first surfaced, and ships the cheap mechanical backstops the two findings asked for. Two axes are reported separately and deliberately: **2 independent domains / 3 occurrences** — the third being a qualitatively new sub-class, a cross-component regression of an already-shipped mitigation.
+
+### Added (Framework)
+
+- **`POLISH-CHARTER-PATTERN.md` graduates v0/N=1 → v1/N=2** (EN + ES + zh-CN). Adds **sub-class 5** — *client-side IPC/RPC proxy method declared vs server interface implemented*, with the named variant "shipped-mitigation regression via an un-updated downstream consumer" (the LNXDrive D-Bus/GOA case: a GTK client kept calling a daemon method the daemon had removed, hidden behind an undefined `#[cfg(feature)]` so it compiled out and evaded both CI and review). Resolves the `analyze declared-vs-wired` open question now that the N=2 automation gate is crossed.
+- **Charter template reconnaissance + cross-component guidance** (`charter-template.md` EN + ES + zh-CN). A comment above `## Files to modify` instructs authors to READ each path before declaring it (or tag created files "New"), and to list **all** consumers when a Charter touches a cross-component API — so a producer-side change can't silently orphan a consumer (#209.c). New format convention added to the closing notes.
+- **`ADOPTERS.md`** records the first N=2 crossing and how it seeded CLI automation.
+
+### Added (CLI)
+
+- **`CHARTER-FILES-EXIST` validate rule** *(`straymark validate --include-charters`)* — warns when a `## Files to modify` row names a path that does not exist on disk and is not tagged "New" (Change column starting with New/Nuevo/新建, or a `(new)` path tag). Catches Charters authored against assumed, un-read code (finding #210). **Warn-only** (never fails the exit code); pure-Rust so it works on Windows-native without bash. Deliberately separate from `straymark charter drift` (which compares declared vs git-modified files) — "Charter mis-declared" (authoring bug) and "implementation drifted" stay in different commands with different rule codes (#210.3).
+- **`charter new` reconnaissance nudge** — the printed "Next steps" now lead with a reconnaissance step: read every file before listing it in `## Files to modify`. The `straymark-charter-new` skill (Claude/Gemini/Codex variants) gains the matching instruction.
+- **`charter_files` module** — shared Rust parser for the `## Files to modify` table (col-1 backtick paths, EN/ES/zh-CN headings, `(new)` exemption, wildcard pass-through), ported from the drift script's awk so the validate rule and the drift check agree on what counts as a declared file.
+
+### Adopter guidance
+
+Run `straymark update` (CLI → `cli-3.17.0`, framework → `fw-4.20.0`). To exercise the new check on existing Charters:
+
+```bash
+straymark validate --include-charters
+```
+
+The `analyze declared-vs-wired` subcommand (the IPC proxy-vs-interface check) ships in a follow-up CLI release; this release lands the pattern crystallization, the path-existence backstop, and the authoring discipline.
+
+---
+
 ## Framework 4.19.0 / CLI 3.16.0 — Codex CLI (OpenAI) skill support
 
 Adds first-class distribution of StrayMark skills for the **Codex CLI** (OpenAI), motivated by an adopter using Codex for external Charter audits in the Sentinel project. Codex's skill loader rejects the Claude-only `allowed-tools` frontmatter key and discovers skills only at the **user level** (`~/.codex/skills/`), not from the project tree like Claude and Gemini do. The release ships a fourth parallel skill variant generated from the Claude source, plus a new CLI command to install them.

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
-| Framework | `fw-` | `fw-4.19.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.16.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.20.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.17.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -309,7 +309,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.19.0)
+# and download the latest fw-* release (e.g., fw-4.20.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.16.0"
+version = "3.17.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/charter_files.rs
+++ b/cli/src/charter_files.rs
@@ -1,0 +1,286 @@
+//! Shared parser for a Charter's `## Files to modify` section.
+//!
+//! Ported from the awk extraction in
+//! `dist/.straymark/scripts/check-charter-drift.sh` (the bash drift script),
+//! so the CLI's pure-Rust consumers (the `CHARTER-FILES-EXIST` validate rule,
+//! the `charter new` reconnaissance nudge) agree byte-for-byte with the drift
+//! script on what counts as a declared file.
+//!
+//! Two consumers, one source of truth:
+//! - `validation.rs` — the `CHARTER-FILES-EXIST` rule warns when a declared
+//!   path that is NOT tagged "new" does not exist on disk (Charter authored
+//!   against assumed code — finding #210). This is a *static authoring* check,
+//!   distinct from the drift script's *dynamic* git-range check.
+//! - the `(new)` exemption keeps from flagging files the Charter itself creates.
+//!
+//! The drift script applies a recognized-extension / `.straymark/` filter via
+//! grep; we mirror it in [`looks_like_path`] so a backtick token like
+//! `` `cargo build` `` is not mistaken for a declared file.
+
+/// A file declared in a Charter's `## Files to modify` section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredFile {
+    /// The path as declared, with any trailing `(new)` tag stripped. May still
+    /// contain a wildcard (`...` or `*`); callers that check disk existence
+    /// must skip those (see [`is_wildcard`]).
+    pub path: String,
+    /// True when the row marks the file as created by this Charter — either the
+    /// Change column starts with "New"/"Nuevo"/"新建", or the path/cell carries
+    /// a `(new)` tag. Existence-checking consumers skip these.
+    pub is_new: bool,
+    /// The trimmed Change-column text (empty for bullet/prose declarations).
+    pub raw_change: String,
+}
+
+/// Recognized source-file extensions, mirroring the grep filter in
+/// `check-charter-drift.sh`. A backtick token is treated as a declared path
+/// only when it ends in one of these or contains `.straymark/`.
+const RECOGNIZED_EXTENSIONS: &[&str] = &[
+    ".go", ".sql", ".yaml", ".yml", ".md", ".sh", ".ts", ".tsx", ".js", ".jsx",
+    ".rs", ".py", ".java", ".kt", ".rb", ".cs", ".cpp", ".c", ".h", ".hpp",
+    ".swift", ".toml", ".json", ".tf",
+];
+
+/// The `## Files to modify` heading in the three shipped locales.
+const SECTION_HEADINGS: &[&str] = &["Files to modify", "Archivos a modificar", "要修改的文件"];
+
+/// Change-column prefixes that mark a file as newly created (locale variants).
+const NEW_MARKERS: &[&str] = &["new", "nuevo", "新建"];
+
+/// True if a declared path uses a wildcard form (`prefix...suffix` ellipsis or
+/// `prefix*suffix` glob). Such paths are git-range patterns, not literal paths,
+/// and cannot be existence-checked.
+pub fn is_wildcard(path: &str) -> bool {
+    path.contains("...") || path.contains('*')
+}
+
+/// True if a backtick token looks like a declared file path: it ends with a
+/// recognized extension, or references something under `.straymark/`.
+fn looks_like_path(token: &str) -> bool {
+    if token.contains(".straymark/") {
+        return true;
+    }
+    RECOGNIZED_EXTENSIONS.iter().any(|ext| token.ends_with(ext))
+}
+
+/// Extract the first backtick-quoted token from a string, if any.
+fn first_backtick_token(s: &str) -> Option<&str> {
+    let start = s.find('`')? + 1;
+    let rest = &s[start..];
+    let end = rest.find('`')?;
+    Some(&rest[..end])
+}
+
+/// True when `cell`/`change` indicates the file is created by this Charter.
+fn detect_new(col1_cell: &str, change: &str) -> bool {
+    let change_lc = change.trim().to_lowercase();
+    if NEW_MARKERS.iter().any(|m| change_lc.starts_with(m)) {
+        return true;
+    }
+    // Fallback: a `(new)` tag anywhere in the path cell (table) or line (bullet).
+    col1_cell.to_lowercase().contains("(new)")
+}
+
+/// Strip a trailing `(new)` tag (and surrounding whitespace) from a path.
+fn strip_new_tag(path: &str) -> String {
+    let trimmed = path.trim();
+    // Tag may appear right after the token, e.g. `src/foo.rs (new)` once the
+    // backticks are removed. Drop any parenthetical "(new)" suffix.
+    let lower = trimmed.to_lowercase();
+    if let Some(idx) = lower.rfind("(new)") {
+        if trimmed[idx + 5..].trim().is_empty() {
+            return trimmed[..idx].trim().to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+/// Parse the `## Files to modify` section of a Charter body and return the
+/// declared files. Recognizes the markdown-table form (column 1 = backtick
+/// path, column 2 = change) and the legacy bullet/prose form (any backtick
+/// token on a line). Non-path tokens are filtered out (see [`looks_like_path`]).
+pub fn parse_files_to_modify(body: &str) -> Vec<DeclaredFile> {
+    let mut out = Vec::new();
+    let mut in_section = false;
+
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+
+        if trimmed.starts_with("## ") {
+            if in_section {
+                // A new `## ` heading ends the section.
+                break;
+            }
+            let title = trimmed.trim_start_matches('#').trim();
+            if SECTION_HEADINGS.contains(&title) {
+                in_section = true;
+            }
+            continue;
+        }
+
+        if !in_section {
+            continue;
+        }
+
+        if trimmed.starts_with('|') {
+            // Markdown table row. split('|') yields a leading empty element.
+            let cols: Vec<&str> = line.split('|').collect();
+            if cols.len() < 2 {
+                continue;
+            }
+            let col1 = cols[1].trim();
+            let col2 = cols.get(2).map(|c| c.trim()).unwrap_or("");
+
+            // Skip separator rows (only dashes/colons/spaces) and header rows.
+            if !col1.is_empty()
+                && col1.chars().all(|c| matches!(c, '-' | ':' | ' '))
+            {
+                continue;
+            }
+            let col1_plain = col1.trim_matches('*').trim();
+            if matches!(col1_plain, "File" | "Archivo" | "文件") {
+                continue;
+            }
+
+            let Some(token) = first_backtick_token(col1) else {
+                continue;
+            };
+            if !looks_like_path(token) {
+                continue;
+            }
+            let is_new = detect_new(col1, col2);
+            out.push(DeclaredFile {
+                path: strip_new_tag(token),
+                is_new,
+                raw_change: col2.to_string(),
+            });
+        } else {
+            // Bullet / prose: extract every backtick token on the line.
+            let is_new_line = trimmed.to_lowercase().contains("(new)");
+            let mut rest = line;
+            while let Some(start) = rest.find('`') {
+                let after = &rest[start + 1..];
+                let Some(end) = after.find('`') else { break };
+                let token = &after[..end];
+                if looks_like_path(token) {
+                    out.push(DeclaredFile {
+                        path: strip_new_tag(token),
+                        is_new: is_new_line,
+                        raw_change: String::new(),
+                    });
+                }
+                rest = &after[end + 1..];
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(files: &[DeclaredFile]) -> Vec<&str> {
+        files.iter().map(|f| f.path.as_str()).collect()
+    }
+
+    #[test]
+    fn parses_table_col1_backtick_paths() {
+        let body = r#"## Files to modify
+
+| File | Change |
+|---|---|
+| `src/main.rs` | Adds routing |
+| `src/config.rs` | New field `foo` |
+
+## Verification
+"#;
+        let files = parse_files_to_modify(body);
+        assert_eq!(paths(&files), vec!["src/main.rs", "src/config.rs"]);
+        // The backtick `foo` in the Change column must NOT be picked up as a path.
+        assert!(files.iter().all(|f| f.path != "foo"));
+    }
+
+    #[test]
+    fn detects_new_via_change_column() {
+        let body = r#"## Files to modify
+
+| File | Change |
+|---|---|
+| `src/old.rs` | Refactor |
+| `.straymark/07-ai-audit/agent-logs/AILOG-x.md` | New, `risk_level: low` |
+| `src/created.rs` | Nuevo módulo |
+"#;
+        let files = parse_files_to_modify(body);
+        let by_path = |p: &str| files.iter().find(|f| f.path == p).unwrap();
+        assert!(!by_path("src/old.rs").is_new);
+        assert!(by_path(".straymark/07-ai-audit/agent-logs/AILOG-x.md").is_new);
+        assert!(by_path("src/created.rs").is_new); // "Nuevo" prefix
+    }
+
+    #[test]
+    fn detects_new_via_path_tag() {
+        let body = r#"## Files to modify
+
+- `src/foo.rs` (new) — created here
+- `src/bar.rs` — existing
+"#;
+        let files = parse_files_to_modify(body);
+        let by_path = |p: &str| files.iter().find(|f| f.path == p).unwrap();
+        assert!(by_path("src/foo.rs").is_new);
+        assert!(!by_path("src/bar.rs").is_new);
+        // The `(new)` tag is stripped from the stored path.
+        assert!(by_path("src/foo.rs").path == "src/foo.rs");
+    }
+
+    #[test]
+    fn skips_separator_and_header_rows() {
+        let body = r#"## Files to modify
+
+| File | Change |
+| --- | --- |
+| `a.rs` | x |
+"#;
+        let files = parse_files_to_modify(body);
+        assert_eq!(paths(&files), vec!["a.rs"]);
+    }
+
+    #[test]
+    fn recognizes_spanish_and_chinese_headings() {
+        let es = "## Archivos a modificar\n\n| File | Change |\n|---|---|\n| `x.rs` | y |\n";
+        let zh = "## 要修改的文件\n\n| File | Change |\n|---|---|\n| `z.go` | w |\n";
+        assert_eq!(paths(&parse_files_to_modify(es)), vec!["x.rs"]);
+        assert_eq!(paths(&parse_files_to_modify(zh)), vec!["z.go"]);
+    }
+
+    #[test]
+    fn preserves_wildcards_for_caller_to_skip() {
+        let body = "## Files to modify\n\n| File | Change |\n|---|---|\n| `AILOG-*.md` | bulk |\n| `.straymark/07-ai-audit/agent-logs/AILOG-...md` | log |\n";
+        let files = parse_files_to_modify(body);
+        assert!(files.iter().any(|f| is_wildcard(&f.path)));
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn stops_at_next_heading() {
+        let body = r#"## Files to modify
+
+| File | Change |
+|---|---|
+| `in.rs` | x |
+
+## Risks
+
+- `out.rs` should not be captured
+"#;
+        let files = parse_files_to_modify(body);
+        assert_eq!(paths(&files), vec!["in.rs"]);
+    }
+
+    #[test]
+    fn empty_when_section_absent() {
+        let body = "## Context\n\nNo files section here.\n";
+        assert!(parse_files_to_modify(body).is_empty());
+    }
+}

--- a/cli/src/commands/charter/new.rs
+++ b/cli/src/commands/charter/new.rs
@@ -153,6 +153,10 @@ pub fn run(
 /// AILOG-2026-05-02-028 in Sentinel).
 fn next_steps(from_ailog: Option<&str>, from_spec: Option<&str>) -> Vec<String> {
     let mut steps: Vec<&str> = vec![
+        "Reconnaissance first: READ every file before you list it in `## Files to modify` — \
+         confirm the path exists (or tag it 'New' in the Change column). Charters authored \
+         against assumed, un-read code are a known failure mode (#210); `straymark validate \
+         --include-charters` flags declared paths that do not exist (CHARTER-FILES-EXIST).",
         "Edit the Charter to fill in Context, Scope, Files to modify, Verification, Risks, Tasks.",
         "Set the trigger field in frontmatter to a concrete observable signal.",
     ];
@@ -796,57 +800,64 @@ ignored.
         assert_eq!(truncate_slug_at_word_boundary("supercalifragilistic", 10), "supercalif");
     }
 
+    /// Assert the steps are numbered 1..=len with no gaps (the cli-3.6.0 F1
+    /// regression was a gap: 2 → 4 when the conditional origin step was
+    /// suppressed without renumbering).
+    fn assert_sequential(steps: &[String]) {
+        for (i, s) in steps.iter().enumerate() {
+            assert!(
+                s.starts_with(&format!("{}. ", i + 1)),
+                "step {} should start with `{}. `; got {:?}",
+                i,
+                i + 1,
+                s
+            );
+        }
+    }
+
     #[test]
-    fn next_steps_no_origin_has_4_sequential_numbered_lines() {
+    fn next_steps_no_origin_has_5_sequential_numbered_lines() {
+        // recon + edit + trigger + origin + in-progress.
         let steps = next_steps(None, None);
-        assert_eq!(steps.len(), 4);
-        assert!(steps[0].starts_with("1. "));
-        assert!(steps[1].starts_with("2. "));
-        assert!(steps[2].starts_with("3. "));
-        assert!(steps[3].starts_with("4. "));
+        assert_eq!(steps.len(), 5);
+        assert_sequential(&steps);
+        // The recon nudge (finding #210) is step 1.
+        assert!(steps[0].contains("Reconnaissance"));
     }
 
     #[test]
     fn next_steps_with_from_ailog_re_sequences_without_gap() {
         // Regression test for cli-3.6.0 F1: when --from-ailog is passed, the
-        // origin-step is suppressed and the remaining steps must renumber to
-        // 1/2/3, NOT skip from 2 to 4 leaving a gap.
+        // origin-step is suppressed and the remaining steps must renumber
+        // sequentially, NOT leave a gap.
         let steps = next_steps(Some("AILOG-2026-04-28-021"), None);
-        assert_eq!(steps.len(), 3);
-        assert!(steps[0].starts_with("1. "));
-        assert!(steps[1].starts_with("2. "));
-        assert!(steps[2].starts_with("3. "));
-        // Verify step 2 is the trigger (not the suppressed origin step) and
-        // step 3 is the in-progress one (not stuck at "4.").
-        assert!(steps[1].contains("trigger"));
-        assert!(steps[2].contains("in-progress"));
+        assert_eq!(steps.len(), 4); // recon + edit + trigger + in-progress
+        assert_sequential(&steps);
+        assert!(steps[0].contains("Reconnaissance"));
+        assert!(steps[2].contains("trigger"));
+        assert!(steps[3].contains("in-progress"));
     }
 
     #[test]
     fn next_steps_with_from_spec_re_sequences_without_gap() {
         let steps = next_steps(None, Some("specs/001-test/spec.md"));
-        assert_eq!(steps.len(), 3);
-        assert!(steps[0].starts_with("1. "));
-        assert!(steps[2].starts_with("3. "));
-        assert!(steps[2].contains("in-progress"));
+        assert_eq!(steps.len(), 4);
+        assert_sequential(&steps);
+        assert!(steps[3].contains("in-progress"));
     }
 
     #[test]
-    fn next_steps_no_step_starts_with_4_when_origin_is_set() {
-        // Defensive: even if the steps grow, when an origin is set, no line
-        // should ever emit a "4. " prefix (because the conditional step is
-        // suppressed and renumbering applies). This guards against regressions
-        // that re-introduce hardcoded numbers.
+    fn next_steps_numbering_has_no_gaps_when_origin_is_set() {
+        // Defensive: when an origin is set the conditional step is suppressed;
+        // the remaining steps must stay sequential (no gap), regardless of how
+        // many fixed steps exist. Guards against regressions that re-introduce
+        // hardcoded numbers.
         for (ailog, spec) in [
             (Some("AILOG-2026-04-28-021"), None),
             (None, Some("specs/x/spec.md")),
         ] {
             let steps = next_steps(ailog, spec);
-            assert!(
-                !steps.iter().any(|s| s.starts_with("4. ")),
-                "no step should be numbered 4 when origin is set; got {:?}",
-                steps
-            );
+            assert_sequential(&steps);
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod ailog;
 mod audit_engine;
 mod audit_schema;
 mod charter;
+mod charter_files;
 mod charter_schema;
 mod commands;
 mod compliance;

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -107,6 +107,9 @@ fn china_in_scope(straymark_dir: &Path) -> bool {
 /// - `originating_ailogs` IDs resolve to real AILOG files under
 ///   `.straymark/07-ai-audit/agent-logs/`.
 /// - `originating_spec` path exists relative to the project root.
+/// - `CHARTER-FILES-EXIST`: every non-`new` path declared in `## Files to
+///   modify` exists on disk (finding #210 — Charter authored against assumed
+///   code). Warning-only; separate from `charter drift`'s OMISSION check.
 ///
 /// Returns the result + number of Charters considered (parsed + parse-failed).
 /// If the schema file itself cannot be loaded, emits a single warning and
@@ -218,6 +221,42 @@ pub fn validate_charters(project_root: &Path, straymark_dir: &Path) -> (Validati
                             .to_string(),
                     ),
                 });
+            }
+        }
+
+        // CHARTER-FILES-EXIST (finding #210): every path declared in the
+        // `## Files to modify` section that is NOT tagged "new" must exist on
+        // disk. A declared path that never existed is a *Charter authoring bug*
+        // (the Charter was written against assumed, un-read code) — distinct
+        // from the *implementation drift* the `charter drift` command catches
+        // (declared but not modified in a git range). Keeping the two checks in
+        // different commands with different rule codes is the separation #210.3
+        // asks for. Emitted as a Warning (not Error): adopters mid-migration may
+        // legitimately list not-yet-tagged new files, and warn-only matches the
+        // REF-001 / REVIEW-PENDING precedent.
+        if let Ok(charter) = crate::charter::parse_charter(path) {
+            for declared in crate::charter_files::parse_files_to_modify(&charter.body) {
+                if declared.is_new || crate::charter_files::is_wildcard(&declared.path) {
+                    continue;
+                }
+                if !project_root.join(&declared.path).exists() {
+                    result.add(ValidationIssue {
+                        file: path.clone(),
+                        rule: "CHARTER-FILES-EXIST".to_string(),
+                        message: format!(
+                            "`## Files to modify` declares a path that does not exist on disk: {} \
+                             (Charter mis-declared — authored against assumed code).",
+                            declared.path
+                        ),
+                        severity: Severity::Warning,
+                        fix_hint: Some(
+                            "Read the path before declaring it. If this Charter creates the file, \
+                             mark its Change column 'New' (or tag the path '(new)') — the validator \
+                             skips existence-checking new files."
+                                .to_string(),
+                        ),
+                    });
+                }
             }
         }
     }

--- a/cli/tests/charter_drift_test.rs
+++ b/cli/tests/charter_drift_test.rs
@@ -150,6 +150,41 @@ fn charter_drift_detects_declared_but_not_modified() {
         .stdout(predicate::str::contains("src/bar.rs"));
 }
 
+/// Separation guard for finding #210.3: `charter drift` reports OMISSION
+/// (declared-but-not-modified) and must NOT emit the `CHARTER-FILES-EXIST`
+/// rule — that authoring check lives in `validate`, a different command. The
+/// two concerns ("Charter mis-declared" vs "implementation drifted") stay in
+/// separate commands with separate rule codes.
+#[test]
+fn charter_drift_does_not_emit_charter_files_exist_rule() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+    // Declare a path that never exists on disk — drift's concern is the git
+    // range, not disk existence, so it must NOT borrow validate's rule.
+    write_charter_with_files(dir.path(), &["src/never-existed.rs"], None);
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/other.rs"), "// x\n").unwrap();
+
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "initial"]);
+    std::fs::write(dir.path().join("src/other.rs"), "// edited\n").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-q", "-m", "edit"]);
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args(["charter", "drift", "CHARTER-01", "--path"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("CHARTER-FILES-EXIST").not());
+}
+
 #[test]
 fn charter_drift_ailog_suppression_clears_documented_paths() {
     if !bash_available() {

--- a/cli/tests/validate_test.rs
+++ b/cli/tests/validate_test.rs
@@ -710,3 +710,104 @@ fn test_validate_staged_no_staged_docs() {
         .success()
         .stdout(predicates::str::contains("No staged documentation"));
 }
+
+// --- CHARTER-FILES-EXIST (finding #210) ---------------------------------
+
+/// Write a Charter with the given `## Files to modify` body block. `heading`
+/// lets a test exercise the locale variants; `rows` is the raw table body.
+fn create_charter(dir: &std::path::Path, heading: &str, rows: &str) {
+    let charters = dir.join(".straymark").join("charters");
+    std::fs::create_dir_all(&charters).unwrap();
+    let content = format!(
+        "---\ncharter_id: CHARTER-01\nstatus: declared\neffort_estimate: M\ntrigger: \"test trigger\"\n---\n\n# Charter: Files Exist Test\n\n## {}\n\n| File | Change |\n|---|---|\n{}\n## Tasks\n\n1. Run.\n",
+        heading, rows
+    );
+    std::fs::write(charters.join("01-files-exist.md"), content).unwrap();
+}
+
+#[test]
+fn test_charter_files_exist_flags_missing_path() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+    create_charter(dir.path(), "Files to modify", "| `src/does-not-exist.rs` | edit |\n");
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--include-charters")
+        .assert()
+        .success() // warning-only: must NOT fail the exit code
+        .stdout(predicate::str::contains("CHARTER-FILES-EXIST"))
+        .stdout(predicate::str::contains("src/does-not-exist.rs"));
+}
+
+#[test]
+fn test_charter_files_exist_skips_new_tagged_row() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+    create_charter(
+        dir.path(),
+        "Files to modify",
+        "| `src/brand-new.rs` | New, `risk_level: low` |\n",
+    );
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--include-charters")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CHARTER-FILES-EXIST").not());
+}
+
+#[test]
+fn test_charter_files_exist_passes_when_path_present() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/real.rs"), "// real\n").unwrap();
+    create_charter(dir.path(), "Files to modify", "| `src/real.rs` | edit |\n");
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--include-charters")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CHARTER-FILES-EXIST").not());
+}
+
+#[test]
+fn test_charter_files_exist_skips_wildcards() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+    create_charter(
+        dir.path(),
+        "Files to modify",
+        "| `.straymark/07-ai-audit/agent-logs/AILOG-*.md` | logs |\n",
+    );
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--include-charters")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CHARTER-FILES-EXIST").not());
+}
+
+#[test]
+fn test_charter_files_exist_detects_spanish_heading() {
+    let dir = TempDir::new().unwrap();
+    setup_straymark(dir.path());
+    create_charter(dir.path(), "Archivos a modificar", "| `src/no-existe.rs` | editar |\n");
+
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.arg("validate")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--include-charters")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CHARTER-FILES-EXIST"))
+        .stdout(predicate::str::contains("src/no-existe.rs"));
+}

--- a/dist/.claude/skills/straymark-charter-new/SKILL.md
+++ b/dist/.claude/skills/straymark-charter-new/SKILL.md
@@ -89,6 +89,8 @@ If the title would derive a poor slug, pass `--slug <slug>` explicitly.
 
 After the file is created, the CLI's "Next steps" output already lists what to fill. Surface it verbatim, then add:
 
+> **Reconnaissance before declaration** (#210): when filling `## Files to modify`, `Read`/`ls` every path before you list it — do not declare a path you have not opened. Charters authored against assumed, un-read code drift before execution even begins (the LNXDrive findings showed declared paths like `lnxdrive-config/src/parser.rs` that never existed). Tag genuinely-new files "New" in the Change column. If the Charter modifies a cross-component API (D-Bus/gRPC/REST contract, shared trait, IPC method), list **all** consumers, not just the producer. `straymark validate --include-charters` flags declared paths that don't exist (`CHARTER-FILES-EXIST`).
+>
 > **Reminder**: Charter status starts at `declared`. Flip to `in-progress` only when execution actually begins. Run `straymark charter drift CHARTER-NN` before `straymark charter close` to catch declared-but-not-modified files (or modified-but-not-declared ones).
 
 ### 6. Report result

--- a/dist/.codex/skills/straymark-charter-new/SKILL.md
+++ b/dist/.codex/skills/straymark-charter-new/SKILL.md
@@ -88,6 +88,8 @@ If the title would derive a poor slug, pass `--slug <slug>` explicitly.
 
 After the file is created, the CLI's "Next steps" output already lists what to fill. Surface it verbatim, then add:
 
+> **Reconnaissance before declaration** (#210): when filling `## Files to modify`, `Read`/`ls` every path before you list it — do not declare a path you have not opened. Charters authored against assumed, un-read code drift before execution even begins (the LNXDrive findings showed declared paths like `lnxdrive-config/src/parser.rs` that never existed). Tag genuinely-new files "New" in the Change column. If the Charter modifies a cross-component API (D-Bus/gRPC/REST contract, shared trait, IPC method), list **all** consumers, not just the producer. `straymark validate --include-charters` flags declared paths that don't exist (`CHARTER-FILES-EXIST`).
+>
 > **Reminder**: Charter status starts at `declared`. Flip to `in-progress` only when execution actually begins. Run `straymark charter drift CHARTER-NN` before `straymark charter close` to catch declared-but-not-modified files (or modified-but-not-declared ones).
 
 ### 6. Report result

--- a/dist/.gemini/skills/straymark-charter-new/SKILL.md
+++ b/dist/.gemini/skills/straymark-charter-new/SKILL.md
@@ -88,6 +88,8 @@ If the title would derive a poor slug, pass `--slug <slug>` explicitly.
 
 After the file is created, the CLI's "Next steps" output already lists what to fill. Surface it verbatim, then add:
 
+> **Reconnaissance before declaration** (#210): when filling `## Files to modify`, `Read`/`ls` every path before you list it — do not declare a path you have not opened. Charters authored against assumed, un-read code drift before execution even begins (the LNXDrive findings showed declared paths like `lnxdrive-config/src/parser.rs` that never existed). Tag genuinely-new files "New" in the Change column. If the Charter modifies a cross-component API (D-Bus/gRPC/REST contract, shared trait, IPC method), list **all** consumers, not just the producer. `straymark validate --include-charters` flags declared paths that don't exist (`CHARTER-FILES-EXIST`).
+>
 > **Reminder**: Charter status starts at `declared`. Flip to `in-progress` only when execution actually begins. Run `straymark charter drift CHARTER-NN` before `straymark charter close` to catch declared-but-not-modified files (or modified-but-not-declared ones).
 
 ### 6. Report result

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -387,4 +387,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -318,4 +318,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md
+++ b/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md
@@ -8,9 +8,13 @@
 
 ## Status
 
-**v0 — proven in N=1 domain** (`StrangeDaysTech/sentinel` CHARTER-19 → CHARTER-27, 2026-05-22).
+**v1 — validated in N=2 independent domains.** Two axes, deliberately reported
+separately so they are not conflated:
 
-This is a **convention + named anti-pattern**, not a CLI feature. Adopters reproduce it locally with a dedicated polish Charter and (optionally) project-local CI guards. The pattern may evolve into a `straymark analyze declared-vs-wired` subcommand once a second adopter validates it (see [Open questions](#open-questions)). The gate for that cristallization mirrors the one used by [`FOLLOW-UPS-BACKLOG-PATTERN.md`](FOLLOW-UPS-BACKLOG-PATTERN.md): v0 → v1 graduation requires N=2.
+- **Independent domains: 2.** `StrangeDaysTech/sentinel` (Go backend, CHARTER-19 → CHARTER-27, 2026-05-22) and `StrangeDaysTech/lnxdrive` (Rust Linux cloud-sync daemon + GTK desktop, 2026-05, [finding #209](https://github.com/StrangeDaysTech/straymark/issues/209)). A Rust desktop app validating a pattern first seen in a Go backend is the strong cross-domain signal the [N-status gate](../../../ADOPTERS.md) requires.
+- **Occurrences: 3.** Sentinel surfaced the original sub-classes (1–4); LNXDrive surfaced a qualitatively new occurrence — a *cross-component regression of a shipped mitigation* (sub-class 5 below).
+
+The N=2 gate for CLI crystallization (mirrored from [`FOLLOW-UPS-BACKLOG-PATTERN.md`](FOLLOW-UPS-BACKLOG-PATTERN.md)) is **now crossed**. The convention + named anti-pattern remains the portable core; the mechanical check graduates to a `straymark analyze declared-vs-wired` subcommand (config-driven set-difference, v0 scope ships in cli-3.17.x+ — see [Open questions](#open-questions)). Adopters can still reproduce the discovery locally with a dedicated polish Charter and (optionally) project-local CI guards.
 
 ---
 
@@ -49,12 +53,24 @@ The anti-pattern presents in at least four sub-classes. Each maps to a mechanica
 | 2 | Metric instrument / observability symbol declared in a metrics package | Record / increment call site in handler or worker code | Each declared instrument has at least one record-call site |
 | 3 | URL referenced from rendered HTML or embedded template (`<script src="/...">`, `<link href="/...">`) | Route registered with the same API surface | Each `src=`/`href=` in served HTML resolves to a registered route |
 | 4 | Route marked public-by-contract (handler doc-comment, dedicated marker) | Entry in the auth middleware's public-prefix / public-paths list | Each public-by-contract handler has a matching prefix entry |
+| 5 | Client-side IPC/RPC proxy method declared (D-Bus proxy, gRPC stub, REST client) — **especially one re-introduced after a shipped mitigation removed the server method** | Server / daemon interface that actually implements the method | Each declared proxy method resolves to an implemented interface method; a cross-component API change must update **all** consumers |
 
-The unifying one-liner across the four sub-classes is:
+The unifying one-liner across the sub-classes is:
 
 > **Every declared surface artifact has at least one wiring site reachable from a real request.**
 
 Adopters extending the list (new declaration↔wiring pairs the reference implementation has not yet surfaced) are welcome to contribute additional sub-classes via issue or PR.
+
+### Sub-class 5 named: shipped-mitigation regression via an un-updated downstream consumer
+
+LNXDrive surfaced sub-class 5 as a *regression of an already-shipped mitigation, across a component boundary* — a sharper data point than a fresh gap. The producer (a D-Bus daemon) had closed a security risk by removing a token-bearing method and shipping a token-safe replacement. A separate component (a GTK preferences client, compiled via a different build system) **kept calling the removed method** and fetching tokens client-side — the exact behavior the mitigation had eliminated.
+
+Two compounding factors made it invisible to every existing backstop:
+
+- **Cross-boundary blindness.** Producer and consumer live in different crates, built by different toolchains (Cargo vs Meson), joined only at runtime over the bus. zbus/D-Bus proxies are validated at *runtime*, not compile time — so the daemon's own tests passed, the client compiled clean, and no single test suite spanned the contract.
+- **Feature-gated dead code.** The stale call sat behind a `#[cfg(feature = "goa")]` whose feature `Cargo.toml` never defined. It compiled *out* entirely — dead code that defeats both CI and code review, since neither exercises an undefined feature. Activating the feature for the first time even surfaced a latent type error that had never compiled: concrete proof the path was never wired.
+
+The legible signal that caught it was the polish/audit's **ex-ante contract check** — a diff of the client's declared proxy methods against the daemon's implemented interface. This generalizes the mechanical check from "every declared surface artifact has a wiring site" to its cross-component corollary: **a producer-side API change must update, or at least account for, every declared consumer of that API.** The Charter discipline that operationalizes this lives in [the template guidance](#related) (#209.c): a mitigation touching a cross-component API lists *all* consumers in `## Files to modify`, so a producer change can't silently orphan a consumer.
 
 ### Why integration tests miss these
 
@@ -96,7 +112,7 @@ The originating RFC discussion is [straymark#199](https://github.com/StrangeDays
 
 These are not resolved in v0. Future revisions of this pattern, or a CLI helper, may address them:
 
-- **Crystallization as `straymark analyze declared-vs-wired` CLI subcommand**. Today the four sub-class checks are project-local (one Go analyzer in the reference implementation). Once a second adopter validates the pattern, the framework may ship a cross-project subcommand parameterized by: which packages contain declared artifacts (metric instrument types, env-var docs format, HTML embed paths, public-route marker convention); which sites count as wiring (record call, env-var reader, route registrar, prefix list). Gate: N=2 adopters.
+- **Crystallization as `straymark analyze declared-vs-wired` CLI subcommand** — *N=2 gate crossed; v0 scope resolved.* With LNXDrive validating the pattern in a second domain, the framework ships a **config-driven set-difference** v0: the operator supplies a declared-side glob+regex and a wired-side glob+regex (the regex capture group is the symbol name), and the command reports symbols declared-but-not-wired (`D \ W`). This is mechanically tractable on *any* stack precisely because the stack-specific knowledge lives in the adopter's regexes, not in the CLI — and it directly catches sub-class 5 (D-Bus proxy method names client-side vs interface method names server-side). **Deferred to a later revision:** AST-based variants of sub-classes 1–4 (env-var docs, metric instruments, HTML embeds, public-route markers), which need per-stack parsers; and the runtime/dynamic checks (full-chain boot, route resolution), which are inherently project-local.
 - **Sub-class enumeration completeness**. The four sub-classes were the ones the reference implementation surfaced. Additional candidates: database column declared in a migration but never read/written by application code; feature flag declared but never checked; protobuf field defined but never serialized. Each additional sub-class needs at least one adopter empirical surfacing to enter the canon.
 - **Integration with `straymark charter close --polish-checklist`**. A polish-specific subcommand could surface the canonical checklist (run runbook end-to-end; verify each declared artifact has a wiring site; verify env-var inventory matches the binary's actual requirements; verify CLI tooling referenced in the runbook exists). Gate: after the `declared-vs-wired` CLI subcommand lands, since the checklist's last item would invoke it.
 - **Per-stack instantiation guides**. The four sub-classes are language-agnostic; the concrete check shape (Go `analysis.Pass`, TypeScript AST walker, Python `ast` module, etc.) is not. A future pattern revision may host per-stack reference implementations as sibling docs.
@@ -106,7 +122,9 @@ These are not resolved in v0. Future revisions of this pattern, or a CLI helper,
 
 ## Credits
 
-Contributed via [issue #199](https://github.com/StrangeDaysTech/straymark/issues/199) by the Sentinel adopter. Empirical foundation: CHARTER-19 → CHARTER-27 chain in `StrangeDaysTech/sentinel`, retrospective [AIDEC-2026-05-22-001](https://github.com/StrangeDaysTech/sentinel/pull/93). Author: José Villaseñor Montfort.
+Originated via [issue #199](https://github.com/StrangeDaysTech/straymark/issues/199) by the Sentinel adopter (N=1). Empirical foundation: CHARTER-19 → CHARTER-27 chain in `StrangeDaysTech/sentinel`, retrospective [AIDEC-2026-05-22-001](https://github.com/StrangeDaysTech/sentinel/pull/93).
+
+Crystallized to **v1 (N=2)** via [finding #209](https://github.com/StrangeDaysTech/straymark/issues/209) by the LNXDrive adopter (Rust desktop, second independent domain), which contributed sub-class 5 (shipped-mitigation regression via an un-updated downstream consumer) and triggered the `analyze declared-vs-wired` subcommand. The companion [finding #210](https://github.com/StrangeDaysTech/straymark/issues/210) added the `charter new` reconnaissance discipline and the `CHARTER-FILES-EXIST` validate rule. Author: José Villaseñor Montfort.
 
 *This document was produced with assistance from generative AI tools (Claude 4.7); all responsibility for the content rests with the human author.*
 
@@ -121,4 +139,4 @@ Contributed via [issue #199](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -242,4 +242,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -387,4 +387,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/POLISH-CHARTER-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/POLISH-CHARTER-PATTERN.md
@@ -8,9 +8,12 @@
 
 ## Estado
 
-**v0 — validado en N=1 dominio** (`StrangeDaysTech/sentinel` CHARTER-19 → CHARTER-27, 2026-05-22).
+**v1 — validado en N=2 dominios independientes.** Dos ejes, reportados por separado a propósito para no confundirlos:
 
-Esto es una **convención + anti-patrón nombrado**, no una funcionalidad del CLI. Los adopters la reproducen localmente con un Charter polish dedicado y (opcionalmente) guards de CI local al proyecto. El patrón puede evolucionar a un subcomando `straymark analyze declared-vs-wired` una vez que un segundo adopter lo valide (ver [Preguntas abiertas](#preguntas-abiertas)). La compuerta para esa cristalización refleja la usada por [`FOLLOW-UPS-BACKLOG-PATTERN.md`](FOLLOW-UPS-BACKLOG-PATTERN.md): la graduación v0 → v1 requiere N=2.
+- **Dominios independientes: 2.** `StrangeDaysTech/sentinel` (backend Go, CHARTER-19 → CHARTER-27, 2026-05-22) y `StrangeDaysTech/lnxdrive` (daemon Rust de sincronización en Linux + escritorio GTK, 2026-05, [hallazgo #209](https://github.com/StrangeDaysTech/straymark/issues/209)). Una app de escritorio en Rust validando un patrón visto primero en un backend Go es la señal cross-domain fuerte que exige la [compuerta de N-status](../../../ADOPTERS.md).
+- **Ocurrencias: 3.** Sentinel afloró las subclases originales (1–4); LNXDrive afloró una ocurrencia cualitativamente nueva — una *regresión cross-component de una mitigación ya entregada* (subclase 5, abajo).
+
+La compuerta N=2 para la cristalización en el CLI (reflejada de [`FOLLOW-UPS-BACKLOG-PATTERN.md`](FOLLOW-UPS-BACKLOG-PATTERN.md)) **ya está cruzada**. La convención + anti-patrón nombrado siguen siendo el núcleo portable; la verificación mecánica gradúa a un subcomando `straymark analyze declared-vs-wired` (set-difference dirigido por config, alcance v0 entregado en cli-3.17.x+ — ver [Preguntas abiertas](#preguntas-abiertas)). Los adopters aún pueden reproducir el descubrimiento localmente con un Charter polish dedicado y (opcionalmente) guards de CI local al proyecto.
 
 ---
 
@@ -49,12 +52,24 @@ El anti-patrón se presenta en al menos cuatro subclases. Cada una mapea a una v
 | 2 | Instrumento métrico / símbolo de observabilidad declarado en un paquete de métricas | Sitio de llamada de registro / incremento en código de handler o worker | Cada instrumento declarado tiene al menos un sitio de llamada de registro |
 | 3 | URL referenciada desde HTML renderizado o plantilla embebida (`<script src="/...">`, `<link href="/...">`) | Ruta registrada con la misma superficie de API | Cada `src=`/`href=` en HTML servido resuelve a una ruta registrada |
 | 4 | Ruta marcada pública-por-contrato (doc-comment del handler, marcador dedicado) | Entrada en la lista de prefijos públicos / paths públicos del middleware de auth | Cada handler público-por-contrato tiene una entrada de prefijo equivalente |
+| 5 | Método proxy IPC/RPC declarado client-side (proxy D-Bus, stub gRPC, cliente REST) — **especialmente uno reintroducido tras una mitigación que eliminó el método del servidor** | Interfaz del servidor / daemon que realmente implementa el método | Cada método proxy declarado resuelve a un método de interfaz implementado; un cambio de API cross-component debe actualizar **todos** los consumidores |
 
-El one-liner unificador a través de las cuatro subclases es:
+El one-liner unificador a través de las subclases es:
 
 > **Cada artefacto de superficie declarado tiene al menos un sitio de cableado alcanzable desde un request real.**
 
 Los adopters que extiendan la lista (nuevos pares declaración↔cableado que la implementación de referencia aún no haya aflorado) están invitados a contribuir subclases adicionales vía issue o PR.
+
+### Subclase 5 nombrada: regresión de mitigación entregada vía un consumidor downstream no actualizado
+
+LNXDrive afloró la subclase 5 como una *regresión de una mitigación ya entregada, a través de una frontera de componentes* — un datapoint más afilado que un gap nuevo. El productor (un daemon D-Bus) había cerrado un riesgo de seguridad eliminando un método portador de tokens y entregando un reemplazo token-safe. Un componente separado (un cliente GTK de preferencias, compilado vía un build system distinto) **seguía llamando al método eliminado** y obteniendo tokens client-side — exactamente el comportamiento que la mitigación había eliminado.
+
+Dos factores que se componen lo hicieron invisible a cada backstop existente:
+
+- **Ceguera cross-frontera.** Productor y consumidor viven en crates distintas, construidas por toolchains distintas (Cargo vs Meson), unidas solo en runtime sobre el bus. Los proxies zbus/D-Bus se validan en *runtime*, no en tiempo de compilación — así que los propios tests del daemon pasaron, el cliente compiló limpio, y ninguna suite de tests abarcaba el contrato.
+- **Código muerto tras feature-gate.** La llamada obsoleta vivía tras un `#[cfg(feature = "goa")]` cuya feature `Cargo.toml` nunca definió. Compilaba *fuera* por completo — código muerto que derrota tanto a CI como a la revisión, ya que ninguno ejerce una feature indefinida. Activar la feature por primera vez incluso afloró un error de tipo latente que nunca había compilado: prueba concreta de que el camino nunca estuvo cableado.
+
+La señal legible que lo atrapó fue la **verificación de contrato ex-ante** del polish/auditoría — un diff de los métodos proxy declarados del cliente contra la interfaz implementada del daemon. Esto generaliza la verificación mecánica de "cada artefacto de superficie declarado tiene un sitio de cableado" a su corolario cross-component: **un cambio de API del lado productor debe actualizar, o al menos contemplar, cada consumidor declarado de esa API.** La disciplina de Charter que operacionaliza esto vive en [la guía de la plantilla](#relacionado) (#209.c): una mitigación que toca una API cross-component lista *todos* los consumidores en `## Archivos a modificar`, para que un cambio del productor no pueda huérfanar silenciosamente a un consumidor.
 
 ### Por qué los tests de integración las omiten
 
@@ -96,7 +111,7 @@ La discusión RFC originante es [straymark#199](https://github.com/StrangeDaysTe
 
 Estas no están resueltas en v0. Revisiones futuras de este patrón, o un helper CLI, pueden abordarlas:
 
-- **Cristalización como subcomando CLI `straymark analyze declared-vs-wired`**. Hoy las verificaciones de las cuatro subclases son project-local (un analizador en Go en la implementación de referencia). Una vez que un segundo adopter valide el patrón, el framework puede entregar un subcomando cross-proyecto parametrizado por: qué paquetes contienen artefactos declarados (tipos de instrumento métrico, formato de docs de env-var, paths de embed HTML, convención de marcador de ruta pública); qué sitios cuentan como cableado (llamada de registro, lector de env-var, registrador de ruta, lista de prefijos). Compuerta: N=2 adopters.
+- **Cristalización como subcomando CLI `straymark analyze declared-vs-wired`** — *compuerta N=2 cruzada; alcance v0 resuelto.* Con LNXDrive validando el patrón en un segundo dominio, el framework entrega un v0 de **set-difference dirigido por config**: el operador provee un glob+regex del lado declarado y un glob+regex del lado cableado (el grupo de captura del regex es el nombre del símbolo), y el comando reporta los símbolos declarados-pero-no-cableados (`D \ W`). Esto es mecánicamente tratable en *cualquier* stack precisamente porque el conocimiento específico del stack vive en los regexes del adopter, no en el CLI — y atrapa directamente la subclase 5 (nombres de método del proxy D-Bus client-side vs nombres de método de interfaz server-side). **Diferido a una revisión posterior:** variantes basadas en AST de las subclases 1–4 (docs de env-var, instrumentos métricos, embeds HTML, marcadores de ruta pública), que necesitan parsers por stack; y las verificaciones runtime/dinámicas (boot de cadena completa, resolución de rutas), que son inherentemente project-local.
 - **Completitud de enumeración de subclases**. Las cuatro subclases fueron las que la implementación de referencia afloró. Candidatas adicionales: columna de base de datos declarada en una migración pero nunca leída/escrita por código de aplicación; feature flag declarado pero nunca verificado; campo protobuf definido pero nunca serializado. Cada subclase adicional necesita al menos un afloramiento empírico de un adopter para entrar al canon.
 - **Integración con `straymark charter close --polish-checklist`**. Un subcomando polish-específico podría aflorar el checklist canónico (ejecuta runbook end-to-end; verifica que cada artefacto declarado tenga un sitio de cableado; verifica que el inventario de env-var coincida con los requisitos reales del binario; verifica que las herramientas CLI referenciadas en el runbook existan). Compuerta: después de que el subcomando CLI `declared-vs-wired` aterrice, ya que el último ítem del checklist lo invocaría.
 - **Guías de instanciación por stack**. Las cuatro subclases son agnósticas de lenguaje; la forma concreta de verificación (`analysis.Pass` de Go, walker de AST de TypeScript, módulo `ast` de Python, etc.) no lo es. Una revisión futura del patrón puede alojar implementaciones de referencia por stack como docs hermanas.
@@ -106,7 +121,9 @@ Estas no están resueltas en v0. Revisiones futuras de este patrón, o un helper
 
 ## Créditos
 
-Contribuido vía [issue #199](https://github.com/StrangeDaysTech/straymark/issues/199) por el adopter Sentinel. Base empírica: cadena CHARTER-19 → CHARTER-27 en `StrangeDaysTech/sentinel`, retrospectiva [AIDEC-2026-05-22-001](https://github.com/StrangeDaysTech/sentinel/pull/93). Autor: José Villaseñor Montfort.
+Originado vía [issue #199](https://github.com/StrangeDaysTech/straymark/issues/199) por el adopter Sentinel (N=1). Base empírica: cadena CHARTER-19 → CHARTER-27 en `StrangeDaysTech/sentinel`, retrospectiva [AIDEC-2026-05-22-001](https://github.com/StrangeDaysTech/sentinel/pull/93).
+
+Cristalizado a **v1 (N=2)** vía [hallazgo #209](https://github.com/StrangeDaysTech/straymark/issues/209) por el adopter LNXDrive (escritorio Rust, segundo dominio independiente), que contribuyó la subclase 5 (regresión de mitigación entregada vía un consumidor downstream no actualizado) y disparó el subcomando `analyze declared-vs-wired`. El hallazgo compañero [#210](https://github.com/StrangeDaysTech/straymark/issues/210) agregó la disciplina de reconocimiento en `charter new` y la regla de validación `CHARTER-FILES-EXIST`. Autor: José Villaseñor Montfort.
 
 *Este documento fue producido con asistencia de herramientas de IA generativa (Claude 4.7); toda responsabilidad por el contenido recae en el autor humano.*
 
@@ -121,4 +138,4 @@ Contribuido vía [issue #199](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -217,4 +217,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -382,4 +382,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -310,4 +310,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/POLISH-CHARTER-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/POLISH-CHARTER-PATTERN.md
@@ -8,9 +8,12 @@
 
 ## 状态
 
-**v0 — 在 N=1 域中已验证**(`StrangeDaysTech/sentinel` CHARTER-19 → CHARTER-27,2026-05-22)。
+**v1 — 在 N=2 个独立域中已验证。** 两个轴,有意分开报告以免混淆:
 
-这是一个**约定 + 命名反模式**,不是 CLI 功能。Adopter 使用专门的 polish Charter 与(可选的)项目本地 CI 守卫在本地复制此模式。在第二个 adopter 验证后,该模式可能演变为 `straymark analyze declared-vs-wired` 子命令(参见[未决问题](#未决问题))。该结晶门反映了 [`FOLLOW-UPS-BACKLOG-PATTERN.md`](FOLLOW-UPS-BACKLOG-PATTERN.md) 所用的门:v0 → v1 升级要求 N=2。
+- **独立域:2 个。** `StrangeDaysTech/sentinel`(Go 后端,CHARTER-19 → CHARTER-27,2026-05-22)与 `StrangeDaysTech/lnxdrive`(Rust Linux 云同步守护进程 + GTK 桌面,2026-05,[发现 #209](https://github.com/StrangeDaysTech/straymark/issues/209))。一个 Rust 桌面应用验证首先在 Go 后端中看到的模式,正是 [N-status 门](../../../ADOPTERS.md)所要求的强 cross-domain 信号。
+- **出现次数:3 次。** Sentinel 浮现了原始子类(1–4);LNXDrive 浮现了一个性质上全新的出现 — 一次*已交付缓解措施的 cross-component 回归*(下方子类 5)。
+
+CLI 结晶的 N=2 门(反映自 [`FOLLOW-UPS-BACKLOG-PATTERN.md`](FOLLOW-UPS-BACKLOG-PATTERN.md))**现已跨越**。约定 + 命名反模式仍是可移植的核心;机械化检查升级为 `straymark analyze declared-vs-wired` 子命令(由配置驱动的 set-difference,v0 范围在 cli-3.17.x+ 中交付 — 见[未决问题](#未决问题))。Adopter 仍可使用专门的 polish Charter 与(可选的)项目本地 CI 守卫在本地复制此发现。
 
 ---
 
@@ -49,12 +52,24 @@ polish Charter 是**发现载体**:它是浮现此类回归的最廉价方法,�
 | 2 | metrics 包中声明的 metric instrument / 可观测性符号 | handler 或 worker 代码中的记录 / 递增调用位置 | 每个声明的 instrument 都至少有一个记录调用位置 |
 | 3 | 从渲染的 HTML 或嵌入模板中引用的 URL(`<script src="/...">`、`<link href="/...">`) | 注册到同一 API 表面的路由 | 已服务 HTML 中的每个 `src=`/`href=` 都解析到一个已注册的路由 |
 | 4 | 标记为公共-按-合约的路由(handler 文档注释、专用标记) | auth middleware 的公共前缀 / 公共路径列表中的条目 | 每个公共-按-合约的 handler 都有匹配的前缀条目 |
+| 5 | 客户端声明的 IPC/RPC proxy 方法(D-Bus proxy、gRPC stub、REST 客户端)— **尤其是在缓解措施移除了服务端方法之后被重新引入的那种** | 真正实现该方法的服务端 / 守护进程接口 | 每个声明的 proxy 方法都解析到一个已实现的接口方法;cross-component 的 API 变更必须更新**所有**消费者 |
 
-跨四个子类的统一一句话是:
+跨子类的统一一句话是:
 
 > **每个声明的表层制品都至少有一个可从真实请求触达的接线位置。**
 
 扩展该列表的 adopter(参考实现尚未浮现的新声明↔接线对)欢迎通过 issue 或 PR 贡献额外子类。
+
+### 子类 5 命名:已交付缓解措施经由未更新的下游消费者发生回归
+
+LNXDrive 将子类 5 浮现为一次*已交付缓解措施的回归,跨越了组件边界* — 比一个全新 gap 更尖锐的数据点。生产者(一个 D-Bus 守护进程)通过移除一个携带 token 的方法并交付一个 token-safe 替代,关闭了一个安全风险。一个独立的组件(一个 GTK 偏好设置客户端,经由不同构建系统编译)**仍在调用已移除的方法**并在客户端获取 token — 正是缓解措施已经消除的行为。
+
+两个叠加因素使其对每一个现有 backstop 都不可见:
+
+- **跨边界盲区。** 生产者与消费者位于不同的 crate,由不同的工具链(Cargo vs Meson)构建,仅在运行时经由总线连接。zbus/D-Bus proxy 在*运行时*而非编译时被验证 — 因此守护进程自己的测试通过,客户端干净编译,没有任何单一测试套件跨越该合约。
+- **feature-gate 后的死代码。** 这个陈旧调用位于一个 `#[cfg(feature = "goa")]` 之后,而 `Cargo.toml` 从未定义该 feature。它被完全编译*掉* — 死代码既击败了 CI 也击败了代码 review,因为两者都不会执行一个未定义的 feature。首次激活该 feature 甚至浮现了一个从未编译过的潜伏类型错误:该路径从未接线的确凿证据。
+
+捕获它的可读信号是 polish/审核的**ex-ante 合约检查** — 客户端声明的 proxy 方法与守护进程已实现接口的 diff。这将"每个声明的表层制品都有一个接线位置"的机械化检查推广到其 cross-component 推论:**生产者侧的 API 变更必须更新、或至少考虑该 API 的每一个声明消费者。** 将其操作化的 Charter 纪律存在于[模板指南](#相关)(#209.c):一个触及 cross-component API 的缓解措施在 `## 要修改的文件` 中列出*所有*消费者,使生产者的变更无法静默地孤立一个消费者。
 
 ### 为什么集成测试会遗漏这些
 
@@ -96,7 +111,7 @@ polish Charter 的手动 smoke(`./binary && curl <已记录的-recipe>`)重新�
 
 这些问题在 v0 中未解决。该模式的未来修订,或 CLI helper,可能解决它们:
 
-- **结晶为 `straymark analyze declared-vs-wired` CLI 子命令**。今天四个子类检查为 project-local(参考实现中的一个 Go analyzer)。一旦第二个 adopter 验证该模式,框架可以发布一个 cross-project 子命令,由以下参数化:哪些包含声明制品(metric instrument 类型、env-var 文档格式、HTML embed 路径、公共路由标记约定);哪些位置算作接线(记录调用、env-var 读取器、路由注册器、prefix 列表)。门:N=2 adopters。
+- **结晶为 `straymark analyze declared-vs-wired` CLI 子命令** — *N=2 门已跨越;v0 范围已确定。* 随着 LNXDrive 在第二个域中验证该模式,框架交付一个**由配置驱动的 set-difference** v0:操作员提供声明侧的 glob+regex 与接线侧的 glob+regex(regex 捕获组即符号名),命令报告声明了但未接线的符号(`D \ W`)。这在*任何* stack 上都是机械化可处理的,正因为 stack 特定知识存在于 adopter 的 regex 中而非 CLI 中 — 并且它直接捕获子类 5(客户端 D-Bus proxy 方法名 vs 服务端接口方法名)。**推迟到后续修订:** 子类 1–4 的基于 AST 的变体(env-var 文档、metric instrument、HTML embed、公共路由标记),它们需要按 stack 的解析器;以及 runtime/动态检查(full-chain boot、路由解析),它们本质上是 project-local。
 - **子类枚举的完整性**。四个子类是参考实现所浮现的。额外候选:在迁移中声明但从未被应用代码读/写的数据库列;声明但从未被检查的 feature flag;定义但从未被序列化的 protobuf 字段。每个额外子类至少需要一次 adopter 的经验浮现才能进入正典。
 - **与 `straymark charter close --polish-checklist` 的集成**。一个 polish 专用子命令可以浮现规范化清单(end-to-end 执行 runbook;验证每个声明制品都有接线位置;验证 env-var 清单匹配二进制的实际需求;验证 runbook 中引用的 CLI 工具都存在)。门:在 `declared-vs-wired` CLI 子命令落地之后,因为清单的最后一项将调用它。
 - **按 stack 的实例化指南**。四个子类与语言无关;具体检查形态(Go 的 `analysis.Pass`、TypeScript 的 AST walker、Python 的 `ast` 模块等)与语言相关。该模式的未来修订可能将按 stack 的参考实现作为兄弟文档托管。
@@ -106,7 +121,9 @@ polish Charter 的手动 smoke(`./binary && curl <已记录的-recipe>`)重新�
 
 ## 致谢
 
-由 Sentinel adopter 通过 [issue #199](https://github.com/StrangeDaysTech/straymark/issues/199) 贡献。经验基础:`StrangeDaysTech/sentinel` 中的 CHARTER-19 → CHARTER-27 链,回顾 [AIDEC-2026-05-22-001](https://github.com/StrangeDaysTech/sentinel/pull/93)。作者:José Villaseñor Montfort。
+由 Sentinel adopter(N=1)通过 [issue #199](https://github.com/StrangeDaysTech/straymark/issues/199) 发起。经验基础:`StrangeDaysTech/sentinel` 中的 CHARTER-19 → CHARTER-27 链,回顾 [AIDEC-2026-05-22-001](https://github.com/StrangeDaysTech/sentinel/pull/93)。
+
+经由 LNXDrive adopter(Rust 桌面,第二个独立域)的[发现 #209](https://github.com/StrangeDaysTech/straymark/issues/209)结晶为 **v1(N=2)**,它贡献了子类 5(已交付缓解措施经由未更新的下游消费者发生回归)并触发了 `analyze declared-vs-wired` 子命令。配套的[发现 #210](https://github.com/StrangeDaysTech/straymark/issues/210)增加了 `charter new` 的侦察纪律与 `CHARTER-FILES-EXIST` 验证规则。作者:José Villaseñor Montfort。
 
 *本文档在生成式 AI 工具(Claude 4.7)的协助下产生;所有内容责任由人类作者承担。*
 
@@ -121,4 +138,4 @@ polish Charter 的手动 smoke(`./binary && curl <已记录的-recipe>`)重新�
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -217,4 +217,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark fw-4.19.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.20.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/templates/charter/charter-template.md
+++ b/dist/.straymark/templates/charter/charter-template.md
@@ -49,10 +49,25 @@ do not classify them as gaps. Ideally cite the Charter or initiative where they 
 
 ## Files to modify
 
+<!-- Reconnaissance first (#210): READ every file before you list it here —
+     confirm the path exists in the tree. Charters authored against assumed,
+     un-read code drift before execution even begins. `straymark validate
+     --include-charters` flags any declared path that does not exist
+     (CHARTER-FILES-EXIST). For a file this Charter CREATES, start its Change
+     column with "New" (the validator skips existence-checking those).
+
+     Cross-component APIs (#209): if this Charter modifies a contract that other
+     components consume — a D-Bus/gRPC/REST interface, a shared trait, an IPC
+     method — list ALL consumers of that API as separate rows, not just the
+     producer. A mitigation that updates the producer but leaves a consumer
+     calling the old contract is the "shipped-mitigation regression" anti-pattern
+     (POLISH-CHARTER-PATTERN.md sub-class 5). -->
+
 | File | Change |
 |---|---|
 | `path/to/file.ext` | [Concrete description of the change] |
-| `...` | `...` |
+| `path/to/api-producer.ext` | [Change to the cross-component API] |
+| `path/to/api-consumer.ext` | [Update consumer to the new contract — do not orphan it] |
 | `.straymark/07-ai-audit/agent-logs/AILOG-...md` | New, `risk_level: [low|medium|high]` |
 
 ## Verification
@@ -239,4 +254,14 @@ v3 addition" — the partition was Sentinel's iteration log, not structural).
    sub-class checks that cover the common cases. Empirical signal from the
    reference implementation: budget the polish Charter as L (not XS/S/M) and
    expect emergent follow-on Charters, not residual cleanup scope creep.
+
+8. `## Files to modify` is authored from READ code, not assumed code (StrayMark
+   findings #209/#210, LNXDrive N=2). Two disciplines: (a) every declared path
+   exists in the tree, or is marked "New" in its Change column — the
+   `CHARTER-FILES-EXIST` validate rule (cli-3.17.0+) flags violations, separating
+   "Charter mis-declared" (authoring bug) from `charter drift`'s "declared but
+   not modified" (implementation drift); (b) a change to a cross-component API
+   lists ALL consumers, not just the producer — see
+   `.straymark/00-governance/POLISH-CHARTER-PATTERN.md` sub-class 5
+   ("shipped-mitigation regression via an un-updated downstream consumer").
 -->

--- a/dist/.straymark/templates/charter/i18n/es/charter-template.md
+++ b/dist/.straymark/templates/charter/i18n/es/charter-template.md
@@ -51,10 +51,26 @@ donde sí van.]
 
 ## Archivos a modificar
 
+<!-- Reconocimiento primero (#210): LEE cada archivo antes de listarlo aquí —
+     confirma que la ruta existe en el árbol. Los Charters redactados contra
+     código asumido, no leído, derivan antes incluso de empezar la ejecución.
+     `straymark validate --include-charters` marca cualquier ruta declarada que
+     no exista (CHARTER-FILES-EXIST). Para un archivo que este Charter CREA,
+     comienza su columna Cambio con "Nuevo" (el validador omite verificar la
+     existencia de esos).
+
+     APIs cross-component (#209): si este Charter modifica un contrato que otros
+     componentes consumen — una interfaz D-Bus/gRPC/REST, un trait compartido, un
+     método IPC — lista TODOS los consumidores de esa API como filas separadas, no
+     solo el productor. Una mitigación que actualiza el productor pero deja a un
+     consumidor llamando al contrato viejo es el anti-patrón de "regresión de
+     mitigación entregada" (POLISH-CHARTER-PATTERN.md subclase 5). -->
+
 | Archivo | Cambio |
 |---|---|
 | `path/al/archivo.ext` | [Descripción concreta del cambio] |
-| `...` | `...` |
+| `path/al/api-productor.ext` | [Cambio en la API cross-component] |
+| `path/al/api-consumidor.ext` | [Actualiza el consumidor al nuevo contrato — no lo huérfanes] |
 | `.straymark/07-ai-audit/agent-logs/AILOG-...md` | Nuevo, `risk_level: [low|medium|high]` |
 
 ## Verification
@@ -230,4 +246,14 @@ Sentinel, no estructural).
    en su AILOG. El script atrapa los mismos drifts ANTES del commit, separando
    "conocidos y documentados" de "olvidados". Cero falsos positivos en 2/2 tests
    empíricos contra los Plans canónicos de Sentinel.
+
+7. `## Archivos a modificar` se redacta desde código LEÍDO, no asumido (hallazgos
+   StrayMark #209/#210, LNXDrive N=2). Dos disciplinas: (a) cada ruta declarada
+   existe en el árbol, o está marcada "Nuevo" en su columna Cambio — la regla de
+   validación `CHARTER-FILES-EXIST` (cli-3.17.0+) marca violaciones, separando
+   "Charter mal declarado" (bug de autoría) del drift "declarado pero no
+   modificado" de `charter drift` (drift de implementación); (b) un cambio a una
+   API cross-component lista TODOS los consumidores, no solo el productor — ver
+   `.straymark/00-governance/POLISH-CHARTER-PATTERN.md` subclase 5
+   ("regresión de mitigación entregada vía un consumidor downstream no actualizado").
 -->

--- a/dist/.straymark/templates/charter/i18n/zh-CN/charter-template.md
+++ b/dist/.straymark/templates/charter/i18n/zh-CN/charter-template.md
@@ -47,10 +47,23 @@ trigger: "[一行：哪个具体信号 — 可观察的事件、声明的决策�
 
 ## 要修改的文件
 
+<!-- 先侦察(#210):在此处列出每个文件之前先 READ 它 — 确认该路径在
+     树中存在。基于假设的、未读的代码所撰写的 Charter 在执行开始之前就会漂移。
+     `straymark validate --include-charters` 会标记任何不存在的已声明路径
+     (CHARTER-FILES-EXIST)。对于此 Charter 所创建的文件,其"变更"列以"新建"
+     开头(验证器会跳过对这些文件的存在性检查)。
+
+     Cross-component API(#209):如果此 Charter 修改了一个其他组件所消费的合约
+     — 一个 D-Bus/gRPC/REST 接口、一个共享 trait、一个 IPC 方法 — 将该 API 的
+     所有消费者作为独立行列出,而不仅是生产者。一个更新了生产者却让某个消费者
+     仍调用旧合约的缓解措施,正是"已交付缓解措施回归"反模式
+     (POLISH-CHARTER-PATTERN.md 子类 5)。 -->
+
 | 文件 | 变更 |
 |---|---|
 | `path/to/file.ext` | [变更的具体描述] |
-| `...` | `...` |
+| `path/to/api-producer.ext` | [对 cross-component API 的变更] |
+| `path/to/api-consumer.ext` | [将消费者更新到新合约 — 不要孤立它] |
 | `.straymark/07-ai-audit/agent-logs/AILOG-...md` | 新建, `risk_level: [low|medium|high]` |
 
 ## 验证
@@ -214,4 +227,12 @@ curl -X PUT "https://${SERVICE_HOST}/api/v1/.../..." \
    未在其 AILOG 中记录的 implementation-gap 和 hallucination 漂移。
    该脚本在提交**之前**捕获相同的漂移，将"已知且已记录"与"已忘记"分开。
    在针对规范 Sentinel 计划的 2/2 经验测试中零误报。
+
+7. `## 要修改的文件` 从 READ 过的代码撰写,而非假设的代码(StrayMark 发现
+   #209/#210,LNXDrive N=2)。两条纪律:(a) 每个已声明路径都存在于树中,或在
+   其"变更"列标记为"新建" — `CHARTER-FILES-EXIST` 验证规则(cli-3.17.0+)会
+   标记违规,将"Charter 误声明"(撰写 bug)与 `charter drift` 的"已声明但未
+   修改"(实现漂移)分开;(b) 对 cross-component API 的变更列出所有消费者,
+   而不仅是生产者 — 见 `.straymark/00-governance/POLISH-CHARTER-PATTERN.md`
+   子类 5("已交付缓解措施经由未更新的下游消费者发生回归")。
 -->

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.19.0"
+version: "4.20.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -47,8 +47,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.19.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.16.0` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.20.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.17.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -324,7 +324,7 @@ Validate StrayMark documents for compliance and correctness.
 | `--fix` | — | Automatically fix simple issues (e.g., missing `review_required: true` for high-risk docs) |
 | `--staged` | — | Validate only staged (git-added) files. Ideal for pre-commit hooks. |
 | `--agent` *(cli-3.16.0+)* | — | Switch to agent-targeted mode and inspect a user-level skills installation instead of project documents. Currently only `codex` — verifies `~/.codex/skills/straymark-*` for presence, parseable YAML frontmatter, required `name`/`description`, and absence of Claude-only keys like `allowed-tools` (whose presence indicates someone copied skills from `.claude/` by mistake). |
-| `--include-charters` | — | Also validate Charters in `.straymark/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Opt-in so projects that don't yet use the Charter pattern are unaffected. |
+| `--include-charters` | — | Also validate Charters in `.straymark/charters/` against the Charter JSON Schema and referential integrity (originating AILOG IDs resolve, originating spec paths exist). Includes **`CHARTER-FILES-EXIST`** *(cli-3.17.0+)*: warns when a `## Files to modify` row names a path that does not exist on disk and is not tagged "New" — catching Charters authored against assumed, un-read code (finding #210). Warn-only; distinct from `charter drift` (which compares declared vs git-modified files). Opt-in so projects that don't yet use the Charter pattern are unaffected. |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | List documents with `review_required: true` and no `review_outcome` older than `--max-pending-days`. **Warn-only** — never fails the validate exit code; useful for CI dashboards of the approval backlog. |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | Threshold in days for `--check-pending-reviews` |
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -239,8 +239,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.19.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.16.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.20.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.17.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -272,7 +272,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.19.0)
+# y descarga el último release fw-* (ej. fw-4.20.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -47,8 +47,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.19.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.16.0` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.20.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.17.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -288,7 +288,7 @@ Valida documentos StrayMark verificando cumplimiento y corrección.
 | `--fix` | — | Corregir automáticamente problemas simples |
 | `--staged` | — | Validar solo archivos staged en Git (ideal para hooks pre-commit) |
 | `--agent` *(cli-3.16.0+)* | — | Cambia a modo agente y revisa una instalación a nivel de usuario de skills en lugar de documentos del proyecto. Actualmente solo `codex` — verifica `~/.codex/skills/straymark-*` para presencia, frontmatter YAML parseable, `name`/`description` requeridos, y ausencia de claves Claude-only como `allowed-tools` (cuya presencia indica que alguien copió skills desde `.claude/` por error). |
-| `--include-charters` | — | Validar también los Charters en `.straymark/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.10.0. |
+| `--include-charters` | — | Validar también los Charters en `.straymark/charters/` contra el JSON Schema y la integridad referencial (los IDs en `originating_ailogs` resuelven; el path en `originating_spec` existe). Incluye **`CHARTER-FILES-EXIST`** *(cli-3.17.0+)*: avisa cuando una fila de `## Archivos a modificar` nombra una ruta que no existe en disco y no está marcada como "Nuevo" — atrapa Charters redactados contra código asumido, no leído (hallazgo #210). Solo-aviso; distinto de `charter drift` (que compara lo declarado contra los archivos modificados en git). Opt-in, default `false` para no afectar a proyectos que no usan el patrón. Por ahora solo se honra fuera de `--staged`; la validación de Charters en modo staged llega en cli-3.10.0. |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | Lista documentos con `review_required: true` y sin `review_outcome` cuya antigüedad supere `--max-pending-days`. **Solo warn** — nunca falla el exit code de validate; útil para dashboards de CI sobre el backlog de aprobaciones. |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | Umbral en días para `--check-pending-reviews`. |
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -257,8 +257,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.19.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.16.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.20.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.17.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -47,8 +47,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.19.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.16.0` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.20.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.17.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -307,7 +307,7 @@ Repairing StrayMark in /home/user/my-project
 | `--fix` | — | 自动修复简单问题（例如为高风险文档添加缺失的 `review_required: true`） |
 | `--staged` | — | 仅验证已暂存（git add）的文件。适合 pre-commit 钩子。 |
 | `--agent` *(cli-3.16.0+)* | — | 切换到代理模式，检查用户级 skills 安装而非项目文档。目前仅支持 `codex` —— 校验 `~/.codex/skills/straymark-*` 是否存在、frontmatter YAML 可解析、`name`/`description` 必填、以及不含 `allowed-tools` 等 Claude 专用键（出现这些键意味着有人误从 `.claude/` 复制了 skill）。 |
-| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `.straymark/charters/` 中的章程。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.10.0 中加入。 |
+| `--include-charters` | — | 同时根据章程 JSON Schema 和引用完整性（`originating_ailogs` 中的 ID 解析；`originating_spec` 路径存在）验证 `.straymark/charters/` 中的章程。包含 **`CHARTER-FILES-EXIST`** *(cli-3.17.0+)*：当 `## 要修改的文件` 中某行所指路径在磁盘上不存在且未标记为"新建"时发出警告 — 捕获基于假设的、未读代码所撰写的章程（发现 #210）。仅警告;不同于 `charter drift`（后者比较声明的文件与 git 修改的文件）。Opt-in，默认 `false`，确保未使用章程模式的项目不受影响。目前仅在非 `--staged` 模式下生效；staged 模式的章程验证将在 cli-3.10.0 中加入。 |
 | `--check-pending-reviews` *(cli-3.7.0+)* | off | 列出所有 `review_required: true` 且没有 `review_outcome`、年龄超过 `--max-pending-days` 的文档。**仅警告** — 永不影响 validate 的退出码；适合用于 CI 仪表板上的审批积压视图。 |
 | `--max-pending-days` *(cli-3.7.0+)* | `14` | `--check-pending-reviews` 的天数阈值。 |
 


### PR DESCRIPTION
## Context

[LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) — StrayMark's second adopter (N=2, Rust Linux daemon + GTK desktop) — sent two upstream findings:

- **[#209](https://github.com/StrangeDaysTech/straymark/issues/209)** — the *surface-declaration-without-wiring* anti-pattern reaches a new domain as a **cross-component regression of a shipped mitigation**: a GTK client kept calling a D-Bus method the daemon had removed, hidden behind a `#[cfg(feature="goa")]` that `Cargo.toml` never defined (compiled out → dead code → invisible to CI and review).
- **[#210](https://github.com/StrangeDaysTech/straymark/issues/210)** — Charters authored against **assumed, un-read code**: declared paths (`lnxdrive-config/src/parser.rs`, `dbus_iface.rs`) that never existed.

Both findings land squarely on gates the framework had left open: `POLISH-CHARTER-PATTERN.md` already named `straymark analyze declared-vs-wired` as the N=2 automation candidate, and `charter drift` parsed `## Files to modify` but never checked path **existence**.

This is **Release A** of a two-release plan: pattern crystallization + the cheap, high-value mechanical backstops. The `analyze declared-vs-wired` subcommand (IPC proxy-vs-interface, config-driven set-difference) follows in a separate CLI release.

## Changes

### Framework (fw-4.20.0)
- **`POLISH-CHARTER-PATTERN.md` → v1/N=2** (EN/ES/zh-CN): new **sub-class 5** (client-side IPC/RPC proxy method vs server interface), named variant *"shipped-mitigation regression via an un-updated downstream consumer"*. Both N axes documented per request: **2 independent domains / 3 occurrences**. Open question for `analyze declared-vs-wired` resolved to a v0 scope.
- **`charter-template.md`** (EN/ES/zh-CN): reconnaissance comment above `## Files to modify` (read before declaring; tag created files "New") + list-**all**-consumers guidance for cross-component APIs (#209.c).
- **`ADOPTERS.md`**: records the first N=2 crossing.

### CLI (cli-3.17.0)
- **`CHARTER-FILES-EXIST`** validate rule (`validate --include-charters`): warns when a `## Files to modify` row names a path that doesn't exist on disk and isn't tagged "New" (#210). **Warn-only**, pure-Rust (Windows-native), **separate from `charter drift`** — "Charter mis-declared" (authoring bug) vs "implementation drifted" stay in different commands with different rule codes (#210.3).
- **`charter new` reconnaissance nudge** (+ `straymark-charter-new` skill: Claude/Gemini/Codex).
- **`charter_files`** — shared Rust parser for the `## Files to modify` table, ported from the drift script's awk so validate and drift agree on declared files.

## Verification
- Full suite green: 328 unit + all integration tests. Codex skills in sync (`gen_codex_skills --check`). `charter_files.rs` clippy-clean.
- New tests: `charter_files` unit (locales, `(new)` tag, wildcards), `CHARTER-FILES-EXIST` integration (missing/New/existing/wildcard/ES-heading), drift separation guard.
- Manual e2e: `validate --include-charters` flags only the non-existent non-"New" path (exit 0, warn-only); `charter new` leads "Next steps" with the recon nudge.

Closes #209, closes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)