### PR TITLE
docs(blog): "What the feature flag compiled away" — the N=2 crossing

### DIFF
--- a/website/blog/2026-05-31-what-the-feature-flag-compiled-away.md
+++ b/website/blog/2026-05-31-what-the-feature-flag-compiled-away.md
@@ -1,0 +1,97 @@
+---
+slug: what-the-feature-flag-compiled-away
+title: What the feature flag compiled away
+authors:
+  - jose
+tags:
+  - straymark
+  - charters
+  - governance
+  - polish-charter
+  - anti-pattern
+  - adopters
+  - lnxdrive
+date: 2026-05-31T00:00:00.000Z
+description: A second adopter, in a different language, validated the "surface declaration without wiring" anti-pattern — and the CLI helper we deferred on purpose finally shipped
+---
+*A week after we named an anti-pattern and deliberately declined to tool for it, a second project — in a different language, on a different stack — surfaced it again, in a sharper form: not a fresh gap, but a regression of an already-shipped security mitigation, hidden in dead code behind a feature flag that was never defined. That was the N=2 signal the framework said it was waiting for. The deferred helper shipped.*
+
+<!-- truncate -->
+
+> *"It compiled clean — the GOA module was dead code, and zbus proxies are validated at runtime, not compile time, so nothing flagged it. Activating the feature for the first time even surfaced a latent type error that had never compiled."*
+
+That sentence comes from Issue [#209](https://github.com/StrangeDaysTech/straymark/issues/209), filed on May 31 by [LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) — a Linux cloud-sync daemon and GTK desktop client written in Rust, FUSE and D-Bus and systemd all the way down. It is the second project in the [StrayMark adopters registry](https://github.com/StrangeDaysTech/straymark/blob/main/ADOPTERS.md), and the first in a domain genuinely unlike Sentinel's Go backend. That difference is the whole point of this post.
+
+Eight days earlier, in [*What the binary couldn't hide*](what-the-binary-couldnt-hide), we documented an anti-pattern — **surface declaration without wiring** — that a polish Charter in Sentinel surfaced ten times in six hours. We named it, shipped the pattern doc as `fw-4.18.0`, and **deferred the CLI helper on purpose**, with the reason stated plainly: Sentinel is N=1. The four sub-classes were the ones one adopter, one stack had surfaced. Tooling built on one domain's failure modes tends to ossify those choices into framework defaults that don't generalize. The pattern doc's `## Open questions` set the gate in one line: *"Crystallization as `straymark analyze declared-vs-wired` CLI subcommand … Gate: N=2 adopters."*
+
+This post is what happened when N=2 arrived — and why the occurrence was a stronger data point than the dozen that named the pattern.
+
+## The regression that compiled itself out
+
+LNXDrive's Charter `CHARTER-01-road-to-v0-1-0-alpha-1` had a Fase 1 that closed a security risk, `RISK-002`. The shape of the fix is worth stating precisely, because the regression is its mirror image.
+
+The authentication flow originally had the daemon expose a D-Bus method, `Auth.CompleteAuthWithTokens`, that carried OAuth tokens across the bus from the client. Tokens on the bus is the risk. Fase 1 closed it the right way: it **removed** that method and shipped `Auth.CompleteAuthViaGOA(account_path)` instead — the daemon now fetches the tokens itself from GNOME Online Accounts, daemon-side, and they never cross the bus. The mitigation shipped. The daemon's tests passed. `RISK-002` was closed.
+
+Then Fase 3 audited the GTK4 preferences panel — a separate crate, compiled through Meson rather than the daemon's Cargo build. The panel **still called `complete_auth_with_tokens`**, and still fetched tokens client-side. The consumer had never been updated when the producer changed its contract. The mitigation had regressed across a component boundary, in the half of the system that the Fase 1 work never touched.
+
+Here is why it stayed invisible for the gap between Fase 1 and Fase 3 — and why no test, no compiler, and no reviewer caught it:
+
+- **The dead call was behind a feature flag that did not exist.** The client's GOA code path sat under `#[cfg(feature = "goa")]`. `Cargo.toml` never defined a `goa` feature. So the entire module compiled *out* — it was dead code. The crate built green because the broken path was never built at all. CI doesn't exercise an undefined feature; neither does code review, which reads the line and moves on. When the panel work in Fase 3 finally activated the feature for the first time, it surfaced a latent **type error that had never compiled** — the concrete, unfalsifiable proof that the path had never once been wired.
+- **The boundary was triple.** Producer and consumer live in different crates, built by different toolchains (Cargo for the daemon, Meson for the panel), joined only at runtime over D-Bus. And zbus proxies are validated at *runtime*, not at compile time — so even with the feature on, the proxy declaring `complete_auth_with_tokens` would have compiled against a daemon interface that no longer offered it, and only failed when a real call hit a real bus.
+
+Strip away the Rust and the D-Bus specifics and you have the same mechanical mistake the Sentinel post named: an artifact declared in one place (the client proxy method), the implementation that should back it living in another place (the daemon interface), and nothing — not the compiler, not CI, not review — correlating the two. The declaration site and the wiring site live far apart, and the gap between them is where the regression hid.
+
+## Why this was sharper than the ten gaps that named the pattern
+
+The Sentinel cases were *fresh* gaps: a Preference Center that 401-looped for ten days, seven OTel instruments declared and never recorded. Features that shipped and never functionally worked. Bad enough.
+
+The LNXDrive case is qualitatively worse in a way that matters for the pattern's canon. It is a **regression of an already-shipped, already-audited mitigation.** `RISK-002` was closed correctly. The fix was real. And it silently drifted back out of compliance — not because anyone re-introduced the risky method, but because the *consumer* of the API was never updated when the *producer* changed it. The thing that made the regression legible wasn't a test. It was the audit's **ex-ante contract check**: a diff of the proxy methods the client declares against the interface the daemon actually implements.
+
+This earns sub-class 5 in the pattern doc, and a name of its own: **shipped-mitigation regression via an un-updated downstream consumer.** The four original sub-classes were variations on "a declared surface was never wired." The fifth adds a sharper edge: "a declared surface *was* wired, the wiring was removed as a fix, and a different component kept calling the old contract."
+
+A word on counting, because StrayMark crystallizes patterns by validation count and it's worth being honest about the arithmetic. There are two axes, and the pattern doc now reports them separately so they aren't conflated:
+
+- **Independent domains: 2.** Sentinel (Go backend) and LNXDrive (Rust desktop). A Rust desktop app validating a pattern first seen in a Go backend is the strong cross-domain signal — far stronger than another Go backend would have been. This is the axis that gates CLI automation.
+- **Occurrences: 3.** Sentinel's original surfacing, plus an earlier Fase 1 documentation drift inside LNXDrive, plus this cross-component regression.
+
+The gate is the domain axis, and it is now crossed.
+
+## The gate we said we were waiting for
+
+In the Sentinel post I wrote that the natural reaction to a vivid finding is to over-build the response, and that the discipline is the opposite: name the meta, defer the tool until at least two adopters have surfaced its shape. I also flagged the specific risk — *"A CLI helper commits the framework to a runtime that mirrors one specific stack's failure modes."*
+
+That risk is exactly what the second domain lets us route around. The helper that shipped — `straymark analyze declared-vs-wired`, in [`cli-3.18.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.18.0) — does not encode Go, or Rust, or D-Bus, or HTTP. It is a **config-driven set difference.** You give it a *declared* side and a *wired* side, each as a `(glob, regex)` pair, and the capture group of each regex is the symbol name. It reports the symbols that appear on the declared side and not on the wired side:
+
+```bash
+straymark analyze declared-vs-wired \
+  --declared-glob "client/**/*.rs"     --declared-pattern 'fn (\w+)' \
+  --wired-glob    "daemon/**/*.rs"      --wired-pattern   'fn (\w+)'
+```
+
+Run against the LNXDrive layout, that flags `complete_auth_with_tokens` — declared in the client proxy, absent from the daemon interface — and exits non-zero. The stack-specific knowledge lives entirely in the adopter's two regexes, committed once as a named profile in `.straymark/config.yml`. The framework supplies the set-difference machinery; the adopter supplies the meaning of "declared" and "wired" for their stack. That is the design that N=1 couldn't have produced: with one domain, you can't tell which parts of your tool are essential and which are accidental to that stack. The second domain is what separates them.
+
+This is the whole argument for the gate, observed in the wild rather than asserted. Had we shipped the helper at N=1 — say, an analyzer that walked Go ASTs for declared-but-unrecorded OTel instruments — it would have been useless to a Rust project talking over D-Bus, and we'd have spent a release cycle generalizing a thing we built too early. Waiting cost us eight days and bought us a tool whose v0 surface is honestly cross-stack.
+
+## The companion finding, and the cheaper backstop
+
+LNXDrive filed a second issue the same day, [#210](https://github.com/StrangeDaysTech/straymark/issues/210), and it's the quieter but more broadly useful of the two. It observed that the Charter's `## Files to modify` section had been written against *assumed* code, not *read* code — and was wrong repeatedly. `RISK-002` declared a new `dbus_iface.rs` and an opaque `SessionHandle` type; neither existed, and the fix shipped in the already-present `service.rs`. `ISSUE-002` named `lnxdrive-config/src/parser.rs`; there is no such crate, and the real parser is `lnxdrive-core/src/config.rs`. A CI-hardening item targeted an engine whose workflow lived at a subdirectory path GitHub Actions silently ignores — it had never run. Each row became a documented "premise correction" during execution.
+
+That's the framework working as a backstop: the ex-ante declaration is what made the later drift *legible*. But the root cause is upstream of drift — it's an authoring error, a path that never existed, not an implementation that diverged. Those are different failures and conflating them adds noise. So `cli-3.17.0` added a validate rule, `CHARTER-FILES-EXIST`: when a `## Files to modify` row names a path that isn't on disk and isn't tagged as newly created, `straymark validate --include-charters` warns. It's warn-only, pure-Rust (so it works without the bash the drift check needs), and — this is the point #210 asked for — it lives in a *different command* from `charter drift`. A path that never existed is a Charter mis-declaration to fix in place; a path declared and not modified is implementation drift to reconcile. Two failures, two rule codes, two commands. The Charter template now also tells authors, in the comment above `## Files to modify`, to read each path before declaring it — and, when a Charter touches a cross-component API, to list *all* the consumers, not just the producer. That last line is the discipline that would have caught the GOA regression at authoring time, before any code was written.
+
+## What we still deliberately didn't do
+
+The same restraint as last time, in a different place. `analyze declared-vs-wired` ships **only** sub-class 5 — the IPC proxy-vs-interface check, the one LNXDrive actually surfaced and the one that is mechanically tractable across stacks with nothing but two regexes. The AST-based variants of sub-classes 1 through 4 — walking code for env-var consumers, metric record sites, HTML route resolution, public-route prefixes — are still deferred, and the pattern doc still lists them under `## Open questions`. They need per-stack parsers, and a set-difference over regex captures is not that. The dynamic checks — booting the binary, resolving routes at runtime — remain inherently project-local. We crossed the gate that the config-driven check needed; we did not use the crossing as license to build everything the pattern could eventually justify.
+
+There's a smaller deferral worth naming too. We considered a hard `recon: confirmed` frontmatter field on Charters — a box the author ticks to assert they read the tree before declaring it. We didn't ship it. A required field breaks non-interactive and skill-driven Charter creation, and it creates a lie surface: agents will tick it reflexively. The soft nudge in `charter new`'s output plus the mechanical `CHARTER-FILES-EXIST` backstop does the same work without the failure mode. If the soft version proves insufficient across more adopters, that's the signal to revisit — the same gate logic, one level down.
+
+## If you've read this far
+
+The portable exercise from the last post still stands, and the second domain extends it. If you run a system split across a producer and a consumer joined at runtime — a daemon and a client, a service and an SDK, a server and a generated stub — write down the methods the consumer *declares* it will call, and the methods the producer *actually implements*, and diff the two sets. You don't need StrayMark to do it; `grep` and `comm` will get you most of the way. The set difference in one direction is the regression this post is about. The set difference in the other direction is dead surface area you can delete. Either way the number is information you didn't have.
+
+And if you operate on a stack we haven't seen yet — and at N=2, that's still most stacks — the path from "interesting observation in my project" to "named in the StrayMark canon" runs through the same channel #199 and #209 both went through: open an issue. Sub-class 6 is out there in some codebase right now, declared in one file and wired in another, waiting for the adopter who'll be the one to surface it.
+
+---
+
+*StrayMark `fw-4.20.0` + `cli-3.17.0` (Release A) and `cli-3.18.0` (Release B) — Issues [#209](https://github.com/StrangeDaysTech/straymark/issues/209) · [#210](https://github.com/StrangeDaysTech/straymark/issues/210) · PRs [#211](https://github.com/StrangeDaysTech/straymark/pull/211) · [#212](https://github.com/StrangeDaysTech/straymark/pull/212). Pattern: [`POLISH-CHARTER-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md) (v1, N=2). Predecessor: [*What the binary couldn't hide*](what-the-binary-couldnt-hide).*
+
+*This document was produced with assistance from generative AI tools (Claude Opus 4.8); all responsibility for the content rests with the human author.*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-05-31-what-the-feature-flag-compiled-away.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-05-31-what-the-feature-flag-compiled-away.md
@@ -1,0 +1,97 @@
+---
+slug: what-the-feature-flag-compiled-away
+title: Lo que el feature flag compiló fuera
+authors:
+  - jose
+tags:
+  - straymark
+  - charters
+  - governance
+  - polish-charter
+  - anti-patron
+  - adopters
+  - lnxdrive
+date: 2026-05-31T00:00:00.000Z
+description: Un segundo adopter, en otro lenguaje, validó el anti-patrón "declaración de superficie sin cableado" — y el helper de CLI que diferimos a propósito por fin shippeó
+---
+*Una semana después de nombrar un anti-patrón y declinar deliberadamente construir tooling para él, un segundo proyecto — en otro lenguaje, sobre otro stack — lo afloró de nuevo, en una forma más afilada: no un gap nuevo, sino la regresión de una mitigación de seguridad ya entregada, escondida en código muerto tras un feature flag que nunca se definió. Esa fue la señal N=2 que el framework decía estar esperando. El helper diferido shippeó.*
+
+<!-- truncate -->
+
+> *"Compiló limpio — el módulo GOA era código muerto, y los proxies de zbus se validan en runtime, no en tiempo de compilación, así que nada lo marcó. Activar la feature por primera vez incluso afloró un error de tipo latente que nunca había compilado."*
+
+Esa frase viene del Issue [#209](https://github.com/StrangeDaysTech/straymark/issues/209), presentado el 31 de mayo por [LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) — un daemon de sincronización en la nube para Linux y un cliente de escritorio GTK escritos en Rust, FUSE y D-Bus y systemd hasta el fondo. Es el segundo proyecto en el [registro de adopters de StrayMark](https://github.com/StrangeDaysTech/straymark/blob/main/ADOPTERS.md), y el primero en un dominio genuinamente distinto al backend Go de Sentinel. Esa diferencia es el punto entero de este post.
+
+Ocho días antes, en [*Lo que el binario no pudo esconder*](what-the-binary-couldnt-hide), documentamos un anti-patrón — **declaración de superficie sin cableado** — que un polish Charter en Sentinel afloró diez veces en seis horas. Lo nombramos, shippeamos el doc del patrón como `fw-4.18.0`, y **diferimos el helper de CLI a propósito**, con la razón dicha sin rodeos: Sentinel es N=1. Las cuatro subclases eran las que un adopter, un stack había aflorado. El tooling construido sobre los modos de fallo de un solo dominio tiende a osificar esas decisiones en defaults del framework que no generalizan. Las `## Open questions` del doc del patrón fijaron la compuerta en una línea: *"Cristalización como subcomando CLI `straymark analyze declared-vs-wired` … Compuerta: N=2 adopters."*
+
+Este post es lo que pasó cuando llegó N=2 — y por qué la ocurrencia fue un dato más fuerte que la docena que nombró el patrón.
+
+## La regresión que se compiló a sí misma fuera
+
+El Charter `CHARTER-01-road-to-v0-1-0-alpha-1` de LNXDrive tenía una Fase 1 que cerró un riesgo de seguridad, `RISK-002`. Vale la pena enunciar la forma del fix con precisión, porque la regresión es su imagen espejo.
+
+El flujo de autenticación originalmente tenía al daemon exponiendo un método D-Bus, `Auth.CompleteAuthWithTokens`, que cargaba tokens OAuth a través del bus desde el cliente. Tokens en el bus es el riesgo. La Fase 1 lo cerró de la forma correcta: **eliminó** ese método y shippeó `Auth.CompleteAuthViaGOA(account_path)` en su lugar — ahora el daemon obtiene los tokens él mismo desde GNOME Online Accounts, daemon-side, y nunca cruzan el bus. La mitigación shippeó. Los tests del daemon pasaron. `RISK-002` quedó cerrado.
+
+Luego la Fase 3 auditó el panel de preferencias GTK4 — un crate separado, compilado vía Meson en vez del build Cargo del daemon. El panel **seguía llamando a `complete_auth_with_tokens`**, y seguía obteniendo tokens client-side. El consumidor nunca había sido actualizado cuando el productor cambió su contrato. La mitigación había regresado a través de una frontera de componentes, en la mitad del sistema que el trabajo de Fase 1 nunca tocó.
+
+Aquí está por qué se mantuvo invisible en el hueco entre Fase 1 y Fase 3 — y por qué ningún test, ningún compilador, ni ningún revisor lo cazó:
+
+- **La llamada muerta estaba tras un feature flag que no existía.** El camino de código GOA del cliente vivía bajo `#[cfg(feature = "goa")]`. `Cargo.toml` nunca definió una feature `goa`. Así que el módulo entero compilaba *fuera* — era código muerto. El crate compilaba en verde porque el camino roto nunca se construía en absoluto. CI no ejerce una feature indefinida; tampoco la revisión de código, que lee la línea y sigue. Cuando el trabajo del panel en Fase 3 por fin activó la feature por primera vez, afloró un **error de tipo latente que nunca había compilado** — la prueba concreta e infalsificable de que el camino nunca estuvo cableado ni una vez.
+- **La frontera era triple.** Productor y consumidor viven en crates distintas, construidas por toolchains distintas (Cargo para el daemon, Meson para el panel), unidas solo en runtime sobre D-Bus. Y los proxies de zbus se validan en *runtime*, no en tiempo de compilación — así que incluso con la feature encendida, el proxy declarando `complete_auth_with_tokens` habría compilado contra una interfaz del daemon que ya no lo ofrecía, y solo habría fallado cuando una llamada real golpeara un bus real.
+
+Quita el Rust y los detalles de D-Bus y tienes la misma equivocación mecánica que nombró el post de Sentinel: un artefacto declarado en un lugar (el método proxy del cliente), la implementación que debería respaldarlo viviendo en otro lugar (la interfaz del daemon), y nada — ni el compilador, ni CI, ni la revisión — correlacionando los dos. El sitio de declaración y el sitio de cableado viven lejos entre sí, y el hueco entre ellos es donde la regresión se escondió.
+
+## Por qué esto fue más afilado que los diez gaps que nombraron el patrón
+
+Los casos de Sentinel eran gaps *nuevos*: un Preference Center que hacía 401-loop durante diez días, siete instrumentos OTel declarados y nunca registrados. Features que shippearon y nunca funcionaron funcionalmente. Suficientemente malo.
+
+El caso de LNXDrive es cualitativamente peor de una forma que importa para el canon del patrón. Es una **regresión de una mitigación ya entregada, ya auditada.** `RISK-002` se cerró correctamente. El fix era real. Y silenciosamente derivó de vuelta fuera de cumplimiento — no porque alguien reintrodujera el método riesgoso, sino porque el *consumidor* de la API nunca se actualizó cuando el *productor* la cambió. Lo que hizo legible la regresión no fue un test. Fue la **verificación de contrato ex-ante** de la auditoría: un diff de los métodos proxy que el cliente declara contra la interfaz que el daemon realmente implementa.
+
+Esto se gana la subclase 5 en el doc del patrón, y un nombre propio: **regresión de mitigación entregada vía un consumidor downstream no actualizado.** Las cuatro subclases originales eran variaciones de "una superficie declarada nunca se cableó". La quinta agrega un filo más cortante: "una superficie declarada *sí* estaba cableada, el cableado se eliminó como un fix, y un componente distinto siguió llamando al contrato viejo".
+
+Una palabra sobre el conteo, porque StrayMark cristaliza patrones por conteo de validación y vale la pena ser honesto con la aritmética. Hay dos ejes, y el doc del patrón ahora los reporta por separado para que no se confundan:
+
+- **Dominios independientes: 2.** Sentinel (backend Go) y LNXDrive (escritorio Rust). Una app de escritorio en Rust validando un patrón visto primero en un backend Go es la señal cross-domain fuerte — mucho más fuerte de lo que habría sido otro backend Go. Este es el eje que abre la automatización en el CLI.
+- **Ocurrencias: 3.** El afloramiento original de Sentinel, más un drift de documentación temprano de Fase 1 dentro de LNXDrive, más esta regresión cross-component.
+
+La compuerta es el eje de dominio, y ahora está cruzada.
+
+## La compuerta que dijimos que estábamos esperando
+
+En el post de Sentinel escribí que la reacción natural ante un hallazgo vívido es sobre-construir la respuesta, y que la disciplina es lo opuesto: nombrar el meta, diferir el tool hasta que al menos dos adopters hayan aflorado su forma. También señalé el riesgo específico — *"Un helper de CLI compromete al framework a un runtime que refleja los modos de fallo de un stack específico."*
+
+Ese riesgo es exactamente lo que el segundo dominio permite esquivar. El helper que shippeó — `straymark analyze declared-vs-wired`, en [`cli-3.18.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.18.0) — no codifica Go, ni Rust, ni D-Bus, ni HTTP. Es un **set-difference dirigido por config.** Le das un lado *declarado* y un lado *cableado*, cada uno como un par `(glob, regex)`, y el grupo de captura de cada regex es el nombre del símbolo. Reporta los símbolos que aparecen del lado declarado y no del lado cableado:
+
+```bash
+straymark analyze declared-vs-wired \
+  --declared-glob "client/**/*.rs"     --declared-pattern 'fn (\w+)' \
+  --wired-glob    "daemon/**/*.rs"      --wired-pattern   'fn (\w+)'
+```
+
+Corrido contra el layout de LNXDrive, eso marca `complete_auth_with_tokens` — declarado en el proxy del cliente, ausente de la interfaz del daemon — y sale con código distinto de cero. El conocimiento específico del stack vive enteramente en los dos regexes del adopter, commiteados una vez como un perfil con nombre en `.straymark/config.yml`. El framework provee la maquinaria de set-difference; el adopter provee el significado de "declarado" y "cableado" para su stack. Ese es el diseño que N=1 no podría haber producido: con un dominio, no puedes distinguir qué partes de tu tool son esenciales y cuáles son accidentales a ese stack. El segundo dominio es lo que las separa.
+
+Este es el argumento entero a favor de la compuerta, observado en la práctica en vez de afirmado. Si hubiéramos shippeado el helper en N=1 — digamos, un analizador que caminara ASTs de Go buscando instrumentos OTel declarados-pero-no-registrados — habría sido inútil para un proyecto Rust hablando sobre D-Bus, y habríamos gastado un ciclo de release generalizando algo que construimos demasiado pronto. Esperar nos costó ocho días y nos compró un tool cuya superficie v0 es honestamente cross-stack.
+
+## El hallazgo compañero, y el backstop más barato
+
+LNXDrive presentó un segundo issue el mismo día, [#210](https://github.com/StrangeDaysTech/straymark/issues/210), y es el más callado pero más ampliamente útil de los dos. Observó que la sección `## Archivos a modificar` del Charter había sido escrita contra código *asumido*, no código *leído* — y estaba mal repetidamente. `RISK-002` declaró un nuevo `dbus_iface.rs` y un tipo opaco `SessionHandle`; ninguno existía, y el fix shippeó en el ya presente `service.rs`. `ISSUE-002` nombró `lnxdrive-config/src/parser.rs`; no existe tal crate, y el parser real es `lnxdrive-core/src/config.rs`. Un ítem de endurecimiento de CI apuntaba a un engine cuyo workflow vivía en un path de subdirectorio que GitHub Actions ignora silenciosamente — nunca había corrido. Cada fila se volvió una "corrección de premisa" documentada durante la ejecución.
+
+Eso es el framework funcionando como backstop: la declaración ex-ante es lo que hizo *legible* el drift posterior. Pero la causa raíz está upstream del drift — es un error de autoría, una ruta que nunca existió, no una implementación que divergió. Esos son fallos distintos y confundirlos agrega ruido. Así que `cli-3.17.0` agregó una regla de validación, `CHARTER-FILES-EXIST`: cuando una fila de `## Archivos a modificar` nombra una ruta que no está en disco y no está tagueada como recién creada, `straymark validate --include-charters` avisa. Es solo-aviso, pure-Rust (así funciona sin el bash que el chequeo de drift necesita), y — este es el punto que pidió #210 — vive en un *comando distinto* a `charter drift`. Una ruta que nunca existió es una mala declaración del Charter que se arregla en el lugar; una ruta declarada y no modificada es drift de implementación que se reconcilia. Dos fallos, dos códigos de regla, dos comandos. La plantilla de Charter ahora también le dice a los autores, en el comentario sobre `## Archivos a modificar`, que lean cada ruta antes de declararla — y, cuando un Charter toca una API cross-component, que listen *todos* los consumidores, no solo el productor. Esa última línea es la disciplina que habría cazado la regresión GOA en tiempo de autoría, antes de escribir cualquier código.
+
+## Lo que aún deliberadamente no hicimos
+
+La misma contención que la vez pasada, en un lugar distinto. `analyze declared-vs-wired` shippea **solo** la subclase 5 — el chequeo proxy-vs-interfaz, el que LNXDrive realmente afloró y el que es mecánicamente tratable a través de stacks sin más que dos regexes. Las variantes basadas en AST de las subclases 1 a 4 — caminar código buscando consumidores de env-var, sitios de registro de métricas, resolución de rutas HTML, prefijos de ruta pública — siguen diferidas, y el doc del patrón aún las lista bajo `## Open questions`. Necesitan parsers por stack, y un set-difference sobre capturas de regex no es eso. Los chequeos dinámicos — bootear el binario, resolver rutas en runtime — siguen siendo inherentemente project-local. Cruzamos la compuerta que el chequeo dirigido-por-config necesitaba; no usamos el cruce como licencia para construir todo lo que el patrón podría eventualmente justificar.
+
+Hay una deferral más pequeña que vale la pena nombrar también. Consideramos un campo de frontmatter duro `recon: confirmed` en los Charters — una casilla que el autor marca para afirmar que leyó el árbol antes de declararlo. No lo shippeamos. Un campo requerido rompe la creación de Charters no-interactiva y dirigida-por-skill, y crea una superficie de mentira: los agentes lo marcarán reflexivamente. El nudge suave en la salida de `charter new` más el backstop mecánico `CHARTER-FILES-EXIST` hace el mismo trabajo sin el modo de fallo. Si la versión suave resulta insuficiente a través de más adopters, esa es la señal para revisitar — la misma lógica de compuerta, un nivel más abajo.
+
+## Si has leído hasta aquí
+
+El ejercicio portable del post anterior sigue en pie, y el segundo dominio lo extiende. Si corres un sistema partido entre un productor y un consumidor unidos en runtime — un daemon y un cliente, un servicio y un SDK, un servidor y un stub generado — anota los métodos que el consumidor *declara* que llamará, y los métodos que el productor *realmente implementa*, y diffea los dos conjuntos. No necesitas StrayMark para hacerlo; `grep` y `comm` te llevan casi todo el camino. El set-difference en una dirección es la regresión de la que trata este post. El set-difference en la otra dirección es superficie muerta que puedes borrar. De cualquier forma el número es información que no tenías.
+
+Y si operas sobre un stack que aún no hemos visto — y en N=2, eso sigue siendo la mayoría de los stacks — el camino de "observación interesante en mi proyecto" a "nombrado en el canon de StrayMark" corre por el mismo canal por el que pasaron #199 y #209: abre un issue. La subclase 6 está ahí afuera en algún codebase ahora mismo, declarada en un archivo y cableada en otro, esperando al adopter que será quien la aflore.
+
+---
+
+*StrayMark `fw-4.20.0` + `cli-3.17.0` (Release A) y `cli-3.18.0` (Release B) — Issues [#209](https://github.com/StrangeDaysTech/straymark/issues/209) · [#210](https://github.com/StrangeDaysTech/straymark/issues/210) · PRs [#211](https://github.com/StrangeDaysTech/straymark/pull/211) · [#212](https://github.com/StrangeDaysTech/straymark/pull/212). Patrón: [`POLISH-CHARTER-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/POLISH-CHARTER-PATTERN.md) (v1, N=2). Predecesor: [*Lo que el binario no pudo esconder*](what-the-binary-couldnt-hide).*
+
+*Este documento fue producido con asistencia de herramientas de IA generativa (Claude Opus 4.8); toda responsabilidad por el contenido recae en el autor humano.*


### PR DESCRIPTION
## Context

A blog post documenting the LNXDrive findings ([#209](https://github.com/StrangeDaysTech/straymark/issues/209)/[#210](https://github.com/StrangeDaysTech/straymark/issues/210)) shipped in PRs #211/#212 — and, more importantly, the milestone they represent: **the first N=2 crossing** in StrayMark's adopter flywheel.

It's a direct **sequel to [*What the binary couldn't hide*](https://straymark.dev/blog/what-the-binary-couldnt-hide)** (the N=1 origin of the *surface-declaration-without-wiring* anti-pattern), which closed by saying the CLI helper was deferred *on purpose* until N=2. This post is that payoff.

## Angle

"Both threads interwoven" (the predecessor's style): opens with the war story — the GTK client calling a D-Bus method the daemon had deleted, hidden behind a `#[cfg(feature="goa")]` that `Cargo.toml` never defined (compiled out → dead code → invisible to CI and review) — and uses it as evidence for the larger argument: deferring automation to N=2 was right, and the second *different-domain* adopter is exactly what let the shipped `analyze declared-vs-wired` helper be honestly config-driven rather than ossifying one stack's choices.

Weaves in the companion finding #210 (`CHARTER-FILES-EXIST`) and keeps the predecessor's "what we deliberately didn't do" + "if you've read this far" structure.

## Files
- `website/blog/2026-05-31-what-the-feature-flag-compiled-away.md` (EN canonical)
- `website/i18n/es/.../2026-05-31-what-the-feature-flag-compiled-away.md` (ES translation)

## Verification
- `npm run build` → `[SUCCESS]` across `en`/`es`/`zh-CN`, **zero broken-link errors** (Docusaurus fails on broken internal links; the cross-links to the predecessor resolve).
- Renders in all three locales; titles correct (`What the feature flag compiled away` / `Lo que el feature flag compiló fuera`); appears first in the blog listing.

Docs-only — merging triggers `deploy-website.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)