### PR TITLE
fix(cli): cli-3.19.1 — parse annotated registry status values leniently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.19.1 — registry status annotations parse leniently
+
+Patch found by validating cli-3.19.0 against the Sentinel production registry (65 entries): operators annotate status values in place — `- **Status**: open — **OVERDUE** (…)`, `open — mitigation in place (…)` — and the exact-match parser demoted those to `unknown`, which would have **undercounted the CLI-owned `total_open`** (observed live: 58 vs 62) on the first v0 → v1 migration write.
+
+### Fixed (CLI)
+
+- **`FuStatus::from_str_loose` / `Severity::from_str_loose`**: when the full value doesn't match the vocabulary, retry on the first whitespace-delimited token — so the in-place annotation idiom parses as its real status. Genuinely unknown values (e.g. `reopened`) still map to `unknown` (no over-match). Verified against the Sentinel registry: 65/65 entries now parse to their intended status (62 open / 3 promoted, zero unknown), matching the operator-declared counters exactly.
+
+---
+
 ## CLI 3.19.0 — `straymark followups` namespace (companion to fw-4.21.0)
 
 Ships the native CLI surface for the follow-ups backlog registry crystallized in fw-4.21.0 ([`ADR-2026-06-03-001`](docs/decisions/ADR-2026-06-03-followups-first-class.md), driven by [#214](https://github.com/StrangeDaysTech/straymark/issues/214)). The registry stops being invisible to tooling: it gains a CLI namespace, a synthetic group in `explore`, and a block in `status`. Collapses Tiers 2 and 4 of [#135](https://github.com/StrangeDaysTech/straymark/issues/135) into one native implementation; Tier 3 (`charter close` soft-integration) remains gated.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.21.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.19.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.19.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2324,7 +2324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.19.0"
+version = "3.19.1"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.19.0"
+version = "3.19.1"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/followups.rs
+++ b/cli/src/followups.rs
@@ -58,7 +58,7 @@ impl FuStatus {
     }
 
     pub fn from_str_loose(s: &str) -> Self {
-        match s.trim().to_lowercase().as_str() {
+        let exact = |v: &str| match v {
             "open" => Self::Open,
             "in-progress" | "in progress" => Self::InProgress,
             "suspected-closed" | "suspected closed" => Self::SuspectedClosed,
@@ -66,6 +66,21 @@ impl FuStatus {
             "superseded" => Self::Superseded,
             "promoted" => Self::Promoted,
             _ => Self::Unknown,
+        };
+        let lower = s.trim().to_lowercase();
+        let parsed = exact(&lower);
+        if parsed != Self::Unknown {
+            return parsed;
+        }
+        // Leniency fallback (cli-3.19.1, found validating against the
+        // Sentinel production registry): operators annotate the status value
+        // in place — `open — **OVERDUE** (…)`, `open — mitigation in place`.
+        // Take the first whitespace-delimited token and rematch, so the
+        // annotation idiom doesn't demote real statuses to Unknown (which
+        // would undercount the CLI-owned `total_open` on migration).
+        match lower.split_whitespace().next() {
+            Some(first) => exact(first),
+            None => Self::Unknown,
         }
     }
 }
@@ -87,11 +102,14 @@ impl Severity {
     }
 
     pub fn from_str_loose(s: &str) -> Option<Self> {
-        match s.trim().to_lowercase().as_str() {
+        let exact = |v: &str| match v {
             "normal" => Some(Self::Normal),
             "blocking" | "prod-blocker" => Some(Self::Blocking),
             _ => None,
-        }
+        };
+        let lower = s.trim().to_lowercase();
+        // Same first-token annotation fallback as FuStatus::from_str_loose.
+        exact(&lower).or_else(|| lower.split_whitespace().next().and_then(exact))
     }
 }
 
@@ -1251,5 +1269,65 @@ Done.
     fn registry_without_frontmatter_errors_with_hint() {
         let err = parse_registry_str(Path::new("x.md"), "# no frontmatter\n").unwrap_err();
         assert!(err.to_string().contains("no YAML frontmatter"));
+    }
+
+    #[test]
+    fn status_tolerates_inline_annotations_after_value() {
+        // Real idiom from the Sentinel production registry (cli-3.19.1):
+        // the status value carries an in-place annotation after an em dash.
+        assert_eq!(
+            FuStatus::from_str_loose("open — **OVERDUE** (15-Apr-2026 was 22 days ago)"),
+            FuStatus::Open
+        );
+        assert_eq!(
+            FuStatus::from_str_loose("open — mitigation in place (`-timeout` default 600s)"),
+            FuStatus::Open
+        );
+        assert_eq!(
+            FuStatus::from_str_loose("suspected-closed — confirm at triage"),
+            FuStatus::SuspectedClosed
+        );
+        assert_eq!(
+            FuStatus::from_str_loose("promoted (see TDE-2026-05-01-001)"),
+            FuStatus::Promoted
+        );
+        // Genuinely unknown values stay Unknown — the annotation fallback
+        // must not over-match.
+        assert_eq!(FuStatus::from_str_loose("reopened — by audit"), FuStatus::Unknown);
+        assert_eq!(FuStatus::from_str_loose(""), FuStatus::Unknown);
+    }
+
+    #[test]
+    fn severity_tolerates_inline_annotations_after_value() {
+        assert_eq!(
+            Severity::from_str_loose("blocking — must land before prod cutover"),
+            Some(Severity::Blocking)
+        );
+        assert_eq!(Severity::from_str_loose("normal (default)"), Some(Severity::Normal));
+        assert_eq!(Severity::from_str_loose("urgent — not a vocab value"), None);
+    }
+
+    #[test]
+    fn annotated_statuses_count_into_recomputed_counters() {
+        // The undercount this fix prevents: an annotated `open` must count
+        // as open, or the CLI-owned total_open writes the wrong number on
+        // migration (observed live: Sentinel registry, 58 vs 62).
+        let content = r#"---
+schema_version: v0
+fully_extracted_ailogs: []
+---
+
+## Bucket: ready
+
+### FU-001 — annotated open
+- **Status**: open — **OVERDUE** (15-Apr-2026)
+
+### FU-002 — plain open
+- **Status**: open
+"#;
+        let reg = parse(content);
+        let c = compute_counters(&reg);
+        assert_eq!(c.open, 2);
+        assert!(reg.entries().all(|e| e.status == FuStatus::Open));
     }
 }

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.21.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.19.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.19.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -241,7 +241,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.21.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.19.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.19.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.21.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.19.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.19.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -259,7 +259,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.21.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.19.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.19.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.21.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.19.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.19.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 


### PR DESCRIPTION
## Summary

Patch surfaced by the plan's final validation step: running the cli-3.19.0 release binary (read-only) against **Sentinel's production registry** (65 structured entries).

### The bug

Sentinel's operator annotates status values in place — a registry idiom none of our fixtures had:

```markdown
- **Status**: open — **OVERDUE** (15-Apr-2026 was 22 days ago)
- **Status**: open — mitigation in place (`-timeout=$(INTEG_TIMEOUT)` default 600s in Makefile)
```

The exact-match parser demoted 4 such entries to `unknown`, which would have **undercounted the CLI-owned `total_open`** (58 written vs 62 intended) on the first `drift --apply` migration — precisely the counter-corruption class the v1 design exists to eliminate (#214 Signal 2).

### The fix

`FuStatus::from_str_loose` / `Severity::from_str_loose`: when the full value doesn't match the vocabulary, retry on the **first whitespace-delimited token**. Genuinely unknown values (`reopened`) still map to `unknown` — no over-match (guarded by tests).

### Verification

- 3 new regression tests with the verbatim Sentinel lines + counter-recompute assertion. Suite: **614 green**.
- Release binary re-run against the live Sentinel registry: **65/65 entries parse to their intended status** (62 open / 3 promoted, 0 unknown) — matching the operator-declared `total_open: 62` exactly.

**After merge**: tag `cli-3.19.1` (Cargo.toml verified: `3.19.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)