### PR TITLE
feat(framework): fw-4.22.0 — /straymark-followups skill across 4 agent surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.22.0 — `/straymark-followups` skill ships the §13 directives as an invocable wrapper
+
+Closes the last gap in the follow-ups first-class lane (fw-4.21.0 / cli-3.19.0): the `AGENT-RULES.md §13` directives — session-start "what's pending?" answered from the canonical registry, pre-commit `followups drift --apply` riding the same commit as the AILOG, post-Charter-close triage and operator-gated `promote` — now ship as an invocable skill across all four agent surfaces, mirroring the `straymark-charter-new` lane. Driven by [#220](https://github.com/StrangeDaysTech/straymark/issues/220) (deferred from the cli-3.19.0 PR because skills ride framework releases and fw-4.21.0 was already tagged). The skill is a **thin wrapper**: parsing, schema validation, counter recomputation, and the FU → TDE elevation all stay in the CLI (`straymark followups list/status/drift/promote`, cli-3.19.0+); the skill only drives the discipline.
+
+### Added (Framework)
+
+- **`/straymark-followups` skill** in all four agent surfaces — `.claude/skills/` (source of truth, full frontmatter), `.gemini/skills/`, `.agent/workflows/`, and the generated `.codex/skills/` (via `gen_codex_skills`). Wraps the three `AGENT-RULES.md §13` sub-flows; `allowed-tools` deliberately omits `Write` — every registry mutation goes through the CLI, and the frontmatter counters stay CLI-owned.
+- **Skills table rows** for `/straymark-followups` in `QUICK-REFERENCE.md` (EN/ES/zh-CN) and in the `CLI-REFERENCE.md` Skills section (EN/ES/zh-CN). The CLI-REFERENCE table also gains the previously missing `/straymark-charter-new` row (shipped in fw-4.12.0, never listed there).
+
+### Adopter guidance
+
+Run `straymark update-framework` (→ `fw-4.22.0`). Claude and Gemini pick the skill up directly from the project tree; for Codex, re-run `straymark install-skills --agent codex` once to refresh the user-level skills directory. `/straymark-followups` is then invocable in any adopter repo that maintains the registry.
+
+---
+
 ## CLI 3.19.1 — registry status annotations parse leniently
 
 Patch found by validating cli-3.19.0 against the Sentinel production registry (65 entries): operators annotate status values in place — `- **Status**: open — **OVERDUE** (…)`, `open — mitigation in place (…)` — and the exact-match parser demoted those to `unknown`, which would have **undercounted the CLI-owned `total_open`** (observed live: 58 vs 62) on the first v0 → v1 migration write.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
-| Framework | `fw-` | `fw-4.21.0` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.22.0` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.19.1` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -311,7 +311,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.21.0)
+# and download the latest fw-* release (e.g., fw-4.22.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/dist/.agent/workflows/straymark-followups.md
+++ b/dist/.agent/workflows/straymark-followups.md
@@ -1,0 +1,83 @@
+---
+description: Maintain the follow-ups backlog registry — the canonical answer to "what's pending?". Session-start glance, pre-commit drift --apply, post-Charter-close triage and operator-gated promote. Thin wrapper over the straymark followups CLI; never edits CLI-owned counters by hand.
+---
+
+# StrayMark Follow-ups Registry Skill
+
+Maintain the central follow-ups registry (`.straymark/follow-ups-backlog.md`) — the first-class artifact that aggregates `§Follow-ups` and `R<N> (new, not in Charter)` entries across AILOGs *(first-class since fw-4.21.0 / cli-3.19.0)*. The agent is the registry's **primary maintainer**; this skill drives the three directives of `AGENT-RULES.md §13` by delegating every mutation to the CLI (`straymark followups list/status/drift/promote`). The skill contains no extraction or counting logic of its own — parsing, schema validation, counter recomputation, and FU → TDE elevation all live in the CLI.
+
+> See `.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16` for the pattern; `AGENT-RULES.md §13` for the shipped directives this skill wraps.
+
+## When to use this skill
+
+Trigger on any of:
+
+- Session start, or the operator asks *"what's pending?"* / *"what follow-ups do we have?"*.
+- You created or modified an AILOG containing `## Follow-ups` or `R<N> (new, not in Charter)` entries and are about to commit.
+- A Charter just closed and the registry entries it resolved need triage.
+- The operator asks to promote a follow-up to a TDE document.
+
+If the project does not maintain the registry (the per-AILOG `§Follow-ups` convention alone is enough below ~20 AILOGs — see the pattern doc), this skill does not apply.
+
+## Instructions
+
+### 1. Session start — answer from the registry
+
+The registry is the **canonical source** for "what's pending". Answer from it; do not re-scan AILOGs.
+
+```bash
+straymark followups status                      # registry pulse: counters recomputed on the fly,
+                                                # per-bucket breakdown, blocking / suspected-closed alerts
+straymark followups list                        # full entry table
+straymark followups list --severity blocking    # focus on blockers
+straymark followups status FU-NNN               # one entry's full field detail
+```
+
+Fall back to an AILOG scan **only** when the registry does not exist, or when `straymark followups drift` reports unextracted AILOGs.
+
+### 2. Pre-commit — registry rides the same commit as the AILOG
+
+Created or modified any AILOG with `## Follow-ups` or `R<N> (new, not in Charter)` entries? Sync before committing:
+
+```bash
+straymark followups drift            # detect unextracted AILOGs (exit 1 on drift)
+straymark followups drift --apply    # extract into `## Bucket: ready`, auto-number FU-NNN ids,
+                                     # recompute counters, upgrade v0 registries to v1 in place
+```
+
+so the registry extension rides **the same commit** as the AILOG. Bullets whose AILOG text already carries a closure marker (`closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash) are extracted as `suspected-closed` automatically — **do not delete them**; the operator confirms at the next triage.
+
+### 3. Post-Charter close — triage what the Charter resolved
+
+Review the registry entries the just-closed Charter resolved:
+
+```bash
+straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
+```
+
+- Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
+- Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
+
+### 4. Report result
+
+Surface the CLI output verbatim (counters, alerts, created TDE paths). Example after a pre-commit sync:
+
+```
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+
+StrayMark: registry synced — commit it together with the AILOG.
+```
+
+## What this skill does NOT do
+
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
+- **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
+- **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.
+- **It does not replace the per-AILOG `§Follow-ups` section.** That stays the write-time capture point; the registry aggregates it via `drift --apply`.
+
+> **Terminal compatibility**: If the terminal does not support box-drawing characters (Unicode), use plain-text formatting with dashes and pipes instead (e.g., `+--+` instead of `╔══╗`).

--- a/dist/.claude/skills/straymark-followups/SKILL.md
+++ b/dist/.claude/skills/straymark-followups/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: straymark-followups
+description: Maintain the follow-ups backlog registry — the canonical answer to "what's pending?". Session-start glance, pre-commit drift --apply, post-Charter-close triage and operator-gated promote. Thin wrapper over the straymark followups CLI; never edits CLI-owned counters by hand.
+allowed-tools: Read, Glob, Bash(git diff *, git log *, git status *, ls *, straymark followups *)
+---
+
+# StrayMark Follow-ups Registry Skill
+
+Maintain the central follow-ups registry (`.straymark/follow-ups-backlog.md`) — the first-class artifact that aggregates `§Follow-ups` and `R<N> (new, not in Charter)` entries across AILOGs *(first-class since fw-4.21.0 / cli-3.19.0)*. The agent is the registry's **primary maintainer**; this skill drives the three directives of `AGENT-RULES.md §13` by delegating every mutation to the CLI (`straymark followups list/status/drift/promote`). The skill contains no extraction or counting logic of its own — parsing, schema validation, counter recomputation, and FU → TDE elevation all live in the CLI.
+
+> See `.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16` for the pattern; `AGENT-RULES.md §13` for the shipped directives this skill wraps.
+
+## When to use this skill
+
+Trigger on any of:
+
+- Session start, or the operator asks *"what's pending?"* / *"what follow-ups do we have?"*.
+- You created or modified an AILOG containing `## Follow-ups` or `R<N> (new, not in Charter)` entries and are about to commit.
+- A Charter just closed and the registry entries it resolved need triage.
+- The operator asks to promote a follow-up to a TDE document.
+
+If the project does not maintain the registry (the per-AILOG `§Follow-ups` convention alone is enough below ~20 AILOGs — see the pattern doc), this skill does not apply.
+
+## Instructions
+
+### 1. Session start — answer from the registry
+
+The registry is the **canonical source** for "what's pending". Answer from it; do not re-scan AILOGs.
+
+```bash
+straymark followups status                      # registry pulse: counters recomputed on the fly,
+                                                # per-bucket breakdown, blocking / suspected-closed alerts
+straymark followups list                        # full entry table
+straymark followups list --severity blocking    # focus on blockers
+straymark followups status FU-NNN               # one entry's full field detail
+```
+
+Fall back to an AILOG scan **only** when the registry does not exist, or when `straymark followups drift` reports unextracted AILOGs.
+
+### 2. Pre-commit — registry rides the same commit as the AILOG
+
+Created or modified any AILOG with `## Follow-ups` or `R<N> (new, not in Charter)` entries? Sync before committing:
+
+```bash
+straymark followups drift            # detect unextracted AILOGs (exit 1 on drift)
+straymark followups drift --apply    # extract into `## Bucket: ready`, auto-number FU-NNN ids,
+                                     # recompute counters, upgrade v0 registries to v1 in place
+```
+
+so the registry extension rides **the same commit** as the AILOG. Bullets whose AILOG text already carries a closure marker (`closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash) are extracted as `suspected-closed` automatically — **do not delete them**; the operator confirms at the next triage.
+
+### 3. Post-Charter close — triage what the Charter resolved
+
+Review the registry entries the just-closed Charter resolved:
+
+```bash
+straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
+```
+
+- Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
+- Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
+
+### 4. Report result
+
+Surface the CLI output verbatim (counters, alerts, created TDE paths). Example after a pre-commit sync:
+
+```
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+
+StrayMark: registry synced — commit it together with the AILOG.
+```
+
+## What this skill does NOT do
+
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
+- **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
+- **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.
+- **It does not replace the per-AILOG `§Follow-ups` section.** That stays the write-time capture point; the registry aggregates it via `drift --apply`.
+
+> **Terminal compatibility**: If the terminal does not support box-drawing characters (Unicode), use plain-text formatting with dashes and pipes instead (e.g., `+--+` instead of `╔══╗`).

--- a/dist/.codex/skills/straymark-followups/SKILL.md
+++ b/dist/.codex/skills/straymark-followups/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: straymark-followups
+description: Maintain the follow-ups backlog registry — the canonical answer to "what's pending?". Session-start glance, pre-commit drift --apply, post-Charter-close triage and operator-gated promote. Thin wrapper over the straymark followups CLI; never edits CLI-owned counters by hand.
+---
+
+# StrayMark Follow-ups Registry Skill
+
+Maintain the central follow-ups registry (`.straymark/follow-ups-backlog.md`) — the first-class artifact that aggregates `§Follow-ups` and `R<N> (new, not in Charter)` entries across AILOGs *(first-class since fw-4.21.0 / cli-3.19.0)*. The agent is the registry's **primary maintainer**; this skill drives the three directives of `AGENT-RULES.md §13` by delegating every mutation to the CLI (`straymark followups list/status/drift/promote`). The skill contains no extraction or counting logic of its own — parsing, schema validation, counter recomputation, and FU → TDE elevation all live in the CLI.
+
+> See `.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16` for the pattern; `AGENT-RULES.md §13` for the shipped directives this skill wraps.
+
+## When to use this skill
+
+Trigger on any of:
+
+- Session start, or the operator asks *"what's pending?"* / *"what follow-ups do we have?"*.
+- You created or modified an AILOG containing `## Follow-ups` or `R<N> (new, not in Charter)` entries and are about to commit.
+- A Charter just closed and the registry entries it resolved need triage.
+- The operator asks to promote a follow-up to a TDE document.
+
+If the project does not maintain the registry (the per-AILOG `§Follow-ups` convention alone is enough below ~20 AILOGs — see the pattern doc), this skill does not apply.
+
+## Instructions
+
+### 1. Session start — answer from the registry
+
+The registry is the **canonical source** for "what's pending". Answer from it; do not re-scan AILOGs.
+
+```bash
+straymark followups status                      # registry pulse: counters recomputed on the fly,
+                                                # per-bucket breakdown, blocking / suspected-closed alerts
+straymark followups list                        # full entry table
+straymark followups list --severity blocking    # focus on blockers
+straymark followups status FU-NNN               # one entry's full field detail
+```
+
+Fall back to an AILOG scan **only** when the registry does not exist, or when `straymark followups drift` reports unextracted AILOGs.
+
+### 2. Pre-commit — registry rides the same commit as the AILOG
+
+Created or modified any AILOG with `## Follow-ups` or `R<N> (new, not in Charter)` entries? Sync before committing:
+
+```bash
+straymark followups drift            # detect unextracted AILOGs (exit 1 on drift)
+straymark followups drift --apply    # extract into `## Bucket: ready`, auto-number FU-NNN ids,
+                                     # recompute counters, upgrade v0 registries to v1 in place
+```
+
+so the registry extension rides **the same commit** as the AILOG. Bullets whose AILOG text already carries a closure marker (`closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash) are extracted as `suspected-closed` automatically — **do not delete them**; the operator confirms at the next triage.
+
+### 3. Post-Charter close — triage what the Charter resolved
+
+Review the registry entries the just-closed Charter resolved:
+
+```bash
+straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
+```
+
+- Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
+- Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
+
+### 4. Report result
+
+Surface the CLI output verbatim (counters, alerts, created TDE paths). Example after a pre-commit sync:
+
+```
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+
+StrayMark: registry synced — commit it together with the AILOG.
+```
+
+## What this skill does NOT do
+
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
+- **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
+- **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.
+- **It does not replace the per-AILOG `§Follow-ups` section.** That stays the write-time capture point; the registry aggregates it via `drift --apply`.
+
+> **Terminal compatibility**: If the terminal does not support box-drawing characters (Unicode), use plain-text formatting with dashes and pipes instead (e.g., `+--+` instead of `╔══╗`).

--- a/dist/.gemini/skills/straymark-followups/SKILL.md
+++ b/dist/.gemini/skills/straymark-followups/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: straymark-followups
+description: Maintain the follow-ups backlog registry — the canonical answer to "what's pending?". Session-start glance, pre-commit drift --apply, post-Charter-close triage and operator-gated promote. Thin wrapper over the straymark followups CLI; never edits CLI-owned counters by hand.
+---
+
+# StrayMark Follow-ups Registry Skill
+
+Maintain the central follow-ups registry (`.straymark/follow-ups-backlog.md`) — the first-class artifact that aggregates `§Follow-ups` and `R<N> (new, not in Charter)` entries across AILOGs *(first-class since fw-4.21.0 / cli-3.19.0)*. The agent is the registry's **primary maintainer**; this skill drives the three directives of `AGENT-RULES.md §13` by delegating every mutation to the CLI (`straymark followups list/status/drift/promote`). The skill contains no extraction or counting logic of its own — parsing, schema validation, counter recomputation, and FU → TDE elevation all live in the CLI.
+
+> See `.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16` for the pattern; `AGENT-RULES.md §13` for the shipped directives this skill wraps.
+
+## When to use this skill
+
+Trigger on any of:
+
+- Session start, or the operator asks *"what's pending?"* / *"what follow-ups do we have?"*.
+- You created or modified an AILOG containing `## Follow-ups` or `R<N> (new, not in Charter)` entries and are about to commit.
+- A Charter just closed and the registry entries it resolved need triage.
+- The operator asks to promote a follow-up to a TDE document.
+
+If the project does not maintain the registry (the per-AILOG `§Follow-ups` convention alone is enough below ~20 AILOGs — see the pattern doc), this skill does not apply.
+
+## Instructions
+
+### 1. Session start — answer from the registry
+
+The registry is the **canonical source** for "what's pending". Answer from it; do not re-scan AILOGs.
+
+```bash
+straymark followups status                      # registry pulse: counters recomputed on the fly,
+                                                # per-bucket breakdown, blocking / suspected-closed alerts
+straymark followups list                        # full entry table
+straymark followups list --severity blocking    # focus on blockers
+straymark followups status FU-NNN               # one entry's full field detail
+```
+
+Fall back to an AILOG scan **only** when the registry does not exist, or when `straymark followups drift` reports unextracted AILOGs.
+
+### 2. Pre-commit — registry rides the same commit as the AILOG
+
+Created or modified any AILOG with `## Follow-ups` or `R<N> (new, not in Charter)` entries? Sync before committing:
+
+```bash
+straymark followups drift            # detect unextracted AILOGs (exit 1 on drift)
+straymark followups drift --apply    # extract into `## Bucket: ready`, auto-number FU-NNN ids,
+                                     # recompute counters, upgrade v0 registries to v1 in place
+```
+
+so the registry extension rides **the same commit** as the AILOG. Bullets whose AILOG text already carries a closure marker (`closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash) are extracted as `suspected-closed` automatically — **do not delete them**; the operator confirms at the next triage.
+
+### 3. Post-Charter close — triage what the Charter resolved
+
+Review the registry entries the just-closed Charter resolved:
+
+```bash
+straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
+```
+
+- Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
+- Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
+
+### 4. Report result
+
+Surface the CLI output verbatim (counters, alerts, created TDE paths). Example after a pre-commit sync:
+
+```
+✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
+  ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
+  Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+
+StrayMark: registry synced — commit it together with the AILOG.
+```
+
+## What this skill does NOT do
+
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
+- **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
+- **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.
+- **It does not replace the per-AILOG `§Follow-ups` section.** That stays the write-time capture point; the registry aggregates it via `drift --apply`.
+
+> **Terminal compatibility**: If the terminal does not support box-drawing characters (Unicode), use plain-text formatting with dashes and pipes instead (e.g., `+--+` instead of `╔══╗`).

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -411,4 +411,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -319,4 +319,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -291,4 +291,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -243,6 +243,7 @@ Mark `review_required: true` when:
 | `/straymark-ailog` / `/straymark-aidec` / `/straymark-adr` | Quick shortcuts for AILOG / AIDEC / ADR |
 | `/straymark-mcard` / `/straymark-sec` | Interactive flows for Model Card / SEC assessment |
 | `/straymark-charter-new` | Scaffold a Charter (declarative ex-ante work unit) |
+| `/straymark-followups` *(fw-4.22.0+)* | Maintain the follow-ups backlog registry — "what's pending?", pre-commit drift, post-close triage/promote |
 | `/straymark-audit-prompt CHARTER-XX` *(fw-4.9.0+, refactored in fw-4.9.0)* | External multi-model audit — write unified prompt at canonical path |
 | `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | Run inside an auditor CLI — read prompt, audit with tool use, write report |
 | `/straymark-audit-review CHARTER-XX` *(fw-4.9.0+, expanded in fw-4.9.0)* | Consolidate N reports into review.md (6 sections) + merge YAML into telemetry |
@@ -258,4 +259,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -411,4 +411,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -312,4 +312,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -291,4 +291,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -218,6 +218,7 @@ Marcar `review_required: true` cuando:
 | `/straymark-ailog` / `/straymark-aidec` / `/straymark-adr` | Atajos rápidos para AILOG / AIDEC / ADR |
 | `/straymark-mcard` / `/straymark-sec` | Flujos interactivos para Model Card / SEC assessment |
 | `/straymark-charter-new` | Andamiar un Charter (unidad de trabajo declarativa ex-ante) |
+| `/straymark-followups` *(fw-4.22.0+)* | Mantener el registry de follow-ups — "¿qué está pendiente?", drift pre-commit, triage/promoción post-cierre |
 | `/straymark-audit-prompt CHARTER-XX` *(fw-4.9.0+, refactorizada en fw-4.9.0)* | Auditoría externa multi-modelo — escribe prompt unificado en path canónico |
 | `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | Corre en una CLI auditora — lee prompt, audita con tool use, escribe report |
 | `/straymark-audit-review CHARTER-XX` *(fw-4.9.0+, expandida en fw-4.9.0)* | Consolida N reports en review.md (6 secciones) + mergea YAML en telemetría |
@@ -233,4 +234,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -406,4 +406,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -291,4 +291,4 @@ straymark followups promote FU-NNN        # 自动化 FU → TDE 提升(见上�
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -218,6 +218,7 @@ risk_level: low | medium | high | critical
 | `/straymark-ailog` / `/straymark-aidec` / `/straymark-adr` | AILOG / AIDEC / ADR 的快速快捷方式 |
 | `/straymark-mcard` / `/straymark-sec` | Model Card / SEC 评估的交互流程 |
 | `/straymark-charter-new` | 搭建一个 Charter（声明式事前工作单元） |
+| `/straymark-followups` *(fw-4.22.0+)* | 维护 follow-ups backlog 注册表 —— “有什么待办？”、提交前 drift、关闭后分诊/promote |
 | `/straymark-audit-prompt CHARTER-XX` *(fw-4.9.0+，在 fw-4.9.0 中重构)* | 外部多模型审计 — 在规范路径写入统一 prompt |
 | `/straymark-audit-execute [CHARTER-XX]` *(fw-4.9.0+)* | 在审计员 CLI 中运行 — 读取 prompt，使用 tool use 审计，写入 report |
 | `/straymark-audit-review CHARTER-XX` *(fw-4.9.0+，在 fw-4.9.0 中扩展)* | 合并 N 个 reports 为 review.md（6 节）+ YAML 合并入遥测 |
@@ -233,4 +234,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark fw-4.21.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.21.0"
+version: "4.22.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -47,7 +47,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.21.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.22.0` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.19.1` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -1385,6 +1385,8 @@ Claude and Gemini discover skills directly from the project tree. **Codex reads 
 | `/straymark-adr` | Quick ADR creation shortcut. | `.straymark/02-design/decisions/ADR-*.md` |
 | `/straymark-mcard` | Interactive Model Card creation flow. | `.straymark/09-ai-models/MCARD-*.md` |
 | `/straymark-sec` | Interactive SEC (security assessment) flow. | `.straymark/08-security/SEC-*.md` |
+| `/straymark-charter-new` *(fw-4.12.0+)* | Scaffold a Charter — declarative ex-ante work unit. Wraps `straymark charter new` (slug derivation, sequential numbering, template substitution); the skill drives origin/effort selection and the reconnaissance-before-declaration discipline. | `.straymark/charters/NN-slug.md` |
+| `/straymark-followups` *(fw-4.22.0+)* | Maintain the follow-ups backlog registry (`AGENT-RULES.md §13`): session-start "what's pending?" answered from the canonical registry, pre-commit `followups drift --apply` riding the same commit as the AILOG, post-Charter-close triage and operator-gated `promote`. Thin wrapper over `straymark followups` — never edits CLI-owned counters. | none directly (writes go through `straymark followups drift --apply` / `promote` → `.straymark/follow-ups-backlog.md`, TDE on promote) |
 | `/straymark-audit-prompt CHARTER-ID` *(fw-4.9.0+, refactored in fw-4.9.0)* | Generate the unified audit prompt for a Charter at the canonical path. Wraps `straymark charter audit --prepare`. The operator then opens N auditor CLIs in the same repo and invokes `/straymark-audit-execute` in each — no copy/paste. | `.straymark/audits/<CHARTER-ID>/audit-prompt.md` |
 | `/straymark-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **Run inside an auditor-side CLI** (gemini-cli, claude-cli, copilot-cli, codex-cli, ...). Reads the prepared prompt from disk, audits with tool use citing `path:line`, writes a report keyed on the auditor's model id. CHARTER-ID argument is optional — auto-discovers prompts that don't yet have a report from this model. | `.straymark/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
 | `/straymark-audit-review CHARTER-ID` *(fw-4.9.0+, expanded in fw-4.9.0)* | Counterpart to `/straymark-audit-prompt`. Reads N reports under `.straymark/audits/<CHARTER-ID>/`, verifies each finding against actual code (Explore agents in parallel), produces a six-section consolidated `review.md` (Executive summary, Scope, Per-auditor evaluation, Remediation plan P0-P4, Discarded findings, Auditor ratings), and runs `straymark charter audit --merge-reports --merge-into` to append `external_audit:` into the Charter telemetry. If the telemetry doesn't yet exist (Charter not yet closed), writes `external-audit-pending.yaml` for later merge at close time. | `.straymark/audits/<CHARTER-ID>/review.md`, `external_audit:` array merged into telemetry (or pending YAML) |

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -240,7 +240,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.21.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.22.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.19.1` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -274,7 +274,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.21.0)
+# y descarga el último release fw-* (ej. fw-4.22.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -47,7 +47,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.21.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.22.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.19.1` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -1075,6 +1075,8 @@ Claude y Gemini descubren los skills directamente del árbol del proyecto. **Cod
 | `/straymark-adr` | Atajo de creación rápida de ADR. | `.straymark/02-design/decisions/ADR-*.md` |
 | `/straymark-mcard` | Flujo interactivo de creación de Model Card. | `.straymark/09-ai-models/MCARD-*.md` |
 | `/straymark-sec` | Flujo interactivo SEC (security assessment). | `.straymark/08-security/SEC-*.md` |
+| `/straymark-charter-new` *(fw-4.12.0+)* | Andamiar un Charter — unidad de trabajo declarativa ex-ante. Envuelve `straymark charter new` (derivación de slug, numeración secuencial, sustitución de plantilla); el skill conduce la selección de origen/esfuerzo y la disciplina de reconocimiento-antes-de-declarar. | `.straymark/charters/NN-slug.md` |
+| `/straymark-followups` *(fw-4.22.0+)* | Mantener el registry de follow-ups (`AGENT-RULES.md §13`): al inicio de sesión responder "¿qué está pendiente?" desde el registry canónico, `followups drift --apply` pre-commit viajando en el mismo commit que el AILOG, triage post-cierre de Charter y `promote` aprobado por el operador. Wrapper delgado sobre `straymark followups` — nunca edita los counters CLI-owned. | ninguno directamente (las escrituras pasan por `straymark followups drift --apply` / `promote` → `.straymark/follow-ups-backlog.md`, TDE al promover) |
 | `/straymark-audit-prompt CHARTER-ID` *(fw-4.9.0+, refactorizada en fw-4.9.0)* | Genera la plantilla unificada del audit prompt para un Charter en el path canónico. Envuelve `straymark charter audit --prepare`. El operador entonces abre N CLIs auditoras en el mismo repo e invoca `/straymark-audit-execute` en cada una — sin copy/paste. | `.straymark/audits/<CHARTER-ID>/audit-prompt.md` |
 | `/straymark-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **Corre dentro de una CLI auditora** (gemini-cli, claude-cli, copilot-cli, codex-cli, ...). Lee el prompt preparado del disco, audita con tool use citando `path:línea`, escribe un report con el id del modelo en el nombre. El argumento CHARTER-ID es opcional — auto-descubre prompts que aún no tienen report de este modelo. | `.straymark/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
 | `/straymark-audit-review CHARTER-ID` *(fw-4.9.0+, expandida en fw-4.9.0)* | Contraparte de `/straymark-audit-prompt`. Lee N reports en `.straymark/audits/<CHARTER-ID>/`, verifica cada finding contra el código real (Explore agents en paralelo), produce un `review.md` consolidado de seis secciones (Resumen ejecutivo, Alcance, Evaluación por auditor, Plan de remediación P0-P4, Hallazgos descartados, Calificación de auditores), y corre `straymark charter audit --merge-reports --merge-into` para anexar `external_audit:` en la telemetría del Charter. Si la telemetría aún no existe (Charter no cerrado), escribe `external-audit-pending.yaml` para merge posterior al close. | `.straymark/audits/<CHARTER-ID>/review.md`, array `external_audit:` mergeado en telemetría (o pending YAML) |

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -258,7 +258,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.21.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.22.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.19.1` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -47,7 +47,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.21.0` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.22.0` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.19.1` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -1208,6 +1208,8 @@ Claude 和 Gemini 直接从项目树发现 skills。**Codex 从 `~/.codex/skills
 | `/straymark-adr` | 快速 ADR 创建快捷方式。 | `.straymark/02-design/decisions/ADR-*.md` |
 | `/straymark-mcard` | 交互式 Model Card 创建流程。 | `.straymark/09-ai-models/MCARD-*.md` |
 | `/straymark-sec` | 交互式 SEC（安全评估）流程。 | `.straymark/08-security/SEC-*.md` |
+| `/straymark-charter-new` *(fw-4.12.0+)* | 搭建 Charter —— 声明式事前工作单元。封装 `straymark charter new`（slug 派生、顺序编号、模板替换）；skill 负责来源/工作量选择以及声明前侦察纪律。 | `.straymark/charters/NN-slug.md` |
+| `/straymark-followups` *(fw-4.22.0+)* | 维护 follow-ups backlog 注册表（`AGENT-RULES.md §13`）：会话开始时从规范注册表回答“有什么待办？”，提交前运行 `followups drift --apply` 使注册表与 AILOG 同一提交，Charter 关闭后分诊以及操作员审批的 `promote`。`straymark followups` 之上的薄封装 —— 绝不手动编辑 CLI 拥有的计数器。 | 无直接产物（写入经由 `straymark followups drift --apply` / `promote` → `.straymark/follow-ups-backlog.md`，promote 时生成 TDE） |
 | `/straymark-audit-prompt CHARTER-ID` *(fw-4.9.0+，在 fw-4.9.0 中重构)* | 在规范路径处生成章程的统一审计 prompt。封装 `straymark charter audit --prepare`。操作员随后在同一仓库中打开 N 个审计员 CLI，在每个中调用 `/straymark-audit-execute` — 无需复制/粘贴。 | `.straymark/audits/<CHARTER-ID>/audit-prompt.md` |
 | `/straymark-audit-execute [CHARTER-ID]` *(fw-4.9.0+)* | **在审计员 CLI 中运行**（gemini-cli、claude-cli、copilot-cli、codex-cli 等）。从磁盘读取已准备的 prompt，使用 tool use 进行审计并引用 `path:line`，写入以审计员模型 ID 为键的 report。CHARTER-ID 参数可选 — 自动发现尚未由此模型生成 report 的 prompts。 | `.straymark/audits/<CHARTER-ID>/report-<sluggified-model-id>.md` |
 | `/straymark-audit-review CHARTER-ID` *(fw-4.9.0+，在 fw-4.9.0 中扩展)* | `/straymark-audit-prompt` 的对应。读取 `.straymark/audits/<CHARTER-ID>/` 下的 N 个 reports，对每个 finding 与实际代码进行交叉验证（并行 Explore agents），生成六节合并的 `review.md`（执行摘要、范围、按审计员评估、修复计划 P0-P4、丢弃的 findings、审计员评分），并运行 `straymark charter audit --merge-reports --merge-into` 将 `external_audit:` 追加到章程遥测中。如果遥测尚不存在（章程未关闭），写入 `external-audit-pending.yaml` 供 close 时合并。 | `.straymark/audits/<CHARTER-ID>/review.md`，`external_audit:` 数组合并入遥测（或 pending YAML） |


### PR DESCRIPTION
Closes #220.

## Summary

Ships the `/straymark-followups` skill — the invocable wrapper for the `AGENT-RULES.md §13` directives, deferred from the cli-3.19.0 PR (#218) because skills ride **framework** releases and fw-4.21.0 was already tagged.

- **New skill in 4 agent surfaces**, mirroring the `straymark-charter-new` lane: `.claude/skills/` (source of truth, full frontmatter), `.gemini/skills/` (reduced frontmatter), `.agent/workflows/` (description-only), and generated `.codex/skills/` via `cargo run --bin gen_codex_skills`.
- **Thin wrapper by design**: session-start "what's pending?" answered from the canonical registry, pre-commit `followups drift --apply` riding the same commit as the AILOG, post-Charter-close triage and operator-gated `promote`. All parsing/schema/counters/elevation logic stays in the CLI (cli-3.19.0+). `allowed-tools` deliberately omits `Write` — every registry mutation goes through the CLI.
- **Skills table rows** in `QUICK-REFERENCE.md` (EN/ES/zh-CN) and the `CLI-REFERENCE.md` Skills section (EN/ES/zh-CN). The CLI-REFERENCE table also gains the previously missing `/straymark-charter-new` row (shipped in fw-4.12.0, never listed there).
- **Bump fw-4.21.0 → 4.22.0**: `dist-manifest.yml`, versioning tables (README + CLI-REFERENCE × EN/ES/zh-CN), 15 governance footers, CHANGELOG entry. Historical `(fw-4.21.0+)` markers untouched.

## Verification

- `cargo run --bin gen_codex_skills -- --check` → "Codex skills are in sync (12 skills)."
- `cargo test` → 614 passed, 0 failed (24 suites).
- `git grep fw-4.21.0` → only historical introduced-in markers remain.

Refs #218, #135, ADR-2026-06-03-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)