### PR TITLE
feat: cli-3.18.0 — `analyze declared-vs-wired` subcommand (#209, Release B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.18.0 — `analyze declared-vs-wired` subcommand (LNXDrive #209, Release B)
+
+Ships the mechanical check the N=2 crossing unlocked: a config-driven set-difference that catches the *surface-declaration-without-wiring* anti-pattern's sub-class 5 — a declared client-side IPC/RPC proxy method with no implemented server-interface counterpart (the LNXDrive D-Bus/GOA regression). Follows the framework crystallization shipped in fw-4.20.0.
+
+### Added (CLI)
+
+- **`straymark analyze declared-vs-wired [path]`** *(new subcommand)* — reports symbols **declared but not wired** (`D \ W`) and, with `--show-orphans`, **wired but not declared** (`W \ D`). Language/IPC-agnostic by construction: the operator supplies a *declared* and a *wired* side as `(glob, regex)` pairs (capture group 1 = symbol name), either inline (`--declared-glob`/`--wired-glob`/`--declared-pattern`/`--wired-pattern`) or via a named `--profile` committed to `.straymark/config.yml`. Output `text`/`json`/`markdown`. Exit `1` when a declared symbol has no wiring counterpart — usable as a CI gate.
+- **`declared_vs_wired.profiles` config block** in `.straymark/config.yml` — named profiles so a stack's regexes are committed once.
+
+### Changed (CLI)
+
+- **`straymark analyze` becomes a subcommand group.** The bare `straymark analyze [path]` is unchanged (still runs complexity analysis); `declared-vs-wired` is the first sub-analysis. Backward-compatible — guarded by a regression test.
+
+### Scope
+
+v0 covers sub-class 5 only (IPC proxy vs interface), the mechanically-tractable cross-stack check. The AST-based variants of sub-classes 1–4 and the dynamic runtime checks remain project-local — see `POLISH-CHARTER-PATTERN.md` Open questions.
+
+---
+
 ## Framework 4.20.0 / CLI 3.17.0 — "declared but not wired" reaches N=2 (LNXDrive findings #209/#210)
 
 Crystallizes the *surface-declaration-without-wiring* pattern to **v1** on the strength of a second independent domain (LNXDrive, a Rust Linux daemon + GTK desktop) validating what Sentinel's Go backend first surfaced, and ships the cheap mechanical backstops the two findings asked for. Two axes are reported separately and deliberately: **2 independent domains / 3 occurrences** — the third being a qualitatively new sub-class, a cross-component regression of an already-shipped mitigation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ Users can now run `straymark update-framework` to get the new version.
 | `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
 | `straymark metrics [path]` | Show governance metrics and documentation statistics |
 | `straymark analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
+| `straymark analyze declared-vs-wired [path]` | Flag declared symbols (IPC/RPC proxy methods) with no implemented wiring counterpart — config-driven set-difference (POLISH-CHARTER-PATTERN sub-class 5) |
 | `straymark audit [path]` | Generate audit trail reports with timeline and traceability |
 | `straymark explore [path]` | Interactive TUI documentation browser |
 | `straymark about` | Show version and license info |

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.20.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.17.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.18.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -856,6 +856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,7 +2324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",
@@ -2329,11 +2335,13 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "flate2",
+ "glob",
  "indicatif",
  "jsonschema",
  "predicates",
  "pulldown-cmark",
  "ratatui",
+ "regex",
  "reqwest",
  "semver",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.17.0"
+version = "3.18.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"
@@ -39,11 +39,13 @@ ratatui = { version = "0.29", optional = true, default-features = false, feature
 crossterm = { version = "0.28", optional = true }
 pulldown-cmark = { version = "0.12", optional = true }
 arborist-metrics = { version = "0.1", optional = true, features = ["all"] }
+regex = { version = "1", optional = true }
+glob = { version = "0.3", optional = true }
 
 [features]
 default = ["tui", "analyze"]
 tui = ["ratatui", "crossterm", "pulldown-cmark"]
-analyze = ["arborist-metrics"]
+analyze = ["arborist-metrics", "regex", "glob"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/cli/src/commands/analyze_declared_vs_wired.rs
+++ b/cli/src/commands/analyze_declared_vs_wired.rs
@@ -1,0 +1,374 @@
+//! `straymark analyze declared-vs-wired` — config-driven set-difference check
+//! for the "surface declaration without wiring" anti-pattern (sub-class 5:
+//! client-side IPC/RPC proxy method declared vs server interface implemented).
+//!
+//! See `.straymark/00-governance/POLISH-CHARTER-PATTERN.md`. This is the v0
+//! crystallization gated on the LNXDrive N=2 validation (findings #209/#210).
+//!
+//! ## Why config-driven, not AST-based
+//!
+//! The five sub-classes are language/IPC-specific; a generic AST analyzer is not
+//! tractable cross-stack. Instead the operator supplies the stack-specific
+//! knowledge as two (glob, regex) pairs — a *declared* side and a *wired* side —
+//! and the command reports the set difference of the captured symbol names:
+//!
+//! - **D \ W** (declared but not wired): a proxy method the client declares that
+//!   no implemented interface provides — the LNXDrive regression. Always reported.
+//! - **W \ D** (wired but not declared): an implemented method no client calls —
+//!   reported only with `--show-orphans` (often benign).
+//!
+//! Each pattern's **capture group 1** is the symbol name compared across sides.
+//!
+//! ## Exit codes
+//! - `0` — no declared-but-not-wired symbols (clean)
+//! - `1` — at least one declared symbol has no wiring counterpart (a finding),
+//!   or a usage error (missing profile/flags, bad regex, unreadable config) —
+//!   the latter surfaces via the top-level `error:` handler in `main`.
+
+use anyhow::{anyhow, bail, Context, Result};
+use colored::Colorize;
+use regex::Regex;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::config::{DeclaredVsWiredProfile, StrayMarkConfig};
+use crate::utils;
+
+/// Parsed CLI inputs for the subcommand.
+pub struct Args {
+    pub path: String,
+    pub profile: Option<String>,
+    pub declared_glob: Option<String>,
+    pub wired_glob: Option<String>,
+    pub declared_pattern: Option<String>,
+    pub wired_pattern: Option<String>,
+    pub show_orphans: bool,
+    pub output: String,
+}
+
+#[derive(Serialize)]
+struct Finding {
+    symbol: String,
+    /// First file the symbol was found in (relative to the analyzed path).
+    source: String,
+}
+
+#[derive(Serialize)]
+struct Report {
+    path: String,
+    profile: String,
+    declared_count: usize,
+    wired_count: usize,
+    declared_not_wired: Vec<Finding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wired_not_declared: Option<Vec<Finding>>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let base = PathBuf::from(&args.path)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(&args.path));
+
+    let (profile_name, profile) = resolve_profile(&args, &base)?;
+
+    let declared_re = compile(&profile.declared_pattern, "declared")?;
+    let wired_re = compile(&profile.wired_pattern, "wired")?;
+
+    let declared = collect_symbols(&base, &profile.declared_glob, &declared_re)
+        .with_context(|| format!("scanning declared glob `{}`", profile.declared_glob))?;
+    let wired = collect_symbols(&base, &profile.wired_glob, &wired_re)
+        .with_context(|| format!("scanning wired glob `{}`", profile.wired_glob))?;
+
+    let declared_not_wired: Vec<Finding> = declared
+        .iter()
+        .filter(|(sym, _)| !wired.contains_key(*sym))
+        .map(|(sym, src)| Finding { symbol: sym.clone(), source: src.clone() })
+        .collect();
+
+    let wired_not_declared = if args.show_orphans {
+        Some(
+            wired
+                .iter()
+                .filter(|(sym, _)| !declared.contains_key(*sym))
+                .map(|(sym, src)| Finding { symbol: sym.clone(), source: src.clone() })
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        None
+    };
+
+    let report = Report {
+        path: base.display().to_string(),
+        profile: profile_name,
+        declared_count: declared.len(),
+        wired_count: wired.len(),
+        declared_not_wired,
+        wired_not_declared,
+    };
+
+    match args.output.as_str() {
+        "json" => print_json(&report),
+        "markdown" => print_markdown(&report),
+        _ => print_text(&report),
+    }
+
+    if !report.declared_not_wired.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Resolve the effective profile from either a named config profile
+/// (`--profile`) or the four inline flags. The two are mutually exclusive in
+/// practice: a named profile wins, inline flags fill the gap otherwise.
+fn resolve_profile(args: &Args, base: &Path) -> Result<(String, DeclaredVsWiredProfile)> {
+    if let Some(name) = &args.profile {
+        let project_root = utils::resolve_project_root(&args.path)
+            .map(|r| r.path)
+            .unwrap_or_else(|| base.to_path_buf());
+        let config = StrayMarkConfig::load(&project_root)
+            .context("loading .straymark/config.yml for --profile lookup")?;
+        let profile = config
+            .declared_vs_wired
+            .profiles
+            .into_iter()
+            .find(|p| p.name == *name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "profile '{}' not found in .straymark/config.yml under `declared_vs_wired.profiles`.\n  \
+                     hint: define it there, or pass --declared-glob/--wired-glob/--declared-pattern/--wired-pattern inline.",
+                    name
+                )
+            })?;
+        return Ok((name.clone(), profile));
+    }
+
+    // Inline mode: all four flags required.
+    match (
+        &args.declared_glob,
+        &args.wired_glob,
+        &args.declared_pattern,
+        &args.wired_pattern,
+    ) {
+        (Some(dg), Some(wg), Some(dp), Some(wp)) => Ok((
+            "inline".to_string(),
+            DeclaredVsWiredProfile {
+                name: "inline".to_string(),
+                declared_glob: dg.clone(),
+                declared_pattern: dp.clone(),
+                wired_glob: wg.clone(),
+                wired_pattern: wp.clone(),
+            },
+        )),
+        _ => bail!(
+            "declared-vs-wired needs either --profile <name> (from .straymark/config.yml) \
+             or all four of --declared-glob, --wired-glob, --declared-pattern, --wired-pattern."
+        ),
+    }
+}
+
+/// Compile a capture regex, requiring at least one capture group (group 1 is the
+/// symbol name).
+fn compile(pattern: &str, side: &str) -> Result<Regex> {
+    let re = Regex::new(pattern)
+        .with_context(|| format!("invalid {side} regex: `{pattern}`"))?;
+    if re.captures_len() < 2 {
+        bail!(
+            "the {side} pattern `{}` has no capture group — wrap the symbol name in parentheses, \
+             e.g. `fn (\\w+)`.",
+            pattern
+        );
+    }
+    Ok(re)
+}
+
+/// Glob files relative to `base`, scan each for `re`, and return a map of
+/// symbol name → first relative file path it appeared in. A `BTreeMap` keeps
+/// the output deterministic (sorted) without an explicit sort.
+fn collect_symbols(base: &Path, glob_pat: &str, re: &Regex) -> Result<BTreeMap<String, String>> {
+    let pattern = format!("{}/{}", base.display(), glob_pat);
+    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    let entries = glob::glob(&pattern)
+        .with_context(|| format!("invalid glob pattern: `{glob_pat}`"))?;
+    for entry in entries {
+        let path = match entry {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if !path.is_file() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue, // skip binary / unreadable files
+        };
+        let rel = path
+            .strip_prefix(base)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        for caps in re.captures_iter(&content) {
+            if let Some(m) = caps.get(1) {
+                out.entry(m.as_str().to_string()).or_insert_with(|| rel.clone());
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn print_text(report: &Report) {
+    println!();
+    println!("  {}", "StrayMark Analyze — declared-vs-wired".bold().cyan());
+    println!("  {}", report.path.dimmed());
+    println!(
+        "  {} {}   {} {} declared / {} wired",
+        "Profile:".dimmed(),
+        report.profile.bold(),
+        "Symbols:".dimmed(),
+        report.declared_count.to_string().bold(),
+        report.wired_count.to_string().bold(),
+    );
+    println!();
+
+    if report.declared_not_wired.is_empty() {
+        println!(
+            "  {} Every declared symbol has a wiring counterpart.",
+            "✓".green().bold()
+        );
+    } else {
+        println!(
+            "  {} {} declared symbol(s) with NO wiring counterpart:",
+            "✗".red().bold(),
+            report.declared_not_wired.len().to_string().red().bold(),
+        );
+        for f in &report.declared_not_wired {
+            println!(
+                "    {} {}  {}",
+                "-".red(),
+                f.symbol.bold(),
+                format!("({})", f.source).dimmed()
+            );
+        }
+        println!();
+        println!(
+            "  {} a declared surface with no implementation is the \"surface declaration",
+            "→".yellow().bold()
+        );
+        println!("    without wiring\" anti-pattern (POLISH-CHARTER-PATTERN.md sub-class 5).");
+    }
+
+    if let Some(orphans) = &report.wired_not_declared {
+        println!();
+        if orphans.is_empty() {
+            println!(
+                "  {} No wired-but-undeclared symbols.",
+                "·".dimmed()
+            );
+        } else {
+            println!(
+                "  {} {} wired symbol(s) no declaration references (often benign):",
+                "·".dimmed(),
+                orphans.len()
+            );
+            for f in orphans {
+                println!("    {} {}  {}", "-".dimmed(), f.symbol, format!("({})", f.source).dimmed());
+            }
+        }
+    }
+
+    println!();
+}
+
+fn print_json(report: &Report) {
+    let json = serde_json::to_string_pretty(report).unwrap_or_else(|_| "{}".into());
+    println!("{}", json);
+}
+
+fn print_markdown(report: &Report) {
+    println!("# StrayMark Analyze — declared-vs-wired");
+    println!();
+    println!("**Path:** `{}`", report.path);
+    println!("**Profile:** `{}`", report.profile);
+    println!(
+        "**Symbols:** {} declared / {} wired",
+        report.declared_count, report.wired_count
+    );
+    println!();
+
+    println!("## Declared but not wired");
+    println!();
+    if report.declared_not_wired.is_empty() {
+        println!("_None — every declared symbol has a wiring counterpart._");
+    } else {
+        println!("| Symbol | Declared in |");
+        println!("|--------|-------------|");
+        for f in &report.declared_not_wired {
+            println!("| `{}` | `{}` |", f.symbol, f.source);
+        }
+    }
+
+    if let Some(orphans) = &report.wired_not_declared {
+        println!();
+        println!("## Wired but not declared");
+        println!();
+        if orphans.is_empty() {
+            println!("_None._");
+        } else {
+            println!("| Symbol | Wired in |");
+            println!("|--------|----------|");
+            for f in orphans {
+                println!("| `{}` | `{}` |", f.symbol, f.source);
+            }
+        }
+    }
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compile_rejects_pattern_without_capture_group() {
+        assert!(compile(r"fn \w+", "declared").is_err());
+        assert!(compile(r"fn (\w+)", "declared").is_ok());
+    }
+
+    #[test]
+    fn collect_symbols_extracts_capture_group_1() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.rs"), "fn foo() {}\nfn bar() {}\n").unwrap();
+        let re = Regex::new(r"fn (\w+)").unwrap();
+        let syms = collect_symbols(tmp.path(), "*.rs", &re).unwrap();
+        assert!(syms.contains_key("foo"));
+        assert!(syms.contains_key("bar"));
+        assert_eq!(syms["foo"], "a.rs");
+    }
+
+    #[test]
+    fn collect_symbols_handles_nested_glob() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("client/src")).unwrap();
+        std::fs::write(tmp.path().join("client/src/proxy.rs"), "fn complete_auth() {}\n").unwrap();
+        let re = Regex::new(r"fn (\w+)").unwrap();
+        let syms = collect_symbols(tmp.path(), "client/**/*.rs", &re).unwrap();
+        assert!(syms.contains_key("complete_auth"));
+    }
+
+    #[test]
+    fn resolve_profile_requires_all_four_inline_flags() {
+        let base = PathBuf::from(".");
+        let args = Args {
+            path: ".".into(),
+            profile: None,
+            declared_glob: Some("a/*.rs".into()),
+            wired_glob: None, // missing
+            declared_pattern: Some(r"fn (\w+)".into()),
+            wired_pattern: Some(r"fn (\w+)".into()),
+            show_orphans: false,
+            output: "text".into(),
+        };
+        assert!(resolve_profile(&args, &base).is_err());
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 pub mod about;
 #[cfg(feature = "analyze")]
 pub mod analyze;
+#[cfg(feature = "analyze")]
+pub mod analyze_declared_vs_wired;
 pub mod approve;
 pub mod audit;
 pub mod charter;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -16,6 +16,36 @@ pub struct StrayMarkConfig {
     /// Default `["global", "eu"]` preserves backward compatibility.
     #[serde(default = "default_regional_scope")]
     pub regional_scope: Vec<String>,
+    /// Named profiles for `straymark analyze declared-vs-wired`. Empty by default.
+    #[serde(default)]
+    pub declared_vs_wired: DeclaredVsWiredConfig,
+}
+
+/// Configuration for `straymark analyze declared-vs-wired` — a set of named
+/// profiles, each pairing a declared-side and a wired-side (glob + capture
+/// regex). Lets adopters commit their stack's regexes once instead of passing
+/// four flags every run.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct DeclaredVsWiredConfig {
+    #[serde(default)]
+    pub profiles: Vec<DeclaredVsWiredProfile>,
+}
+
+/// One declared-vs-wired profile. The capture patterns must each expose a
+/// capture group 1 whose value is the symbol name to compare across sides.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct DeclaredVsWiredProfile {
+    pub name: String,
+    /// Glob (relative to the analyzed path) for files holding declarations
+    /// (e.g. a D-Bus proxy, a gRPC stub, a REST client).
+    pub declared_glob: String,
+    /// Regex matched against declared files; capture group 1 = symbol name.
+    pub declared_pattern: String,
+    /// Glob (relative to the analyzed path) for files holding implementations
+    /// (e.g. the daemon/server interface).
+    pub wired_glob: String,
+    /// Regex matched against wired files; capture group 1 = symbol name.
+    pub wired_pattern: String,
 }
 
 /// Configuration for the `straymark analyze` command
@@ -52,6 +82,7 @@ impl Default for StrayMarkConfig {
             language: default_language(),
             complexity: ComplexityConfig::default(),
             regional_scope: default_regional_scope(),
+            declared_vs_wired: DeclaredVsWiredConfig::default(),
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -238,9 +238,13 @@ enum Commands {
         #[arg(long = "path", default_value = ".")]
         path: String,
     },
-    /// Analyze code complexity using cognitive and cyclomatic metrics
+    /// Analyze code: complexity metrics (default) or declared-vs-wired contract checks
     #[cfg(feature = "analyze")]
+    #[command(args_conflicts_with_subcommands = true)]
     Analyze {
+        /// Sub-analysis to run. Omit for the default complexity analysis.
+        #[command(subcommand)]
+        command: Option<AnalyzeCommands>,
         /// Target directory or file (default: current directory)
         #[arg(default_value = ".")]
         path: String,
@@ -269,6 +273,43 @@ enum Commands {
     Charter {
         #[command(subcommand)]
         command: CharterCommands,
+    },
+}
+
+/// Sub-analyses under `straymark analyze`.
+#[cfg(feature = "analyze")]
+#[derive(Subcommand)]
+enum AnalyzeCommands {
+    /// Flag declared symbols (e.g. client IPC/RPC proxy methods) that have no
+    /// wiring counterpart on the implementation side — the "surface declaration
+    /// without wiring" anti-pattern (POLISH-CHARTER-PATTERN.md sub-class 5).
+    /// Config-driven: supply --profile (from .straymark/config.yml) or the four
+    /// inline globs/patterns. Capture group 1 of each pattern is the symbol name.
+    DeclaredVsWired {
+        /// Target directory (default: current directory)
+        #[arg(default_value = ".")]
+        path: String,
+        /// Named profile from `.straymark/config.yml` (`declared_vs_wired.profiles`)
+        #[arg(long)]
+        profile: Option<String>,
+        /// Glob (relative to path) for files holding declarations
+        #[arg(long)]
+        declared_glob: Option<String>,
+        /// Glob (relative to path) for files holding implementations
+        #[arg(long)]
+        wired_glob: Option<String>,
+        /// Regex over declared files; capture group 1 = symbol name
+        #[arg(long)]
+        declared_pattern: Option<String>,
+        /// Regex over wired files; capture group 1 = symbol name
+        #[arg(long)]
+        wired_pattern: Option<String>,
+        /// Also report symbols wired but never declared (W \ D)
+        #[arg(long)]
+        show_orphans: bool,
+        /// Output format
+        #[arg(long, default_value = "text", value_parser = ["text", "json", "markdown"])]
+        output: String,
     },
 }
 
@@ -563,11 +604,35 @@ fn main() {
         ),
         #[cfg(feature = "analyze")]
         Commands::Analyze {
+            command,
             path,
             threshold,
             output,
             top,
-        } => commands::analyze::run(&path, threshold, &output, top),
+        } => match command {
+            Some(AnalyzeCommands::DeclaredVsWired {
+                path,
+                profile,
+                declared_glob,
+                wired_glob,
+                declared_pattern,
+                wired_pattern,
+                show_orphans,
+                output,
+            }) => commands::analyze_declared_vs_wired::run(
+                commands::analyze_declared_vs_wired::Args {
+                    path,
+                    profile,
+                    declared_glob,
+                    wired_glob,
+                    declared_pattern,
+                    wired_pattern,
+                    show_orphans,
+                    output,
+                },
+            ),
+            None => commands::analyze::run(&path, threshold, &output, top),
+        },
         #[cfg(feature = "tui")]
         Commands::Explore { path, lang } => commands::explore::run(&path, lang.as_deref()),
         Commands::Charter { command } => match command {

--- a/cli/tests/analyze_declared_vs_wired_test.rs
+++ b/cli/tests/analyze_declared_vs_wired_test.rs
@@ -1,0 +1,139 @@
+//! Integration tests for `straymark analyze declared-vs-wired` (finding #209,
+//! POLISH-CHARTER-PATTERN.md sub-class 5).
+
+#![cfg(feature = "analyze")]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Lay out a client proxy (two declared methods) and a daemon interface (one
+/// implemented), reproducing the LNXDrive regression: the client still declares
+/// a method the daemon removed.
+fn setup_proxy_vs_interface(dir: &Path) {
+    std::fs::create_dir_all(dir.join("client/src")).unwrap();
+    std::fs::create_dir_all(dir.join("daemon/src")).unwrap();
+    std::fs::write(
+        dir.join("client/src/proxy.rs"),
+        "fn complete_auth_via_goa() {}\nfn complete_auth_with_tokens() {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("daemon/src/interface.rs"),
+        "fn complete_auth_via_goa() {}\n",
+    )
+    .unwrap();
+}
+
+fn run_inline(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("straymark").unwrap();
+    cmd.args(["analyze", "declared-vs-wired"])
+        .arg(dir.to_str().unwrap())
+        .args(["--declared-glob", "client/**/*.rs"])
+        .args(["--declared-pattern", r"fn (\w+)"])
+        .args(["--wired-glob", "daemon/**/*.rs"])
+        .args(["--wired-pattern", r"fn (\w+)"]);
+    cmd
+}
+
+#[test]
+fn flags_declared_symbol_with_no_wiring() {
+    let dir = TempDir::new().unwrap();
+    setup_proxy_vs_interface(dir.path());
+
+    run_inline(dir.path())
+        .assert()
+        .failure() // exit 1 — a finding
+        .stdout(predicate::str::contains("complete_auth_with_tokens"))
+        .stdout(predicate::str::contains("declared symbol(s) with NO wiring"));
+}
+
+#[test]
+fn clean_when_every_declared_symbol_is_wired() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join("client/src")).unwrap();
+    std::fs::create_dir_all(dir.path().join("daemon/src")).unwrap();
+    std::fs::write(dir.path().join("client/src/proxy.rs"), "fn ping() {}\n").unwrap();
+    std::fs::write(dir.path().join("daemon/src/interface.rs"), "fn ping() {}\n").unwrap();
+
+    run_inline(dir.path())
+        .assert()
+        .success() // exit 0 — clean
+        .stdout(predicate::str::contains("Every declared symbol has a wiring counterpart"));
+}
+
+#[test]
+fn json_output_lists_declared_not_wired() {
+    let dir = TempDir::new().unwrap();
+    setup_proxy_vs_interface(dir.path());
+
+    run_inline(dir.path())
+        .args(["--output", "json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"declared_not_wired\""))
+        .stdout(predicate::str::contains("\"complete_auth_with_tokens\""));
+}
+
+#[test]
+fn errors_without_profile_or_inline_flags() {
+    let dir = TempDir::new().unwrap();
+    setup_proxy_vs_interface(dir.path());
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args(["analyze", "declared-vs-wired"])
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--profile").or(predicate::str::contains("declared-glob")));
+}
+
+#[test]
+fn resolves_named_profile_from_config() {
+    let dir = TempDir::new().unwrap();
+    setup_proxy_vs_interface(dir.path());
+    let straymark = dir.path().join(".straymark");
+    std::fs::create_dir_all(&straymark).unwrap();
+    std::fs::write(
+        straymark.join("config.yml"),
+        r#"language: en
+declared_vs_wired:
+  profiles:
+    - name: dbus
+      declared_glob: "client/**/*.rs"
+      declared_pattern: "fn (\\w+)"
+      wired_glob: "daemon/**/*.rs"
+      wired_pattern: "fn (\\w+)"
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .args(["analyze", "declared-vs-wired"])
+        .arg(dir.path().to_str().unwrap())
+        .args(["--profile", "dbus"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("complete_auth_with_tokens"))
+        .stdout(predicate::str::contains("dbus"));
+}
+
+#[test]
+fn bare_analyze_still_runs_complexity() {
+    // Backward-compat guard: turning `analyze` into a subcommand group must not
+    // break `straymark analyze [path]`.
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("x.rs"), "fn simple() { let a = 1; }\n").unwrap();
+
+    Command::cargo_bin("straymark")
+        .unwrap()
+        .arg("analyze")
+        .arg(dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("StrayMark Analyze"))
+        .stdout(predicate::str::contains("Threshold"));
+}

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.20.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.17.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.18.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -1104,6 +1104,71 @@ $ straymark analyze /path/to/project
 > **Documentation trigger:** AI agents use `straymark analyze --output json` as the primary method to determine when to create AILOG documents. If `summary.above_threshold > 0` in the JSON output, the agent should create an AILOG. When the CLI is not available, agents fall back to the >20 lines of business logic heuristic.
 
 > **Powered by arborist-metrics:** the cognitive and cyclomatic complexity factors are computed by [`arborist-metrics`](https://github.com/StrangeDaysTech/arborist-metrics/) — our open-source Rust library for multi-language code metrics, developed by StrangeDaysTech S.A.S. de C.V. Also available standalone on [crates.io](https://crates.io/crates/arborist-metrics).
+
+---
+
+### `straymark analyze declared-vs-wired [path] [--profile <name> | --declared-glob … --wired-glob … --declared-pattern … --wired-pattern …] [--show-orphans] [--output <format>]` *(cli-3.18.0+)*
+
+Flag declared symbols that have **no wiring counterpart** on the implementation side — the *"surface declaration without wiring"* anti-pattern, sub-class 5 (client-side IPC/RPC proxy method vs server interface). Crystallized from the LNXDrive N=2 validation (findings [#209](https://github.com/StrangeDaysTech/straymark/issues/209)/[#210](https://github.com/StrangeDaysTech/straymark/issues/210)); see `.straymark/00-governance/POLISH-CHARTER-PATTERN.md`.
+
+It is a **config-driven set difference**, language/IPC-agnostic by construction: you supply a *declared* side and a *wired* side as `(glob, regex)` pairs; the **capture group 1** of each regex is the symbol name. The command reports **D \ W** (declared but not wired) and, with `--show-orphans`, **W \ D** (wired but never declared).
+
+**Arguments and flags:**
+
+| Argument/Flag | Default | Description |
+|---------------|---------|-------------|
+| `path` | `.` | Target directory |
+| `--profile` | — | Named profile from `.straymark/config.yml` (`declared_vs_wired.profiles`). Alternative to the four inline flags. |
+| `--declared-glob` | — | Glob (relative to `path`) for files holding declarations (proxy/stub/client). |
+| `--wired-glob` | — | Glob (relative to `path`) for files holding implementations (daemon/server interface). |
+| `--declared-pattern` | — | Regex over declared files; **capture group 1** = symbol name. |
+| `--wired-pattern` | — | Regex over wired files; **capture group 1** = symbol name. |
+| `--show-orphans` | off | Also report symbols wired but never declared (`W \ D`). |
+| `--output` | `text` | `text`, `json`, or `markdown`. |
+
+You must pass **either** `--profile` **or** all four inline globs/patterns.
+
+**Exit codes:** `0` clean (every declared symbol is wired); `1` at least one declared symbol has no wiring counterpart (a finding) — suitable as a CI gate.
+
+**Configuration** (optional, in `.straymark/config.yml`):
+
+```yaml
+declared_vs_wired:
+  profiles:
+    - name: dbus
+      declared_glob: "client/**/*.rs"     # the GTK client's D-Bus proxy
+      declared_pattern: "fn (\\w+)"
+      wired_glob: "daemon/src/interface.rs" # the daemon's implemented interface
+      wired_pattern: "fn (\\w+)"
+```
+
+**Examples:**
+
+```bash
+# Inline (one-off)
+$ straymark analyze declared-vs-wired \
+    --declared-glob "client/**/*.rs" --declared-pattern 'fn (\w+)' \
+    --wired-glob "daemon/**/*.rs"    --wired-pattern 'fn (\w+)'
+
+# Named profile (committed once), JSON for CI
+$ straymark analyze declared-vs-wired --profile dbus --output json
+```
+
+**Example output:**
+
+```
+  StrayMark Analyze — declared-vs-wired
+  /home/user/project
+  Profile: dbus   Symbols: 12 declared / 11 wired
+
+  ✗ 1 declared symbol(s) with NO wiring counterpart:
+    - complete_auth_with_tokens  (client/src/proxy.rs)
+
+  → a declared surface with no implementation is the "surface declaration
+    without wiring" anti-pattern (POLISH-CHARTER-PATTERN.md sub-class 5).
+```
+
+> **v0 scope:** this is the mechanically-tractable cross-stack check (sub-class 5). The AST-based variants of sub-classes 1–4 (env-var docs, metric instruments, HTML embeds, public-route markers) and the dynamic runtime checks remain project-local — see the pattern doc's Open questions.
 
 ---
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -240,7 +240,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.20.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.17.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.18.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.20.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.17.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.18.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -827,6 +827,57 @@ $ straymark analyze /ruta/al/proyecto
 > **Trigger de documentación:** Los agentes de IA usan `straymark analyze --output json` como método primario para determinar cuándo crear documentos AILOG. Si `summary.above_threshold > 0` en la salida JSON, el agente debe crear un AILOG. Cuando el CLI no está disponible, los agentes usan la heurística de >20 líneas de lógica de negocio como alternativa.
 
 > **Impulsado por arborist-metrics:** el cálculo del factor de complejidad cognitiva y ciclomática se realiza mediante [`arborist-metrics`](https://github.com/StrangeDaysTech/arborist-metrics/) — nuestra librería Rust open source para métricas de código multi-lenguaje, desarrollada también por StrangeDaysTech S.A.S. de C.V. Disponible también de forma standalone en [crates.io](https://crates.io/crates/arborist-metrics).
+
+---
+
+### `straymark analyze declared-vs-wired [path] [--profile <nombre> | --declared-glob … --wired-glob … --declared-pattern … --wired-pattern …] [--show-orphans] [--output <formato>]` *(cli-3.18.0+)*
+
+Marca símbolos declarados que **no tienen contraparte de cableado** del lado de la implementación — el anti-patrón *"declaración de superficie sin cableado"*, subclase 5 (método proxy IPC/RPC client-side vs interfaz del servidor). Cristalizado a partir de la validación N=2 de LNXDrive (hallazgos [#209](https://github.com/StrangeDaysTech/straymark/issues/209)/[#210](https://github.com/StrangeDaysTech/straymark/issues/210)); ver `.straymark/00-governance/POLISH-CHARTER-PATTERN.md`.
+
+Es un **set-difference dirigido por config**, agnóstico de lenguaje/IPC por construcción: provees un lado *declarado* y un lado *cableado* como pares `(glob, regex)`; el **grupo de captura 1** de cada regex es el nombre del símbolo. El comando reporta **D \ W** (declarado pero no cableado) y, con `--show-orphans`, **W \ D** (cableado pero nunca declarado).
+
+**Argumentos y flags:**
+
+| Argumento/Flag | Default | Descripción |
+|---------------|---------|-------------|
+| `path` | `.` | Directorio objetivo |
+| `--profile` | — | Perfil con nombre desde `.straymark/config.yml` (`declared_vs_wired.profiles`). Alternativa a los cuatro flags inline. |
+| `--declared-glob` | — | Glob (relativo a `path`) de archivos con declaraciones (proxy/stub/cliente). |
+| `--wired-glob` | — | Glob (relativo a `path`) de archivos con implementaciones (interfaz del daemon/servidor). |
+| `--declared-pattern` | — | Regex sobre archivos declarados; **grupo de captura 1** = nombre del símbolo. |
+| `--wired-pattern` | — | Regex sobre archivos cableados; **grupo de captura 1** = nombre del símbolo. |
+| `--show-orphans` | off | Reporta también símbolos cableados pero nunca declarados (`W \ D`). |
+| `--output` | `text` | `text`, `json`, o `markdown`. |
+
+Debes pasar **o** `--profile` **o** los cuatro globs/patterns inline.
+
+**Códigos de salida:** `0` limpio (cada símbolo declarado está cableado); `1` al menos un símbolo declarado sin contraparte de cableado (un hallazgo) — apto como compuerta de CI.
+
+**Configuración** (opcional, en `.straymark/config.yml`):
+
+```yaml
+declared_vs_wired:
+  profiles:
+    - name: dbus
+      declared_glob: "client/**/*.rs"     # el proxy D-Bus del cliente GTK
+      declared_pattern: "fn (\\w+)"
+      wired_glob: "daemon/src/interface.rs" # la interfaz implementada del daemon
+      wired_pattern: "fn (\\w+)"
+```
+
+**Ejemplos:**
+
+```bash
+# Inline (puntual)
+$ straymark analyze declared-vs-wired \
+    --declared-glob "client/**/*.rs" --declared-pattern 'fn (\w+)' \
+    --wired-glob "daemon/**/*.rs"    --wired-pattern 'fn (\w+)'
+
+# Perfil con nombre (commiteado una vez), JSON para CI
+$ straymark analyze declared-vs-wired --profile dbus --output json
+```
+
+> **Alcance v0:** esta es la verificación cross-stack mecánicamente tratable (subclase 5). Las variantes basadas en AST de las subclases 1–4 (docs de env-var, instrumentos métricos, embeds HTML, marcadores de ruta pública) y las verificaciones runtime dinámicas siguen siendo project-local — ver las Preguntas abiertas del doc del patrón.
 
 ---
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -258,7 +258,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.20.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.17.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.18.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.20.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.17.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.18.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -942,6 +942,57 @@ $ straymark analyze /path/to/project
 > **文档触发：** AI Agent 使用 `straymark analyze --output json` 作为确定何时创建 AILOG 文档的主要方法。如果 JSON 输出中 `summary.above_threshold > 0`，Agent 应创建 AILOG。当 CLI 不可用时，Agent 回退到 >20 行业务逻辑的启发式规则。
 
 > **由 arborist-metrics 驱动：** 认知复杂度与圈复杂度因子由 [`arborist-metrics`](https://github.com/StrangeDaysTech/arborist-metrics/) 计算 —— 这是我们开源的 Rust 多语言代码度量库，同样由 StrangeDaysTech S.A.S. de C.V. 开发。也可在 [crates.io](https://crates.io/crates/arborist-metrics) 作为独立库使用。
+
+---
+
+### `straymark analyze declared-vs-wired [path] [--profile <名称> | --declared-glob … --wired-glob … --declared-pattern … --wired-pattern …] [--show-orphans] [--output <格式>]` *(cli-3.18.0+)*
+
+标记在实现侧**没有接线对应物**的已声明符号 —— 即"声明了表层但未接线"反模式的子类 5（客户端 IPC/RPC proxy 方法 vs 服务端接口）。由 LNXDrive 的 N=2 验证（发现 [#209](https://github.com/StrangeDaysTech/straymark/issues/209)/[#210](https://github.com/StrangeDaysTech/straymark/issues/210)）结晶而来；见 `.straymark/00-governance/POLISH-CHARTER-PATTERN.md`。
+
+它是一个**由配置驱动的 set-difference**，本质上与语言/IPC 无关：你提供一个*声明*侧和一个*接线*侧，各为 `(glob, regex)` 对；每个 regex 的**捕获组 1** 即符号名。命令报告 **D \ W**（已声明但未接线），以及在 `--show-orphans` 下报告 **W \ D**（已接线但从未声明）。
+
+**参数与标志：**
+
+| 参数/标志 | 默认 | 说明 |
+|---------------|---------|-------------|
+| `path` | `.` | 目标目录 |
+| `--profile` | — | 来自 `.straymark/config.yml` 的命名 profile（`declared_vs_wired.profiles`）。可替代四个内联标志。 |
+| `--declared-glob` | — | 声明文件的 glob（相对于 `path`，proxy/stub/客户端）。 |
+| `--wired-glob` | — | 实现文件的 glob（相对于 `path`，daemon/服务端接口）。 |
+| `--declared-pattern` | — | 对声明文件的 regex；**捕获组 1** = 符号名。 |
+| `--wired-pattern` | — | 对接线文件的 regex；**捕获组 1** = 符号名。 |
+| `--show-orphans` | off | 同时报告已接线但从未声明的符号（`W \ D`）。 |
+| `--output` | `text` | `text`、`json` 或 `markdown`。 |
+
+必须传入 `--profile` **或** 四个内联 glob/pattern 之一。
+
+**退出码：** `0` 干净（每个已声明符号都已接线）；`1` 至少一个已声明符号没有接线对应物（一个发现）—— 适合作为 CI 门。
+
+**配置**（可选，在 `.straymark/config.yml`）：
+
+```yaml
+declared_vs_wired:
+  profiles:
+    - name: dbus
+      declared_glob: "client/**/*.rs"     # GTK 客户端的 D-Bus proxy
+      declared_pattern: "fn (\\w+)"
+      wired_glob: "daemon/src/interface.rs" # daemon 已实现的接口
+      wired_pattern: "fn (\\w+)"
+```
+
+**示例：**
+
+```bash
+# 内联（一次性）
+$ straymark analyze declared-vs-wired \
+    --declared-glob "client/**/*.rs" --declared-pattern 'fn (\w+)' \
+    --wired-glob "daemon/**/*.rs"    --wired-pattern 'fn (\w+)'
+
+# 命名 profile（提交一次），JSON 供 CI 使用
+$ straymark analyze declared-vs-wired --profile dbus --output json
+```
+
+> **v0 范围：** 这是机械化可处理的 cross-stack 检查（子类 5）。子类 1–4 的基于 AST 的变体（env-var 文档、metric instrument、HTML embed、公共路由标记）以及动态 runtime 检查仍是 project-local —— 见模式文档的未决问题。
 
 ---
 


### PR DESCRIPTION
## Context

**Release B** of the LNXDrive [#209](https://github.com/StrangeDaysTech/straymark/issues/209) work. Release A ([#211](https://github.com/StrangeDaysTech/straymark/pull/211), `fw-4.20.0`/`cli-3.17.0`) crystallized the *surface-declaration-without-wiring* pattern to **v1/N=2** and added sub-class 5. This release ships the CLI automation that the N=2 crossing unlocked — deliberately split out because it introduces a new config schema.

The check catches the LNXDrive regression directly: a GTK client kept declaring a D-Bus proxy method (`complete_auth_with_tokens`) that the daemon had removed. A diff of declared proxy methods vs the implemented interface surfaces it; nothing else did (the call was feature-gated dead code).

## What it does

`straymark analyze declared-vs-wired [path]` — a **config-driven set difference**, language/IPC-agnostic by construction. The operator supplies a *declared* side and a *wired* side as `(glob, regex)` pairs; **capture group 1** of each regex is the symbol name. Reports:

- **D \ W** — declared but not wired (the finding). Exit `1` → CI-gate friendly.
- **W \ D** — wired but never declared, with `--show-orphans` (often benign).

Inputs come either inline (`--declared-glob`/`--wired-glob`/`--declared-pattern`/`--wired-pattern`) or from a named `--profile` in `.straymark/config.yml` (`declared_vs_wired.profiles`). Output `text`/`json`/`markdown`.

```bash
straymark analyze declared-vs-wired --profile dbus --output json
```

## Design notes

- **Honest v0 scope:** only sub-class 5 (IPC proxy vs interface) — the mechanically-tractable cross-stack check. The AST variants of sub-classes 1–4 and dynamic runtime checks stay project-local (documented in the pattern doc's Open questions). No generic AST analyzer was attempted.
- **`analyze` becomes a subcommand group**; bare `straymark analyze [path]` is unchanged (complexity), guarded by a backward-compat regression test (`args_conflicts_with_subcommands`).
- `regex` + `glob` added as `analyze`-feature-gated deps.

## Verification
- 4 unit + 6 integration tests (finding / clean / json / named-profile / missing-flags error / **bare-analyze compat**). Full suite green. Clippy-clean on new code.
- Manual e2e: reproduces the LNXDrive case (flags `complete_auth_with_tokens`, exit 1); text/json/markdown + `--show-orphans` verified; `analyze <path>` still runs complexity.

CLI-only release (`cli-3.18.0`); framework unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)