### PR TITLE
docs(framework): fw-4.23.1 — migration sweep warning from Sentinel update report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Framework 4.23.1 — migration sweep warning from the reference adopter's update run
+
+Docs-only patch driven by the Sentinel update report ([#225](https://github.com/StrangeDaysTech/straymark/issues/225), cli-3.16.0 → 3.19.x / fw-4.20.0 → 4.22.0): the deprecated v0 bash script produced **silent false-negatives on drift detection itself** — its format-sensitive extractor (required both a `## Risk` heading and the exact `- **R<N> (new` bullet shape) never registered 8 AILOGs whose risks were written as bare paragraphs, reporting "in sync" while 29 entries sat unextracted. The native lenient parser caught them all on the first post-migration sweep.
+
+### Changed (Framework)
+
+- **`FOLLOW-UPS-BACKLOG-PATTERN.md` migration paragraph** (EN/ES/zh-CN): the migration command is now `drift --scan-all --apply`, with an explicit warning to run that first sweep with `--scan-all` *even if the legacy script reported "in sync"* — including the #225 data point (8 AILOGs / 29 entries silently missed).
+- **`CLI-REFERENCE.md` lenient-parsing note** (EN/ES/zh-CN): the v0 → v1 upgrade fires on *any* write command — `drift --apply` (even with nothing to extract, cli-3.20.0+), `recount`, or `promote`. #225 Finding 2 (upgrade not firing on a no-op `--apply`) was already resolved by cli-3.20.0; this aligns the prose.
+
+### Adopter guidance
+
+Nothing to re-run if you already migrated with `--scan-all` (Sentinel's case). If you migrated with a plain `drift --apply` and the legacy script was your only drift check, run `straymark followups drift --scan-all --apply` once — the v0 script may have been blind to format variants your AILOGs use.
+
+---
+
 ## Framework 4.23.0 / CLI 3.20.0 — N=2 feedback: `followups recount` + born-resolved closure idioms
 
 First fixes driven by **external adopter feedback**: the lnxdrive adoption run ([#222](https://github.com/StrangeDaysTech/straymark/issues/222), the first N=2 data point gating the v1 schema's hard stabilization per principle #12 / ADR-2026-06-03-001) surfaced two gaps in the follow-ups lane — both ergonomic/vocabulary, neither schema-level.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ StrayMark uses independent version tags for each component:
 
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
-| Framework | `fw-` | `fw-4.23.0` | Templates (12 types), governance, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.23.1` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.20.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
@@ -311,7 +311,7 @@ See [CLI Reference](https://github.com/StrangeDaysTech/straymark/blob/main/docs/
 ```bash
 # Download the latest framework release ZIP from GitHub
 # Go to https://github.com/StrangeDaysTech/straymark/releases
-# and download the latest fw-* release (e.g., fw-4.23.0)
+# and download the latest fw-* release (e.g., fw-4.23.1)
 
 # Extract and copy to your project
 unzip straymark-fw-*.zip -d your-project/

--- a/dist/.straymark/00-governance/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/AGENT-RULES.md
@@ -412,4 +412,4 @@ When a project accumulates a high volume of AILOGs across multiple Charters and 
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Use a Level 1 (Context) diagram to illustrate:
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/DOCUMENTATION-POLICY.md
@@ -319,4 +319,4 @@ See also [ADR-2025-01-20-001] for architectural context.
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -219,7 +219,9 @@ The cost of per-AILOG granularity: when a follow-up is added to an already-extra
 
 ### Legacy bash script (deprecated)
 
-The v0 reference implementation (`scripts/check-followups-drift.sh`, ~296 lines of POSIX bash in the Sentinel adopter's repo) is **deprecated as of cli-3.19.0**. It keeps working for v0 registries but is no longer maintained and lacks the anti-noise refinement and counter recompute. Migration path: delete the script, run `straymark followups drift --apply` once (this also upgrades the registry to v1), and update any pre-commit hook to call the CLI instead.
+The v0 reference implementation (`scripts/check-followups-drift.sh`, ~296 lines of POSIX bash in the Sentinel adopter's repo) is **deprecated as of cli-3.19.0**. It keeps working for v0 registries but is no longer maintained and lacks the anti-noise refinement and counter recompute. Migration path: delete the script, run `straymark followups drift --scan-all --apply` once (this also upgrades the registry to v1), and update any pre-commit hook to call the CLI instead.
+
+**Run that first post-migration sweep with `--scan-all` even if the script reported "in sync"**: the bash extractor was format-sensitive (it required both a `## Risk` heading and the exact `- **R<N> (new` bullet shape) and produced **silent false-negatives** on format variants — AILOGs writing risks as bare paragraphs never registered as having follow-up content at all. In the reference adopter's migration ([issue #225](https://github.com/StrangeDaysTech/straymark/issues/225)), the native lenient parser caught **8 AILOGs / 29 entries** that the script had reported as "in sync" the day before. Silent false-negatives on drift detection are the exact failure mode the tool exists to prevent — which is why the script is deprecated rather than maintained.
 
 ---
 
@@ -307,4 +309,4 @@ Contributed via [issue #111](https://github.com/StrangeDaysTech/straymark/issues
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/QUICK-REFERENCE.md
@@ -259,4 +259,4 @@ Mark `review_required: true` when:
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/es/AGENT-RULES.md
@@ -412,4 +412,4 @@ Cuando un proyecto acumula un volumen alto de AILOGs a lo largo de múltiples Ch
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/es/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Usar un diagrama de Nivel 1 (Contexto) para ilustrar:
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/es/DOCUMENTATION-POLICY.md
@@ -312,4 +312,4 @@ Ver también [ADR-2025-01-20-001] para contexto arquitectónico.
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/es/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -219,7 +219,9 @@ El costo de la granularidad per-AILOG: cuando se agrega un follow-up a un AILOG 
 
 ### Script bash legacy (deprecado)
 
-La implementación de referencia v0 (`scripts/check-followups-drift.sh`, ~296 líneas de bash POSIX en el repo del adopter Sentinel) está **deprecada a partir de cli-3.19.0**. Sigue funcionando para registries v0 pero ya no se mantiene y carece del refinamiento anti-ruido y del recálculo de contadores. Ruta de migración: borra el script, ejecuta `straymark followups drift --apply` una vez (esto también actualiza el registry a v1), y actualiza cualquier pre-commit hook para que llame al CLI en su lugar.
+La implementación de referencia v0 (`scripts/check-followups-drift.sh`, ~296 líneas de bash POSIX en el repo del adopter Sentinel) está **deprecada a partir de cli-3.19.0**. Sigue funcionando para registries v0 pero ya no se mantiene y carece del refinamiento anti-ruido y del recálculo de contadores. Ruta de migración: borra el script, ejecuta `straymark followups drift --scan-all --apply` una vez (esto también actualiza el registry a v1), y actualiza cualquier pre-commit hook para que llame al CLI en su lugar.
+
+**Corre ese primer barrido post-migración con `--scan-all` aunque el script reportara "in sync"**: el extractor bash era sensible al formato (exigía un heading `## Risk` y la forma exacta de bullet `- **R<N> (new`) y producía **falsos negativos silenciosos** ante variantes de formato — los AILOGs que escribían riesgos como párrafos planos nunca registraban como portadores de follow-ups. En la migración del adopter de referencia ([issue #225](https://github.com/StrangeDaysTech/straymark/issues/225)), el parser nativo leniente capturó **8 AILOGs / 29 entradas** que el script había reportado como "in sync" el día anterior. Los falsos negativos silenciosos en la detección de drift son exactamente el modo de falla que la herramienta existe para prevenir — por eso el script está deprecado en vez de mantenido.
 
 ---
 
@@ -307,4 +309,4 @@ Contribuido vía [issue #111](https://github.com/StrangeDaysTech/straymark/issue
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/es/QUICK-REFERENCE.md
@@ -234,4 +234,4 @@ Marcar `review_required: true` cuando:
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/AGENT-RULES.md
@@ -407,4 +407,4 @@ confidence: high | medium | low
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/C4-DIAGRAM-GUIDE.md
@@ -234,4 +234,4 @@ Rel(api, db, "Reads/Writes", "SQL")
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/DOCUMENTATION-POLICY.md
@@ -311,4 +311,4 @@ review_outcome: approved                # approved | revisions_requested | rejec
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/FOLLOW-UPS-BACKLOG-PATTERN.md
@@ -219,7 +219,9 @@ Per-AILOG 粒度的成本:当在 Charter 关闭后向已提取的 AILOG 添加 f
 
 ### 旧版 bash 脚本（已弃用）
 
-v0 参考实现（`scripts/check-followups-drift.sh`,Sentinel adopter repo 中约 296 行 POSIX bash）**自 cli-3.19.0 起已弃用**。它对 v0 注册表仍可工作,但不再维护,且缺少反噪声精化和计数器重新计算。迁移路径:删除该脚本,运行一次 `straymark followups drift --apply`(这同时将注册表升级到 v1),并更新任何 pre-commit hook 改为调用 CLI。
+v0 参考实现（`scripts/check-followups-drift.sh`,Sentinel adopter repo 中约 296 行 POSIX bash）**自 cli-3.19.0 起已弃用**。它对 v0 注册表仍可工作,但不再维护,且缺少反噪声精化和计数器重新计算。迁移路径:删除该脚本,运行一次 `straymark followups drift --scan-all --apply`(这同时将注册表升级到 v1),并更新任何 pre-commit hook 改为调用 CLI。
+
+**即使脚本报告"in sync",首次迁移后扫描也要带上 `--scan-all`**:bash 提取器对格式敏感（同时要求 `## Risk` 标题和精确的 `- **R<N> (new` bullet 形态）,对格式变体产生**静默假阴性** —— 以纯段落书写风险的 AILOG 根本不会被识别为含有 follow-up 内容。在参考 adopter 的迁移中（[issue #225](https://github.com/StrangeDaysTech/straymark/issues/225)）,原生宽容解析器捕获了脚本前一天还报告为"in sync"的 **8 个 AILOG / 29 个条目**。漂移检测上的静默假阴性正是该工具旨在防止的失败模式 —— 这也是脚本被弃用而非继续维护的原因。
 
 ---
 
@@ -307,4 +309,4 @@ straymark followups promote FU-NNN        # 自动化 FU → TDE 提升(见上�
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
+++ b/dist/.straymark/00-governance/i18n/zh-CN/QUICK-REFERENCE.md
@@ -234,4 +234,4 @@ risk_level: low | medium | high | critical
 
 ---
 
-*StrayMark fw-4.23.0 | [Strange Days Tech](https://strangedays.tech)*
+*StrayMark fw-4.23.1 | [Strange Days Tech](https://strangedays.tech)*

--- a/dist/dist-manifest.yml
+++ b/dist/dist-manifest.yml
@@ -1,4 +1,4 @@
-version: "4.23.0"
+version: "4.23.1"
 description: "StrayMark distribution manifest"
 repository: "https://github.com/StrangeDaysTech/straymark"
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -47,7 +47,7 @@ StrayMark uses **independent version tags** for each component:
 
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
-| Framework | `fw-` | `fw-4.23.0` | Templates (12 types), governance docs, directives, Charter template + schema |
+| Framework | `fw-` | `fw-4.23.1` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.20.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
@@ -888,7 +888,7 @@ $ straymark charter amend CHARTER-18 \
 
 Manage the **follow-ups backlog registry** (`.straymark/follow-ups-backlog.md`) — the first-class artifact that aggregates `§Follow-ups` and `R<N> (new, not in Charter)` entries across AILOGs. Schema: `.straymark/schemas/follow-ups-backlog.schema.v1.json` (experimental v1). Convention: `FOLLOW-UPS-BACKLOG-PATTERN.md` and `STRAYMARK.md §16`; shipped agent directives in `AGENT-RULES.md §13`.
 
-Parsing is **lenient**: v0 registries (pre-fw-4.21.0) are read without errors; the first write command (`drift --apply` or `promote`) upgrades them to v1 in place, non-destructively. Frontmatter `total_*` counters are **CLI-owned** — recomputed on every write; never edit them by hand.
+Parsing is **lenient**: v0 registries (pre-fw-4.21.0) are read without errors; the first write command (`drift --apply` — even with nothing to extract, cli-3.20.0+ —, `recount`, or `promote`) upgrades them to v1 in place, non-destructively. Frontmatter `total_*` counters are **CLI-owned** — recomputed on every write; never edit them by hand.
 
 - `straymark followups list` — enumerate entries *(cli-3.19.0+)*
 - `straymark followups status` — registry pulse / entry detail *(cli-3.19.0+)*

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -240,7 +240,7 @@ StrayMark usa tags de versión independientes para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
-| Framework | `fw-` | `fw-4.23.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
+| Framework | `fw-` | `fw-4.23.1` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.20.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
@@ -274,7 +274,7 @@ Ver [Referencia CLI](adopters/CLI-REFERENCE.md) para uso detallado.
 ```bash
 # Descargar el último release ZIP del framework desde GitHub
 # Ve a https://github.com/StrangeDaysTech/straymark/releases
-# y descarga el último release fw-* (ej. fw-4.23.0)
+# y descarga el último release fw-* (ej. fw-4.23.1)
 
 # Extraer y copiar a tu proyecto
 unzip straymark-fw-*.zip -d tu-proyecto/

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -47,7 +47,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
-| Framework | `fw-` | `fw-4.23.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
+| Framework | `fw-` | `fw-4.23.1` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.20.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
@@ -690,7 +690,7 @@ Los adopters pueden `git add` el directorio entero `.straymark/audits/` para un 
 
 Gestiona el **registro del backlog de follow-ups** (`.straymark/follow-ups-backlog.md`) — el artefacto de primera clase que agrega las entradas `§Follow-ups` y `R<N> (new, not in Charter)` a través de los AILOGs. Schema: `.straymark/schemas/follow-ups-backlog.schema.v1.json` (v1 experimental). Convención: `FOLLOW-UPS-BACKLOG-PATTERN.md` y `STRAYMARK.md §16`; directivas de agente distribuidas en `AGENT-RULES.md §13`.
 
-El parsing es **tolerante**: los registros v0 (pre-fw-4.21.0) se leen sin errores; el primer comando de escritura (`drift --apply` o `promote`) los actualiza a v1 in place, de forma no destructiva. Los contadores `total_*` del frontmatter son **propiedad del CLI** — se recalculan en cada escritura; nunca los edites a mano.
+El parsing es **tolerante**: los registros v0 (pre-fw-4.21.0) se leen sin errores; el primer comando de escritura (`drift --apply` — incluso sin nada que extraer, cli-3.20.0+ —, `recount` o `promote`) los actualiza a v1 in place, de forma no destructiva. Los contadores `total_*` del frontmatter son **propiedad del CLI** — se recalculan en cada escritura; nunca los edites a mano.
 
 - `straymark followups list` — enumera las entradas *(cli-3.19.0+)*
 - `straymark followups status` — pulso del registro / detalle de una entrada *(cli-3.19.0+)*

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -258,7 +258,7 @@ StrayMark 为每个组件使用独立的版本标签：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.23.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
+| Framework | `fw-` | `fw-4.23.1` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.20.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -47,7 +47,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
-| Framework | `fw-` | `fw-4.23.0` | 模板（12 种类型）、治理文档、指令 |
+| Framework | `fw-` | `fw-4.23.1` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.20.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
@@ -733,7 +733,7 @@ $ straymark charter audit CHARTER-05 --finalize
 
 管理**后续事项积压注册表**（`.straymark/follow-ups-backlog.md`）—— 这是跨 AILOG 聚合 `§Follow-ups` 与 `R<N> (new, not in Charter)` 条目的一等产物。Schema：`.straymark/schemas/follow-ups-backlog.schema.v1.json`（实验性 v1）。约定：`FOLLOW-UPS-BACKLOG-PATTERN.md` 与 `STRAYMARK.md §16`；随附的代理指令见 `AGENT-RULES.md §13`。
 
-解析是**宽容的**：v0 注册表（fw-4.21.0 之前）可被无误读取；首个写入命令（`drift --apply` 或 `promote`）会就地、非破坏性地将其升级为 v1。frontmatter 的 `total_*` 计数器由 **CLI 拥有** —— 每次写入时重新计算；切勿手工编辑。
+解析是**宽容的**：v0 注册表（fw-4.21.0 之前）可被无误读取；首个写入命令（`drift --apply` —— 即使没有可提取内容,cli-3.20.0+ ——、`recount` 或 `promote`）会就地、非破坏性地将其升级为 v1。frontmatter 的 `total_*` 计数器由 **CLI 拥有** —— 每次写入时重新计算；切勿手工编辑。
 
 - `straymark followups list` — 枚举条目 *(cli-3.19.0+)*
 - `straymark followups status` — 注册表概览 / 条目详情 *(cli-3.19.0+)*


### PR DESCRIPTION
Closes #225.

## Summary

Docs-only framework patch responding to the Sentinel update report (#225):

- **Finding 1** — `FOLLOW-UPS-BACKLOG-PATTERN.md` migration paragraph (EN/ES/zh-CN) now mandates `drift --scan-all --apply` on the first post-migration sweep, *even if the legacy script reported "in sync"*, with the #225 data point: the v0 bash extractor's format sensitivity produced silent false-negatives (8 AILOGs / 29 entries missed).
- **Finding 2** — already resolved by cli-3.20.0 (no-op `--apply` and `recount` both upgrade v0 → v1 + recompute; verified by repro + integration tests). The `CLI-REFERENCE.md` lenient-parsing note (EN/ES/zh-CN) is aligned with that behavior.
- Bump fw-4.23.0 → **fw-4.23.1**: manifest, versioning tables ×6, governance footers ×15, CHANGELOG entry.

No CLI changes; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)