### PR TITLE
feat(cli): cli-3.19.0 — `straymark followups` namespace (list/status/drift/promote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.19.0 — `straymark followups` namespace (companion to fw-4.21.0)
+
+Ships the native CLI surface for the follow-ups backlog registry crystallized in fw-4.21.0 ([`ADR-2026-06-03-001`](docs/decisions/ADR-2026-06-03-followups-first-class.md), driven by [#214](https://github.com/StrangeDaysTech/straymark/issues/214)). The registry stops being invisible to tooling: it gains a CLI namespace, a synthetic group in `explore`, and a block in `status`. Collapses Tiers 2 and 4 of [#135](https://github.com/StrangeDaysTech/straymark/issues/135) into one native implementation; Tier 3 (`charter close` soft-integration) remains gated.
+
+### Added (CLI)
+
+- **`straymark followups list [--bucket] [--status] [--severity] [--label]`** *(new subcommand group)* — filterable table of registry entries (FU id, status, severity, bucket, destination, description). Malformed `### FU-` headings warn without failing.
+- **`straymark followups status [FU-NNN]`** — registry pulse with counters **recomputed on the fly** from actual entry statuses (trustworthy even when the file frontmatter is stale — divergence is flagged), per-bucket breakdown, blocking/suspected-closed alerts, and advisory schema validation against `follow-ups-backlog.schema.v1.json`. With an id: entry field detail.
+- **`straymark followups drift [--apply] [--scan-all] [--range]`** — native replacement for the deprecated adopter-side `check-followups-drift.sh` (~296 lines of bash retired). Per-AILOG granularity via `fully_extracted_ailogs` (0 false positives across 76 AILOGs in the reference adopter). `--apply` extracts into `## Bucket: ready`, registers the AILOG, **recomputes the CLI-owned counters** (#214 Signal 2) and upgrades v0 registries to v1 in place — non-destructively (unknown frontmatter fields survive; writes are surgical text edits, never a re-serialization). **Anti-noise refinement** (#214 Signal 1): bullets carrying a closure marker (`closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash) land as **`suspected-closed`** instead of `ready`/TBD noise — across both documented occurrences that noise was 20–75% per batch. Seeds the registry from the framework template on first `--apply`.
+- **`straymark followups promote FU-NNN [--title]`** — automates the FU → TDE elevation: creates the TDE from the framework template with `promoted_from_followup: FU-NNN`, flips the entry to `promoted` with `Destination`/`Promoted to` → TDE id, recomputes counters. Non-interactive by design (agent-friendly); prioritization stays human per `AGENT-RULES.md §3`.
+- **`explore` TUI: synthetic "Follow-ups" group** — the registry file plus one sub-node per non-empty bucket, one entry per FU (badge `FU`; labels surface as tags; `FU-NNN` ids resolve as references). Appears only when the registry exists, mirroring `_charters`.
+- **`status`: Follow-ups block** — status breakdown (open / in-progress / suspected-closed / closed+superseded / promoted) recomputed from entry statuses, with a blocking-severity alert; one-line adoption hint when no registry exists.
+- **`cli/src/followups.rs`** — lenient registry parser (pure functions, no CLI deps; doc-tagged as the straymark-core move target for Loom M0) + **42 new tests** (25 unit, 17 integration) covering v0 lenient parsing, the v1 dimensions, closure-marker detection, counter recompute, idempotent upgrade, and the promote round-trip.
+
+### Changed (CLI)
+
+- `split_frontmatter` moved from `charter.rs` to `utils.rs` — one shared definition for the Charter and registry parsers.
+
+### Adopter guidance
+
+Run `straymark update` (CLI → `cli-3.19.0`, framework → `fw-4.21.0`). If you maintain a v0 registry: `straymark followups drift --apply` migrates it in one command; then delete the local bash script and point any pre-commit hook at the CLI. The `/straymark-followups` skill ships in a follow-up framework release.
+
+---
+
 ## Framework 4.21.0 — Follow-ups backlog becomes a first-class entity (schema v1)
 
 Promotes the follow-ups backlog from documented convention (v0, adopter-side bash) to **first-class framework entity**, following the lane Charter used: canonical schema, shipped agent directives, onboarding-level visibility. Driven by [#214](https://github.com/StrangeDaysTech/straymark/issues/214) (Sentinel post-stage triage at N=91 FUs — extractor noise ×2, silent counter drift, ad-hoc severity) and recorded in [`ADR-2026-06-03-001`](docs/decisions/ADR-2026-06-03-followups-first-class.md), which documents the design-principle #12 reframe: the structural evidence (91 FUs, schema already iterated under empirical pressure, 0 extraction false positives across 76 AILOGs, stable bucket vocabulary, internal Loom roadmap demand) justifies crystallizing as **v1 experimental**; hard stabilization stays gated on a second adopter. The native CLI surface (`straymark followups list/status/drift/promote`) ships in the companion release cli-3.19.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,10 @@ Users can now run `straymark update-framework` to get the new version.
 | `straymark metrics [path]` | Show governance metrics and documentation statistics |
 | `straymark analyze [path]` | Analyze code complexity (cognitive + cyclomatic metrics) |
 | `straymark analyze declared-vs-wired [path]` | Flag declared symbols (IPC/RPC proxy methods) with no implemented wiring counterpart — config-driven set-difference (POLISH-CHARTER-PATTERN sub-class 5) |
+| `straymark followups list [--bucket] [--status] [--severity] [--label]` | List follow-ups registry entries with filters |
+| `straymark followups status [FU-NNN]` | Registry pulse (counters recomputed on the fly) or entry detail |
+| `straymark followups drift [--apply] [--scan-all]` | Detect/extract AILOGs with unextracted follow-up content (native, anti-noise `suspected-closed`, recomputes CLI-owned counters, upgrades v0→v1) |
+| `straymark followups promote FU-NNN` | Elevate an entry to a TDE document with `promoted_from_followup` traceability |
 | `straymark audit [path]` | Generate audit trail reports with timeline and traceability |
 | `straymark explore [path]` | Interactive TUI documentation browser |
 | `straymark about` | Show version and license info |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Built-in safeguards ensure humans stay in control:
 Built-in commands that turn the discipline into actionable feedback:
 
 - **`straymark charter <new|list|status|close|drift|batch-complete|audit|refresh-suggest|amend>`** — Bounded units of work declared ex-ante, audited ex-post. `close` records post-execution telemetry; `drift` detects file-vs-commit drift with AILOG-aware suppression and (cli-3.13.0+) gates on `### Batch N (pending)` entries in the AILOG `## Batch Ledger`; `batch-complete` (cli-3.13.0+) marks a batch as complete in the ledger for multi-batch Charters (3+ batches or >1 day); `audit` orchestrates a multi-model external review (3-step prepare/calibrate/finalize, orchestration-only — no LLM API calls); `refresh-suggest` (cli-3.14.0+) prints a heuristic recommendation for a pre-declare SpecKit refresh when a multi-Charter module's rolling `r_n_plus_one_emergent_count` mean exceeds a threshold; `amend` (cli-3.14.0+) scaffolds a post-close Batch N.4 amendment (audit-driven remediation) on the same execute branch without opening a new Charter. For IDE-driven workflows, the inline skills `/straymark-audit-prompt` and `/straymark-audit-review` wrap the CLI to surface prompts in the conversation and merge findings into telemetry.
+- **`straymark followups <list|status|drift|promote>`** *(cli-3.19.0+)* — First-class follow-ups backlog registry (`.straymark/follow-ups-backlog.md`, schema v1 experimental): `drift --apply` extracts `§Follow-ups` / `R<N> (new)` entries from AILOGs per-AILOG (closure-marked bullets land as `suspected-closed`), counters are CLI-owned and recomputed on every write, and `promote` elevates entries to TDE documents with full traceability. See `STRAYMARK.md §16` and `FOLLOW-UPS-BACKLOG-PATTERN.md`.
 - **`straymark approve <doc-id>`** — Record a formal human approval (writes `reviewed_by` / `reviewed_at` / `review_outcome` and the `## Approval` body section in one edit; closes the gap canonized in DOCUMENTATION-POLICY §3.5)
 - **`straymark validate`** — 25+ validation rules for document correctness (12 China-specific are scope-aware); `--include-charters` extends to `.straymark/charters/`; `--check-pending-reviews` lists approval backlog (warn-only)
 - **`straymark metrics`** — Governance KPIs, review rates, risk distribution, trends
@@ -277,7 +278,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.21.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.18.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.19.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -294,6 +295,7 @@ Check installed versions with `straymark status` or `straymark about`.
 | `straymark repair [path]` | Restore missing directories and framework files |
 | `straymark validate [path]` | Validate documents for compliance and correctness (use `--include-charters` for Charters, `--check-pending-reviews` for approval backlog) |
 | `straymark charter <subcommand>` | Manage Charters: `new`, `list`, `status`, `close` (record telemetry), `drift` (file-vs-commit drift with AILOG-awareness + Batch Ledger gate), `batch-complete` (mark a batch as complete in the AILOG `## Batch Ledger` for multi-batch Charters), `audit` (multi-model external review, orchestration-only), `refresh-suggest` (pre-declare SpecKit refresh heuristic for multi-Charter modules, fw-4.16.0+), `amend` (scaffold a post-close Batch N.4 amendment, fw-4.16.0+) |
+| `straymark followups <subcommand>` *(cli-3.19.0+)* | Manage the follow-ups backlog registry: `list` (filterable entries), `status` (pulse with CLI-owned counters recomputed on the fly), `drift` (detect/extract unprocessed AILOGs — native replacement for the v0 bash script, with anti-noise `suspected-closed` extraction), `promote` (FU → TDE with `promoted_from_followup` traceability) |
 | `straymark approve <doc-id>` | Record a formal human approval on a `review_required: true` document (frontmatter + canonical body section) |
 | `straymark compliance [path]` | Check regulatory compliance (EU AI Act, ISO 42001, NIST) |
 | `straymark metrics [path]` | Show governance metrics and documentation statistics |

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2324,7 +2324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.18.0"
+version = "3.19.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/charter.rs
+++ b/cli/src/charter.rs
@@ -334,26 +334,9 @@ fn charter_number_from_path(p: &PathBuf) -> Option<u32> {
     prefix.parse::<u32>().ok()
 }
 
-/// Split a markdown document into (frontmatter, body) at the first pair of `---`
-/// delimiters. Returns `None` if the document has no frontmatter block.
-/// Accepts both `\n` and `\r\n` line endings on the closing delimiter.
-fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
-    // Opening delimiter: must be at the very start of the file.
-    let after_open = content.strip_prefix("---\n").or_else(|| content.strip_prefix("---\r\n"))?;
-    // Closing delimiter: find the first occurrence of `\n---\n` or `\r\n---\r\n`.
-    let (end, delim_len) = if let Some(idx) = after_open.find("\n---\n") {
-        (idx, 5)
-    } else if let Some(idx) = after_open.find("\r\n---\r\n") {
-        (idx, 7)
-    } else if let Some(idx) = after_open.find("\n---\r\n") {
-        (idx, 6)
-    } else {
-        return None;
-    };
-    let frontmatter = &after_open[..end];
-    let body = &after_open[end + delim_len..];
-    Some((frontmatter, body))
-}
+// `split_frontmatter` moved to `crate::utils` (cli-3.19.0) so the Charter
+// parser and the follow-ups registry parser share one definition.
+use crate::utils::split_frontmatter;
 
 #[cfg(test)]
 mod tests {

--- a/cli/src/commands/followups/drift.rs
+++ b/cli/src/commands/followups/drift.rs
@@ -1,0 +1,291 @@
+//! `straymark followups drift` — keep the registry in sync with AILOGs.
+//!
+//! Native Rust replacement (cli-3.19.0) for the deprecated adopter-side
+//! `check-followups-drift.sh`. Three modes, mirroring the v0 script:
+//!
+//! - **default** — scan AILOGs changed in `git diff origin/main..HEAD`
+//!   (fallback `origin/master..HEAD`, then `HEAD~1..HEAD` with a warning).
+//!   Warn + exit 1 when an AILOG with follow-up content is not in
+//!   `fully_extracted_ailogs`.
+//! - **`--apply`** — same scan + extract new entries into `## Bucket: ready`,
+//!   append the AILOG ids to `fully_extracted_ailogs`, **recompute the
+//!   `total_*` counters** (#214 Signal 2) and upgrade v0 → v1 in place.
+//!   Entries whose AILOG text carries a closure marker are extracted as
+//!   `suspected-closed` instead of `open` (#214 Signal 1 — the anti-noise
+//!   refinement).
+//! - **`--scan-all`** — sweep every AILOG in the project.
+//!
+//! Granularity is **per-AILOG**, never per-bullet — the empirically validated
+//! design choice (0 false positives across 76 AILOGs in the reference
+//! adopter). See `FOLLOW-UPS-BACKLOG-PATTERN.md` §Drift detection.
+//!
+//! ## Exit codes
+//! - `0` — no drift (or `--apply` extracted everything)
+//! - `1` — drift found (default mode only)
+
+use anyhow::{anyhow, Result};
+use chrono::Local;
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::ailog;
+use crate::followups::{self, ExtractedFu};
+use crate::utils;
+
+pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
+    let project_root = &resolved.path;
+
+    let registry_path = followups::registry_path(project_root);
+    if !registry_path.exists() {
+        if apply {
+            // Seed from the framework template so --apply works on first run.
+            let template = project_root
+                .join(".straymark")
+                .join("templates")
+                .join("follow-ups-backlog.md");
+            if template.exists() {
+                std::fs::copy(&template, &registry_path)?;
+                utils::info(&format!(
+                    "Created {} from the framework template.",
+                    registry_path
+                        .strip_prefix(project_root)
+                        .unwrap_or(&registry_path)
+                        .display()
+                ));
+            } else {
+                return Err(anyhow!(
+                    "No registry at {} and no template at .straymark/templates/follow-ups-backlog.md.\n  \
+                     hint: run `straymark update-framework` (the template ships with fw-4.21.0+).",
+                    registry_path.display()
+                ));
+            }
+        } else {
+            println!(
+                "No follow-ups registry yet. Run `straymark followups drift --scan-all --apply` to create and seed it (see STRAYMARK.md §16)."
+            );
+            return Ok(());
+        }
+    }
+
+    let registry = followups::parse_registry(&registry_path)?;
+    for w in &registry.warnings {
+        utils::warn(w);
+    }
+
+    // Candidate AILOG files.
+    let agent_logs = ailog::agent_logs_dir(project_root);
+    let candidates: Vec<PathBuf> = if scan_all {
+        walk_ailogs(&agent_logs)
+    } else {
+        ailogs_in_git_range(project_root, &agent_logs, range)
+    };
+
+    // Drift = AILOG with follow-up content whose id is NOT in
+    // fully_extracted_ailogs.
+    let extracted_set: std::collections::HashSet<&str> = registry
+        .frontmatter
+        .fully_extracted_ailogs
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+
+    let mut drifted: Vec<(String, PathBuf, Vec<ExtractedFu>)> = Vec::new();
+    for path in candidates {
+        let Some(id) = followups::ailog_id_from_path(&path) else {
+            continue;
+        };
+        if extracted_set.contains(id.as_str()) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let found = followups::extract_followups_from_ailog(&content);
+        if !found.is_empty() {
+            drifted.push((id, path, found));
+        }
+    }
+
+    if drifted.is_empty() {
+        println!(
+            "{} registry in sync — no AILOGs with unextracted follow-up content.",
+            "OK".green().bold()
+        );
+        return Ok(());
+    }
+
+    if !apply {
+        eprintln!(
+            "{} {} AILOG(s) have follow-up content not yet in the registry:",
+            "WARNING:".red().bold(),
+            drifted.len()
+        );
+        for (id, path, found) in &drifted {
+            eprintln!(
+                "  - {} ({} entr{}) — {}",
+                id,
+                found.len(),
+                if found.len() == 1 { "y" } else { "ies" },
+                path.strip_prefix(project_root).unwrap_or(path).display()
+            );
+        }
+        eprintln!();
+        eprintln!("  Action: run `straymark followups drift --apply` to extract them.");
+        std::process::exit(1);
+    }
+
+    // ── --apply: extract into the registry ──
+    let today = Local::now().format("%Y-%m-%d").to_string();
+    let mut body = registry.body.clone();
+    let mut next_n = followups::next_fu_number(&registry);
+    let mut added = 0usize;
+    let mut suspected = 0usize;
+
+    for (id, _path, found) in &drifted {
+        for fu in found {
+            // Re-parse spans against the evolving body so each insert lands
+            // at the (possibly moved) end of the ready bucket.
+            let current =
+                followups::parse_registry_str(&registry_path, &followups::assemble(&registry.frontmatter_raw, &body))?;
+            let block = followups::render_new_entry(next_n, fu, id, &today);
+            body = followups::insert_into_bucket(&current, "ready", &block);
+            if fu.suspected_closed {
+                suspected += 1;
+            }
+            next_n += 1;
+            added += 1;
+        }
+    }
+
+    // Frontmatter: append AILOG ids, set last_scan, recompute counters + v1.
+    let new_ids: Vec<String> = drifted.iter().map(|(id, _, _)| id.clone()).collect();
+    let mut fm = followups::fm_append_list_items(
+        &registry.frontmatter_raw,
+        "fully_extracted_ailogs",
+        &new_ids,
+    );
+    fm = followups::fm_set_scalar(&fm, "last_scan", &today);
+    let final_registry =
+        followups::parse_registry_str(&registry_path, &followups::assemble(&fm, &body))?;
+    let counters = followups::compute_counters(&final_registry);
+    fm = followups::fm_apply_counters_and_v1(&fm, &counters);
+
+    let was_v0 = registry.is_v0();
+    std::fs::write(&registry_path, followups::assemble(&fm, &body))?;
+
+    utils::success(&format!(
+        "Extracted {} entr{} from {} AILOG(s) into `## Bucket: ready`.",
+        added,
+        if added == 1 { "y" } else { "ies" },
+        drifted.len()
+    ));
+    if suspected > 0 {
+        println!(
+            "  {} {} extracted as {} (closure marker in source AILOG) — confirm at the next triage.",
+            "!".magenta().bold(),
+            suspected,
+            "suspected-closed".magenta()
+        );
+    }
+    if was_v0 {
+        utils::info("Registry upgraded to schema v1 (non-destructive — counters are now CLI-owned).");
+    }
+    println!(
+        "  Counters recomputed: {} open / {} suspected-closed / {} promoted (total {}).",
+        counters.open, counters.suspected_closed, counters.promoted, counters.total
+    );
+    println!("  Next: reclassify bucket/trigger/destination at triage (`straymark followups list --bucket ready`).");
+    Ok(())
+}
+
+/// All AILOG .md files under the agent-logs directory (recursive).
+fn walk_ailogs(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walk_ailogs(&path));
+        } else if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.starts_with("AILOG-") && n.ends_with(".md"))
+            .unwrap_or(false)
+        {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// AILOG files touched in the given git range. Range resolution:
+/// explicit `--range` > `origin/main..HEAD` > `origin/master..HEAD` >
+/// `HEAD~1..HEAD` (with a warning).
+fn ailogs_in_git_range(
+    project_root: &Path,
+    agent_logs: &Path,
+    range: Option<&str>,
+) -> Vec<PathBuf> {
+    let range = match range {
+        Some(r) => r.to_string(),
+        None => {
+            if git_ref_exists(project_root, "origin/main") {
+                "origin/main..HEAD".to_string()
+            } else if git_ref_exists(project_root, "origin/master") {
+                "origin/master..HEAD".to_string()
+            } else {
+                utils::warn("No origin/main or origin/master — falling back to HEAD~1..HEAD.");
+                "HEAD~1..HEAD".to_string()
+            }
+        }
+    };
+
+    let output = Command::new("git")
+        .args(["diff", "--name-only", &range])
+        .current_dir(project_root)
+        .output();
+    let Ok(output) = output else {
+        utils::warn("git not available — nothing to scan (use --scan-all for a filesystem sweep).");
+        return Vec::new();
+    };
+    if !output.status.success() {
+        utils::warn(&format!(
+            "`git diff --name-only {}` failed — nothing to scan (use --scan-all for a filesystem sweep).",
+            range
+        ));
+        return Vec::new();
+    }
+
+    let agent_logs_rel = agent_logs
+        .strip_prefix(project_root)
+        .unwrap_or(agent_logs)
+        .to_path_buf();
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(PathBuf::from)
+        .filter(|p| {
+            p.starts_with(&agent_logs_rel)
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with("AILOG-") && n.ends_with(".md"))
+                    .unwrap_or(false)
+        })
+        .map(|p| project_root.join(p))
+        .filter(|p| p.exists())
+        .collect()
+}
+
+fn git_ref_exists(project_root: &Path, r: &str) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", r])
+        .current_dir(project_root)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}

--- a/cli/src/commands/followups/list.rs
+++ b/cli/src/commands/followups/list.rs
@@ -1,0 +1,168 @@
+//! `straymark followups list` — enumerate registry entries with filters.
+//!
+//! Output is a plain-text table to stdout. Parse warnings (malformed entry
+//! headings) are reported to stderr but do not fail the command — list what
+//! you can, surface what you can't (same contract as `charter list`).
+
+use anyhow::{anyhow, Result};
+use colored::Colorize;
+
+use crate::followups::{self, Entry, FuStatus, Severity};
+use crate::utils;
+
+pub struct Filters<'a> {
+    pub bucket: Option<&'a str>,
+    pub status: Option<&'a str>,
+    pub severity: Option<&'a str>,
+    pub label: Option<&'a str>,
+}
+
+pub fn run(path: &str, filters: &Filters) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
+    let project_root = &resolved.path;
+
+    let registry_path = followups::registry_path(project_root);
+    if !registry_path.exists() {
+        println!(
+            "No follow-ups registry yet. Copy `.straymark/templates/follow-ups-backlog.md` to \
+             `.straymark/follow-ups-backlog.md` and run `straymark followups drift --scan-all --apply` \
+             to seed it (see STRAYMARK.md §16)."
+        );
+        return Ok(());
+    }
+
+    let registry = followups::parse_registry(&registry_path)?;
+    for w in &registry.warnings {
+        utils::warn(w);
+    }
+
+    let entries: Vec<&Entry> = registry
+        .entries()
+        .filter(|e| matches_filters(e, filters))
+        .collect();
+
+    if entries.is_empty() {
+        if registry.entries().count() == 0 {
+            println!("Registry is empty. Run `straymark followups drift --scan-all --apply` to seed it from existing AILOGs.");
+        } else {
+            println!("No entries match the given filter.");
+        }
+        return Ok(());
+    }
+
+    print_table(&entries);
+    Ok(())
+}
+
+fn matches_filters(e: &Entry, f: &Filters) -> bool {
+    if let Some(bucket) = f.bucket {
+        if !e.bucket.eq_ignore_ascii_case(bucket) {
+            return false;
+        }
+    }
+    if let Some(status) = f.status {
+        if e.status != FuStatus::from_str_loose(status) {
+            return false;
+        }
+    }
+    if let Some(severity) = f.severity {
+        match Severity::from_str_loose(severity) {
+            Some(want) => {
+                if e.severity != Some(want) {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
+    if let Some(label) = f.label {
+        if !e.labels.iter().any(|l| l.eq_ignore_ascii_case(label)) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Columns: FU, STATUS, SEV, BUCKET, DEST, DESCRIPTION.
+fn print_table(entries: &[&Entry]) {
+    const DEST_MAX: usize = 24;
+    const BUCKET_MAX: usize = 18;
+
+    let fu_w = entries
+        .iter()
+        .map(|e| e.fu_id.len())
+        .max()
+        .unwrap_or(2)
+        .max("FU".len());
+    let status_w = entries
+        .iter()
+        .map(|e| e.status.as_str().len())
+        .max()
+        .unwrap_or(0)
+        .max("STATUS".len());
+    let sev_w = "SEV".len().max("blocking".len());
+    let bucket_w = entries
+        .iter()
+        .map(|e| utils::visual_width(&e.bucket).min(BUCKET_MAX))
+        .max()
+        .unwrap_or(0)
+        .max("BUCKET".len());
+    let dest_w = entries
+        .iter()
+        .map(|e| utils::visual_width(e.destination.as_deref().unwrap_or("—")).min(DEST_MAX))
+        .max()
+        .unwrap_or(0)
+        .max("DEST".len());
+
+    println!(
+        "  {}  {}  {}  {}  {}  {}",
+        utils::pad_right_visual("FU", fu_w).bold(),
+        utils::pad_right_visual("STATUS", status_w).bold(),
+        utils::pad_right_visual("SEV", sev_w).bold(),
+        utils::pad_right_visual("BUCKET", bucket_w).bold(),
+        utils::pad_right_visual("DEST", dest_w).bold(),
+        "DESCRIPTION".bold(),
+    );
+
+    for e in entries {
+        let sev = match e.severity {
+            Some(Severity::Blocking) => "blocking",
+            Some(Severity::Normal) => "normal",
+            None => "—",
+        };
+        let dest = utils::truncate_visual(e.destination.as_deref().unwrap_or("—"), DEST_MAX);
+        let bucket = utils::truncate_visual(&e.bucket, BUCKET_MAX);
+        // Pad before coloring — escape codes don't contribute to visual width.
+        let padded_status = utils::pad_right_visual(e.status.as_str(), status_w);
+        let padded_sev = utils::pad_right_visual(sev, sev_w);
+
+        println!(
+            "  {}  {}  {}  {}  {}  {}",
+            utils::pad_right_visual(&e.fu_id, fu_w),
+            colorize_status(e.status, &padded_status),
+            colorize_severity(e.severity, &padded_sev),
+            utils::pad_right_visual(&bucket, bucket_w),
+            utils::pad_right_visual(&dest, dest_w),
+            e.description,
+        );
+    }
+}
+
+fn colorize_status(status: FuStatus, text: &str) -> colored::ColoredString {
+    match status {
+        FuStatus::Open => text.normal(),
+        FuStatus::InProgress => text.yellow(),
+        FuStatus::SuspectedClosed => text.magenta(),
+        FuStatus::Closed | FuStatus::Superseded => text.green(),
+        FuStatus::Promoted => text.cyan(),
+        FuStatus::Unknown => text.dimmed(),
+    }
+}
+
+fn colorize_severity(severity: Option<Severity>, text: &str) -> colored::ColoredString {
+    match severity {
+        Some(Severity::Blocking) => text.red().bold(),
+        _ => text.normal(),
+    }
+}

--- a/cli/src/commands/followups/mod.rs
+++ b/cli/src/commands/followups/mod.rs
@@ -1,0 +1,13 @@
+//! `straymark followups` — first-class CLI surface for the follow-ups
+//! backlog registry (`.straymark/follow-ups-backlog.md`).
+//!
+//! Subcommands mirror the `charter` namespace: `list` / `status` enumerate
+//! and inspect, `drift` keeps the registry in sync with AILOGs (native
+//! replacement for the deprecated adopter-side bash script), `promote`
+//! automates the FU → TDE elevation. See `FOLLOW-UPS-BACKLOG-PATTERN.md`
+//! and `STRAYMARK.md §16`.
+
+pub mod drift;
+pub mod list;
+pub mod promote;
+pub mod status;

--- a/cli/src/commands/followups/promote.rs
+++ b/cli/src/commands/followups/promote.rs
@@ -1,0 +1,222 @@
+//! `straymark followups promote FU-NNN` — automate the FU → TDE elevation.
+//!
+//! Automates the three-step flow of `FOLLOW-UPS-BACKLOG-PATTERN.md`
+//! §Promotion to TDE:
+//!
+//! 1. Create the TDE document from the framework template (same machinery as
+//!    `straymark new --type tde`), pre-filling the title from the FU
+//!    description and `promoted_from_followup: FU-NNN` for traceability.
+//! 2. In the registry entry: `Status: promoted`, `Destination: <TDE id>`,
+//!    `Promoted to: <TDE id>`.
+//! 3. Recompute the CLI-owned frontmatter counters (+ v0 → v1 upgrade).
+//!
+//! Non-interactive by design (agent-friendly): the FU description becomes the
+//! TDE title unless `--title` overrides it. The operator fills impact/effort/
+//! type in the created document — promotion is the *traceable hand-off*, not
+//! the prioritization (that stays human, per AGENT-RULES.md §3).
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Local;
+use colored::Colorize;
+use std::path::Path;
+
+use crate::followups::{self, FuStatus};
+use crate::utils;
+
+pub fn run(path: &str, fu_id: &str, title: Option<&str>) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
+    let project_root = &resolved.path;
+    let straymark_dir = project_root.join(".straymark");
+
+    let registry_path = followups::registry_path(project_root);
+    if !registry_path.exists() {
+        bail!(
+            "No follow-ups registry at {}.\n  hint: see STRAYMARK.md §16 for the adoption walkthrough.",
+            registry_path.display()
+        );
+    }
+    let registry = followups::parse_registry(&registry_path)?;
+    let entry = followups::find_entry(&registry, fu_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "Entry {} not found in the registry.\n  hint: run `straymark followups list` to see entries.",
+                fu_id
+            )
+        })?
+        .clone();
+
+    if entry.status == FuStatus::Promoted {
+        bail!(
+            "{} is already promoted (Promoted to: {}). Nothing to do.",
+            entry.fu_id,
+            entry.promoted_to.as_deref().unwrap_or("?")
+        );
+    }
+    if matches!(entry.status, FuStatus::Closed | FuStatus::Superseded) {
+        bail!(
+            "{} is {} — promote applies to open/in-progress entries. Reopen it first if the debt is real.",
+            entry.fu_id,
+            entry.status.as_str()
+        );
+    }
+
+    // ── 1. Create the TDE document ──
+    let tde_title = title.unwrap_or(&entry.description).to_string();
+    let (tde_id, tde_path) = create_tde(project_root, &straymark_dir, &tde_title, &entry)?;
+
+    // ── 2 + 3. Update the registry entry + counters ──
+    let mut body = followups::set_entry_field(&registry.body, &entry, "Status", "promoted");
+    // Spans moved after the first edit — re-parse before each subsequent one.
+    let reparsed = followups::parse_registry_str(
+        &registry_path,
+        &followups::assemble(&registry.frontmatter_raw, &body),
+    )?;
+    let entry2 = followups::find_entry(&reparsed, &entry.fu_id).unwrap().clone();
+    body = followups::set_entry_field(&body, &entry2, "Destination", &tde_id);
+    let reparsed = followups::parse_registry_str(
+        &registry_path,
+        &followups::assemble(&registry.frontmatter_raw, &body),
+    )?;
+    let entry3 = followups::find_entry(&reparsed, &entry.fu_id).unwrap().clone();
+    body = followups::set_entry_field(&body, &entry3, "Promoted to", &tde_id);
+
+    let final_registry = followups::parse_registry_str(
+        &registry_path,
+        &followups::assemble(&registry.frontmatter_raw, &body),
+    )?;
+    let counters = followups::compute_counters(&final_registry);
+    let fm = followups::fm_apply_counters_and_v1(&registry.frontmatter_raw, &counters);
+    std::fs::write(&registry_path, followups::assemble(&fm, &body))?;
+
+    let tde_rel = tde_path
+        .strip_prefix(project_root)
+        .unwrap_or(&tde_path)
+        .display()
+        .to_string();
+    utils::success(&format!("{} promoted → {}", entry.fu_id, tde_id));
+    println!("  TDE created: {}", tde_rel);
+    println!(
+        "  Registry updated: Status promoted, Destination/Promoted to → {} (counters recomputed).",
+        tde_id
+    );
+    println!();
+    println!("  {}", "Next steps:".bold());
+    println!("    1. Fill impact / effort / type and the body sections in the TDE.");
+    println!("    2. Prioritization and assignment stay human (AGENT-RULES.md §3).");
+    println!(
+        "    3. Commit both files together: {}",
+        format!("git add {} .straymark/follow-ups-backlog.md", tde_rel).dimmed()
+    );
+    println!();
+    Ok(())
+}
+
+/// Create the TDE document from the (localized) framework template. Returns
+/// `(tde_id, path)`. Mirrors the fill logic of `commands::new` for the TDE
+/// type, plus the `promoted_from_followup` traceability field.
+fn create_tde(
+    project_root: &Path,
+    straymark_dir: &Path,
+    title: &str,
+    entry: &followups::Entry,
+) -> Result<(String, std::path::PathBuf)> {
+    let lang = crate::config::StrayMarkConfig::resolve_language(project_root);
+    let templates_dir = straymark_dir.join("templates");
+    let template_path = utils::resolve_localized_path(&templates_dir, "TEMPLATE-TDE.md", &lang);
+    let template = std::fs::read_to_string(&template_path).with_context(|| {
+        format!(
+            "TDE template not found at {}. Run `straymark repair` to restore framework files.",
+            template_path.display()
+        )
+    })?;
+
+    let today = Local::now().format("%Y-%m-%d").to_string();
+    let tde_dir = straymark_dir.join("06-evolution").join("technical-debt");
+    let seq = next_tde_sequence(&tde_dir, &today);
+    let tde_id = format!("TDE-{}-{}", today, seq);
+
+    let mut content = template
+        .replace("id: TDE-YYYY-MM-DD-NNN", &format!("id: {}", tde_id))
+        .replace("YYYY-MM-DD-NNN", &format!("{}-{}", today, seq))
+        .replace("YYYY-MM-DD", &today)
+        .replace("[Technical debt title]", title)
+        .replace("[Título de la deuda técnica]", title)
+        .replace("[Technical Debt Title]", title)
+        .replace("[agent-name-v1.0]", "straymark-cli-promote")
+        .replace("[nombre-agente-v1.0]", "straymark-cli-promote");
+
+    // Traceability: the template ships `promoted_from_followup: null` from
+    // fw-4.13.1; replace the value (tolerating the trailing comment).
+    if let Some(idx) = content.find("promoted_from_followup:") {
+        let line_end = content[idx..]
+            .find('\n')
+            .map(|i| idx + i)
+            .unwrap_or(content.len());
+        content.replace_range(
+            idx..line_end,
+            &format!("promoted_from_followup: {}", entry.fu_id),
+        );
+    } else if let Some(idx) = content.find("\n---\n") {
+        // Older template without the field — insert it before the closing ---.
+        content.insert_str(idx, &format!("\npromoted_from_followup: {}", entry.fu_id));
+    }
+
+    // Seed the Summary with the FU context when the placeholder is present.
+    let origin_note = format!(
+        "{} (origin: {})",
+        entry.description,
+        entry.origin.as_deref().unwrap_or("follow-ups backlog")
+    );
+    content = content
+        .replace(
+            "[Brief description of the identified technical debt]",
+            &origin_note,
+        )
+        .replace(
+            "[Descripción breve de la deuda técnica identificada]",
+            &origin_note,
+        );
+
+    let slug = slugify(title);
+    let filename = format!("TDE-{}-{}-{}.md", today, seq, slug);
+    utils::ensure_dir(&tde_dir)?;
+    let filepath = tde_dir.join(filename);
+    std::fs::write(&filepath, content)?;
+    Ok((tde_id, filepath))
+}
+
+fn next_tde_sequence(tde_dir: &Path, today: &str) -> String {
+    let prefix = format!("TDE-{}-", today);
+    let mut max_seq = 0u32;
+    if let Ok(entries) = std::fs::read_dir(tde_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_str().unwrap_or("");
+            if let Some(rest) = name.strip_prefix(&prefix) {
+                let head: String = rest.chars().take(3).collect();
+                if head.chars().count() == 3 {
+                    if let Ok(n) = head.parse::<u32>() {
+                        max_seq = max_seq.max(n);
+                    }
+                }
+            }
+        }
+    }
+    format!("{:03}", max_seq + 1)
+}
+
+fn slugify(title: &str) -> String {
+    let lower = title.to_lowercase();
+    let parts: Vec<&str> = lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let slug = parts.join("-");
+    if slug.chars().count() > 50 {
+        let truncated: String = slug.chars().take(50).collect();
+        truncated.trim_end_matches('-').to_string()
+    } else {
+        slug
+    }
+}

--- a/cli/src/commands/followups/status.rs
+++ b/cli/src/commands/followups/status.rs
@@ -1,0 +1,267 @@
+//! `straymark followups status` — registry pulse, or detail view of one entry.
+//!
+//! The pulse always shows counters **recomputed on the fly** from actual
+//! entry statuses, flagging divergence from the (CLI-owned) frontmatter
+//! counters when the file is stale. Schema validation against
+//! `follow-ups-backlog.schema.v1.json` is advisory — issues print as
+//! warnings, never failures.
+
+use anyhow::{anyhow, Result};
+use colored::Colorize;
+
+use crate::followups::{self, Entry, FuStatus, Registry, Severity};
+use crate::followups_schema;
+use crate::utils::{self, pad_right_visual, visual_width};
+
+pub fn run(path: &str, fu_id: Option<&str>) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
+    let project_root = &resolved.path;
+
+    let registry_path = followups::registry_path(project_root);
+    if !registry_path.exists() {
+        println!(
+            "No follow-ups registry yet. Copy `.straymark/templates/follow-ups-backlog.md` to \
+             `.straymark/follow-ups-backlog.md` and run `straymark followups drift --scan-all --apply` \
+             to seed it (see STRAYMARK.md §16)."
+        );
+        return Ok(());
+    }
+
+    let registry = followups::parse_registry(&registry_path)?;
+    for w in &registry.warnings {
+        utils::warn(w);
+    }
+
+    match fu_id {
+        Some(id) => print_entry_detail(&registry, id),
+        None => {
+            print_pulse(&registry);
+            // Advisory schema validation (warn-only; absent schema → dimmed hint).
+            let straymark_dir = project_root.join(".straymark");
+            match followups_schema::validate_frontmatter(&straymark_dir, &registry.frontmatter_raw)
+            {
+                Ok(issues) if issues.is_empty() => {}
+                Ok(issues) => {
+                    for issue in issues {
+                        utils::warn(&format!("schema: {}", issue));
+                    }
+                }
+                Err(e) => println!("  {}", format!("(schema check skipped: {})", e).dimmed()),
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_pulse(registry: &Registry) {
+    let fm = &registry.frontmatter;
+    let counters = followups::compute_counters(registry);
+
+    println!();
+    println!("  {}", "Follow-ups Backlog".bold().cyan());
+    println!();
+    println!(
+        "  Schema: {}   Last scan: {}   AILOGs extracted: {}",
+        fm.schema_version.as_deref().unwrap_or("v0"),
+        fm.last_scan.as_deref().unwrap_or("—"),
+        fm.fully_extracted_ailogs.len()
+    );
+    if registry.is_v0() {
+        println!(
+            "  {}",
+            "v0 registry — the first `followups drift --apply` upgrades it to v1 in place."
+                .dimmed()
+        );
+    }
+    println!();
+
+    // Status breakdown (recomputed — the trustworthy numbers).
+    let rows: Vec<(&str, u32, colored::Color)> = vec![
+        ("open", counters.open, colored::Color::White),
+        ("in-progress", counters.in_progress, colored::Color::Yellow),
+        (
+            "suspected-closed",
+            counters.suspected_closed,
+            colored::Color::Magenta,
+        ),
+        (
+            "closed + superseded",
+            counters.closed_cumulative,
+            colored::Color::Green,
+        ),
+        ("promoted", counters.promoted, colored::Color::Cyan),
+    ];
+    let label_w = rows
+        .iter()
+        .map(|(l, _, _)| visual_width(l))
+        .max()
+        .unwrap_or(10);
+    let count_w = 5;
+
+    println!(
+        "  {} {} {}",
+        pad_right_visual("Status", label_w).dimmed(),
+        "│".dimmed(),
+        pad_right_visual("Count", count_w).dimmed(),
+    );
+    println!(
+        "  {}",
+        format!("{}─┼─{}", "─".repeat(label_w), "─".repeat(count_w)).dimmed()
+    );
+    for (label, count, color) in &rows {
+        let count_str = format!("{count:>count_w$}");
+        let padded = pad_right_visual(label, label_w);
+        if *count > 0 {
+            println!("  {} │ {}", padded, count_str.color(*color).bold());
+        } else {
+            println!("  {} │ {}", padded.dimmed(), count_str.dimmed());
+        }
+    }
+    println!(
+        "  {} │ {}",
+        pad_right_visual("TOTAL", label_w).bold(),
+        format!("{:>count_w$}", counters.total).cyan().bold(),
+    );
+    println!();
+
+    // Per-bucket open breakdown.
+    let buckets: Vec<(&str, usize)> = registry
+        .sections
+        .iter()
+        .filter(|s| s.is_bucket)
+        .map(|s| {
+            (
+                s.name.as_str(),
+                s.entries
+                    .iter()
+                    .filter(|e| matches!(e.status, FuStatus::Open | FuStatus::InProgress))
+                    .count(),
+            )
+        })
+        .collect();
+    if !buckets.is_empty() {
+        let bw = buckets
+            .iter()
+            .map(|(b, _)| visual_width(b))
+            .max()
+            .unwrap_or(10);
+        println!("  {}", "Open by bucket".bold());
+        for (bucket, n) in &buckets {
+            let n_str = format!("{n:>count_w$}");
+            if *n > 0 {
+                println!("  {} │ {}", pad_right_visual(bucket, bw), n_str);
+            } else {
+                println!(
+                    "  {} │ {}",
+                    pad_right_visual(bucket, bw).dimmed(),
+                    n_str.dimmed()
+                );
+            }
+        }
+        println!();
+    }
+
+    if counters.blocking_open > 0 {
+        println!(
+            "  {} {} open blocking entr{} — must land before production cutover. Run `straymark followups list --severity blocking`.",
+            "!".red().bold(),
+            counters.blocking_open,
+            if counters.blocking_open == 1 { "y" } else { "ies" },
+        );
+        println!();
+    }
+    if counters.suspected_closed > 0 {
+        println!(
+            "  {} {} suspected-closed entr{} awaiting triage confirmation (closure marker in source AILOG).",
+            "!".magenta().bold(),
+            counters.suspected_closed,
+            if counters.suspected_closed == 1 { "y" } else { "ies" },
+        );
+        println!();
+    }
+
+    // Flag stale frontmatter counters (informational — the next write fixes them).
+    let declared_open = fm.total_open;
+    if let Some(declared) = declared_open {
+        if declared != counters.open {
+            println!(
+                "  {} frontmatter says total_open: {} but the real count is {} — the next `followups drift --apply` or `promote` recomputes it.",
+                "!".yellow().bold(),
+                declared,
+                counters.open
+            );
+            println!();
+        }
+    }
+}
+
+fn print_entry_detail(registry: &Registry, id: &str) -> Result<()> {
+    let entry = followups::find_entry(registry, id).ok_or_else(|| {
+        anyhow!(
+            "Entry {} not found in the registry.\n  hint: run `straymark followups list` to see entries.",
+            id
+        )
+    })?;
+
+    println!();
+    println!("  {} — {}", entry.fu_id.bold().cyan(), entry.description.bold());
+    println!();
+    print_field("Bucket", Some(&entry.bucket));
+    print_field("Status", Some(entry.status.as_str()));
+    print_field(
+        "Severity",
+        entry.severity.map(|s| s.as_str()),
+    );
+    print_field("Origin", entry.origin.as_deref());
+    print_field("Origin-class", entry.origin_class.as_deref());
+    print_field("Trigger", entry.trigger.as_deref());
+    print_field("Destination", entry.destination.as_deref());
+    print_field("Cost", entry.cost.as_deref());
+    if !entry.labels.is_empty() {
+        print_field("Labels", Some(&entry.labels.join(", ")));
+    }
+    print_field("Notes", entry.notes.as_deref());
+    print_field("Promoted to", entry.promoted_to.as_deref());
+    println!();
+
+    if matches!(entry.status, FuStatus::Open | FuStatus::InProgress)
+        && entry.severity == Some(Severity::Blocking)
+    {
+        println!(
+            "  {} blocking severity — must land before production cutover.",
+            "!".red().bold()
+        );
+        println!();
+    }
+    let _ = print_promote_hint(entry);
+    Ok(())
+}
+
+fn print_field(label: &str, value: Option<&str>) {
+    match value {
+        Some(v) if !v.is_empty() => {
+            println!("  {} {}", pad_right_visual(&format!("{label}:"), 14).dimmed(), v)
+        }
+        _ => println!(
+            "  {} {}",
+            pad_right_visual(&format!("{label}:"), 14).dimmed(),
+            "—".dimmed()
+        ),
+    }
+}
+
+fn print_promote_hint(entry: &Entry) -> Result<()> {
+    if matches!(entry.status, FuStatus::Open | FuStatus::InProgress) {
+        println!(
+            "  {}",
+            format!(
+                "If this entry meets the TDE criteria (AGENT-RULES.md §3), run `straymark followups promote {}`.",
+                entry.fu_id
+            )
+            .dimmed()
+        );
+        println!();
+    }
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod charter;
 pub mod compliance;
 #[cfg(feature = "tui")]
 pub mod explore;
+pub mod followups;
 pub mod init;
 pub mod install_skills;
 pub mod metrics;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -231,6 +231,12 @@ pub fn run(path: &str) -> Result<()> {
     let charter_counts = count_charters(&target);
     print_charters_block(&charter_counts);
 
+    // ── Follow-ups ──
+    // The follow-ups backlog registry (first-class since fw-4.21.0 /
+    // cli-3.19.0). Counts are recomputed from actual entry statuses —
+    // never read from the (possibly stale) frontmatter counters.
+    print_followups_block(&target);
+
     // ── Hints ──
     if total_missing > 0 {
         println!(
@@ -413,6 +419,78 @@ fn print_charters_block(c: &CharterCounts) {
             "!".yellow().bold(),
             c.unparseable,
             if c.unparseable == 1 { "" } else { "s" },
+        );
+    }
+    println!();
+}
+
+fn print_followups_block(project_root: &Path) {
+    println!("  {}", "Follow-ups".bold());
+    let registry_path = crate::followups::registry_path(project_root);
+    if !registry_path.exists() {
+        println!(
+            "  {} {}",
+            "·".dimmed(),
+            "No follow-ups registry yet — adopt the pattern at ~20+ AILOGs (see STRAYMARK.md §16).".dimmed(),
+        );
+        println!();
+        return;
+    }
+    let registry = match crate::followups::parse_registry(&registry_path) {
+        Ok(r) => r,
+        Err(e) => {
+            println!("  {} registry unreadable: {}", "!".yellow().bold(), e);
+            println!();
+            return;
+        }
+    };
+    let c = crate::followups::compute_counters(&registry);
+
+    let rows: Vec<(&str, u32, colored::Color)> = vec![
+        ("open", c.open, colored::Color::White),
+        ("in-progress", c.in_progress, colored::Color::Yellow),
+        ("suspected-closed", c.suspected_closed, colored::Color::Magenta),
+        ("closed + superseded", c.closed_cumulative, colored::Color::Green),
+        ("promoted", c.promoted, colored::Color::Cyan),
+    ];
+    let label_w = rows
+        .iter()
+        .map(|(l, _, _)| visual_width(l))
+        .max()
+        .unwrap_or(11);
+    let count_w = 5;
+
+    println!();
+    println!(
+        "  {} {} {}",
+        pad_right_visual("Status", label_w).dimmed(),
+        "│".dimmed(),
+        pad_right_visual("Count", count_w).dimmed(),
+    );
+    println!(
+        "  {}",
+        format!("{}─┼─{}", "─".repeat(label_w), "─".repeat(count_w)).dimmed()
+    );
+    for (label, count, color) in &rows {
+        let count_str = format!("{count:>count_w$}");
+        let padded = pad_right_visual(label, label_w);
+        if *count > 0 {
+            println!("  {} │ {}", padded, count_str.color(*color).bold());
+        } else {
+            println!("  {} │ {}", padded.dimmed(), count_str.dimmed());
+        }
+    }
+    println!(
+        "  {} │ {}",
+        pad_right_visual("TOTAL", label_w).bold(),
+        format!("{:>count_w$}", c.total).cyan().bold(),
+    );
+    if c.blocking_open > 0 {
+        println!(
+            "  {} {} open blocking entr{} — `straymark followups list --severity blocking`.",
+            "!".red().bold(),
+            c.blocking_open,
+            if c.blocking_open == 1 { "y" } else { "ies" },
         );
     }
     println!();

--- a/cli/src/followups.rs
+++ b/cli/src/followups.rs
@@ -1,0 +1,1255 @@
+//! Follow-ups backlog registry — StrayMark's first-class pending-work artifact.
+//!
+//! The registry is a single markdown file at `.straymark/follow-ups-backlog.md`
+//! aggregating `§Follow-ups` and `R<N> (new, not in Charter)` entries across
+//! AILOGs. Schema: `dist/.straymark/schemas/follow-ups-backlog.schema.v1.json`
+//! (experimental v1). Convention: `FOLLOW-UPS-BACKLOG-PATTERN.md` and
+//! `STRAYMARK.md §16`.
+//!
+//! Conceptually distinct from `DocType` (governance documents) and from
+//! Charters: one registry per project, entries (`FU-NNN`) live inside it as
+//! semi-structured markdown blocks under `## Bucket: <name>` headings.
+//!
+//! Parsing is **lenient by design** (ADR-2026-06-03-001): a missing field is
+//! `None`, never an error; an unparseable `### FU-` block becomes a warning,
+//! never a failure; v0 registries (no v1 fields) parse identically. Write
+//! operations (`drift --apply`, `promote`) are surgical text edits that
+//! preserve unknown frontmatter fields and untouched body content — the
+//! v0 → v1 upgrade rewrites only the version marker and the counters.
+//!
+//! Move target: straymark-core (Loom M0) — keep this module free of
+//! clap/colored/dialoguer; presentation lives in `commands/followups/`.
+
+use anyhow::{anyhow, Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Canonical registry location, relative to the project root.
+pub fn registry_path(project_root: &Path) -> PathBuf {
+    project_root.join(".straymark").join("follow-ups-backlog.md")
+}
+
+/// Entry lifecycle status. `SuspectedClosed` is new in schema v1 — assigned by
+/// `drift --apply` when the source AILOG text carries an explicit closure
+/// marker (see [`has_closure_marker`]). `Unknown` preserves lenient parsing:
+/// an unrecognized value never fails, it just doesn't count toward any bucket
+/// of the recomputed counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FuStatus {
+    Open,
+    InProgress,
+    SuspectedClosed,
+    Closed,
+    Superseded,
+    Promoted,
+    Unknown,
+}
+
+impl FuStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::InProgress => "in-progress",
+            Self::SuspectedClosed => "suspected-closed",
+            Self::Closed => "closed",
+            Self::Superseded => "superseded",
+            Self::Promoted => "promoted",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn from_str_loose(s: &str) -> Self {
+        match s.trim().to_lowercase().as_str() {
+            "open" => Self::Open,
+            "in-progress" | "in progress" => Self::InProgress,
+            "suspected-closed" | "suspected closed" => Self::SuspectedClosed,
+            "closed" => Self::Closed,
+            "superseded" => Self::Superseded,
+            "promoted" => Self::Promoted,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Entry severity (v1, optional). `blocking` canonicalizes the `PROD-BLOCKER`
+/// prose convention from the reference adopter (issue #214 Signal 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Normal,
+    Blocking,
+}
+
+impl Severity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Blocking => "blocking",
+        }
+    }
+
+    pub fn from_str_loose(s: &str) -> Option<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "normal" => Some(Self::Normal),
+            "blocking" | "prod-blocker" => Some(Self::Blocking),
+            _ => None,
+        }
+    }
+}
+
+/// One `### FU-NNN — <description>` block inside a section. Byte spans are
+/// offsets into `Registry::body` so write operations can edit surgically.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub fu_id: String,
+    pub fu_number: u32,
+    pub description: String,
+    /// Section (bucket) this entry lives under, e.g. "ready". Non-bucket
+    /// sections (e.g. "Promoted to TDE") carry their heading text instead.
+    pub bucket: String,
+    pub origin: Option<String>,
+    pub origin_class: Option<String>,
+    pub status: FuStatus,
+    pub status_raw: Option<String>,
+    pub severity: Option<Severity>,
+    pub trigger: Option<String>,
+    pub destination: Option<String>,
+    pub cost: Option<String>,
+    pub labels: Vec<String>,
+    pub notes: Option<String>,
+    pub promoted_to: Option<String>,
+    /// Byte offset of the `### ` heading line start, into `Registry::body`.
+    pub span_start: usize,
+    /// Byte offset one past the entry's last byte (start of the next heading
+    /// or end of section), into `Registry::body`.
+    pub span_end: usize,
+}
+
+/// A `## ` section of the registry body. Sections whose heading starts with
+/// `Bucket:` are canonical buckets; other sections (e.g. "Promoted to TDE",
+/// "Closed in this scan") still collect entries so counters see everything.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // span fields are part of the surgical-edit contract (Loom M0 lifts this struct)
+pub struct Section {
+    /// Bucket name (`ready`) for `## Bucket: <name>` headings; the full
+    /// heading text otherwise.
+    pub name: String,
+    pub is_bucket: bool,
+    /// Byte offset of the heading line start, into `Registry::body`.
+    pub start: usize,
+    /// Byte offset one past the section's last byte (start of the next `## `
+    /// heading, or end of body).
+    pub end: usize,
+    pub entries: Vec<Entry>,
+}
+
+/// Typed view of the registry frontmatter. Every field is optional or
+/// defaulted — lenient by design. Unknown fields survive untouched because
+/// writes are surgical edits on the raw frontmatter text, never a
+/// re-serialization of this struct. Fields the CLI does not read yet stay
+/// in the typed mirror anyway — this struct is the contract Loom M0 lifts
+/// into straymark-core.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[allow(dead_code)]
+pub struct RegistryFrontmatter {
+    #[serde(default)]
+    pub schema_version: Option<String>,
+    #[serde(default)]
+    pub last_scan: Option<String>,
+    #[serde(default)]
+    pub last_scan_range: Option<String>,
+    #[serde(default)]
+    pub buckets: Vec<String>,
+    #[serde(default)]
+    pub fully_extracted_ailogs: Vec<String>,
+    #[serde(default)]
+    pub total_open: Option<u32>,
+    #[serde(default)]
+    pub total_promoted: Option<u32>,
+    #[serde(default)]
+    pub total_closed_in_session: Option<u32>,
+    #[serde(default)]
+    pub total_phase_blocked: Option<u32>,
+    #[serde(default)]
+    pub total_suspected_closed: Option<u32>,
+}
+
+/// A parsed registry. `frontmatter_raw` and `body` are kept verbatim so write
+/// operations preserve everything the parser does not understand.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Registry {
+    pub path: PathBuf,
+    pub frontmatter: RegistryFrontmatter,
+    pub frontmatter_raw: String,
+    pub body: String,
+    pub sections: Vec<Section>,
+    /// Non-fatal parse warnings (malformed `### FU-` headings, etc.).
+    pub warnings: Vec<String>,
+}
+
+impl Registry {
+    /// All entries across all sections, in document order.
+    pub fn entries(&self) -> impl Iterator<Item = &Entry> {
+        self.sections.iter().flat_map(|s| s.entries.iter())
+    }
+
+    pub fn is_v0(&self) -> bool {
+        !matches!(self.frontmatter.schema_version.as_deref(), Some("v1"))
+    }
+}
+
+/// Parse the registry from disk. Errors only on IO failure or a missing
+/// frontmatter block (a registry without frontmatter has no
+/// `fully_extracted_ailogs`, so drift detection cannot run).
+pub fn parse_registry(path: &Path) -> Result<Registry> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read registry at {}", path.display()))?;
+    parse_registry_str(path, &content)
+}
+
+/// Parse from raw content (split out for testability).
+pub fn parse_registry_str(path: &Path, content: &str) -> Result<Registry> {
+    let (fm_raw, body) = crate::utils::split_frontmatter(content).ok_or_else(|| {
+        anyhow!(
+            "Registry at {} has no YAML frontmatter (expected --- delimiters at top of file).\n  \
+             hint: copy `.straymark/templates/follow-ups-backlog.md` to start a registry.",
+            path.display()
+        )
+    })?;
+    let frontmatter: RegistryFrontmatter = serde_yaml::from_str(fm_raw).unwrap_or_default();
+
+    let mut warnings = Vec::new();
+    let sections = parse_sections(body, &mut warnings);
+
+    Ok(Registry {
+        path: path.to_path_buf(),
+        frontmatter,
+        frontmatter_raw: fm_raw.to_string(),
+        body: body.to_string(),
+        sections,
+        warnings,
+    })
+}
+
+/// Split the body into `## ` sections and parse `### FU-` entries in each.
+fn parse_sections(body: &str, warnings: &mut Vec<String>) -> Vec<Section> {
+    // Collect (offset, heading_text) for every `## ` line (exactly two #).
+    let mut heads: Vec<(usize, String)> = Vec::new();
+    let mut offset = 0usize;
+    for line in body.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            if !trimmed.starts_with("### ") {
+                heads.push((offset, rest.trim().to_string()));
+            }
+        }
+        offset += line.len();
+    }
+
+    let mut sections = Vec::with_capacity(heads.len());
+    for (i, (start, heading)) in heads.iter().enumerate() {
+        let end = heads.get(i + 1).map(|(o, _)| *o).unwrap_or(body.len());
+        let (name, is_bucket) = match heading.strip_prefix("Bucket:") {
+            Some(rest) => {
+                // Tolerate trailing annotations: `ready          (1 entry)`.
+                let name = rest
+                    .trim()
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                (name, true)
+            }
+            None => (heading.clone(), false),
+        };
+        let entries = parse_entries(body, *start, end, &name, warnings);
+        sections.push(Section {
+            name,
+            is_bucket,
+            start: *start,
+            end,
+            entries,
+        });
+    }
+    sections
+}
+
+/// Parse `### FU-NNN — desc` blocks between `start` and `end` of `body`.
+fn parse_entries(
+    body: &str,
+    start: usize,
+    end: usize,
+    bucket: &str,
+    warnings: &mut Vec<String>,
+) -> Vec<Entry> {
+    let section = &body[start..end];
+    // Locate entry heading offsets (relative to section start).
+    let mut heads: Vec<(usize, String)> = Vec::new();
+    let mut offset = 0usize;
+    for line in section.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if trimmed.starts_with("### ") {
+            heads.push((offset, trimmed.to_string()));
+        }
+        offset += line.len();
+    }
+
+    let mut entries = Vec::new();
+    for (i, (rel_start, heading)) in heads.iter().enumerate() {
+        let rel_end = heads.get(i + 1).map(|(o, _)| *o).unwrap_or(section.len());
+        let abs_start = start + rel_start;
+        let abs_end = start + rel_end;
+
+        let Some((fu_id, fu_number, description)) = parse_entry_heading(heading) else {
+            // A `###` heading that isn't an FU entry (e.g. a dated triage
+            // subsection under "Closed in this scan") is not a warning —
+            // only malformed `### FU-` headings are.
+            if heading.starts_with("### FU-") {
+                warnings.push(format!(
+                    "Malformed entry heading (expected `### FU-NNN — description`): {}",
+                    heading
+                ));
+            }
+            continue;
+        };
+
+        let block = &section[*rel_start..rel_end];
+        let mut entry = Entry {
+            fu_id,
+            fu_number,
+            description,
+            bucket: bucket.to_string(),
+            origin: None,
+            origin_class: None,
+            status: FuStatus::Unknown,
+            status_raw: None,
+            severity: None,
+            trigger: None,
+            destination: None,
+            cost: None,
+            labels: Vec::new(),
+            notes: None,
+            promoted_to: None,
+            span_start: abs_start,
+            span_end: abs_end,
+        };
+
+        for line in block.lines() {
+            let Some((field, value)) = parse_field_line(line) else {
+                continue;
+            };
+            let value = value.trim();
+            match field.to_lowercase().as_str() {
+                "origin" => entry.origin = some_nonempty(value),
+                "origin-class" | "origin class" | "origin_class" => {
+                    entry.origin_class = some_nonempty(value)
+                }
+                "status" => {
+                    entry.status_raw = some_nonempty(value);
+                    entry.status = FuStatus::from_str_loose(value);
+                }
+                "severity" => entry.severity = Severity::from_str_loose(value),
+                "trigger" => entry.trigger = some_nonempty(value),
+                "destination" => entry.destination = some_nonempty(value),
+                "cost" => entry.cost = some_nonempty(value),
+                "labels" | "tags" => {
+                    entry.labels = value
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                }
+                "notes" => entry.notes = some_nonempty(value),
+                "promoted to" | "promoted-to" | "promoted_to" => {
+                    entry.promoted_to = some_nonempty(value)
+                }
+                _ => {} // unknown field — lenient, preserved in the raw body
+            }
+        }
+        entries.push(entry);
+    }
+    entries
+}
+
+fn some_nonempty(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Parse `### FU-NNN — desc` (em dash, hyphen, or colon separator).
+/// Returns (fu_id, number, description) or None when the heading isn't an
+/// FU entry.
+fn parse_entry_heading(heading: &str) -> Option<(String, u32, String)> {
+    let rest = heading.strip_prefix("### ")?.trim();
+    let after_fu = rest.strip_prefix("FU-")?;
+    let digits: String = after_fu.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    let number: u32 = digits.parse().ok()?;
+    let fu_id = format!("FU-{}", digits);
+    let after_digits = &after_fu[digits.len()..];
+    let description = after_digits
+        .trim_start_matches([' ', '\t'])
+        .trim_start_matches(['—', '–', '-', ':'])
+        .trim()
+        .to_string();
+    Some((fu_id, number, description))
+}
+
+/// Parse a `- **Field**: value` bullet line. Returns (field, value).
+fn parse_field_line(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("- **")?;
+    let close = rest.find("**")?;
+    let field = &rest[..close];
+    let after = rest[close + 2..].trim_start();
+    let value = after.strip_prefix(':')?;
+    Some((field, value))
+}
+
+/// Find an entry by user-supplied id: `FU-085`, `085`, or `85`.
+pub fn find_entry<'a>(registry: &'a Registry, id_input: &str) -> Option<&'a Entry> {
+    let trimmed = id_input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(e) = registry.entries().find(|e| e.fu_id == trimmed) {
+        return Some(e);
+    }
+    let digits = trimmed.strip_prefix("FU-").unwrap_or(trimmed);
+    if let Ok(n) = digits.parse::<u32>() {
+        return registry.entries().find(|e| e.fu_number == n);
+    }
+    None
+}
+
+/// Next sequential FU number: `max(NNN) + 1`, or 1 on an empty registry.
+pub fn next_fu_number(registry: &Registry) -> u32 {
+    registry
+        .entries()
+        .map(|e| e.fu_number)
+        .max()
+        .map(|n| n + 1)
+        .unwrap_or(1)
+}
+
+/// Counters recomputed from actual entry statuses — the CLI-owned source of
+/// truth since schema v1 (issue #214 Signal 2). Semantics:
+/// - `open` / `in_progress` / `suspected_closed` / `promoted` — entries with
+///   that exact `Status`.
+/// - `closed_cumulative` — `closed` + `superseded` (the registry keeps full
+///   history; "in session" granularity is not derivable from the file).
+/// - `phase_blocked_open` — `open` entries living in the `phase-blocked` bucket.
+/// - `blocking_open` — `open` or `in-progress` entries with `Severity: blocking`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Counters {
+    pub open: u32,
+    pub in_progress: u32,
+    pub suspected_closed: u32,
+    pub closed_cumulative: u32,
+    pub promoted: u32,
+    pub phase_blocked_open: u32,
+    pub blocking_open: u32,
+    pub total: u32,
+}
+
+pub fn compute_counters(registry: &Registry) -> Counters {
+    let mut c = Counters::default();
+    for e in registry.entries() {
+        c.total += 1;
+        match e.status {
+            FuStatus::Open => c.open += 1,
+            FuStatus::InProgress => c.in_progress += 1,
+            FuStatus::SuspectedClosed => c.suspected_closed += 1,
+            FuStatus::Closed | FuStatus::Superseded => c.closed_cumulative += 1,
+            FuStatus::Promoted => c.promoted += 1,
+            FuStatus::Unknown => {}
+        }
+        if e.status == FuStatus::Open && e.bucket == "phase-blocked" {
+            c.phase_blocked_open += 1;
+        }
+        if matches!(e.status, FuStatus::Open | FuStatus::InProgress)
+            && e.severity == Some(Severity::Blocking)
+        {
+            c.blocking_open += 1;
+        }
+    }
+    c
+}
+
+// ───────────────────────── surgical frontmatter edits ─────────────────────────
+//
+// Writes never re-serialize `RegistryFrontmatter` — that would drop unknown
+// fields and reorder keys. Instead these helpers edit the raw frontmatter
+// text line by line, preserving everything they don't touch.
+
+/// Replace the value of a top-level scalar `key: value` line, or append the
+/// line at the end of the frontmatter when the key is absent.
+pub fn fm_set_scalar(fm: &str, key: &str, value: &str) -> String {
+    let prefix = format!("{}:", key);
+    let mut out: Vec<String> = Vec::new();
+    let mut replaced = false;
+    for line in fm.lines() {
+        if !replaced && line.starts_with(&prefix) {
+            out.push(format!("{} {}", prefix, value));
+            replaced = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    if !replaced {
+        out.push(format!("{} {}", prefix, value));
+    }
+    out.join("\n")
+}
+
+/// Append items to a top-level YAML block list `key:`. Handles the
+/// `key: []` empty-flow form by converting it to a block list. Item
+/// indentation mirrors the existing items (default two spaces).
+pub fn fm_append_list_items(fm: &str, key: &str, items: &[String]) -> String {
+    if items.is_empty() {
+        return fm.to_string();
+    }
+    let prefix = format!("{}:", key);
+    let lines: Vec<&str> = fm.lines().collect();
+    let Some(key_idx) = lines.iter().position(|l| l.starts_with(&prefix)) else {
+        // Key absent — append key + items at the end.
+        let mut out = fm.to_string();
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&prefix);
+        out.push('\n');
+        for item in items {
+            out.push_str(&format!("  - {}\n", item));
+        }
+        return out.trim_end_matches('\n').to_string();
+    };
+
+    let mut out: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    let key_line = lines[key_idx];
+    let after_colon = key_line[prefix.len()..].trim();
+
+    if after_colon == "[]" {
+        // Convert empty flow list to a block list.
+        out[key_idx] = prefix.clone();
+        let mut insert_at = key_idx + 1;
+        for item in items {
+            out.insert(insert_at, format!("  - {}", item));
+            insert_at += 1;
+        }
+        return out.join("\n");
+    }
+
+    // Find the end of the block list: last consecutive line after key_idx
+    // that is an indented `- ` item (or a comment inside the block).
+    let mut indent = "  ".to_string();
+    let mut last_item = key_idx;
+    for (i, line) in lines.iter().enumerate().skip(key_idx + 1) {
+        let t = line.trim_start();
+        if t.starts_with("- ") && line.starts_with(' ') {
+            indent = line[..line.len() - t.len()].to_string();
+            last_item = i;
+        } else if t.starts_with('#') && last_item > key_idx {
+            // comment inside the list — keep scanning
+            continue;
+        } else {
+            break;
+        }
+    }
+    let mut insert_at = last_item + 1;
+    for item in items {
+        out.insert(insert_at, format!("{}- {}", indent, item));
+        insert_at += 1;
+    }
+    out.join("\n")
+}
+
+/// Apply the recomputed counters + the v1 marker to a frontmatter text.
+/// Sets `schema_version: v1` and every `total_*` counter (adding missing
+/// counter lines). This is the entire v0 → v1 upgrade — idempotent and
+/// non-destructive (all v1 entry fields are optional).
+pub fn fm_apply_counters_and_v1(fm: &str, counters: &Counters) -> String {
+    let mut out = fm_set_scalar(fm, "schema_version", "v1");
+    out = fm_set_scalar(&out, "total_open", &counters.open.to_string());
+    out = fm_set_scalar(&out, "total_promoted", &counters.promoted.to_string());
+    out = fm_set_scalar(
+        &out,
+        "total_closed_in_session",
+        &counters.closed_cumulative.to_string(),
+    );
+    out = fm_set_scalar(
+        &out,
+        "total_phase_blocked",
+        &counters.phase_blocked_open.to_string(),
+    );
+    out = fm_set_scalar(
+        &out,
+        "total_suspected_closed",
+        &counters.suspected_closed.to_string(),
+    );
+    out
+}
+
+/// Reassemble a registry file from (frontmatter, body). Line endings are
+/// normalized to `\n` (split_frontmatter accepts CRLF input).
+pub fn assemble(fm: &str, body: &str) -> String {
+    format!("---\n{}\n---\n{}", fm.trim_end_matches('\n'), body)
+}
+
+// ───────────────────────── AILOG extraction (drift) ─────────────────────────
+
+/// A follow-up bullet extracted from an AILOG.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedFu {
+    /// First line of the bullet, cleaned of list markers.
+    pub description: String,
+    /// Origin pointer suffix, e.g. "§Follow-ups" or "§R3 (new, not in Charter)".
+    pub origin_section: String,
+    /// True when the bullet text carries an in-Charter closure marker —
+    /// extracted as `suspected-closed` instead of `open` (#214 Signal 1).
+    pub suspected_closed: bool,
+}
+
+/// Extract follow-up content from an AILOG body: top-level bullets of the
+/// `## Follow-ups` section plus any `R<N> (new, not in Charter)` risk lines.
+pub fn extract_followups_from_ailog(content: &str) -> Vec<ExtractedFu> {
+    let mut out = Vec::new();
+
+    // ── `## Follow-ups` section bullets ──
+    if let Some(section) = extract_section(content, |h| {
+        h.eq_ignore_ascii_case("Follow-ups") || h.eq_ignore_ascii_case("Follow-Ups")
+    }) {
+        // Group top-level bullets with their continuation lines so closure
+        // markers on continuation lines are seen.
+        let mut current: Option<String> = None;
+        for line in section.lines() {
+            if let Some(rest) = line.strip_prefix("- ") {
+                if let Some(buf) = current.take() {
+                    push_extracted(&mut out, &buf, "§Follow-ups");
+                }
+                current = Some(rest.to_string());
+            } else if let Some(buf) = current.as_mut() {
+                if line.starts_with("  ") || line.trim().is_empty() {
+                    buf.push('\n');
+                    buf.push_str(line.trim_start());
+                } else {
+                    let done = current.take().unwrap();
+                    push_extracted(&mut out, &done, "§Follow-ups");
+                }
+            }
+        }
+        if let Some(buf) = current.take() {
+            push_extracted(&mut out, &buf, "§Follow-ups");
+        }
+    }
+
+    // ── `R<N> (new, not in Charter)` risk lines (anywhere in the file) ──
+    for line in content.lines() {
+        if line.contains("(new, not in Charter)") {
+            let cleaned = line
+                .trim_start()
+                .trim_start_matches("- ")
+                .replace("**", "")
+                .trim()
+                .to_string();
+            if cleaned.is_empty() {
+                continue;
+            }
+            let rn = extract_rn_token(&cleaned);
+            let origin = match rn {
+                Some(t) => format!("§{} (new, not in Charter)", t),
+                None => "§Risk (new, not in Charter)".to_string(),
+            };
+            let suspected = has_closure_marker(line);
+            out.push(ExtractedFu {
+                description: first_line(&cleaned),
+                origin_section: origin,
+                suspected_closed: suspected,
+            });
+        }
+    }
+
+    out
+}
+
+fn push_extracted(out: &mut Vec<ExtractedFu>, bullet: &str, origin: &str) {
+    let desc = first_line(bullet);
+    if desc.is_empty() {
+        return;
+    }
+    out.push(ExtractedFu {
+        description: desc,
+        origin_section: origin.to_string(),
+        suspected_closed: has_closure_marker(bullet),
+    });
+}
+
+fn first_line(s: &str) -> String {
+    s.lines().next().unwrap_or("").trim().to_string()
+}
+
+/// Find a `R<digits>` token in a risk line (e.g. "R3 (new, not in Charter)").
+fn extract_rn_token(line: &str) -> Option<String> {
+    for word in line.split(|c: char| !c.is_ascii_alphanumeric()) {
+        if let Some(rest) = word.strip_prefix('R') {
+            if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()) {
+                return Some(word.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Extract the body of the first `## <heading>` section matching `pred`.
+fn extract_section(content: &str, pred: impl Fn(&str) -> bool) -> Option<String> {
+    let mut buf = String::new();
+    let mut in_section = false;
+    for line in content.lines() {
+        if let Some(h) = line.strip_prefix("## ") {
+            if in_section {
+                break;
+            }
+            if pred(h.trim()) {
+                in_section = true;
+                continue;
+            }
+        }
+        if in_section {
+            buf.push_str(line);
+            buf.push('\n');
+        }
+    }
+    if buf.trim().is_empty() {
+        None
+    } else {
+        Some(buf)
+    }
+}
+
+/// True when the text carries an explicit in-Charter closure marker:
+/// "closed in-Charter" / "closed in Charter" / "resolved in-Charter" /
+/// "fixed in batch N" (case-insensitive), or a backtick-wrapped commit hash
+/// (7-40 hex chars). The signal that drives `suspected-closed` extraction
+/// (#214 Signal 1 — 20-75% of auto-appended entries per batch were already
+/// resolved in-Charter across both documented occurrences).
+pub fn has_closure_marker(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    if lower.contains("closed in-charter")
+        || lower.contains("closed in charter")
+        || lower.contains("resolved in-charter")
+        || lower.contains("resolved in charter")
+    {
+        return true;
+    }
+    // "fixed in batch <N>"
+    if let Some(idx) = lower.find("fixed in batch ") {
+        let rest = &lower[idx + "fixed in batch ".len()..];
+        if rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            return true;
+        }
+    }
+    // Backtick-wrapped hex run of 7-40 chars (commit hash reference).
+    let mut chars = text.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '`' {
+            let rest = &text[i + 1..];
+            if let Some(close) = rest.find('`') {
+                let inner = &rest[..close];
+                let len = inner.chars().count();
+                if (7..=40).contains(&len)
+                    && inner.chars().all(|c| c.is_ascii_hexdigit())
+                    && inner.chars().any(|c| c.is_ascii_digit())
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Derive the AILOG id from a filename: first five dash-separated tokens
+/// (`AILOG-2026-06-03-003-slug.md` → `AILOG-2026-06-03-003`).
+pub fn ailog_id_from_path(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    if !stem.starts_with("AILOG-") {
+        return None;
+    }
+    let id: String = stem.split('-').take(5).collect::<Vec<_>>().join("-");
+    Some(id)
+}
+
+/// Render a new entry block for `drift --apply`.
+pub fn render_new_entry(
+    fu_number: u32,
+    extracted: &ExtractedFu,
+    ailog_id: &str,
+    today: &str,
+) -> String {
+    let status = if extracted.suspected_closed {
+        "suspected-closed"
+    } else {
+        "open"
+    };
+    let mut notes = format!("Auto-appended by `straymark followups drift --apply` {}.", today);
+    if extracted.suspected_closed {
+        notes.push_str(" Closure marker detected in the source AILOG — confirm and mark `closed`, or reopen.");
+    }
+    format!(
+        "### FU-{:03} — {}\n\
+         - **Origin**: {} {}\n\
+         - **Status**: {}\n\
+         - **Trigger**: TBD\n\
+         - **Destination**: TBD\n\
+         - **Cost**: TBD\n\
+         - **Notes**: {}\n",
+        fu_number, extracted.description, ailog_id, extracted.origin_section, status, notes
+    )
+}
+
+/// Insert `block` at the end of the `## Bucket: <bucket>` section of `body`.
+/// Creates the bucket section at the end of the body when it is absent.
+pub fn insert_into_bucket(registry: &Registry, bucket: &str, block: &str) -> String {
+    let body = &registry.body;
+    let target = registry
+        .sections
+        .iter()
+        .find(|s| s.is_bucket && s.name == bucket);
+
+    match target {
+        Some(section) => {
+            // Insert before the next section heading, trimming trailing blank
+            // lines of the section so spacing stays tight.
+            let head = &body[..section.end];
+            let tail = &body[section.end..];
+            let head_trimmed = head.trim_end_matches('\n');
+            format!("{}\n\n{}\n{}", head_trimmed, block.trim_end_matches('\n'), tail)
+        }
+        None => {
+            let trimmed = body.trim_end_matches('\n');
+            format!(
+                "{}\n\n## Bucket: {}\n\n{}\n",
+                trimmed,
+                bucket,
+                block.trim_end_matches('\n')
+            )
+        }
+    }
+}
+
+/// Surgically update one field bullet inside an entry's span. Replaces the
+/// existing `- **<field>**: ...` line or appends a new bullet at the end of
+/// the entry's bullet list. Returns the updated body.
+pub fn set_entry_field(body: &str, entry: &Entry, field: &str, value: &str) -> String {
+    let block = &body[entry.span_start..entry.span_end];
+    let mut lines: Vec<String> = block.lines().map(|s| s.to_string()).collect();
+    let needle = format!("- **{}**", field);
+    let mut replaced = false;
+    for line in lines.iter_mut() {
+        if line.trim_start().starts_with(&needle) {
+            *line = format!("- **{}**: {}", field, value);
+            replaced = true;
+            break;
+        }
+    }
+    if !replaced {
+        // Insert after the last `- **` bullet line.
+        let last_bullet = lines
+            .iter()
+            .rposition(|l| l.trim_start().starts_with("- **"));
+        let insert_at = last_bullet.map(|i| i + 1).unwrap_or(lines.len());
+        lines.insert(insert_at, format!("- **{}**: {}", field, value));
+    }
+    let mut new_block = lines.join("\n");
+    // Preserve the block's trailing newline shape.
+    if block.ends_with('\n') && !new_block.ends_with('\n') {
+        new_block.push('\n');
+    }
+    let mut out = String::with_capacity(body.len() + 32);
+    out.push_str(&body[..entry.span_start]);
+    out.push_str(&new_block);
+    out.push_str(&body[entry.span_end..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const V0_REGISTRY: &str = r#"---
+last_scan: 2026-05-06
+schema_version: v0
+total_open: 47
+total_promoted: 3
+total_closed_in_session: 2
+total_phase_blocked: 1
+buckets:
+  - ready
+  - time-triggered
+  - charter-triggered
+  - phase-blocked
+  - operational
+fully_extracted_ailogs:
+  - AILOG-2026-04-11-001
+  - AILOG-2026-04-12-001
+custom_field: kept
+---
+
+# Follow-ups Backlog
+
+## Bucket: ready
+
+### FU-001 — Wire the retry budget into the sync loop
+- **Origin**: AILOG-2026-04-11-001 §Follow-ups
+- **Status**: open
+- **Trigger**: ready
+- **Destination**: operations
+- **Cost**: S
+- **Notes**: first entry
+
+### FU-002 — Validate flake on month boundary
+- **Origin**: AILOG-2026-04-12-001 §R5 (new, not in Charter)
+- **Status**: open
+- **Trigger**: when next month boundary passes in CI
+- **Destination**: TBD
+- **Cost**: TBD
+
+## Bucket: phase-blocked
+
+### FU-003 — Phase 6 dashboard hook
+- **Origin**: AILOG-2026-04-12-001 §Follow-ups
+- **Status**: open
+- **Trigger**: when Phase 6 exists
+- **Destination**: Phase 6+
+- **Cost**: M
+
+## Promoted to TDE
+
+### FU-004 — Transversal auth debt
+- **Origin**: AILOG-2026-04-11-001 §R2 (new, not in Charter)
+- **Status**: promoted
+- **Promoted to**: TDE-2026-05-01-001
+"#;
+
+    const V1_ENTRY: &str = r#"---
+schema_version: v1
+last_scan: 2026-06-03
+buckets: [ready]
+fully_extracted_ailogs: []
+---
+
+## Bucket: ready
+
+### FU-010 — Harden staging probe
+- **Origin**: AILOG-2026-06-01-002 §Follow-ups
+- **Origin-class**: staging
+- **Status**: open
+- **Severity**: blocking
+- **Trigger**: ready
+- **Destination**: mini-charter
+- **Cost**: M
+- **Labels**: staging-hardening, reliability
+- **Notes**: PROD path
+"#;
+
+    fn parse(content: &str) -> Registry {
+        parse_registry_str(Path::new("follow-ups-backlog.md"), content).unwrap()
+    }
+
+    #[test]
+    fn parses_v0_registry_leniently() {
+        let reg = parse(V0_REGISTRY);
+        assert!(reg.is_v0());
+        assert_eq!(reg.frontmatter.fully_extracted_ailogs.len(), 2);
+        assert_eq!(reg.entries().count(), 4);
+        let fu1 = find_entry(&reg, "FU-001").unwrap();
+        assert_eq!(fu1.status, FuStatus::Open);
+        assert_eq!(fu1.bucket, "ready");
+        // v1 fields absent → None / empty, never an error.
+        assert!(fu1.severity.is_none());
+        assert!(fu1.origin_class.is_none());
+        assert!(fu1.labels.is_empty());
+        assert!(reg.warnings.is_empty());
+    }
+
+    #[test]
+    fn parses_v1_entry_dimensions() {
+        let reg = parse(V1_ENTRY);
+        assert!(!reg.is_v0());
+        let e = find_entry(&reg, "10").unwrap();
+        assert_eq!(e.severity, Some(Severity::Blocking));
+        assert_eq!(e.origin_class.as_deref(), Some("staging"));
+        assert_eq!(e.labels, vec!["staging-hardening", "reliability"]);
+        assert_eq!(e.destination.as_deref(), Some("mini-charter"));
+    }
+
+    #[test]
+    fn malformed_fu_heading_is_warning_not_error() {
+        let content = r#"---
+schema_version: v0
+fully_extracted_ailogs: []
+---
+
+## Bucket: ready
+
+### FU- — missing number
+- **Status**: open
+
+### FU-007 — good entry
+- **Status**: open
+"#;
+        let reg = parse(content);
+        assert_eq!(reg.entries().count(), 1);
+        assert_eq!(reg.warnings.len(), 1);
+        assert!(reg.warnings[0].contains("Malformed"));
+    }
+
+    #[test]
+    fn non_bucket_sections_still_collect_entries() {
+        let reg = parse(V0_REGISTRY);
+        let promoted = reg
+            .sections
+            .iter()
+            .find(|s| !s.is_bucket && s.name == "Promoted to TDE")
+            .unwrap();
+        assert_eq!(promoted.entries.len(), 1);
+        assert_eq!(promoted.entries[0].status, FuStatus::Promoted);
+    }
+
+    #[test]
+    fn bucket_heading_tolerates_trailing_annotation() {
+        let content = "---\nschema_version: v0\nfully_extracted_ailogs: []\n---\n\n## Bucket: ready          (1 entry)\n\n### FU-001 — x\n- **Status**: open\n";
+        let reg = parse(content);
+        assert_eq!(reg.sections[0].name, "ready");
+        assert!(reg.sections[0].is_bucket);
+    }
+
+    #[test]
+    fn find_entry_accepts_bare_and_padded_numbers() {
+        let reg = parse(V0_REGISTRY);
+        assert_eq!(find_entry(&reg, "FU-002").unwrap().fu_number, 2);
+        assert_eq!(find_entry(&reg, "002").unwrap().fu_number, 2);
+        assert_eq!(find_entry(&reg, "2").unwrap().fu_number, 2);
+        assert!(find_entry(&reg, "99").is_none());
+        assert!(find_entry(&reg, "").is_none());
+    }
+
+    #[test]
+    fn next_fu_number_is_max_plus_one() {
+        let reg = parse(V0_REGISTRY);
+        assert_eq!(next_fu_number(&reg), 5);
+    }
+
+    #[test]
+    fn counters_recompute_from_statuses_not_frontmatter() {
+        // Frontmatter claims total_open: 47 — the real count is 3 (#214 Signal 2).
+        let reg = parse(V0_REGISTRY);
+        let c = compute_counters(&reg);
+        assert_eq!(c.open, 3);
+        assert_eq!(c.promoted, 1);
+        assert_eq!(c.phase_blocked_open, 1);
+        assert_eq!(c.total, 4);
+    }
+
+    #[test]
+    fn blocking_open_counts_open_and_in_progress_blocking() {
+        let reg = parse(V1_ENTRY);
+        let c = compute_counters(&reg);
+        assert_eq!(c.blocking_open, 1);
+    }
+
+    #[test]
+    fn fm_set_scalar_replaces_and_appends() {
+        let fm = "schema_version: v0\ntotal_open: 47";
+        let out = fm_set_scalar(fm, "schema_version", "v1");
+        assert!(out.contains("schema_version: v1"));
+        let out = fm_set_scalar(&out, "total_suspected_closed", "0");
+        assert!(out.ends_with("total_suspected_closed: 0"));
+    }
+
+    #[test]
+    fn fm_append_list_items_extends_block_list() {
+        let fm = "schema_version: v0\nfully_extracted_ailogs:\n  - AILOG-2026-04-11-001\nbuckets:\n  - ready";
+        let out = fm_append_list_items(fm, "fully_extracted_ailogs", &["AILOG-2026-06-03-001".to_string()]);
+        let idx_old = out.find("AILOG-2026-04-11-001").unwrap();
+        let idx_new = out.find("AILOG-2026-06-03-001").unwrap();
+        assert!(idx_new > idx_old);
+        // The new item must land inside the list, before `buckets:`.
+        assert!(idx_new < out.find("buckets:").unwrap());
+    }
+
+    #[test]
+    fn fm_append_list_items_converts_empty_flow_list() {
+        let fm = "schema_version: v1\nfully_extracted_ailogs: []";
+        let out = fm_append_list_items(fm, "fully_extracted_ailogs", &["AILOG-2026-06-03-001".to_string()]);
+        assert!(out.contains("fully_extracted_ailogs:\n  - AILOG-2026-06-03-001"));
+        // Result must be parseable YAML with one item.
+        let parsed: RegistryFrontmatter = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(parsed.fully_extracted_ailogs.len(), 1);
+    }
+
+    #[test]
+    fn v0_upgrade_preserves_unknown_fields() {
+        let reg = parse(V0_REGISTRY);
+        let counters = compute_counters(&reg);
+        let fm = fm_apply_counters_and_v1(&reg.frontmatter_raw, &counters);
+        assert!(fm.contains("schema_version: v1"));
+        assert!(fm.contains("custom_field: kept"), "unknown fields must survive");
+        assert!(fm.contains("total_open: 3"));
+        // Idempotent: applying again changes nothing.
+        let fm2 = fm_apply_counters_and_v1(&fm, &counters);
+        assert_eq!(fm, fm2);
+    }
+
+    #[test]
+    fn extract_followups_finds_section_bullets_and_risk_lines() {
+        let ailog = r#"# AILOG-2026-06-03-003 — staging run
+
+## Risk
+
+- **R3 (new, not in Charter)**: bus handler writes escape the unit suite.
+
+## Follow-ups
+
+- Extend E2E coverage to write-path-A
+- Formal validation run — closed in-Charter (commit `ab12cd34ef`), 5/6 pass
+
+## Outcome
+
+Done.
+"#;
+        let found = extract_followups_from_ailog(ailog);
+        assert_eq!(found.len(), 3);
+        let bullets: Vec<&str> = found.iter().map(|f| f.description.as_str()).collect();
+        assert!(bullets.iter().any(|b| b.contains("Extend E2E coverage")));
+        let closed = found
+            .iter()
+            .find(|f| f.description.contains("Formal validation"))
+            .unwrap();
+        assert!(closed.suspected_closed, "closure marker must be detected");
+        let open = found
+            .iter()
+            .find(|f| f.description.contains("Extend E2E"))
+            .unwrap();
+        assert!(!open.suspected_closed);
+        let risk = found
+            .iter()
+            .find(|f| f.origin_section.contains("R3"))
+            .unwrap();
+        assert!(risk.origin_section.contains("(new, not in Charter)"));
+    }
+
+    #[test]
+    fn closure_markers_detected_case_insensitively() {
+        assert!(has_closure_marker("Closed in-Charter by the runbook rewrite"));
+        assert!(has_closure_marker("fixed in batch 3"));
+        assert!(has_closure_marker("resolved in Charter close"));
+        assert!(has_closure_marker("see commit `deadbeef42` for the fix"));
+        assert!(!has_closure_marker("should be closed when X lands"));
+        assert!(!has_closure_marker("fixed in batch processing generally"));
+        // Backtick word that isn't a hash (no digit / not hex).
+        assert!(!has_closure_marker("see `feedface` once")); // hex but no digit
+        assert!(!has_closure_marker("run `cargo test` first"));
+    }
+
+    #[test]
+    fn ailog_id_from_path_takes_five_tokens() {
+        assert_eq!(
+            ailog_id_from_path(Path::new("AILOG-2026-06-03-003-staging-incident.md")).as_deref(),
+            Some("AILOG-2026-06-03-003")
+        );
+        assert_eq!(
+            ailog_id_from_path(Path::new("AILOG-2026-06-03-004.md")).as_deref(),
+            Some("AILOG-2026-06-03-004")
+        );
+        assert!(ailog_id_from_path(Path::new("README.md")).is_none());
+    }
+
+    #[test]
+    fn insert_into_bucket_appends_at_section_end() {
+        let reg = parse(V0_REGISTRY);
+        let block = render_new_entry(
+            5,
+            &ExtractedFu {
+                description: "New thing".to_string(),
+                origin_section: "§Follow-ups".to_string(),
+                suspected_closed: false,
+            },
+            "AILOG-2026-06-03-001",
+            "2026-06-04",
+        );
+        let new_body = insert_into_bucket(&reg, "ready", &block);
+        // FU-005 must land inside the ready section: after FU-002, before
+        // `## Bucket: phase-blocked`.
+        let idx_new = new_body.find("### FU-005").unwrap();
+        assert!(idx_new > new_body.find("### FU-002").unwrap());
+        assert!(idx_new < new_body.find("## Bucket: phase-blocked").unwrap());
+        // Re-parse: 5 entries now.
+        let reparsed = parse(&assemble(&reg.frontmatter_raw, &new_body));
+        assert_eq!(reparsed.entries().count(), 5);
+        assert_eq!(find_entry(&reparsed, "FU-005").unwrap().bucket, "ready");
+    }
+
+    #[test]
+    fn insert_into_bucket_creates_missing_section() {
+        let content = "---\nschema_version: v1\nfully_extracted_ailogs: []\n---\n\n# Registry\n";
+        let reg = parse(content);
+        let new_body = insert_into_bucket(&reg, "ready", "### FU-001 — x\n- **Status**: open\n");
+        assert!(new_body.contains("## Bucket: ready"));
+        let reparsed = parse(&assemble(&reg.frontmatter_raw, &new_body));
+        assert_eq!(reparsed.entries().count(), 1);
+    }
+
+    #[test]
+    fn set_entry_field_replaces_existing_bullet() {
+        let reg = parse(V0_REGISTRY);
+        let entry = find_entry(&reg, "FU-001").unwrap().clone();
+        let new_body = set_entry_field(&reg.body, &entry, "Status", "promoted");
+        let reparsed = parse(&assemble(&reg.frontmatter_raw, &new_body));
+        assert_eq!(
+            find_entry(&reparsed, "FU-001").unwrap().status,
+            FuStatus::Promoted
+        );
+        // Other entries untouched.
+        assert_eq!(find_entry(&reparsed, "FU-002").unwrap().status, FuStatus::Open);
+    }
+
+    #[test]
+    fn set_entry_field_appends_missing_bullet() {
+        let reg = parse(V0_REGISTRY);
+        let entry = find_entry(&reg, "FU-001").unwrap().clone();
+        let new_body = set_entry_field(&reg.body, &entry, "Promoted to", "TDE-2026-06-04-001");
+        let reparsed = parse(&assemble(&reg.frontmatter_raw, &new_body));
+        assert_eq!(
+            find_entry(&reparsed, "FU-001").unwrap().promoted_to.as_deref(),
+            Some("TDE-2026-06-04-001")
+        );
+    }
+
+    #[test]
+    fn render_new_entry_marks_suspected_closed() {
+        let block = render_new_entry(
+            92,
+            &ExtractedFu {
+                description: "Formal run".to_string(),
+                origin_section: "§Follow-ups".to_string(),
+                suspected_closed: true,
+            },
+            "AILOG-2026-06-03-001",
+            "2026-06-04",
+        );
+        assert!(block.contains("### FU-092 — Formal run"));
+        assert!(block.contains("- **Status**: suspected-closed"));
+        assert!(block.contains("Closure marker detected"));
+    }
+
+    #[test]
+    fn registry_without_frontmatter_errors_with_hint() {
+        let err = parse_registry_str(Path::new("x.md"), "# no frontmatter\n").unwrap_err();
+        assert!(err.to_string().contains("no YAML frontmatter"));
+    }
+}

--- a/cli/src/followups_schema.rs
+++ b/cli/src/followups_schema.rs
@@ -1,0 +1,111 @@
+//! JSON Schema validation for the follow-ups registry frontmatter.
+//!
+//! The schema ships at `.straymark/schemas/follow-ups-backlog.schema.v1.json`
+//! (experimental v1 — fw-4.21.0). Validation is advisory: `straymark
+//! followups status` surfaces issues as warnings, never as failures, in line
+//! with the registry's lenient-parsing contract (ADR-2026-06-03-001). Unlike
+//! `charter_schema`, results are plain strings — the registry is not part of
+//! the `straymark validate` document pipeline.
+
+use anyhow::{anyhow, Context, Result};
+use jsonschema::JSONSchema;
+use serde_json::Value;
+use std::path::Path;
+
+/// Path to the registry schema relative to a project's `.straymark/` directory.
+pub const SCHEMA_RELATIVE_PATH: &str = "schemas/follow-ups-backlog.schema.v1.json";
+
+/// Validate a registry's raw frontmatter against the shipped schema.
+/// Returns a list of human-readable issues (empty when valid), or an error
+/// when the schema file itself is missing or broken — callers typically
+/// downgrade that to a dimmed hint (older framework installs predate the
+/// schema).
+pub fn validate_frontmatter(straymark_dir: &Path, frontmatter_raw: &str) -> Result<Vec<String>> {
+    let schema_path = straymark_dir.join(SCHEMA_RELATIVE_PATH);
+    let raw = std::fs::read_to_string(&schema_path).with_context(|| {
+        format!(
+            "Registry schema not found at {} (ships with fw-4.21.0+; run `straymark update-framework`)",
+            schema_path.display()
+        )
+    })?;
+    let schema_json: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("Registry schema at {} is not valid JSON", schema_path.display()))?;
+    let compiled = JSONSchema::options()
+        .compile(&schema_json)
+        .map_err(|e| anyhow!("Failed to compile registry schema: {e}"))?;
+
+    let yaml_value: serde_yaml::Value = serde_yaml::from_str(frontmatter_raw)
+        .context("Registry frontmatter is not parseable YAML")?;
+    let json_value = yaml_to_json(&yaml_value)?;
+
+    let issues = match compiled.validate(&json_value) {
+        Ok(()) => Vec::new(),
+        Err(errors) => errors
+            .map(|e| {
+                let path = e.instance_path.to_string();
+                if path.is_empty() {
+                    e.to_string()
+                } else {
+                    format!("{}: {}", path, e)
+                }
+            })
+            .collect(),
+    };
+    Ok(issues)
+}
+
+/// Convert YAML to JSON for schema validation. Mirrors the conversion in
+/// `charter_schema` (kept local: that module's helper is private and the
+/// two modules migrate to straymark-core on different timelines).
+fn yaml_to_json(yaml: &serde_yaml::Value) -> Result<Value> {
+    serde_json::to_value(yaml).context("Failed to convert registry frontmatter YAML to JSON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Minimal but real copy of the shipped schema's required-fields core.
+    const MINI_SCHEMA: &str = r#"{
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["schema_version", "last_scan", "buckets", "fully_extracted_ailogs"],
+        "additionalProperties": true,
+        "properties": {
+            "schema_version": {"type": "string", "enum": ["v0", "v1"]}
+        }
+    }"#;
+
+    fn setup(schema: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("schemas");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("follow-ups-backlog.schema.v1.json"), schema).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn valid_frontmatter_yields_no_issues() {
+        let tmp = setup(MINI_SCHEMA);
+        let fm = "schema_version: v1\nlast_scan: 2026-06-04\nbuckets: [ready]\nfully_extracted_ailogs: []";
+        let issues = validate_frontmatter(tmp.path(), fm).unwrap();
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn missing_required_field_is_reported() {
+        let tmp = setup(MINI_SCHEMA);
+        let fm = "schema_version: v1\nlast_scan: 2026-06-04\nbuckets: [ready]";
+        let issues = validate_frontmatter(tmp.path(), fm).unwrap();
+        assert!(!issues.is_empty());
+        assert!(issues.iter().any(|i| i.contains("fully_extracted_ailogs")));
+    }
+
+    #[test]
+    fn missing_schema_file_is_an_error_with_update_hint() {
+        let tmp = TempDir::new().unwrap();
+        let err = validate_frontmatter(tmp.path(), "schema_version: v1").unwrap_err();
+        assert!(err.to_string().contains("update-framework"));
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,8 @@ mod compliance;
 mod config;
 mod document;
 mod download;
+mod followups;
+mod followups_schema;
 mod inject;
 mod manifest;
 mod metrics_engine;
@@ -273,6 +275,82 @@ enum Commands {
     Charter {
         #[command(subcommand)]
         command: CharterCommands,
+    },
+    /// Manage the follow-ups backlog registry (.straymark/follow-ups-backlog.md)
+    Followups {
+        #[command(subcommand)]
+        command: FollowupsCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum FollowupsCommands {
+    /// List registry entries with optional filters
+    List {
+        /// Filter by bucket (ready, time-triggered, charter-triggered,
+        /// phase-blocked, operational)
+        #[arg(long)]
+        bucket: Option<String>,
+        /// Filter by entry status (open, in-progress, suspected-closed,
+        /// closed, superseded, promoted)
+        #[arg(long)]
+        status: Option<String>,
+        /// Filter by severity (normal, blocking)
+        #[arg(long)]
+        severity: Option<String>,
+        /// Filter by label (case-insensitive exact match on one tag)
+        #[arg(long)]
+        label: Option<String>,
+        /// Project directory (default: current directory)
+        #[arg(default_value = ".")]
+        path: String,
+    },
+    /// Show the registry pulse (counters recomputed on the fly), or one
+    /// entry's detail when an FU id is given
+    Status {
+        /// Entry identifier (FU-NNN or just NNN)
+        fu_id: Option<String>,
+        /// Project directory (default: current directory).
+        /// A flag (rather than positional) so it cannot be confused with
+        /// the optional fu_id positional.
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
+    /// Detect AILOGs with follow-up content not yet extracted into the
+    /// registry. Native replacement (cli-3.19.0) for the deprecated
+    /// adopter-side check-followups-drift.sh. Exit 1 on drift unless --apply.
+    Drift {
+        /// Extract the missing entries into `## Bucket: ready`, append the
+        /// AILOG ids to fully_extracted_ailogs, recompute the CLI-owned
+        /// counters, and upgrade v0 registries to v1 in place. Entries whose
+        /// source AILOG carries a closure marker (`closed in-Charter`,
+        /// `fixed in batch N`, a commit hash) land as `suspected-closed`.
+        #[arg(long)]
+        apply: bool,
+        /// Sweep every AILOG in the project instead of the git range.
+        #[arg(long)]
+        scan_all: bool,
+        /// Git revision range for the default scan (default:
+        /// origin/main..HEAD, falling back to origin/master..HEAD, then
+        /// HEAD~1..HEAD).
+        #[arg(long, conflicts_with = "scan_all")]
+        range: Option<String>,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
+    /// Promote an entry to a TDE document (creates the TDE with
+    /// promoted_from_followup traceability, marks the entry `promoted`,
+    /// recomputes counters). Non-interactive; prioritization stays human.
+    Promote {
+        /// Entry identifier (FU-NNN or just NNN)
+        fu_id: String,
+        /// TDE title override (default: the FU description)
+        #[arg(long)]
+        title: Option<String>,
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
     },
 }
 
@@ -730,6 +808,35 @@ fn main() {
                 &ailog_title,
                 merge_into.as_deref(),
             ),
+        },
+        Commands::Followups { command } => match command {
+            FollowupsCommands::List {
+                bucket,
+                status,
+                severity,
+                label,
+                path,
+            } => commands::followups::list::run(
+                &path,
+                &commands::followups::list::Filters {
+                    bucket: bucket.as_deref(),
+                    status: status.as_deref(),
+                    severity: severity.as_deref(),
+                    label: label.as_deref(),
+                },
+            ),
+            FollowupsCommands::Status { fu_id, path } => {
+                commands::followups::status::run(&path, fu_id.as_deref())
+            }
+            FollowupsCommands::Drift {
+                apply,
+                scan_all,
+                range,
+                path,
+            } => commands::followups::drift::run(&path, apply, scan_all, range.as_deref()),
+            FollowupsCommands::Promote { fu_id, title, path } => {
+                commands::followups::promote::run(&path, &fu_id, title.as_deref())
+            }
         },
     };
 

--- a/cli/src/tui/i18n_strings.rs
+++ b/cli/src/tui/i18n_strings.rs
@@ -45,6 +45,10 @@ pub fn t<'a>(en: &'a str, lang: &str) -> &'a str {
         // the rest of the bilingual technical vocabulary (Plan→Charter rename).
         ("Charters", "es") => "Charters",
         ("Charters", "zh-CN") => "章程",
+        // "Follow-ups" stays as a loanword in ES (same convention as Charters);
+        // the entry vocabulary inside the registry is canonical English.
+        ("Follow-ups", "es") => "Follow-ups",
+        ("Follow-ups", "zh-CN") => "跟进事项",
 
         // ── Subgroup labels ───────────────────────────────────────────
         ("Exceptions", "es") => "Excepciones",

--- a/cli/src/tui/index.rs
+++ b/cli/src/tui/index.rs
@@ -228,6 +228,25 @@ impl DocIndex {
             });
         }
 
+        // Synthetic "Follow-ups" group (cli-3.19.0, ADR-2026-06-03-001).
+        // The registry is one file, but its FU-NNN entries are the units the
+        // operator navigates — so each entry becomes a DocEntry under a
+        // per-bucket subgroup. Selecting any entry opens the registry file.
+        // Added only when the registry exists; bucket names are canonical
+        // English vocabulary (machine-parsed), so they are not localized.
+        if let Some((registry_entry, bucket_subgroups, n_entries)) =
+            scan_followups(project_root, &mut relations)
+        {
+            total_docs += 1 + n_entries;
+            groups.push(DocGroup {
+                name: "_followups".to_string(),
+                label: t("Follow-ups", language).to_string(),
+                path: crate::followups::registry_path(project_root),
+                subgroups: bucket_subgroups,
+                files: vec![registry_entry],
+            });
+        }
+
         Self {
             groups,
             relations,
@@ -576,6 +595,70 @@ fn scan_charters(project_root: &Path, relations: &mut RelationIndex) -> Vec<DocE
         entries.push(entry);
     }
     entries
+}
+
+/// Build the synthetic Follow-ups group content: the registry file itself as
+/// a root entry plus one `DocSubgroup` per non-empty bucket, each holding one
+/// `DocEntry` per FU. Every entry's path points at the registry file (entries
+/// are blocks, not files). Returns `None` when the registry does not exist or
+/// cannot be parsed — the TUI shows no empty stub, mirroring `_charters`.
+fn scan_followups(
+    project_root: &Path,
+    relations: &mut RelationIndex,
+) -> Option<(DocEntry, Vec<DocSubgroup>, usize)> {
+    let registry_path = crate::followups::registry_path(project_root);
+    if !registry_path.exists() {
+        return None;
+    }
+    let registry = crate::followups::parse_registry(&registry_path).ok()?;
+
+    let registry_entry = DocEntry {
+        filename: "follow-ups-backlog.md".to_string(),
+        path: registry_path.clone(),
+        title: "Follow-ups Backlog (registry)".to_string(),
+        id: String::new(),
+        doc_type: "FU".to_string(),
+        tags: Vec::new(),
+        created: registry.frontmatter.last_scan.clone().unwrap_or_default(),
+        has_frontmatter: true,
+    };
+
+    let mut subgroups = Vec::new();
+    let mut n_entries = 0usize;
+    for section in registry.sections.iter().filter(|s| s.is_bucket) {
+        if section.entries.is_empty() {
+            continue;
+        }
+        let files: Vec<DocEntry> = section
+            .entries
+            .iter()
+            .map(|e| {
+                relations
+                    .id_to_path
+                    .insert(e.fu_id.clone(), registry_path.clone());
+                DocEntry {
+                    filename: "follow-ups-backlog.md".to_string(),
+                    path: registry_path.clone(),
+                    title: format!("{} — {}", e.fu_id, e.description),
+                    id: e.fu_id.clone(),
+                    doc_type: "FU".to_string(),
+                    tags: e.labels.clone(),
+                    created: String::new(),
+                    has_frontmatter: true,
+                }
+            })
+            .collect();
+        n_entries += files.len();
+        subgroups.push(DocSubgroup {
+            name: section.name.clone(),
+            label: section.name.clone(),
+            path: registry_path.clone(),
+            files,
+            user_dirs: Vec::new(),
+        });
+    }
+
+    Some((registry_entry, subgroups, n_entries))
 }
 
 fn quick_scan_frontmatter(path: &Path, relations: &mut RelationIndex) -> ScannedMeta {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -153,6 +153,30 @@ pub fn resolve_localized_path(dir: &Path, filename: &str, lang: &str) -> PathBuf
     dir.join(filename)
 }
 
+/// Split a markdown document into (frontmatter, body) at the first pair of `---`
+/// delimiters. Returns `None` if the document has no frontmatter block.
+/// Accepts both `\n` and `\r\n` line endings on the closing delimiter.
+/// Shared by the Charter parser (`crate::charter`) and the follow-ups
+/// registry parser (`crate::followups`) so both artifacts agree on what a
+/// frontmatter block is.
+pub fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
+    // Opening delimiter: must be at the very start of the file.
+    let after_open = content.strip_prefix("---\n").or_else(|| content.strip_prefix("---\r\n"))?;
+    // Closing delimiter: find the first occurrence of `\n---\n` or `\r\n---\r\n`.
+    let (end, delim_len) = if let Some(idx) = after_open.find("\n---\n") {
+        (idx, 5)
+    } else if let Some(idx) = after_open.find("\r\n---\r\n") {
+        (idx, 7)
+    } else if let Some(idx) = after_open.find("\n---\r\n") {
+        (idx, 6)
+    } else {
+        return None;
+    };
+    let frontmatter = &after_open[..end];
+    let body = &after_open[end + delim_len..];
+    Some((frontmatter, body))
+}
+
 /// Visual width of a string in terminal columns, accounting for double-wide
 /// characters (CJK, some emoji). This is the unit every TUI layout should
 /// use — `.len()` measures bytes and `.chars().count()` measures code points,

--- a/cli/tests/followups_test.rs
+++ b/cli/tests/followups_test.rs
@@ -1,0 +1,489 @@
+//! Integration tests for `straymark followups` (cli-3.19.0,
+//! ADR-2026-06-03-001): list / status / drift / promote against fixture
+//! registries, including a Sentinel-style v0 registry (lenient parsing +
+//! in-place upgrade) and the anti-noise / counter-recompute behaviors that
+//! resolve issue #214 Signals 1-2.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// Minimal StrayMark project scaffold: `.straymark/` with the directories
+/// the followups commands touch.
+fn scaffold(dir: &Path) -> PathBuf {
+    let straymark = dir.join(".straymark");
+    std::fs::create_dir_all(straymark.join("07-ai-audit/agent-logs")).unwrap();
+    std::fs::create_dir_all(straymark.join("06-evolution/technical-debt")).unwrap();
+    std::fs::create_dir_all(straymark.join("templates")).unwrap();
+    std::fs::create_dir_all(straymark.join("schemas")).unwrap();
+    straymark
+}
+
+/// Sentinel-style v0 registry: no v1 fields, stale counters (#214 Signal 2 —
+/// frontmatter claims total_open: 47, real count is 2).
+const V0_REGISTRY: &str = r#"---
+last_scan: 2026-05-06
+schema_version: v0
+total_open: 47
+total_promoted: 0
+total_closed_in_session: 0
+total_phase_blocked: 0
+buckets:
+  - ready
+  - time-triggered
+  - charter-triggered
+  - phase-blocked
+  - operational
+fully_extracted_ailogs:
+  - AILOG-2026-04-11-001
+---
+
+# Follow-ups Backlog
+
+## Bucket: ready
+
+### FU-001 — Wire the retry budget into the sync loop
+- **Origin**: AILOG-2026-04-11-001 §Follow-ups
+- **Status**: open
+- **Trigger**: ready
+- **Destination**: operations
+- **Cost**: S
+
+## Bucket: charter-triggered
+
+### FU-002 — Extend E2E coverage to the write paths
+- **Origin**: AILOG-2026-04-11-001 §R3 (new, not in Charter)
+- **Status**: open
+- **Trigger**: next Charter touching writes
+- **Destination**: TBD
+- **Cost**: M
+
+## Bucket: phase-blocked
+
+## Bucket: operational
+"#;
+
+/// v1 registry exercising the new dimensions.
+const V1_REGISTRY: &str = r#"---
+schema_version: v1
+last_scan: 2026-06-03
+total_open: 2
+total_promoted: 0
+total_closed_in_session: 0
+total_phase_blocked: 0
+total_suspected_closed: 0
+buckets:
+  - ready
+fully_extracted_ailogs: []
+---
+
+## Bucket: ready
+
+### FU-010 — Harden staging probe
+- **Origin**: AILOG-2026-06-01-002 §Follow-ups
+- **Origin-class**: staging
+- **Status**: open
+- **Severity**: blocking
+- **Trigger**: ready
+- **Destination**: mini-charter
+- **Cost**: M
+- **Labels**: staging-hardening, reliability
+
+### FU-011 — Document the rollout runbook
+- **Origin**: AILOG-2026-06-01-002 §Follow-ups
+- **Status**: open
+- **Trigger**: ready
+- **Destination**: chore
+- **Cost**: S
+"#;
+
+const TDE_TEMPLATE: &str = r#"---
+id: TDE-YYYY-MM-DD-NNN
+title: [Technical debt title]
+status: identified
+created: YYYY-MM-DD
+agent: [agent-name-v1.0]
+confidence: high | medium | low
+review_required: false
+risk_level: low | medium | high
+type: code | architecture | infrastructure | documentation | testing
+impact: low | medium | high
+effort: low | medium | high
+iso_42001_clause: []
+tags: []
+related: []
+priority: null
+assigned_to: null
+promoted_from_followup: null    # FU-NNN if promoted from .straymark/follow-ups-backlog.md
+---
+
+# TDE: [Technical Debt Title]
+
+## Summary
+
+[Brief description of the identified technical debt]
+"#;
+
+fn cmd() -> Command {
+    Command::cargo_bin("straymark").unwrap()
+}
+
+fn write_registry(straymark: &Path, content: &str) {
+    std::fs::write(straymark.join("follow-ups-backlog.md"), content).unwrap();
+}
+
+// ───────────────────────────── list / status ─────────────────────────────
+
+#[test]
+fn list_shows_entries_from_v0_registry() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY);
+
+    cmd()
+        .args(["followups", "list", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FU-001"))
+        .stdout(predicate::str::contains("FU-002"))
+        .stdout(predicate::str::contains("charter-triggered"));
+}
+
+#[test]
+fn list_filters_by_severity_and_label() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+
+    cmd()
+        .args(["followups", "list"])
+        .args(["--severity", "blocking"])
+        .arg(tmp.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FU-010"))
+        .stdout(predicate::str::contains("FU-011").not());
+
+    cmd()
+        .args(["followups", "list"])
+        .args(["--label", "reliability"])
+        .arg(tmp.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FU-010"))
+        .stdout(predicate::str::contains("FU-011").not());
+}
+
+#[test]
+fn list_filters_by_bucket_and_status() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY);
+
+    cmd()
+        .args(["followups", "list"])
+        .args(["--bucket", "ready", "--status", "open"])
+        .arg(tmp.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FU-001"))
+        .stdout(predicate::str::contains("FU-002").not());
+}
+
+#[test]
+fn list_without_registry_prints_adoption_hint() {
+    let tmp = TempDir::new().unwrap();
+    scaffold(tmp.path());
+
+    cmd()
+        .args(["followups", "list", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No follow-ups registry yet"));
+}
+
+#[test]
+fn status_pulse_recomputes_and_flags_stale_counters() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY);
+
+    cmd()
+        .args(["followups", "status", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        // Recomputed truth: 2 open, despite frontmatter claiming 47.
+        .stdout(predicate::str::contains("total_open: 47"))
+        .stdout(predicate::str::contains("real count is 2"));
+}
+
+#[test]
+fn status_detail_shows_v1_dimensions() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+
+    cmd()
+        .args(["followups", "status", "FU-010", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("blocking"))
+        .stdout(predicate::str::contains("staging"))
+        .stdout(predicate::str::contains("staging-hardening"));
+}
+
+#[test]
+fn status_unknown_entry_fails_with_hint() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+
+    cmd()
+        .args(["followups", "status", "FU-999", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn malformed_entry_is_warning_not_failure() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    let broken = V1_REGISTRY.replace(
+        "### FU-011 — Document the rollout runbook",
+        "### FU- — heading without a number",
+    );
+    write_registry(&straymark, &broken);
+
+    cmd()
+        .args(["followups", "list", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FU-010"))
+        .stdout(predicate::str::contains("Malformed"));
+}
+
+// ───────────────────────────── drift ─────────────────────────────
+
+fn write_ailog(straymark: &Path, filename: &str, content: &str) {
+    std::fs::write(
+        straymark.join("07-ai-audit/agent-logs").join(filename),
+        content,
+    )
+    .unwrap();
+}
+
+const AILOG_WITH_FOLLOWUPS: &str = r#"# AILOG-2026-06-03-003 — staging incident
+
+## Risk
+
+- **R3 (new, not in Charter)**: bus handler writes escape the unit suite.
+
+## Follow-ups
+
+- Extend NON-owner integration coverage to write-path-B
+- Formal SC validation run — closed in-Charter (commit `ab12cd34ef`), 5/6 pass
+
+## Outcome
+
+Done.
+"#;
+
+#[test]
+fn drift_scan_all_detects_unextracted_ailog_and_exits_1() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY);
+    write_ailog(&straymark, "AILOG-2026-06-03-003-staging.md", AILOG_WITH_FOLLOWUPS);
+
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("AILOG-2026-06-03-003"));
+}
+
+#[test]
+fn drift_scan_all_clean_when_everything_extracted() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY);
+    // The only AILOG is already in fully_extracted_ailogs.
+    write_ailog(
+        &straymark,
+        "AILOG-2026-04-11-001-first.md",
+        "# AILOG\n\n## Follow-ups\n\n- already extracted\n",
+    );
+
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("registry in sync"));
+}
+
+#[test]
+fn drift_apply_extracts_marks_suspected_recomputes_and_upgrades_v1() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY);
+    write_ailog(&straymark, "AILOG-2026-06-03-003-staging.md", AILOG_WITH_FOLLOWUPS);
+
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--apply", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 3"))
+        .stdout(predicate::str::contains("suspected-closed"))
+        .stdout(predicate::str::contains("upgraded to schema v1"));
+
+    let updated = std::fs::read_to_string(straymark.join("follow-ups-backlog.md")).unwrap();
+
+    // (1) New entries with sequential numbers landed in the ready bucket.
+    assert!(updated.contains("### FU-003"));
+    assert!(updated.contains("### FU-004"));
+    assert!(updated.contains("### FU-005"));
+    // (2) Anti-noise (#214 Signal 1): the bullet with the closure marker is
+    // suspected-closed, the plain one is open.
+    let closed_idx = updated.find("Formal SC validation run").unwrap();
+    let closed_block = &updated[closed_idx..closed_idx + 400];
+    assert!(closed_block.contains("- **Status**: suspected-closed"));
+    let open_idx = updated.find("Extend NON-owner integration coverage").unwrap();
+    let open_block = &updated[open_idx..open_idx + 400];
+    assert!(open_block.contains("- **Status**: open"));
+    // (3) AILOG registered as fully extracted.
+    assert!(updated.contains("AILOG-2026-06-03-003"));
+    // (4) v0 → v1 upgrade + counter recompute (#214 Signal 2): 47 → real.
+    assert!(updated.contains("schema_version: v1"));
+    assert!(updated.contains("total_open: 4")); // FU-001, FU-002 + 2 new open
+    assert!(updated.contains("total_suspected_closed: 1"));
+
+    // (5) Idempotent: a second run is clean.
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("registry in sync"));
+}
+
+#[test]
+fn drift_apply_seeds_registry_from_template_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    // Ship the framework template (as fw-4.21.0 does).
+    std::fs::write(
+        straymark.join("templates/follow-ups-backlog.md"),
+        "---\nlast_scan: YYYY-MM-DD\nschema_version: v1\ntotal_open: 0\nbuckets:\n  - ready\nfully_extracted_ailogs: []\n---\n\n## Bucket: ready\n",
+    )
+    .unwrap();
+    write_ailog(&straymark, "AILOG-2026-06-03-001-x.md", "# A\n\n## Follow-ups\n\n- do the thing\n");
+
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--apply", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("from the framework template"))
+        .stdout(predicate::str::contains("Extracted 1"));
+
+    let created = std::fs::read_to_string(straymark.join("follow-ups-backlog.md")).unwrap();
+    assert!(created.contains("### FU-001 — do the thing"));
+}
+
+// ───────────────────────────── promote ─────────────────────────────
+
+#[test]
+fn promote_creates_tde_with_backlink_and_updates_entry() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+    std::fs::write(straymark.join("templates/TEMPLATE-TDE.md"), TDE_TEMPLATE).unwrap();
+
+    cmd()
+        .args(["followups", "promote", "FU-010", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("promoted"))
+        .stdout(predicate::str::contains("TDE-"));
+
+    // TDE exists with the traceability backlink.
+    let tde_dir = straymark.join("06-evolution/technical-debt");
+    let tde_files: Vec<_> = std::fs::read_dir(&tde_dir).unwrap().flatten().collect();
+    assert_eq!(tde_files.len(), 1);
+    let tde_content = std::fs::read_to_string(tde_files[0].path()).unwrap();
+    assert!(tde_content.contains("promoted_from_followup: FU-010"));
+    assert!(tde_content.contains("Harden staging probe"));
+
+    // Registry entry flipped to promoted with the TDE pointer; counters
+    // recomputed (1 open left, 1 promoted).
+    let updated = std::fs::read_to_string(straymark.join("follow-ups-backlog.md")).unwrap();
+    let entry_idx = updated.find("### FU-010").unwrap();
+    let entry_block = &updated[entry_idx..updated.find("### FU-011").unwrap()];
+    assert!(entry_block.contains("- **Status**: promoted"));
+    assert!(entry_block.contains("- **Promoted to**: TDE-"));
+    assert!(entry_block.contains("- **Destination**: TDE-"));
+    assert!(updated.contains("total_open: 1"));
+    assert!(updated.contains("total_promoted: 1"));
+}
+
+#[test]
+fn promote_rejects_already_promoted_entry() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+    std::fs::write(straymark.join("templates/TEMPLATE-TDE.md"), TDE_TEMPLATE).unwrap();
+
+    cmd()
+        .args(["followups", "promote", "FU-010", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    cmd()
+        .args(["followups", "promote", "FU-010", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already promoted"));
+}
+
+#[test]
+fn promote_unknown_entry_fails_with_hint() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+
+    cmd()
+        .args(["followups", "promote", "FU-404", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+// ───────────────────────────── status command block ─────────────────────────────
+
+#[test]
+fn project_status_shows_followups_block() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    // status needs the manifest to exist for the version row; tolerate absence.
+    write_registry(&straymark, V1_REGISTRY);
+
+    cmd()
+        .args(["status", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Follow-ups"))
+        .stdout(predicate::str::contains("blocking"));
+}
+
+#[test]
+fn project_status_hints_when_no_registry() {
+    let tmp = TempDir::new().unwrap();
+    scaffold(tmp.path());
+
+    cmd()
+        .args(["status", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No follow-ups registry yet"));
+}

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -11,7 +11,7 @@
 
 1. [Installation](#installation)
 2. [Versioning](#versioning)
-3. [Commands](#commands) — init, update, remove, status, repair, validate, new, charter, compliance, metrics, analyze, audit, explore, about
+3. [Commands](#commands) — init, update, remove, status, repair, validate, new, charter, followups, compliance, metrics, analyze, audit, explore, about
 4. [Environment Variables](#environment-variables)
 5. [Exit Codes](#exit-codes)
 
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.21.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.18.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.19.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -880,6 +880,70 @@ $ straymark charter amend CHARTER-18 \
 
   Next: review the new AILOG, edit it with concrete details, then commit
   on the original execute branch (do NOT branch off main).
+```
+
+---
+
+### `straymark followups <subcommand>` *(cli-3.19.0+)*
+
+Manage the **follow-ups backlog registry** (`.straymark/follow-ups-backlog.md`) — the first-class artifact that aggregates `§Follow-ups` and `R<N> (new, not in Charter)` entries across AILOGs. Schema: `.straymark/schemas/follow-ups-backlog.schema.v1.json` (experimental v1). Convention: `FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16`; shipped agent directives in `AGENT-RULES.md §13`.
+
+Parsing is **lenient**: v0 registries (pre-fw-4.21.0) are read without errors; the first write command (`drift --apply` or `promote`) upgrades them to v1 in place, non-destructively. Frontmatter `total_*` counters are **CLI-owned** — recomputed on every write; never edit them by hand.
+
+- `straymark followups list` — enumerate entries *(cli-3.19.0+)*
+- `straymark followups status` — registry pulse / entry detail *(cli-3.19.0+)*
+- `straymark followups drift` — sync the registry with AILOGs (native replacement for the deprecated adopter-side `check-followups-drift.sh`) *(cli-3.19.0+)*
+- `straymark followups promote` — elevate an entry to a TDE document *(cli-3.19.0+)*
+
+#### `straymark followups list [--bucket <name>] [--status <s>] [--severity <s>] [--label <tag>] [path]`
+
+Table of entries: FU id, status, severity, bucket, destination, description. Parse warnings (malformed `### FU-` headings) go to stderr without failing the command.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--bucket <name>` | — | Filter by bucket: `ready`, `time-triggered`, `charter-triggered`, `phase-blocked`, `operational` |
+| `--status <s>` | — | Filter by status: `open`, `in-progress`, `suspected-closed`, `closed`, `superseded`, `promoted` |
+| `--severity <s>` | — | Filter by severity: `normal`, `blocking` |
+| `--label <tag>` | — | Filter by label (case-insensitive exact match on one tag) |
+
+```bash
+$ straymark followups list --severity blocking
+  FU      STATUS  SEV       BUCKET  DEST          DESCRIPTION
+  FU-010  open    blocking  ready   mini-charter  Harden staging probe
+```
+
+#### `straymark followups status [FU-NNN] [--path <dir>]`
+
+Without an id: the registry pulse — counters **recomputed on the fly** from actual entry statuses (trustworthy even when the file's frontmatter is stale; divergence is flagged), per-bucket open breakdown, blocking and suspected-closed alerts, advisory schema validation. With an id: the entry's full field detail.
+
+#### `straymark followups drift [--apply] [--scan-all] [--range <REV..REV>] [--path <dir>]`
+
+Detect AILOGs whose follow-up content is not yet extracted into the registry. Granularity is **per-AILOG** (the `fully_extracted_ailogs` frontmatter list) — the empirically validated design choice (0 false positives across 76 AILOGs in the reference adopter).
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| *(default)* | — | Scan AILOGs changed in `origin/main..HEAD` (fallback `origin/master..HEAD`, then `HEAD~1..HEAD` with a warning). Warn + **exit 1** on drift. |
+| `--apply` | off | Extract the missing entries into `## Bucket: ready` with auto-numbered `FU-NNN` ids, append the AILOG ids to `fully_extracted_ailogs`, **recompute the counters**, and upgrade v0 registries to v1 in place. Seeds the registry from the framework template when absent. |
+| `--scan-all` | off | Sweep every AILOG in the project instead of the git range. |
+| `--range <REV..REV>` | — | Explicit git range for the default scan. |
+
+**Anti-noise refinement** (issue #214 Signal 1): bullets whose AILOG text carries an explicit closure marker — `closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash — are extracted as **`suspected-closed`** instead of `open`, so already-resolved work stops polluting the `ready` bucket as TBD noise. The operator confirms (→ `closed`) or reopens at the next triage.
+
+```bash
+$ straymark followups drift --scan-all --apply
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+```
+
+#### `straymark followups promote <FU-NNN> [--title <title>] [--path <dir>]`
+
+Automate the FU → TDE elevation (`FOLLOW-UPS-BACKLOG-PATTERN.md` §Promotion to TDE): creates the TDE document from the framework template with `promoted_from_followup: FU-NNN` traceability, flips the entry to `Status: promoted` with `Destination`/`Promoted to` pointing at the TDE id, and recomputes the counters. Non-interactive (agent-friendly); the FU description becomes the TDE title unless `--title` overrides it. Prioritization and assignment stay human (`AGENT-RULES.md §3`).
+
+```bash
+$ straymark followups promote FU-010
+✓ FU-010 promoted → TDE-2026-06-04-001
+  TDE created: .straymark/06-evolution/technical-debt/TDE-2026-06-04-001-harden-staging-probe.md
 ```
 
 ---

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -143,6 +143,7 @@ Salvaguardas incorporadas que aseguran que los humanos mantengan el control:
 Comandos integrados que convierten la disciplina en feedback accionable:
 
 - **`straymark charter <new|list|status|close|drift|batch-complete|audit|refresh-suggest|amend>`** — Unidades acotadas declaradas ex-ante, auditadas ex-post. `close` registra telemetría; `drift` detecta drift archivos-vs-commits con supresión AILOG-aware y (cli-3.13.0+) hace gate sobre entradas `### Batch N (pending)` en `## Batch Ledger` del AILOG; `batch-complete` (cli-3.13.0+) marca un batch como completado en la ledger para Charters multi-batch (3+ lotes o >1 día); `audit` orquesta revisión externa multi-modelo (flujo de 3 pasos prepare/calibrate/finalize, orchestration-only — sin invocación de APIs de LLM); `refresh-suggest` (cli-3.14.0+) imprime una recomendación heurística para un refresh SpecKit pre-declare cuando la media móvil de `r_n_plus_one_emergent_count` de un módulo multi-Charter supera un umbral; `amend` (cli-3.14.0+) hace scaffolding de una enmienda post-close Batch N.4 (remediación dirigida por auditoría) sobre la misma rama de execute sin abrir un Charter nuevo. Para flujos IDE-driven, las skills inline `/straymark-audit-prompt` y `/straymark-audit-review` envuelven al CLI para mostrar prompts en la conversación y mergear findings en la telemetría.
+- **`straymark followups <list|status|drift|promote>`** *(cli-3.19.0+)* — Registro de backlog de follow-ups de primera clase (`.straymark/follow-ups-backlog.md`, schema v1 experimental): `drift --apply` extrae las entradas `§Follow-ups` / `R<N> (new)` de los AILOGs por-AILOG (los bullets con marcador de cierre aterrizan como `suspected-closed`), los contadores son propiedad del CLI y se recalculan en cada escritura, y `promote` eleva las entradas a documentos TDE con trazabilidad completa. Ver `STRAYMARK.md §16` y `FOLLOW-UPS-BACKLOG-PATTERN.md`.
 - **`straymark approve <doc-id>`** — Registra una aprobación humana formal (escribe `reviewed_by` / `reviewed_at` / `review_outcome` y la sección body `## Approval` en una sola edición; cierra el gap canonizado en DOCUMENTATION-POLICY §3.5)
 - **`straymark validate`** — 25+ reglas de validación para corrección documental (12 específicas de China son scope-aware); `--include-charters` extiende a `.straymark/charters/`; `--check-pending-reviews` lista el backlog de aprobaciones (warn-only)
 - **`straymark metrics`** — KPIs de gobernanza, tasas de revisión, distribución de riesgo, tendencias
@@ -240,7 +241,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.21.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.18.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.19.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -257,6 +258,7 @@ Verifica las versiones instaladas con `straymark status` o `straymark about`.
 | `straymark repair [path]` | Restaurar directorios y archivos del framework faltantes |
 | `straymark validate [path]` | Validar documentos por cumplimiento y corrección (use `--include-charters` para Charters, `--check-pending-reviews` para el backlog de aprobaciones) |
 | `straymark charter <subcomando>` | Gestionar Charters: `new`, `list`, `status`, `close` (registra telemetría), `drift` (drift archivos-vs-commit con AILOG-awareness) |
+| `straymark followups <subcomando>` *(cli-3.19.0+)* | Gestiona el registro del backlog de follow-ups: `list` (entradas filtrables), `status` (pulso con contadores propiedad del CLI recalculados al vuelo), `drift` (detecta/extrae AILOGs no procesados — reemplazo nativo del script bash v0, con extracción anti-ruido `suspected-closed`), `promote` (FU → TDE con trazabilidad `promoted_from_followup`) |
 | `straymark approve <doc-id>` | Registra una aprobación humana formal en un documento `review_required: true` (frontmatter + sección body canónica) |
 | `straymark compliance [path]` | Verificar cumplimiento regulatorio (EU AI Act, ISO 42001, NIST) |
 | `straymark metrics [path]` | Mostrar métricas de gobernanza y estadísticas |

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -11,7 +11,7 @@
 
 1. [Instalación](#instalación)
 2. [Versionado](#versionado)
-3. [Comandos](#comandos) — init, update, remove, status, repair, validate, new, charter, compliance, metrics, analyze, audit, explore, about
+3. [Comandos](#comandos) — init, update, remove, status, repair, validate, new, charter, followups, compliance, metrics, analyze, audit, explore, about
 4. [Variables de Entorno](#variables-de-entorno)
 5. [Códigos de Salida](#códigos-de-salida)
 
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.21.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.18.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.19.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -683,6 +683,70 @@ Los adopters pueden `git add` el directorio entero `.straymark/audits/` para un 
 > **¿Por qué orchestration-only?** Implementar 3 HTTP clients (OpenAI / Google / Anthropic) son 1-2 semanas + mantenimiento perpetuo. v1 audit-skills extiende el orchestration-only a un segundo modo (CLI auditor-side con tool use enforcement) donde el operador corre sus propias CLIs auditoras y los prompts de StrayMark enforzan la disciplina (`citar path:línea de archivos efectivamente abiertos`). StrayMark no maneja API keys, no invoca APIs, no mantiene HTTP clients.
 
 > **Alternativa con skill *(fw-4.9.0+, expandida en fw-4.9.0)*.** Tres skills envuelven el CLI para flujos IDE-driven: `/straymark-audit-prompt CHARTER-ID` (llama a `--prepare`), `/straymark-audit-execute CHARTER-ID` (corre en CLIs auditoras para leer el prompt y escribir un report), y `/straymark-audit-review CHARTER-ID` (consolida N reports en `review.md` y mergea YAML). Con estas skills el operador nunca copia/pega prompts ni reports — el intercambio sucede vía paths canónicos del filesystem bajo `.straymark/audits/`. Ver la sección [Skills](#skills) más abajo. El CLI sigue siendo la fuente única de verdad — las skills solo añaden UX-inline.
+
+---
+
+### `straymark followups <subcommand>` *(cli-3.19.0+)*
+
+Gestiona el **registro del backlog de follow-ups** (`.straymark/follow-ups-backlog.md`) — el artefacto de primera clase que agrega las entradas `§Follow-ups` y `R<N> (new, not in Charter)` a través de los AILOGs. Schema: `.straymark/schemas/follow-ups-backlog.schema.v1.json` (v1 experimental). Convención: `FOLLOW-UPS-BACKLOG-PATTERN.md` y `STRAYMARK.md §16`; directivas de agente distribuidas en `AGENT-RULES.md §13`.
+
+El parsing es **tolerante**: los registros v0 (pre-fw-4.21.0) se leen sin errores; el primer comando de escritura (`drift --apply` o `promote`) los actualiza a v1 in place, de forma no destructiva. Los contadores `total_*` del frontmatter son **propiedad del CLI** — se recalculan en cada escritura; nunca los edites a mano.
+
+- `straymark followups list` — enumera las entradas *(cli-3.19.0+)*
+- `straymark followups status` — pulso del registro / detalle de una entrada *(cli-3.19.0+)*
+- `straymark followups drift` — sincroniza el registro con los AILOGs (reemplazo nativo del `check-followups-drift.sh` adopter-side, ya deprecado) *(cli-3.19.0+)*
+- `straymark followups promote` — eleva una entrada a un documento TDE *(cli-3.19.0+)*
+
+#### `straymark followups list [--bucket <name>] [--status <s>] [--severity <s>] [--label <tag>] [path]`
+
+Tabla de entradas: id FU, status, severidad, bucket, destino, descripción. Las advertencias de parsing (encabezados `### FU-` malformados) van a stderr sin hacer fallar el comando.
+
+| Flag | Default | Descripción |
+|------|---------|-------------|
+| `--bucket <name>` | — | Filtra por bucket: `ready`, `time-triggered`, `charter-triggered`, `phase-blocked`, `operational` |
+| `--status <s>` | — | Filtra por status: `open`, `in-progress`, `suspected-closed`, `closed`, `superseded`, `promoted` |
+| `--severity <s>` | — | Filtra por severidad: `normal`, `blocking` |
+| `--label <tag>` | — | Filtra por etiqueta (match exacto case-insensitive sobre una sola etiqueta) |
+
+```bash
+$ straymark followups list --severity blocking
+  FU      STATUS  SEV       BUCKET  DEST          DESCRIPTION
+  FU-010  open    blocking  ready   mini-charter  Harden staging probe
+```
+
+#### `straymark followups status [FU-NNN] [--path <dir>]`
+
+Sin un id: el pulso del registro — contadores **recalculados al vuelo** a partir de los status reales de las entradas (fiables incluso cuando el frontmatter del archivo está obsoleto; la divergencia se señala), desglose de entradas `open` por bucket, alertas de `blocking` y `suspected-closed`, validación de schema advisory. Con un id: el detalle completo de los campos de la entrada.
+
+#### `straymark followups drift [--apply] [--scan-all] [--range <REV..REV>] [--path <dir>]`
+
+Detecta los AILOGs cuyo contenido de follow-ups aún no se ha extraído al registro. La granularidad es **por-AILOG** (la lista `fully_extracted_ailogs` del frontmatter) — la decisión de diseño validada empíricamente (0 falsos positivos a través de 76 AILOGs en el adoptante de referencia).
+
+| Flag | Default | Descripción |
+|------|---------|-------------|
+| *(default)* | — | Escanea los AILOGs cambiados en `origin/main..HEAD` (fallback `origin/master..HEAD`, luego `HEAD~1..HEAD` con una advertencia). Avisa + **exit 1** ante drift. |
+| `--apply` | off | Extrae las entradas faltantes a `## Bucket: ready` con ids `FU-NNN` auto-numerados, añade los ids de los AILOGs a `fully_extracted_ailogs`, **recalcula los contadores**, y actualiza los registros v0 a v1 in place. Siembra el registro desde el template del framework cuando no existe. |
+| `--scan-all` | off | Barre cada AILOG del proyecto en lugar del rango de git. |
+| `--range <REV..REV>` | — | Rango de git explícito para el escaneo por defecto. |
+
+**Refinamiento anti-ruido** (issue #214 Signal 1): los bullets cuyo texto del AILOG lleva un marcador de cierre explícito — `closed in-Charter`, `fixed in batch N`, un commit hash entre backticks — se extraen como **`suspected-closed`** en lugar de `open`, así el trabajo ya resuelto deja de contaminar el bucket `ready` como ruido TBD. El operador confirma (→ `closed`) o reabre en el siguiente triage.
+
+```bash
+$ straymark followups drift --scan-all --apply
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+```
+
+#### `straymark followups promote <FU-NNN> [--title <title>] [--path <dir>]`
+
+Automatiza la elevación FU → TDE (`FOLLOW-UPS-BACKLOG-PATTERN.md` §Promotion to TDE): crea el documento TDE desde el template del framework con trazabilidad `promoted_from_followup: FU-NNN`, cambia la entrada a `Status: promoted` con `Destination`/`Promoted to` apuntando al id del TDE, y recalcula los contadores. No interactivo (agent-friendly); la descripción del FU se vuelve el título del TDE salvo que `--title` lo sobreescriba. La priorización y la asignación siguen siendo humanas (`AGENT-RULES.md §3`).
+
+```bash
+$ straymark followups promote FU-010
+✓ FU-010 promoted → TDE-2026-06-04-001
+  TDE created: .straymark/06-evolution/technical-debt/TDE-2026-06-04-001-harden-staging-probe.md
+```
 
 ---
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -143,6 +143,7 @@ StrayMark 的产品决策基于十二条明确的原则。它们按层级排序�
 将纪律转化为可执行反馈的内置命令：
 
 - **`straymark charter <new|list|status|close|drift|batch-complete|audit|refresh-suggest|amend>`** — 事前声明、事后审计的有界工作单元。`close` 记录执行后遥测；`drift` 以 AILOG-aware 抑制方式检测文件-与-commit 的偏差，并（cli-3.13.0+）对 AILOG `## Batch Ledger` 中的 `### Batch N (pending)` 条目进行门控；`batch-complete`（cli-3.13.0+）将批次标记为已在多批次章程（3+ 批次或 >1 天）的台账中完成；`audit` 编排多模型外部审查（三步骤 prepare/calibrate/finalize，仅编排——不调用 LLM API）；`refresh-suggest`（cli-3.14.0+）当多 Charter 模块的 `r_n_plus_one_emergent_count` 滚动均值超过阈值时，输出预声明 SpecKit 刷新的启发式建议；`amend`（cli-3.14.0+）为关闭后审计驱动的 Batch N.4 修订做脚手架，在原 execute 分支上落地而不开启新 Charter。对于 IDE 驱动的工作流，内联 skills `/straymark-audit-prompt` 和 `/straymark-audit-review` 封装 CLI，在对话中展示 prompts 并将 findings 合并到遥测中。
+- **`straymark followups <list|status|drift|promote>`** *(cli-3.19.0+)* — 一等的后续事项积压注册表（`.straymark/follow-ups-backlog.md`，schema v1 实验性）：`drift --apply` 按 AILOG 从 AILOG 中提取 `§Follow-ups` / `R<N> (new)` 条目（带闭合标记的 bullet 落为 `suspected-closed`），计数器由 CLI 拥有并在每次写入时重新计算，`promote` 将条目提升为带完整溯源的 TDE 文档。详见 `STRAYMARK.md §16` 与 `FOLLOW-UPS-BACKLOG-PATTERN.md`。
 - **`straymark approve <doc-id>`** — 记录一次正式的人工审批（一次性写入 `reviewed_by` / `reviewed_at` / `review_outcome` 与 `## Approval` body 章节；闭合 DOCUMENTATION-POLICY §3.5 中规范化的缺口）
 - **`straymark validate`** — 25+ 条文档正确性验证规则（其中 12 条针对中国法规、按 scope 启用）；`--include-charters` 可同时检查 `.straymark/charters/`；`--check-pending-reviews` 列出审批积压（仅警告）
 - **`straymark metrics`** — 治理 KPI、审查率、风险分布、趋势
@@ -258,7 +259,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.21.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.18.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.19.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 
@@ -275,6 +276,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | `straymark repair [path]` | 恢复缺失的目录和框架文件 |
 | `straymark validate [path]` | 验证文档的合规性和正确性（`--include-charters` 同时校验 Charter；`--check-pending-reviews` 列出审批积压） |
 | `straymark charter <子命令>` | 管理章程：`new`、`list`、`status`、`close`（记录遥测）、`drift`（带 AILOG-awareness 的偏差检测） |
+| `straymark followups <子命令>` *(cli-3.19.0+)* | 管理后续事项积压注册表：`list`（可过滤的条目）、`status`（带 CLI 拥有、即时重新计算的计数器的概览）、`drift`（检测/提取未处理的 AILOG —— v0 bash 脚本的原生替代，带抗噪声的 `suspected-closed` 提取）、`promote`（FU → TDE，带 `promoted_from_followup` 溯源） |
 | `straymark approve <doc-id>` | 在 `review_required: true` 的文档上记录一次正式的人工审批（frontmatter + 规范的 body 章节） |
 | `straymark compliance [path]` | 检查法规合规（EU AI Act、ISO 42001、NIST） |
 | `straymark metrics [path]` | 显示治理指标和文档统计 |

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -11,7 +11,7 @@
 
 1. [安装](#安装)
 2. [版本管理](#版本管理)
-3. [命令](#命令) — init, update, remove, status, repair, validate, new, charter, compliance, metrics, analyze, audit, explore, about
+3. [命令](#命令) — init, update, remove, status, repair, validate, new, charter, followups, compliance, metrics, analyze, audit, explore, about
 4. [环境变量](#环境变量)
 5. [退出码](#退出码)
 
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.21.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.18.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.19.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -726,6 +726,70 @@ $ straymark charter audit CHARTER-05 --finalize
 > **为什么仅编排？** 实现 3 个 HTTP 客户端（OpenAI / Google / Anthropic）需要 1-2 周 + 当 API 变化时的永久维护。Phase 3 v0 是实验性的 — CLI 的价值是 canon（prompt 形状 + output schema + 与遥测的集成），而非 API 调用本身。当 adopter 报告真实需求时，v1 可能加入 HTTP 客户端；在此之前，人在环模式与激发 Phase 3 的 Sentinel 实证 `/plan-audit` 模式相符。
 
 > **Skill 替代方案 *(fw-4.9.0+)*。** 当与 AI 助手在循环中协作时（Claude Code、Gemini Code、Cursor 等），skills `/straymark-audit-prompt CHARTER-ID` 和 `/straymark-audit-review CHARTER-ID` 封装此命令并在对话中内联展示 prompts。Skills 还处理校准器步骤（驱动对话的 Agent 运行校准器）并触发 `--finalize --merge-into`，使得 `external_audit:` 数组直接追加到遥测中无需手动复制粘贴。详见下方的 [Skills](#skills) 章节。CLI 仍是唯一真相来源 — skills 仅添加 UX-inline。
+
+---
+
+### `straymark followups <subcommand>` *(cli-3.19.0+)*
+
+管理**后续事项积压注册表**（`.straymark/follow-ups-backlog.md`）—— 这是跨 AILOG 聚合 `§Follow-ups` 与 `R<N> (new, not in Charter)` 条目的一等产物。Schema：`.straymark/schemas/follow-ups-backlog.schema.v1.json`（实验性 v1）。约定：`FOLLOW-UPS-BACKLOG-PATTERN.md` 与 `STRAYMARK.md §16`；随附的代理指令见 `AGENT-RULES.md §13`。
+
+解析是**宽容的**：v0 注册表（fw-4.21.0 之前）可被无误读取；首个写入命令（`drift --apply` 或 `promote`）会就地、非破坏性地将其升级为 v1。frontmatter 的 `total_*` 计数器由 **CLI 拥有** —— 每次写入时重新计算；切勿手工编辑。
+
+- `straymark followups list` — 枚举条目 *(cli-3.19.0+)*
+- `straymark followups status` — 注册表概览 / 条目详情 *(cli-3.19.0+)*
+- `straymark followups drift` — 将注册表与 AILOG 同步（已弃用的 adopter 侧 `check-followups-drift.sh` 的原生替代）*(cli-3.19.0+)*
+- `straymark followups promote` — 将条目提升为 TDE 文档 *(cli-3.19.0+)*
+
+#### `straymark followups list [--bucket <name>] [--status <s>] [--severity <s>] [--label <tag>] [path]`
+
+条目表格：FU id、status、severity、bucket、destination、description。解析告警（格式错误的 `### FU-` 标题）输出到 stderr 而不会使命令失败。
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--bucket <name>` | — | 按 bucket 过滤：`ready`、`time-triggered`、`charter-triggered`、`phase-blocked`、`operational` |
+| `--status <s>` | — | 按 status 过滤：`open`、`in-progress`、`suspected-closed`、`closed`、`superseded`、`promoted` |
+| `--severity <s>` | — | 按 severity 过滤：`normal`、`blocking` |
+| `--label <tag>` | — | 按 label 过滤（对单个 tag 的大小写不敏感精确匹配） |
+
+```bash
+$ straymark followups list --severity blocking
+  FU      STATUS  SEV       BUCKET  DEST          DESCRIPTION
+  FU-010  open    blocking  ready   mini-charter  Harden staging probe
+```
+
+#### `straymark followups status [FU-NNN] [--path <dir>]`
+
+不带 id：注册表概览 —— 计数器从实际条目状态**即时重新计算**（即使文件 frontmatter 已陈旧也可信；分歧会被标记）、按 bucket 的 open 明细、blocking 与 suspected-closed 告警、咨询性 schema 校验。带 id：该条目的完整字段详情。
+
+#### `straymark followups drift [--apply] [--scan-all] [--range <REV..REV>] [--path <dir>]`
+
+检测其后续事项内容尚未提取到注册表的 AILOG。粒度为**按 AILOG**（frontmatter 的 `fully_extracted_ailogs` 列表）—— 经实证验证的设计选择（在参考 adopter 的 76 个 AILOG 中 0 误报）。
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| *(default)* | — | 扫描在 `origin/main..HEAD` 中变更的 AILOG（回退到 `origin/master..HEAD`，再回退到带告警的 `HEAD~1..HEAD`）。有漂移时告警并 **exit 1**。 |
+| `--apply` | off | 将缺失的条目提取到 `## Bucket: ready`，使用自动编号的 `FU-NNN` id，把 AILOG id 追加到 `fully_extracted_ailogs`，**重新计算计数器**，并就地把 v0 注册表升级为 v1。注册表不存在时从框架模板播种。 |
+| `--scan-all` | off | 扫描项目中的每一个 AILOG，而非 git 范围。 |
+| `--range <REV..REV>` | — | 默认扫描的显式 git 范围。 |
+
+**抗噪声精炼**（issue #214 Signal 1）：其 AILOG 文本带有显式闭合标记的条目 —— `closed in-Charter`、`fixed in batch N`、反引号包裹的 commit hash —— 会被提取为 **`suspected-closed`** 而非 `open`，从而避免已解决的工作以 TBD 噪声污染 `ready` bucket。操作员在下次分诊时确认（→ `closed`）或重开。
+
+```bash
+$ straymark followups drift --scan-all --apply
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+```
+
+#### `straymark followups promote <FU-NNN> [--title <title>] [--path <dir>]`
+
+自动化 FU → TDE 的提升（`FOLLOW-UPS-BACKLOG-PATTERN.md` §Promotion to TDE）：从框架模板创建带 `promoted_from_followup: FU-NNN` 溯源的 TDE 文档，将条目翻转为 `Status: promoted` 并使 `Destination`/`Promoted to` 指向该 TDE id，再重新计算计数器。非交互式（对 agent 友好）；除非 `--title` 覆盖，否则 FU 描述将成为 TDE 标题。优先级排序与分配仍由人工决定（`AGENT-RULES.md §3`）。
+
+```bash
+$ straymark followups promote FU-010
+✓ FU-010 promoted → TDE-2026-06-04-001
+  TDE created: .straymark/06-evolution/technical-debt/TDE-2026-06-04-001-harden-staging-probe.md
+```
 
 ---
 


### PR DESCRIPTION
## Summary

CLI half of [ADR-2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md), companion to **fw-4.21.0** (#217). Collapses Tiers 2+4 of #135 into one native implementation; Tier 3 stays gated.

### New namespace

| Command | What it does |
|---|---|
| `followups list` | Filterable table (`--bucket`, `--status`, `--severity`, `--label`) |
| `followups status [FU-NNN]` | Registry pulse — counters **recomputed on the fly**, stale frontmatter flagged (#214 Signal 2) — or entry detail |
| `followups drift [--apply\|--scan-all]` | Native replacement for the adopter-side bash script. `--apply`: per-AILOG extraction, **CLI-owned counter recompute**, idempotent **v0→v1 in-place upgrade**, **anti-noise** (closure markers → `suspected-closed`, #214 Signal 1) |
| `followups promote FU-NNN` | FU → TDE with `promoted_from_followup` traceability; non-interactive (prioritization stays human) |

### Integration

- **`explore` TUI**: synthetic *Follow-ups* group — registry root + sub-node per bucket, one entry per FU (badge `FU`, labels as tags, `FU-NNN` ids resolve as refs). Mirrors `_charters`.
- **`status`**: Follow-ups block with recomputed breakdown + blocking-severity alert.
- `split_frontmatter` extracted to `utils.rs` (shared by charter + followups parsers).
- `followups.rs` is pure parsing (no clap/colored) and doc-tagged `Move target: straymark-core (Loom M0)`.

### Robustness contract (lenient by design)

- v0 registries (Sentinel-style, 91 FUs in production) parse with zero errors; all v1 fields optional.
- Writes are **surgical text edits** — unknown frontmatter fields survive, untouched body content is preserved byte-for-byte.
- Malformed `### FU-` headings warn, never fail.

### Tests

**611 green** (569 existing + 42 new: 25 unit in `followups.rs`/`followups_schema.rs`, 17 integration in `tests/followups_test.rs`): v0 lenient parsing, v1 dimensions, closure-marker detection (incl. false-positive guards), counter recompute 47→real, idempotent upgrade, promote round-trip, TUI group presence/absence, status block.

Smoke-tested end-to-end on a Sentinel-style fixture: drift→status→list→promote→detail ([transcript in PR conversation if needed]).

### Not in this PR

- `/straymark-followups` skill (ships in dist/ → rides the next fw release; dogfooded as an FU in the close-out PR).
- #135 Tier 3 (`charter close` soft-integration) — still gated on N=2 friction signal.

**After merge**: tag `cli-3.19.0` (Cargo.toml verified: `3.19.0`).

Refs #214, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)