### PR TITLE
feat(framework+cli): fw-4.23.0 / cli-3.20.0 — followups recount + born-resolved closure idioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.23.0 / CLI 3.20.0 — N=2 feedback: `followups recount` + born-resolved closure idioms
+
+First fixes driven by **external adopter feedback**: the lnxdrive adoption run ([#222](https://github.com/StrangeDaysTech/straymark/issues/222), the first N=2 data point gating the v1 schema's hard stabilization per principle #12 / ADR-2026-06-03-001) surfaced two gaps in the follow-ups lane — both ergonomic/vocabulary, neither schema-level.
+
+### Added (CLI)
+
+- **`straymark followups recount`** (#222 Finding 1) — recompute the CLI-owned `total_*` counters from actual entry statuses and rewrite the frontmatter, without scanning AILOGs or touching entries. Closes the loop between the sanctioned manual-triage workflow (Triage/Consumption = manual status edits) and the CLI-owned counter invariant: until now the only recomputing commands (`drift --apply`, `promote`) were no-ops after a pure-triage session, stranding the file with knowingly stale counters and no §13-compliant fix. Idempotent; upgrades v0 → v1 in place like every other write command.
+- **Born-resolved closure idioms** (#222 Finding 2) — the anti-noise vocabulary now recognizes a closure verb (`updated` / `corrected` / `remediated` / `resolved` / `fixed` / `closed`) followed by `in this PR` / `in this commit` (e.g. the lnxdrive phrasing `Charter row updated atomically in this PR`), extracting those bullets as `suspected-closed` instead of reintroducing the TBD noise that #214 Signal 1 removed.
+
+### Changed (CLI)
+
+- **`followups drift --apply` recomputes counters even with zero extractions** (#222 Finding 1) — a pre-commit `drift --apply` now also reconciles counters left stale by a manual-triage session, making the `status` warning's remediation claim actually true.
+- `followups status` stale-counter warning now points at `straymark followups recount`.
+
+### Added (Framework)
+
+- **Canonical closure-marker idioms** documented in `FOLLOW-UPS-BACKLOG-PATTERN.md` (EN/ES/zh-CN) — the fixed vocabulary the anti-noise refinement recognizes, so AILOG authors converge on recognizable phrasings at write time instead of discovering unrecognized idioms at extraction.
+
+### Changed (Framework)
+
+- **`AGENT-RULES.md §13` post-Charter-close directive** (EN/ES/zh-CN) gains the recount step: after flipping statuses by hand, run `straymark followups recount` so the CLI-owned counters ride the same commit as the triage. The `/straymark-followups` skill (4 surfaces), `STRAYMARK.md §16` lifecycle table, and `QUICK-REFERENCE.md` command line follow suit.
+
+### Adopter guidance
+
+Run `straymark update` (CLI → `cli-3.20.0`, framework → `fw-4.23.0`). If your registry carries stale counters from a manual triage (the lnxdrive case): `straymark followups recount` fixes it in one command.
+
+---
+
 ## Framework 4.22.0 — `/straymark-followups` skill ships the §13 directives as an invocable wrapper
 
 Closes the last gap in the follow-ups first-class lane (fw-4.21.0 / cli-3.19.0): the `AGENT-RULES.md §13` directives — session-start "what's pending?" answered from the canonical registry, pre-commit `followups drift --apply` riding the same commit as the AILOG, post-Charter-close triage and operator-gated `promote` — now ship as an invocable skill across all four agent surfaces, mirroring the `straymark-charter-new` lane. Driven by [#220](https://github.com/StrangeDaysTech/straymark/issues/220) (deferred from the cli-3.19.0 PR because skills ride framework releases and fw-4.21.0 was already tagged). The skill is a **thin wrapper**: parsing, schema validation, counter recomputation, and the FU → TDE elevation all stay in the CLI (`straymark followups list/status/drift/promote`, cli-3.19.0+); the skill only drives the discipline.

--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
-| Framework | `fw-` | `fw-4.22.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.19.1` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.23.0` | Templates (12 types), governance, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.20.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 
@@ -311,7 +311,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.22.0)
+# and download the latest fw-* release (e.g., fw-4.23.0)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2324,7 +2324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.19.1"
+version = "3.20.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/commands/followups/drift.rs
+++ b/cli/src/commands/followups/drift.rs
@@ -114,6 +114,28 @@ pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Resu
             "{} registry in sync — no AILOGs with unextracted follow-up content.",
             "OK".green().bold()
         );
+        // --apply always reconciles the CLI-owned counters, even with zero
+        // extractions (#222 Finding 1): after a sanctioned manual-triage
+        // session the statuses changed but nothing is left to extract, and
+        // without this write the frontmatter stays knowingly stale.
+        if apply {
+            let counters = followups::compute_counters(&registry);
+            let fm =
+                followups::fm_apply_counters_and_v1(&registry.frontmatter_raw, &counters);
+            if fm != registry.frontmatter_raw {
+                let was_v0 = registry.is_v0();
+                std::fs::write(&registry_path, followups::assemble(&fm, &registry.body))?;
+                println!(
+                    "  Counters recomputed: {} open / {} suspected-closed / {} promoted (total {}).",
+                    counters.open, counters.suspected_closed, counters.promoted, counters.total
+                );
+                if was_v0 {
+                    utils::info(
+                        "Registry upgraded to schema v1 (non-destructive — counters are now CLI-owned).",
+                    );
+                }
+            }
+        }
         return Ok(());
     }
 

--- a/cli/src/commands/followups/mod.rs
+++ b/cli/src/commands/followups/mod.rs
@@ -3,11 +3,13 @@
 //!
 //! Subcommands mirror the `charter` namespace: `list` / `status` enumerate
 //! and inspect, `drift` keeps the registry in sync with AILOGs (native
-//! replacement for the deprecated adopter-side bash script), `promote`
-//! automates the FU → TDE elevation. See `FOLLOW-UPS-BACKLOG-PATTERN.md`
-//! and `STRAYMARK.md §16`.
+//! replacement for the deprecated adopter-side bash script), `recount`
+//! reconciles the CLI-owned counters after a manual-triage session,
+//! `promote` automates the FU → TDE elevation. See
+//! `FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16`.
 
 pub mod drift;
 pub mod list;
 pub mod promote;
+pub mod recount;
 pub mod status;

--- a/cli/src/commands/followups/recount.rs
+++ b/cli/src/commands/followups/recount.rs
@@ -1,0 +1,70 @@
+//! `straymark followups recount` — recompute the CLI-owned frontmatter
+//! counters from actual entry statuses, without scanning AILOGs.
+//!
+//! Closes the manual-triage loop found in the first external adoption
+//! (issue #222 Finding 1): the v1 lifecycle sanctions Triage and Consumption
+//! as manual status edits, but until cli-3.20.0 the only commands that
+//! recomputed the CLI-owned `total_*` counters were `drift --apply` and
+//! `promote` — both no-ops after a pure-triage session, stranding the
+//! frontmatter with knowingly stale counters and no §13-compliant fix.
+//!
+//! `recount` is the dedicated, idempotent verb: parse the registry, recompute
+//! the counters from entry statuses (the same `compute_counters` the pulse
+//! uses), rewrite the frontmatter (upgrading v0 → v1 in place, like every
+//! other write command), and report. No AILOG scan, no extraction, no entry
+//! mutation — counters only.
+
+use anyhow::{anyhow, bail, Result};
+use colored::Colorize;
+
+use crate::followups;
+use crate::utils;
+
+pub fn run(path: &str) -> Result<()> {
+    let resolved = utils::resolve_project_root(path)
+        .ok_or_else(|| anyhow!("StrayMark not installed. Run 'straymark init' first."))?;
+    let project_root = &resolved.path;
+
+    let registry_path = followups::registry_path(project_root);
+    if !registry_path.exists() {
+        bail!(
+            "No follow-ups registry at {}.\n  hint: run `straymark followups drift --scan-all --apply` to create and seed it (see STRAYMARK.md §16).",
+            registry_path.display()
+        );
+    }
+
+    let registry = followups::parse_registry(&registry_path)?;
+    for w in &registry.warnings {
+        utils::warn(w);
+    }
+
+    let counters = followups::compute_counters(&registry);
+    let fm = followups::fm_apply_counters_and_v1(&registry.frontmatter_raw, &counters);
+
+    if fm == registry.frontmatter_raw {
+        println!(
+            "{} counters already in sync: {} open / {} suspected-closed / {} promoted (total {}).",
+            "OK".green().bold(),
+            counters.open,
+            counters.suspected_closed,
+            counters.promoted,
+            counters.total
+        );
+        return Ok(());
+    }
+
+    let was_v0 = registry.is_v0();
+    std::fs::write(
+        &registry_path,
+        followups::assemble(&fm, &registry.body),
+    )?;
+
+    utils::success(&format!(
+        "Counters recomputed: {} open / {} suspected-closed / {} promoted (total {}).",
+        counters.open, counters.suspected_closed, counters.promoted, counters.total
+    ));
+    if was_v0 {
+        utils::info("Registry upgraded to schema v1 (non-destructive — counters are now CLI-owned).");
+    }
+    Ok(())
+}

--- a/cli/src/commands/followups/status.rs
+++ b/cli/src/commands/followups/status.rs
@@ -181,12 +181,12 @@ fn print_pulse(registry: &Registry) {
         println!();
     }
 
-    // Flag stale frontmatter counters (informational — the next write fixes them).
+    // Flag stale frontmatter counters (informational — `recount` fixes them).
     let declared_open = fm.total_open;
     if let Some(declared) = declared_open {
         if declared != counters.open {
             println!(
-                "  {} frontmatter says total_open: {} but the real count is {} — the next `followups drift --apply` or `promote` recomputes it.",
+                "  {} frontmatter says total_open: {} but the real count is {} — run `straymark followups recount` to reconcile (any write command also recomputes).",
                 "!".yellow().bold(),
                 declared,
                 counters.open

--- a/cli/src/followups.rs
+++ b/cli/src/followups.rs
@@ -748,11 +748,25 @@ fn extract_section(content: &str, pred: impl Fn(&str) -> bool) -> Option<String>
     }
 }
 
+/// Closure verbs recognized by the born-resolved idiom family
+/// "<verb> … in this PR / in this commit" (#222 Finding 2).
+const CLOSURE_VERBS: [&str; 6] = [
+    "updated",
+    "corrected",
+    "remediated",
+    "resolved",
+    "fixed",
+    "closed",
+];
+
 /// True when the text carries an explicit in-Charter closure marker:
 /// "closed in-Charter" / "closed in Charter" / "resolved in-Charter" /
-/// "fixed in batch N" (case-insensitive), or a backtick-wrapped commit hash
-/// (7-40 hex chars). The signal that drives `suspected-closed` extraction
-/// (#214 Signal 1 — 20-75% of auto-appended entries per batch were already
+/// "fixed in batch N", a born-resolved idiom — a closure verb (`updated` /
+/// `corrected` / `remediated` / `resolved` / `fixed` / `closed`) followed by
+/// "in this PR" or "in this commit" (#222 Finding 2, first external adopter)
+/// — all case-insensitive, or a backtick-wrapped commit hash (7-40 hex
+/// chars). The signal that drives `suspected-closed` extraction (#214
+/// Signal 1 — 20-75% of auto-appended entries per batch were already
 /// resolved in-Charter across both documented occurrences).
 pub fn has_closure_marker(text: &str) -> bool {
     let lower = text.to_lowercase();
@@ -768,6 +782,17 @@ pub fn has_closure_marker(text: &str) -> bool {
         let rest = &lower[idx + "fixed in batch ".len()..];
         if rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
             return true;
+        }
+    }
+    // Born-resolved idiom: a closure verb anywhere before "in this PR" /
+    // "in this commit" (e.g. "Charter row updated atomically in this PR").
+    // rfind takes the last context occurrence, maximizing the verb window.
+    for ctx in ["in this pr", "in this commit"] {
+        if let Some(ctx_idx) = lower.rfind(ctx) {
+            let before = &lower[..ctx_idx];
+            if CLOSURE_VERBS.iter().any(|v| before.contains(v)) {
+                return true;
+            }
         }
     }
     // Backtick-wrapped hex run of 7-40 chars (commit hash reference).
@@ -1172,6 +1197,23 @@ Done.
         // Backtick word that isn't a hash (no digit / not hex).
         assert!(!has_closure_marker("see `feedface` once")); // hex but no digit
         assert!(!has_closure_marker("run `cargo test` first"));
+    }
+
+    #[test]
+    fn closure_markers_born_resolved_idiom_family() {
+        // #222 Finding 2 — the exact lnxdrive phrasing that landed as `open`.
+        assert!(has_closure_marker(
+            "Charter `## Files to modify` row updated atomically in this PR."
+        ));
+        assert!(has_closure_marker("remediated in this PR"));
+        assert!(has_closure_marker("the regression was Corrected in this commit"));
+        assert!(has_closure_marker("scope drift recognized and fixed in this PR"));
+        // Verb required — context phrase alone is not a closure.
+        assert!(!has_closure_marker("discussed in this PR"));
+        assert!(!has_closure_marker("tracked in this PR for visibility"));
+        // Context phrase required — future-tense / follow-up phrasing is not.
+        assert!(!has_closure_marker("will be updated in a follow-up PR"));
+        assert!(!has_closure_marker("should be corrected in the next commit"));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -339,6 +339,16 @@ enum FollowupsCommands {
         #[arg(long = "path", default_value = ".")]
         path: String,
     },
+    /// Recompute the CLI-owned frontmatter counters from actual entry
+    /// statuses, without scanning AILOGs. The §13-compliant way to reconcile
+    /// counters after a manual-triage session (statuses flipped by hand,
+    /// nothing left to extract or promote). Idempotent; upgrades v0
+    /// registries to v1 in place like every other write command.
+    Recount {
+        /// Project directory (default: current directory)
+        #[arg(long = "path", default_value = ".")]
+        path: String,
+    },
     /// Promote an entry to a TDE document (creates the TDE with
     /// promoted_from_followup traceability, marks the entry `promoted`,
     /// recomputes counters). Non-interactive; prioritization stays human.
@@ -834,6 +844,7 @@ fn main() {
                 range,
                 path,
             } => commands::followups::drift::run(&path, apply, scan_all, range.as_deref()),
+            FollowupsCommands::Recount { path } => commands::followups::recount::run(&path),
             FollowupsCommands::Promote { fu_id, title, path } => {
                 commands::followups::promote::run(&path, &fu_id, title.as_deref())
             }

--- a/cli/tests/followups_test.rs
+++ b/cli/tests/followups_test.rs
@@ -391,6 +391,99 @@ fn drift_apply_seeds_registry_from_template_when_absent() {
     assert!(created.contains("### FU-001 — do the thing"));
 }
 
+#[test]
+fn drift_apply_recomputes_counters_with_zero_extractions() {
+    // #222 Finding 1 (second half): after a manual-triage session there is
+    // nothing left to extract, but --apply must still reconcile the
+    // CLI-owned counters instead of early-returning with a stale file.
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY); // claims total_open: 47, real count 2
+    write_ailog(
+        &straymark,
+        "AILOG-2026-04-11-001-first.md",
+        "# AILOG\n\n## Follow-ups\n\n- already extracted\n",
+    );
+
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--apply", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("registry in sync"))
+        .stdout(predicate::str::contains("Counters recomputed: 2 open"));
+
+    let updated = std::fs::read_to_string(straymark.join("follow-ups-backlog.md")).unwrap();
+    assert!(updated.contains("total_open: 2"));
+    assert!(updated.contains("schema_version: v1"));
+}
+
+#[test]
+fn drift_apply_extracts_born_resolved_idiom_as_suspected_closed() {
+    // #222 Finding 2: the exact lnxdrive phrasing ("updated atomically in
+    // this PR") must land as suspected-closed, not open/TBD noise.
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V1_REGISTRY);
+    write_ailog(
+        &straymark,
+        "AILOG-2026-06-04-001-drift.md",
+        "# AILOG\n\n## Drift\n\n- R1 (new, not in Charter): probe path normalization — Charter `## Files to modify` row updated atomically in this PR.\n",
+    );
+
+    cmd()
+        .args(["followups", "drift", "--scan-all", "--apply", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("suspected-closed"));
+
+    let updated = std::fs::read_to_string(straymark.join("follow-ups-backlog.md")).unwrap();
+    let idx = updated.find("probe path normalization").unwrap();
+    let block = &updated[idx..(idx + 400).min(updated.len())];
+    assert!(block.contains("- **Status**: suspected-closed"));
+}
+
+// ───────────────────────────── recount (#222 Finding 1) ─────────────────────────────
+
+#[test]
+fn recount_reconciles_counters_after_manual_triage_and_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let straymark = scaffold(tmp.path());
+    write_registry(&straymark, V0_REGISTRY); // claims total_open: 47, real count 2
+
+    cmd()
+        .args(["followups", "recount", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Counters recomputed: 2 open"))
+        .stdout(predicate::str::contains("upgraded to schema v1"));
+
+    let updated = std::fs::read_to_string(straymark.join("follow-ups-backlog.md")).unwrap();
+    assert!(updated.contains("total_open: 2"));
+    assert!(updated.contains("schema_version: v1"));
+    // Entries and body untouched — counters only.
+    assert!(updated.contains("### FU-001 — Wire the retry budget into the sync loop"));
+    assert!(updated.contains("### FU-002 — Extend E2E coverage to the write paths"));
+
+    // Second run: nothing to do.
+    cmd()
+        .args(["followups", "recount", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already in sync"));
+}
+
+#[test]
+fn recount_errors_when_no_registry() {
+    let tmp = TempDir::new().unwrap();
+    scaffold(tmp.path());
+
+    cmd()
+        .args(["followups", "recount", "--path", tmp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No follow-ups registry"));
+}
+
 // ───────────────────────────── promote ─────────────────────────────
 
 #[test]

--- a/dist/.agent/workflows/straymark-followups.md
+++ b/dist/.agent/workflows/straymark-followups.md
@@ -53,11 +53,13 @@ Review the registry entries the just-closed Charter resolved:
 
 ```bash
 straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups recount                          # reconcile the CLI-owned counters after manual status flips (cli-3.20.0+)
 straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
 ```
 
 - Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
 - Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- After flipping statuses by hand, run `straymark followups recount` so the CLI-owned counters ride the same commit as the triage.
 - For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
 
 ### 4. Report result
@@ -74,7 +76,7 @@ StrayMark: registry synced — commit it together with the AILOG.
 
 ## What this skill does NOT do
 
-- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: `straymark followups recount` (or any write command) recomputes them. Hand-editing them is a §13 violation.
 - **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
 - **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
 - **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.

--- a/dist/.claude/skills/straymark-followups/SKILL.md
+++ b/dist/.claude/skills/straymark-followups/SKILL.md
@@ -55,11 +55,13 @@ Review the registry entries the just-closed Charter resolved:
 
 ```bash
 straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups recount                          # reconcile the CLI-owned counters after manual status flips (cli-3.20.0+)
 straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
 ```
 
 - Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
 - Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- After flipping statuses by hand, run `straymark followups recount` so the CLI-owned counters ride the same commit as the triage.
 - For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
 
 ### 4. Report result
@@ -76,7 +78,7 @@ StrayMark: registry synced — commit it together with the AILOG.
 
 ## What this skill does NOT do
 
-- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: `straymark followups recount` (or any write command) recomputes them. Hand-editing them is a §13 violation.
 - **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
 - **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
 - **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.

--- a/dist/.codex/skills/straymark-followups/SKILL.md
+++ b/dist/.codex/skills/straymark-followups/SKILL.md
@@ -54,11 +54,13 @@ Review the registry entries the just-closed Charter resolved:
 
 ```bash
 straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups recount                          # reconcile the CLI-owned counters after manual status flips (cli-3.20.0+)
 straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
 ```
 
 - Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
 - Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- After flipping statuses by hand, run `straymark followups recount` so the CLI-owned counters ride the same commit as the triage.
 - For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
 
 ### 4. Report result
@@ -75,7 +77,7 @@ StrayMark: registry synced — commit it together with the AILOG.
 
 ## What this skill does NOT do
 
-- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: `straymark followups recount` (or any write command) recomputes them. Hand-editing them is a §13 violation.
 - **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
 - **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
 - **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.

--- a/dist/.gemini/skills/straymark-followups/SKILL.md
+++ b/dist/.gemini/skills/straymark-followups/SKILL.md
@@ -54,11 +54,13 @@ Review the registry entries the just-closed Charter resolved:
 
 ```bash
 straymark followups list --status suspected-closed   # entries awaiting confirm-or-reopen
+straymark followups recount                          # reconcile the CLI-owned counters after manual status flips (cli-3.20.0+)
 straymark followups promote FU-NNN                   # FU → TDE elevation (operator-approved)
 ```
 
 - Mark resolved entries `closed` (with the closing Charter id in `Notes`) or `superseded`.
 - Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- After flipping statuses by hand, run `straymark followups recount` so the CLI-owned counters ride the same commit as the triage.
 - For un-resolved entries that meet the TDE criteria of `AGENT-RULES.md §3` (heritage, transversal, dedicated Charter, human prioritization), **propose** promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
 
 ### 4. Report result
@@ -75,7 +77,7 @@ StrayMark: registry synced — commit it together with the AILOG.
 
 ## What this skill does NOT do
 
-- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: every write command recomputes them. Hand-editing them is a §13 violation.
+- **It does not edit the frontmatter counters** (`total_open`, `total_promoted`, `total_suspected_closed`, …). They are CLI-owned: `straymark followups recount` (or any write command) recomputes them. Hand-editing them is a §13 violation.
 - **It does not promote without the operator.** `straymark followups promote` is proposed, never auto-run — prioritization and assignment stay human (`AGENT-RULES.md §3`).
 - **It does not delete `suspected-closed` entries.** The operator confirms (→ `closed`) or reopens them at the next triage.
 - **It does not re-scan AILOGs to answer "what's pending?"** when the registry exists — the registry is canonical; `drift` tells you when it is not trustworthy.

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -399,9 +399,10 @@ Review the registry entries the just-closed Charter resolved:
 
 - Mark them `closed` (with the closing Charter id in `Notes`) or `superseded`.
 - Confirm or reopen any `suspected-closed` entries that the Charter's AILOGs produced.
+- Then run `straymark followups recount` *(cli-3.20.0+)* so the CLI-owned counters ride the same commit as the triage.
 - For un-resolved entries that meet the TDE criteria of §3 (heritage, transversal, dedicated Charter, human prioritization), propose promotion via `straymark followups promote FU-NNN` — promotion itself is operator-approved, per the autonomy limits of §3.
 
-Counters in the registry frontmatter (`total_open`, …) are **CLI-owned**: never edit them by hand; every write command recomputes them.
+Counters in the registry frontmatter (`total_open`, …) are **CLI-owned**: never edit them by hand; `straymark followups recount` (or any write command) recomputes them.
 
 ---
 
@@ -411,4 +412,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -319,4 +319,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -127,7 +127,7 @@ Each entry inside a bucket follows this shape (v1 fields marked; all of them opt
 
 - `open` — pending, not yet acted on.
 - `in-progress` — a Charter has been declared or is executing that addresses this entry.
-- `suspected-closed` *(new in v1)* — auto-extracted by `drift --apply` from an AILOG whose text carries an explicit closure marker (`closed in-Charter`, `fixed in batch N`, a commit hash). The operator confirms (→ `closed`) or reopens (→ `open`) at the next triage. See "Drift detection" below.
+- `suspected-closed` *(new in v1)* — auto-extracted by `drift --apply` from an AILOG whose text carries an explicit closure marker (`closed in-Charter`, `fixed in batch N`, a commit hash, or a born-resolved idiom like `updated atomically in this PR` — see "Canonical closure-marker idioms" below). The operator confirms (→ `closed`) or reopens (→ `open`) at the next triage. See "Drift detection" below.
 - `closed` — entry resolved (Charter merged, operational task done, time elapsed and reviewed).
 - `superseded` — addressed by other work that did not reference this entry directly.
 - `promoted` — the entry was elevated to a TDE document because it met the transversal-debt criteria (see "Promotion to TDE" below). The `Promoted to:` field carries the TDE id.
@@ -196,6 +196,21 @@ straymark followups drift --scan-all   # periodic full sweep over every AILOG
 4. **Recomputes all `total_*` counters** from actual entry statuses (Signal 2).
 5. If the registry is `schema_version: v0`, upgrades it to `v1` in place — non-destructively and idempotently (all v1 fields are optional; nothing is rewritten except the version marker and the counters).
 
+Since cli-3.20.0, `--apply` recomputes the counters **even when there is nothing to extract** — so a pre-commit `drift --apply` also reconciles counters left stale by a manual-triage session (first external adopter feedback, issue #222 Finding 1).
+
+### Canonical closure-marker idioms
+
+The anti-noise refinement recognizes a fixed vocabulary, case-insensitively. AILOG authors should converge on these phrasings at write time so born-resolved entries land as `suspected-closed` instead of TBD noise:
+
+| Idiom family | Examples |
+|---|---|
+| In-Charter closure | `closed in-Charter`, `closed in Charter`, `resolved in-Charter`, `resolved in Charter` |
+| Batch fix | `fixed in batch 3` (requires the number) |
+| Commit reference | a backtick-wrapped commit hash: `` `ab12cd34ef` `` (7–40 hex chars, at least one digit) |
+| Born-resolved *(cli-3.20.0+, #222 Finding 2)* | a closure verb — `updated` / `corrected` / `remediated` / `resolved` / `fixed` / `closed` — followed by `in this PR` or `in this commit`, e.g. `Charter row updated atomically in this PR` |
+
+Phrasings outside this vocabulary (e.g. `done earlier`, `no longer relevant`) extract as `open`; the operator flips them at triage. When a new closure idiom recurs in your AILOGs, propose it upstream rather than hand-editing extractions.
+
 ### Per-AILOG vs per-bullet granularity
 
 Tracking is **per-AILOG**, not per-bullet. An AILOG is either fully extracted (its id is in `fully_extracted_ailogs` — trust the registry) or it is not (extract everything). Per-bullet matching would require fingerprinting (text hashing or fuzzy comparison), which produces false positives whenever a registry entry paraphrases the AILOG bullet — and curated entries always paraphrase. This design choice is empirically validated: **0 false positives across 76 AILOGs and ~10 apply runs** in the reference adopter.
@@ -216,6 +231,7 @@ straymark followups list --bucket ready --status open --severity blocking --labe
 straymark followups status                # registry pulse: counters (recomputed on the fly), per-bucket/severity breakdown
 straymark followups status FU-NNN         # detail view of one entry
 straymark followups drift [--apply|--scan-all]   # drift detection (see above)
+straymark followups recount               # recompute the CLI-owned counters after a manual-triage session (cli-3.20.0+)
 straymark followups promote FU-NNN        # automate FU → TDE promotion (see above)
 ```
 
@@ -229,7 +245,7 @@ Since fw-4.21.0 the agent directives **ship with the framework** in [`AGENT-RULE
 
 - **Session start**: glance at `.straymark/follow-ups-backlog.md` (or run `straymark followups status`) to know what is pending across the project.
 - **Pre-commit**: created or modified any AILOG with `## Follow-ups` or `R<N> (new, not in Charter)` entries? → run `straymark followups drift --apply` in the same commit.
-- **Post-Charter close**: review entries the Charter resolved; mark them `closed` (with the closing Charter id in `Notes`) or `superseded`; confirm or reopen any `suspected-closed` entries; promote un-resolved entries that meet the TDE criteria via `straymark followups promote`.
+- **Post-Charter close**: review entries the Charter resolved; mark them `closed` (with the closing Charter id in `Notes`) or `superseded`; confirm or reopen any `suspected-closed` entries; then run `straymark followups recount` so the CLI-owned counters ride the same commit as the triage; promote un-resolved entries that meet the TDE criteria via `straymark followups promote`.
 
 This makes the agent the registry's primary maintainer, the CLI the verification layer, and the operator the periodic reviewer (re-bucketing, confirming suspected-closed, pruning superseded, promoting to TDE when criteria apply).
 
@@ -291,4 +307,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -85,7 +85,7 @@ The follow-ups backlog is **not** a doc type either — a single-file registry a
 | `Follow-ups registry` | `.straymark/follow-ups-backlog.md` (schema: `follow-ups-backlog.schema.v1.json`, experimental) | Agent extracts via `followups drift --apply` (pre-commit); operator owns triage and promotion approval |
 
 ```bash
-straymark followups list / status / drift [--apply] / promote FU-NNN
+straymark followups list / status / drift [--apply] / recount / promote FU-NNN
 ```
 
 > See section 16 of `STRAYMARK.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md`, and AGENT-RULES.md §13 for the shipped agent directives.
@@ -259,4 +259,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -399,9 +399,10 @@ Revisa las entradas del registry que el Charter recién cerrado resolvió:
 
 - Márcalas `closed` (con el id del Charter de cierre en `Notes`) o `superseded`.
 - Confirma o reabre cualquier entrada `suspected-closed` que produjeron los AILOGs del Charter.
+- Luego corre `straymark followups recount` *(cli-3.20.0+)* para que los contadores CLI-owned viajen en el mismo commit que el triage.
 - Para entradas no resueltas que cumplen los criterios de TDE de §3 (herencia, transversal, Charter dedicado, priorización humana), propón la promoción vía `straymark followups promote FU-NNN` — la promoción misma es aprobada por el operador, según los límites de autonomía de §3.
 
-Los contadores en el frontmatter del registry (`total_open`, …) son **CLI-owned**: nunca los edites a mano; cada comando de escritura los recalcula.
+Los contadores en el frontmatter del registry (`total_open`, …) son **CLI-owned**: nunca los edites a mano; `straymark followups recount` (o cualquier comando de escritura) los recalcula.
 
 ---
 
@@ -411,4 +412,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -312,4 +312,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -127,7 +127,7 @@ Cada entrada dentro de un bucket sigue esta forma (campos v1 marcados; todos opc
 
 - `open` — pendiente, sin acción aún.
 - `in-progress` — un Charter ha sido declarado o está en ejecución para atender esta entrada.
-- `suspected-closed` *(nuevo en v1)* — auto-extraído por `drift --apply` desde un AILOG cuyo texto carga un marcador de cierre explícito (`closed in-Charter`, `fixed in batch N`, un hash de commit). El operador confirma (→ `closed`) o reabre (→ `open`) en el siguiente triage. Ver "Detección de drift" abajo.
+- `suspected-closed` *(nuevo en v1)* — auto-extraído por `drift --apply` desde un AILOG cuyo texto carga un marcador de cierre explícito (`closed in-Charter`, `fixed in batch N`, un hash de commit, o un modismo born-resolved como `updated atomically in this PR` — ver "Modismos canónicos de marcador de cierre" abajo). El operador confirma (→ `closed`) o reabre (→ `open`) en el siguiente triage. Ver "Detección de drift" abajo.
 - `closed` — entrada resuelta (Charter mergeado, tarea operativa hecha, tiempo transcurrido y revisado).
 - `superseded` — atendida por otro trabajo que no referenció esta entrada directamente.
 - `promoted` — la entrada fue elevada a un documento TDE porque cumple los criterios de deuda transversal (ver "Promoción a TDE" abajo). El campo `Promoted to:` carga el id del TDE.
@@ -196,6 +196,21 @@ straymark followups drift --scan-all   # barrido completo periódico sobre cada 
 4. **Recalcula todos los contadores `total_*`** desde los estados reales de las entradas (Señal 2).
 5. Si el registry es `schema_version: v0`, lo actualiza a `v1` in situ — de forma no destructiva e idempotente (todos los campos v1 son opcionales; no se reescribe nada excepto el marcador de versión y los contadores).
 
+Desde cli-3.20.0, `--apply` recalcula los contadores **incluso cuando no hay nada que extraer** — así un `drift --apply` pre-commit también reconcilia contadores que una sesión de triage manual dejó obsoletos (feedback del primer adopter externo, issue #222 Finding 1).
+
+### Modismos canónicos de marcador de cierre
+
+El refinamiento anti-ruido reconoce un vocabulario fijo, sin distinguir mayúsculas. Los autores de AILOGs deben converger en estas fórmulas al escribir, para que las entradas born-resolved aterricen como `suspected-closed` en vez de ruido TBD:
+
+| Familia de modismo | Ejemplos |
+|---|---|
+| Cierre in-Charter | `closed in-Charter`, `closed in Charter`, `resolved in-Charter`, `resolved in Charter` |
+| Fix por batch | `fixed in batch 3` (requiere el número) |
+| Referencia a commit | un hash de commit entre backticks: `` `ab12cd34ef` `` (7–40 chars hex, al menos un dígito) |
+| Born-resolved *(cli-3.20.0+, #222 Finding 2)* | un verbo de cierre — `updated` / `corrected` / `remediated` / `resolved` / `fixed` / `closed` — seguido de `in this PR` o `in this commit`, p.ej. `Charter row updated atomically in this PR` |
+
+Las fórmulas fuera de este vocabulario (p.ej. `done earlier`, `no longer relevant`) se extraen como `open`; el operador las cambia en el triage. Cuando un nuevo modismo de cierre se repita en tus AILOGs, proponlo upstream en vez de editar extracciones a mano.
+
 ### Granularidad per-AILOG vs per-bullet
 
 El tracking es **per-AILOG**, no per-bullet. Un AILOG está totalmente extraído (su id está en `fully_extracted_ailogs` — confiar en el registry) o no lo está (extraer todo). El matching per-bullet requeriría fingerprinting (hashing de texto o comparación fuzzy), que produce falsos positivos cada vez que una entrada del registry parafrasea el bullet del AILOG — y las entradas curadas siempre parafrasean. Esta decisión de diseño está validada empíricamente: **0 falsos positivos a lo largo de 76 AILOGs y ~10 corridas de apply** en el adopter de referencia.
@@ -216,6 +231,7 @@ straymark followups list --bucket ready --status open --severity blocking --labe
 straymark followups status                # pulso del registry: contadores (recalculados al vuelo), desglose por bucket/severity
 straymark followups status FU-NNN         # vista de detalle de una entrada
 straymark followups drift [--apply|--scan-all]   # detección de drift (ver arriba)
+straymark followups recount               # recalcula los contadores CLI-owned tras una sesión de triage manual (cli-3.20.0+)
 straymark followups promote FU-NNN        # automatiza la promoción FU → TDE (ver arriba)
 ```
 
@@ -229,7 +245,7 @@ Desde fw-4.21.0 las directivas de agente **se shippean con el framework** en [`A
 
 - **Session start**: echa un vistazo a `.straymark/follow-ups-backlog.md` (o ejecuta `straymark followups status`) para saber qué está pendiente en el proyecto.
 - **Pre-commit**: ¿creaste o modificaste algún AILOG con entradas `## Follow-ups` o `R<N> (new, not in Charter)`? → ejecuta `straymark followups drift --apply` en el mismo commit.
-- **Post-Charter close**: revisa las entradas que el Charter resolvió; márcalas `closed` (con el id del Charter de cierre en `Notes`) o `superseded`; confirma o reabre cualquier entrada `suspected-closed`; promueve las entradas no resueltas que cumplen los criterios de TDE vía `straymark followups promote`.
+- **Post-Charter close**: revisa las entradas que el Charter resolvió; márcalas `closed` (con el id del Charter de cierre en `Notes`) o `superseded`; confirma o reabre cualquier entrada `suspected-closed`; luego corre `straymark followups recount` para que los contadores CLI-owned viajen en el mismo commit que el triage; promueve las entradas no resueltas que cumplen los criterios de TDE vía `straymark followups promote`.
 
 Esto hace al agente el mantenedor primario del registry, al CLI la capa de verificación, y al operador el revisor periódico (re-bucketing, confirmar suspected-closed, podar superseded, promover a TDE cuando los criterios aplican).
 
@@ -291,4 +307,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -76,7 +76,7 @@ El backlog de follow-ups tampoco es un tipo de documento — un registry de un s
 | `Registry de follow-ups` | `.straymark/follow-ups-backlog.md` (schema: `follow-ups-backlog.schema.v1.json`, experimental) | El agente extrae vía `followups drift --apply` (pre-commit); el operador es dueño del triage y de la aprobación de promociones |
 
 ```bash
-straymark followups list / status / drift [--apply] / promote FU-NNN
+straymark followups list / status / drift [--apply] / recount / promote FU-NNN
 ```
 
 > Ver sección 16 de `STRAYMARK.md`, `FOLLOW-UPS-BACKLOG-PATTERN.md` y AGENT-RULES.md §13 para las directivas de agente shippeadas.
@@ -234,4 +234,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -394,9 +394,10 @@ confidence: high | medium | low
 
 - 将其标记为 `closed`（在 `Notes` 中带有关闭 Charter id）或 `superseded`。
 - 确认或重新打开该 Charter 的 AILOG 产生的任何 `suspected-closed` 条目。
+- 然后运行 `straymark followups recount` *(cli-3.20.0+)*,使 CLI 拥有的计数器与分诊在同一个 commit 中。
 - 对于符合 §3 TDE 标准（遗留、横向、专用 Charter、人工优先级）的未解决条目,通过 `straymark followups promote FU-NNN` 提议提升 —— 提升本身需操作员批准,依据 §3 的自主权限制。
 
-注册表 frontmatter 中的计数器（`total_open`、…）为 **CLI-owned**:绝不手工编辑;每个写入命令都会重新计算它们。
+注册表 frontmatter 中的计数器（`total_open`、…）为 **CLI-owned**:绝不手工编辑;`straymark followups recount`（或任何写入命令）会重新计算它们。
 
 ---
 
@@ -406,4 +407,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -127,7 +127,7 @@ bucket 内的每个条目遵循以下形式（标注了 v1 字段;所有这些�
 
 - `open` — 待处理,尚未采取行动。
 - `in-progress` — 已声明或正在执行的 Charter 处理此条目。
-- `suspected-closed` *(v1 新增)* —— 由 `drift --apply` 从其文本携带显式关闭标记（`closed in-Charter`、`fixed in batch N`、某个 commit 哈希）的 AILOG 中自动提取。操作员在下一次 triage 时确认（→ `closed`）或重新打开（→ `open`）。见下方"漂移检测"。
+- `suspected-closed` *(v1 新增)* —— 由 `drift --apply` 从其文本携带显式关闭标记（`closed in-Charter`、`fixed in batch N`、某个 commit 哈希，或诸如 `updated atomically in this PR` 的 born-resolved 习语 —— 见下方"规范关闭标记习语"）的 AILOG 中自动提取。操作员在下一次 triage 时确认（→ `closed`）或重新打开（→ `open`）。见下方"漂移检测"。
 - `closed` — 条目已解决(Charter 已合并、操作任务已完成、时间已过且已审查)。
 - `superseded` — 由其他工作处理,该工作未直接引用此条目。
 - `promoted` — 条目因满足横向债务标准而被提升为 TDE 文档(见下方"提升为 TDE")。`Promoted to:` 字段携带 TDE id。
@@ -196,6 +196,21 @@ straymark followups drift --scan-all   # 对每个 AILOG 的周期性完整扫�
 4. **根据实际条目状态重新计算所有 `total_*` 计数器**(信号 2)。
 5. 如果注册表为 `schema_version: v0`,则就地将其升级到 `v1` —— 非破坏性且幂等地(所有 v1 字段都是可选的;除版本标记和计数器外什么都不重写)。
 
+自 cli-3.20.0 起,`--apply` **即使没有可提取的内容也会重新计算计数器** —— 因此提交前的 `drift --apply` 也能修复手动分诊会话留下的过期计数器（首个外部 adopter 反馈,issue #222 Finding 1）。
+
+### 规范关闭标记习语
+
+反噪声精化识别一个固定词汇表（不区分大小写）。AILOG 作者应在写入时收敛到这些表述,使 born-resolved 条目以 `suspected-closed` 而非 TBD 噪声落地:
+
+| 习语族 | 示例 |
+|---|---|
+| In-Charter 关闭 | `closed in-Charter`、`closed in Charter`、`resolved in-Charter`、`resolved in Charter` |
+| 批次修复 | `fixed in batch 3`（需要数字） |
+| Commit 引用 | 反引号包裹的 commit 哈希:`` `ab12cd34ef` ``（7–40 个十六进制字符,至少一个数字） |
+| Born-resolved *(cli-3.20.0+,#222 Finding 2)* | 关闭动词 —— `updated` / `corrected` / `remediated` / `resolved` / `fixed` / `closed` —— 后跟 `in this PR` 或 `in this commit`,例如 `Charter row updated atomically in this PR` |
+
+词汇表之外的表述（如 `done earlier`、`no longer relevant`）会以 `open` 提取;操作员在分诊时翻转。当新的关闭习语在你的 AILOG 中反复出现时,请向上游提议,而不是手动编辑提取结果。
+
 ### Per-AILOG 与 per-bullet 粒度
 
 跟踪是 **per-AILOG**,而非 per-bullet。AILOG 要么被完全提取(其 id 在 `fully_extracted_ailogs` 中 — 信任注册表),要么未被提取(提取所有内容)。Per-bullet 匹配将需要指纹识别(文本哈希或模糊比较),每当注册表条目对 AILOG 的 bullet 进行改写时,这都会产生误报 — 而经过整理的条目总是会改写。这个设计选择经过经验验证:在参考 adopter 中,**跨 76 个 AILOG 和约 10 次 apply 运行,0 个误报**。
@@ -216,6 +231,7 @@ straymark followups list --bucket ready --status open --severity blocking --labe
 straymark followups status                # 注册表脉搏:计数器(即时重新计算)、按 bucket/severity 细分
 straymark followups status FU-NNN         # 单个条目的详情视图
 straymark followups drift [--apply|--scan-all]   # 漂移检测(见上文)
+straymark followups recount               # 手动分诊会话后重新计算 CLI 拥有的计数器(cli-3.20.0+)
 straymark followups promote FU-NNN        # 自动化 FU → TDE 提升(见上文)
 ```
 
@@ -229,7 +245,7 @@ straymark followups promote FU-NNN        # 自动化 FU → TDE 提升(见上�
 
 - **会话开始**:扫视 `.straymark/follow-ups-backlog.md`(或运行 `straymark followups status`)以了解项目中所有待处理事项。
 - **Pre-commit**:创建或修改了任何带有 `## Follow-ups` 或 `R<N> (new, not in Charter)` 条目的 AILOG 吗? → 在同一个 commit 中运行 `straymark followups drift --apply`。
-- **Charter 关闭后**:审查 Charter 解决的条目;将其标记为 `closed`(在 `Notes` 中带有关闭 Charter id)或 `superseded`;确认或重新打开任何 `suspected-closed` 条目;通过 `straymark followups promote` 提升符合 TDE 标准的未解决条目。
+- **Charter 关闭后**:审查 Charter 解决的条目;将其标记为 `closed`(在 `Notes` 中带有关闭 Charter id)或 `superseded`;确认或重新打开任何 `suspected-closed` 条目;然后运行 `straymark followups recount`,使 CLI 拥有的计数器与分诊在同一个 commit 中;通过 `straymark followups promote` 提升符合 TDE 标准的未解决条目。
 
 这使代理成为注册表的主要维护者,CLI 成为验证层,操作员成为周期性审查者(重新分类、确认 suspected-closed、修剪 superseded、在符合标准时提升为 TDE)。
 
@@ -291,4 +307,4 @@ straymark followups promote FU-NNN        # 自动化 FU → TDE 提升(见上�
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -76,7 +76,7 @@ follow-ups backlog 同样**不是**文档类型 —— 它是一个单文件注�
 | `Follow-ups registry` | `.straymark/follow-ups-backlog.md`（schema: `follow-ups-backlog.schema.v1.json`,实验性） | 代理通过 `followups drift --apply` 提取（pre-commit）;操作者拥有 triage 与提升批准 |
 
 ```bash
-straymark followups list / status / drift [--apply] / promote FU-NNN
+straymark followups list / status / drift [--apply] / recount / promote FU-NNN
 ```
 
 > 参见 `STRAYMARK.md` 第 16 节、`FOLLOW-UPS-BACKLOG-PATTERN.md` 及 AGENT-RULES.md §13,了解随框架发布的代理指令。
@@ -234,4 +234,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark fw-4.22.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/STRAYMARK.md
+++ b/dist/STRAYMARK.md
@@ -474,8 +474,8 @@ Follow-ups originate not only from planning (ex-ante) but from **execution reali
 | Stage | What happens | CLI |
 |-------|--------------|-----|
 | **Extraction** | New AILOG with `§Follow-ups` / `R<N> (new)` content → entries auto-extracted into `## Bucket: ready` (or `suspected-closed` when the AILOG text marks them resolved in-Charter). | `straymark followups drift --apply` |
-| **Triage** | Operator reclassifies bucket/trigger/destination, fills `Severity`/`Labels`, confirms or reopens `suspected-closed` entries. Typically once per stage close (~1h per 4-8 Charters at reference-adopter scale). | (manual edit + `followups list`) |
-| **Consumption** | Entries feed Charter planning; when a Charter addresses an entry, mark `in-progress` → `closed` with provenance in `Notes`. | (manual edit) |
+| **Triage** | Operator reclassifies bucket/trigger/destination, fills `Severity`/`Labels`, confirms or reopens `suspected-closed` entries. Typically once per stage close (~1h per 4-8 Charters at reference-adopter scale). | (manual edit + `followups list`; then `followups recount` to reconcile the CLI-owned counters) |
+| **Consumption** | Entries feed Charter planning; when a Charter addresses an entry, mark `in-progress` → `closed` with provenance in `Notes`. | (manual edit + `followups recount`) |
 | **Promotion** | Entries meeting the transversal-debt criteria (AGENT-RULES.md §3) are elevated to a TDE document with full traceability. | `straymark followups promote FU-NNN` |
 
 ### How it relates to existing artifacts
@@ -490,6 +490,7 @@ Follow-ups originate not only from planning (ex-ante) but from **execution reali
 straymark followups list                  # enumerate entries (filters: --bucket, --status, --severity, --label)
 straymark followups status [FU-NNN]       # registry pulse (counters recomputed on the fly) / entry detail
 straymark followups drift [--apply|--scan-all]   # detect/extract AILOGs not yet in the registry
+straymark followups recount               # recompute the CLI-owned counters after a manual-triage session (cli-3.20.0+)
 straymark followups promote FU-NNN        # automate FU → TDE promotion
 ```
 

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.22.0"
+version: "4.23.0"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -47,8 +47,8 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.22.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.19.1` | The `straymark` binary |
+| Framework | `fw-` | `fw-4.23.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| CLI | `cli-` | `cli-3.20.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -893,6 +893,7 @@ Parsing is **lenient**: v0 registries (pre-fw-4.21.0) are read without errors; t
 - `straymark followups list` — enumerate entries *(cli-3.19.0+)*
 - `straymark followups status` — registry pulse / entry detail *(cli-3.19.0+)*
 - `straymark followups drift` — sync the registry with AILOGs (native replacement for the deprecated adopter-side `check-followups-drift.sh`) *(cli-3.19.0+)*
+- `straymark followups recount` — recompute the CLI-owned counters after a manual-triage session *(cli-3.20.0+)*
 - `straymark followups promote` — elevate an entry to a TDE document *(cli-3.19.0+)*
 
 #### `straymark followups list [--bucket <name>] [--status <s>] [--severity <s>] [--label <tag>] [path]`
@@ -923,17 +924,26 @@ Detect AILOGs whose follow-up content is not yet extracted into the registry. Gr
 | Flag | Default | Description |
 |------|---------|-------------|
 | *(default)* | — | Scan AILOGs changed in `origin/main..HEAD` (fallback `origin/master..HEAD`, then `HEAD~1..HEAD` with a warning). Warn + **exit 1** on drift. |
-| `--apply` | off | Extract the missing entries into `## Bucket: ready` with auto-numbered `FU-NNN` ids, append the AILOG ids to `fully_extracted_ailogs`, **recompute the counters**, and upgrade v0 registries to v1 in place. Seeds the registry from the framework template when absent. |
+| `--apply` | off | Extract the missing entries into `## Bucket: ready` with auto-numbered `FU-NNN` ids, append the AILOG ids to `fully_extracted_ailogs`, **recompute the counters**, and upgrade v0 registries to v1 in place. Seeds the registry from the framework template when absent. Since cli-3.20.0 the counters are recomputed **even when there is nothing to extract** (#222 Finding 1). |
 | `--scan-all` | off | Sweep every AILOG in the project instead of the git range. |
 | `--range <REV..REV>` | — | Explicit git range for the default scan. |
 
-**Anti-noise refinement** (issue #214 Signal 1): bullets whose AILOG text carries an explicit closure marker — `closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash — are extracted as **`suspected-closed`** instead of `open`, so already-resolved work stops polluting the `ready` bucket as TBD noise. The operator confirms (→ `closed`) or reopens at the next triage.
+**Anti-noise refinement** (issue #214 Signal 1): bullets whose AILOG text carries an explicit closure marker — `closed in-Charter`, `fixed in batch N`, a backtick-wrapped commit hash, or *(cli-3.20.0+, #222 Finding 2)* a born-resolved idiom (a closure verb `updated`/`corrected`/`remediated`/`resolved`/`fixed`/`closed` followed by `in this PR` / `in this commit`, e.g. `updated atomically in this PR`) — are extracted as **`suspected-closed`** instead of `open`, so already-resolved work stops polluting the `ready` bucket as TBD noise. The operator confirms (→ `closed`) or reopens at the next triage. The canonical idiom vocabulary is documented in `FOLLOW-UPS-BACKLOG-PATTERN.md`.
 
 ```bash
 $ straymark followups drift --scan-all --apply
 ✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
   ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
   Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+```
+
+#### `straymark followups recount [--path <dir>]` *(cli-3.20.0+)*
+
+Recompute the CLI-owned `total_*` counters from actual entry statuses and rewrite the frontmatter — without scanning AILOGs, extracting, or touching entries. The §13-compliant way to reconcile counters after a **manual-triage session** (statuses flipped by hand per the sanctioned Triage/Consumption lifecycle, nothing left to extract or promote — #222 Finding 1, first external adopter). Idempotent: a second run reports the counters as already in sync. Upgrades v0 registries to v1 in place, like every other write command.
+
+```bash
+$ straymark followups recount
+✓ Counters recomputed: 0 open / 0 suspected-closed / 2 promoted (total 2).
 ```
 
 #### `straymark followups promote <FU-NNN> [--title <title>] [--path <dir>]`

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -240,8 +240,8 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.22.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.19.1` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.23.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| CLI | `cli-` | `cli-3.20.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 
@@ -274,7 +274,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.22.0)
+# y descarga el último release fw-* (ej. fw-4.23.0)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -47,8 +47,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.22.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.19.1` | El binario `straymark` |
+| Framework | `fw-` | `fw-4.23.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| CLI | `cli-` | `cli-3.20.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -695,6 +695,7 @@ El parsing es **tolerante**: los registros v0 (pre-fw-4.21.0) se leen sin errore
 - `straymark followups list` — enumera las entradas *(cli-3.19.0+)*
 - `straymark followups status` — pulso del registro / detalle de una entrada *(cli-3.19.0+)*
 - `straymark followups drift` — sincroniza el registro con los AILOGs (reemplazo nativo del `check-followups-drift.sh` adopter-side, ya deprecado) *(cli-3.19.0+)*
+- `straymark followups recount` — recalcula los contadores propiedad del CLI tras una sesión de triage manual *(cli-3.20.0+)*
 - `straymark followups promote` — eleva una entrada a un documento TDE *(cli-3.19.0+)*
 
 #### `straymark followups list [--bucket <name>] [--status <s>] [--severity <s>] [--label <tag>] [path]`
@@ -725,17 +726,26 @@ Detecta los AILOGs cuyo contenido de follow-ups aún no se ha extraído al regis
 | Flag | Default | Descripción |
 |------|---------|-------------|
 | *(default)* | — | Escanea los AILOGs cambiados en `origin/main..HEAD` (fallback `origin/master..HEAD`, luego `HEAD~1..HEAD` con una advertencia). Avisa + **exit 1** ante drift. |
-| `--apply` | off | Extrae las entradas faltantes a `## Bucket: ready` con ids `FU-NNN` auto-numerados, añade los ids de los AILOGs a `fully_extracted_ailogs`, **recalcula los contadores**, y actualiza los registros v0 a v1 in place. Siembra el registro desde el template del framework cuando no existe. |
+| `--apply` | off | Extrae las entradas faltantes a `## Bucket: ready` con ids `FU-NNN` auto-numerados, añade los ids de los AILOGs a `fully_extracted_ailogs`, **recalcula los contadores**, y actualiza los registros v0 a v1 in place. Siembra el registro desde el template del framework cuando no existe. Desde cli-3.20.0 los contadores se recalculan **incluso cuando no hay nada que extraer** (#222 Finding 1). |
 | `--scan-all` | off | Barre cada AILOG del proyecto en lugar del rango de git. |
 | `--range <REV..REV>` | — | Rango de git explícito para el escaneo por defecto. |
 
-**Refinamiento anti-ruido** (issue #214 Signal 1): los bullets cuyo texto del AILOG lleva un marcador de cierre explícito — `closed in-Charter`, `fixed in batch N`, un commit hash entre backticks — se extraen como **`suspected-closed`** en lugar de `open`, así el trabajo ya resuelto deja de contaminar el bucket `ready` como ruido TBD. El operador confirma (→ `closed`) o reabre en el siguiente triage.
+**Refinamiento anti-ruido** (issue #214 Signal 1): los bullets cuyo texto del AILOG lleva un marcador de cierre explícito — `closed in-Charter`, `fixed in batch N`, un commit hash entre backticks, o *(cli-3.20.0+, #222 Finding 2)* un modismo born-resolved (un verbo de cierre `updated`/`corrected`/`remediated`/`resolved`/`fixed`/`closed` seguido de `in this PR` / `in this commit`, p.ej. `updated atomically in this PR`) — se extraen como **`suspected-closed`** en lugar de `open`, así el trabajo ya resuelto deja de contaminar el bucket `ready` como ruido TBD. El operador confirma (→ `closed`) o reabre en el siguiente triage.
 
 ```bash
 $ straymark followups drift --scan-all --apply
 ✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
   ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
   Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+```
+
+#### `straymark followups recount [--path <dir>]` *(cli-3.20.0+)*
+
+Recalcula los contadores `total_*` propiedad del CLI desde los estados reales de las entradas y reescribe el frontmatter — sin escanear AILOGs, sin extraer y sin tocar entradas. La vía conforme al §13 para reconciliar contadores tras una **sesión de triage manual** (estados cambiados a mano según el ciclo de vida sancionado de Triage/Consumo, sin nada que extraer ni promover — #222 Finding 1, primer adopter externo). Idempotente: una segunda corrida reporta los contadores ya en sync. Actualiza registros v0 a v1 in situ, como todo comando de escritura.
+
+```bash
+$ straymark followups recount
+✓ Counters recomputed: 0 open / 0 suspected-closed / 2 promoted (total 2).
 ```
 
 #### `straymark followups promote <FU-NNN> [--title <title>] [--path <dir>]`

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -258,8 +258,8 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.22.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.19.1` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.23.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| CLI | `cli-` | `cli-3.20.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -47,8 +47,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.22.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.19.1` | `straymark` 二进制文件 |
+| Framework | `fw-` | `fw-4.23.0` | 模板（12 种类型）、治理文档、指令 |
+| CLI | `cli-` | `cli-3.20.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -738,6 +738,7 @@ $ straymark charter audit CHARTER-05 --finalize
 - `straymark followups list` — 枚举条目 *(cli-3.19.0+)*
 - `straymark followups status` — 注册表概览 / 条目详情 *(cli-3.19.0+)*
 - `straymark followups drift` — 将注册表与 AILOG 同步（已弃用的 adopter 侧 `check-followups-drift.sh` 的原生替代）*(cli-3.19.0+)*
+- `straymark followups recount` — 手动分诊会话后重新计算 CLI 拥有的计数器 *(cli-3.20.0+)*
 - `straymark followups promote` — 将条目提升为 TDE 文档 *(cli-3.19.0+)*
 
 #### `straymark followups list [--bucket <name>] [--status <s>] [--severity <s>] [--label <tag>] [path]`
@@ -768,17 +769,26 @@ $ straymark followups list --severity blocking
 | Flag | Default | Description |
 |------|---------|-------------|
 | *(default)* | — | 扫描在 `origin/main..HEAD` 中变更的 AILOG（回退到 `origin/master..HEAD`，再回退到带告警的 `HEAD~1..HEAD`）。有漂移时告警并 **exit 1**。 |
-| `--apply` | off | 将缺失的条目提取到 `## Bucket: ready`，使用自动编号的 `FU-NNN` id，把 AILOG id 追加到 `fully_extracted_ailogs`，**重新计算计数器**，并就地把 v0 注册表升级为 v1。注册表不存在时从框架模板播种。 |
+| `--apply` | off | 将缺失的条目提取到 `## Bucket: ready`，使用自动编号的 `FU-NNN` id，把 AILOG id 追加到 `fully_extracted_ailogs`，**重新计算计数器**，并就地把 v0 注册表升级为 v1。注册表不存在时从框架模板播种。自 cli-3.20.0 起,**即使没有可提取的内容也会重新计算计数器**(#222 Finding 1)。 |
 | `--scan-all` | off | 扫描项目中的每一个 AILOG，而非 git 范围。 |
 | `--range <REV..REV>` | — | 默认扫描的显式 git 范围。 |
 
-**抗噪声精炼**（issue #214 Signal 1）：其 AILOG 文本带有显式闭合标记的条目 —— `closed in-Charter`、`fixed in batch N`、反引号包裹的 commit hash —— 会被提取为 **`suspected-closed`** 而非 `open`，从而避免已解决的工作以 TBD 噪声污染 `ready` bucket。操作员在下次分诊时确认（→ `closed`）或重开。
+**抗噪声精炼**（issue #214 Signal 1）：其 AILOG 文本带有显式闭合标记的条目 —— `closed in-Charter`、`fixed in batch N`、反引号包裹的 commit hash，或 *(cli-3.20.0+,#222 Finding 2)* born-resolved 习语（关闭动词 `updated`/`corrected`/`remediated`/`resolved`/`fixed`/`closed` 后跟 `in this PR` / `in this commit`,如 `updated atomically in this PR`）—— 会被提取为 **`suspected-closed`** 而非 `open`，从而避免已解决的工作以 TBD 噪声污染 `ready` bucket。操作员在下次分诊时确认（→ `closed`）或重开。
 
 ```bash
 $ straymark followups drift --scan-all --apply
 ✓ Extracted 4 entries from 1 AILOG(s) into `## Bucket: ready`.
   ! 1 extracted as suspected-closed (closure marker in source AILOG) — confirm at the next triage.
   Counters recomputed: 3 open / 1 suspected-closed / 0 promoted (total 4).
+```
+
+#### `straymark followups recount [--path <dir>]` *(cli-3.20.0+)*
+
+根据实际条目状态重新计算 CLI 拥有的 `total_*` 计数器并重写 frontmatter —— 不扫描 AILOG、不提取、不触碰条目。这是在**手动分诊会话**之后（按照被认可的分诊/消费生命周期手动翻转状态,没有可提取或可提升的内容 —— #222 Finding 1,首个外部 adopter）符合 §13 地调和计数器的方式。幂等:第二次运行会报告计数器已同步。像其他写入命令一样,就地将 v0 注册表升级到 v1。
+
+```bash
+$ straymark followups recount
+✓ Counters recomputed: 0 open / 0 suspected-closed / 2 promoted (total 2).
 ```
 
 #### `straymark followups promote <FU-NNN> [--title <title>] [--path <dir>]`


### PR DESCRIPTION
Closes #222.

## Summary

First fixes driven by **external adopter feedback** (lnxdrive, the first N=2 data point gating the v1 schema's hard stabilization per principle #12 / ADR-2026-06-03-001).

### CLI (cli-3.20.0)

- **`straymark followups recount`** (#222 Finding 1) — recompute the CLI-owned `total_*` counters from actual entry statuses, without scanning AILOGs or touching entries. Closes the loop between the sanctioned manual-triage workflow and the CLI-owned counter invariant. Idempotent; upgrades v0 → v1 in place.
- **`drift --apply` recomputes counters even with zero extractions** — a pre-commit `drift --apply` also reconciles counters left stale by a pure-triage session; the `status` stale-counter warning now points at `recount`.
- **Born-resolved closure idioms** (#222 Finding 2) — `has_closure_marker` now recognizes a closure verb (`updated`/`corrected`/`remediated`/`resolved`/`fixed`/`closed`) followed by `in this PR` / `in this commit` (the exact lnxdrive phrasing `updated atomically in this PR` is a test case), extracting as `suspected-closed`.

### Framework (fw-4.23.0)

- **Canonical closure-marker idioms** table in `FOLLOW-UPS-BACKLOG-PATTERN.md` (EN/ES/zh-CN) so AILOG authors converge on recognizable phrasings at write time.
- **Recount step** added to `AGENT-RULES.md §13` post-Charter-close (EN/ES/zh-CN), the `/straymark-followups` skill (4 surfaces, Codex regenerated), `STRAYMARK.md §16` lifecycle table, and the `QUICK-REFERENCE.md` command line.
- Version bumps: `dist-manifest.yml` 4.23.0, `Cargo.toml` 3.20.0, versioning tables ×6, governance footers ×15, combined CHANGELOG entry.

## Verification

- `cargo test` → 619 passed, 0 failed (24 suites; +6 new: born-resolved unit family, recount/drift-recompute/born-resolved integration).
- `cargo run --bin gen_codex_skills -- --check` → in sync (12 skills).
- `git grep fw-4.22.0` / `3.19.1` → only historical introduced-in markers remain.

Refs #214, #220, ADR-2026-06-03-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)