### PR TITLE
docs: CLAUDE.md website section — zh-CN is a site locale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ straymark/
 │   ├── .straymark/          # Templates, governance, config
 │   ├── STRAYMARK.md         # Unified governance rules
 │   └── dist-manifest.yml   # What gets installed
-├── docs/                   # Project documentation (EN + ES)
+├── docs/                   # Project documentation (EN + ES + zh-CN)
 ├── .github/workflows/      # CI/CD
 │   ├── release-cli.yml     # Build + release CLI binaries
 │   └── release-framework.yml
@@ -326,10 +326,11 @@ Configured in `docusaurus.config.ts` under `i18n`:
 ```ts
 i18n: {
   defaultLocale: 'en',
-  locales: ['en', 'es'],
+  locales: ['en', 'es', 'zh-CN'],
   localeConfigs: {
     en: {label: 'English'},
     es: {label: 'Español'},
+    'zh-CN': {label: '简体中文'},
   },
 }
 ```


### PR DESCRIPTION
Factual correction, CLAUDE.md only: the website i18n snippet was stale (`locales: ['en', 'es']`) vs the real `website/docusaurus.config.ts` (`['en', 'es', 'zh-CN']`, live at https://straymark.dev/zh-CN/). Also updates the `docs/` tree comment to EN + ES + zh-CN.

No content changes outside CLAUDE.md; no deploy triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)