### PR TITLE
docs(blog): "What the bash script said was in sync" — follow-ups become first-class (EN/ES/zh-CN)

### DIFF
--- a/website/blog/2026-06-04-what-the-bash-script-said-was-in-sync.md
+++ b/website/blog/2026-06-04-what-the-bash-script-said-was-in-sync.md
@@ -1,0 +1,88 @@
+---
+slug: what-the-bash-script-said-was-in-sync
+title: What the bash script said was in sync
+authors:
+  - jose
+tags:
+  - straymark
+  - follow-ups
+  - governance
+  - adopters
+  - sentinel
+  - lnxdrive
+  - cli
+date: 2026-06-04T00:00:00.000Z
+description: Follow-ups became StrayMark's second first-class entity — and within a day, two external migrations stress-tested the design. The reference adopter's deprecated bash script had been reporting "in sync" while 29 entries sat invisible to it.
+---
+*The day after follow-ups became a first-class entity — schema, CLI namespace, shipped agent directives, an invocable skill — two adopters ran the migration end to end and filed their reports. One found the loop we hadn't closed. The other found something better: the deprecated bash script it was replacing had been silently blind for who knows how long, reporting "in sync" while 8 AILOGs and 29 entries sat unextracted. Both reports turned into releases the same day.*
+
+<!-- truncate -->
+
+> *"…despite the legacy script reporting **'in sync' as recently as the day before**, including `--scan-all` runs."*
+
+That line is from Issue [#225](https://github.com/StrangeDaysTech/straymark/issues/225), the [Sentinel](https://github.com/StrangeDaysTech/sentinel) update report, and it's the sentence this post is named after. To explain why it matters — and why it's the strongest argument for the release lane it closed — we have to start with what a follow-up *is*.
+
+## The pending-work problem
+
+Every AILOG in StrayMark can end with a `## Follow-ups` section: the things this change deferred. Risks that surfaced mid-Charter get the same treatment — `R4 (new, not in Charter): …`. It's a write-time convention, and at write time it works perfectly: the implementer knows exactly what they're deferring, and they write it down next to the work that deferred it.
+
+The failure mode is read time. *"What's pending across the project?"* is an operator question, and the per-AILOG convention answers it with a multi-file scan that gets worse with every Charter. The reference adopter hit the wall first: by Sentinel's CHARTER-12 the answer was 47 follow-ups deep and scattered across dozens of AILOGs, and the framework's response — [`fw-4.10.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.10.0), back in May — was a *convention*: one central registry file, `.straymark/follow-ups-backlog.md`, five buckets keyed on **when each entry becomes actionable**, and an adopter-side bash script (~296 lines of POSIX awk and grep) to detect AILOGs whose follow-ups hadn't been extracted yet.
+
+That v0 lane worked — and then it accumulated exactly the kind of debt you'd expect from a convention maintained by hand at N=91. Issue [#214](https://github.com/StrangeDaysTech/straymark/issues/214) documented the signals from the operator's seat. The frontmatter counters, maintained manually, had drifted to fiction: declared `total_open: 47` against 65 real, four weeks after the last reconciliation. And every extraction batch carried 20–75% noise — entries that were *already resolved* when the script appended them, because the bullet text said so (`closed in-Charter`, `fixed in batch 3`) and the script couldn't read.
+
+## First-class, with a gate
+
+The response was [ADR-2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md): the follow-ups backlog stops being a convention and becomes StrayMark's second first-class artifact, the same lane Charter took — its own canonical path, its own schema, its own CLI namespace, its own group in the `explore` TUI.
+
+[`fw-4.21.0` / `cli-3.19.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.19.0) shipped the substance:
+
+- **A JSON schema (v1, experimental)** for the registry frontmatter, plus the v1 entry dimensions the operator had been improvising in prose: `Severity: blocking` (canonicalizing a `PROD-BLOCKER` notes convention), `Origin-class` (planning artifact vs execution reality), free `Labels`, a `Destination` vocabulary.
+- **`straymark followups list / status / drift / promote`** — native, replacing the bash script. `drift --apply` extracts unextracted AILOGs per-AILOG (the granularity that produced 0 false positives across 76 AILOGs in the reference adopter), `promote` automates the FU → TDE elevation with traceability, `status` is the registry pulse.
+- **CLI-owned counters.** The `total_*` fields are recomputed from actual entry statuses on every write. The silent counter-drift failure mode is not "discouraged" — it is mechanically dead.
+- **Anti-noise extraction.** Bullets whose source text carries a closure marker land as `suspected-closed` instead of polluting the ready bucket as TBD noise. The operator confirms or reopens at triage.
+- **Agent directives that travel.** `AGENT-RULES.md §13` ships with the framework: glance at the registry at session start, `drift --apply` in the same commit as the AILOG, triage at Charter close. Adopters stopped copying a block into their own agent configs.
+
+And one deliberate brake, in the ADR itself: the schema ships as **experimental v1**. Hard stabilization is gated on a second adopter — the same N=2 discipline that [the last post](what-the-feature-flag-compiled-away) spent its middle section defending. One adopter's workflow, however well documented, is one stack's shape.
+
+[`fw-4.22.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.22.0) completed the surface with the part that had to wait for a framework release: the `/straymark-followups` skill, in all four agent surfaces, wrapping the §13 directives. A thin wrapper by design — its `allowed-tools` deliberately omits `Write`, because every registry mutation goes through the CLI and the counters stay CLI-owned. The skill drives discipline; it owns no logic.
+
+## Then both adopters showed up at once
+
+What happened next is the part worth writing down, because it compressed the feedback loop the gate exists to wait for into a single day.
+
+**[LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) adopted the registry cold** — first external adoption, 74 docs, Issue [#222](https://github.com/StrangeDaysTech/straymark/issues/222). The extraction itself was clean (cross-checked against a manual grep: zero missed AILOGs). Both findings were at the edges:
+
+- **The loop we hadn't closed.** The lifecycle explicitly sanctions *manual* triage — the operator flips statuses by hand. But the only commands that recomputed the CLI-owned counters were `drift --apply` and `promote`, and both are no-ops when there's nothing to extract or promote. After a pure-triage session the registry sat with knowingly stale counters and no compliant way to fix them: hand-editing violates §13, and the `status` warning's promise ("the next write recomputes") was only true if a future write happened to occur. The sanctioned workflow and the invariant didn't meet.
+- **A closure idiom we didn't speak.** Both extracted entries were born resolved — their source text said `Charter row updated atomically in this PR`. The anti-noise vocabulary knew `closed in-Charter`, `fixed in batch N`, and commit hashes; it didn't know this phrasing, so both entries landed as `open` TBD noise. The exact regression the refinement existed to kill, through an unrecognized idiom.
+
+[`fw-4.23.0` / `cli-3.20.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.20.0) shipped the same day: a dedicated **`followups recount`** verb (recompute counters, touch nothing else, idempotent), `drift --apply` reconciling counters even with zero extractions, the **born-resolved idiom family** in the closure vocabulary — and, more durably, the canonical idiom table documented in the pattern doc, so AILOG authors converge on recognizable phrasings at write time instead of discovering unrecognized ones at extraction.
+
+**Sentinel ran the official migration** — Issue [#225](https://github.com/StrangeDaysTech/straymark/issues/225): delete the script, `drift --scan-all --apply`, repoint the pre-commit hook. And the native parser immediately extracted 29 entries from 8 AILOGs that the bash script had reported as fully in sync — including in `--scan-all` runs — the day before.
+
+The root cause, verified against the deleted script in git history, is the kind of thing that makes "deprecated" feel insufficient as a word. The awk extractor required both a `## Risk` section heading *and* the exact `- **R<N> (new` bullet shape. Those 8 AILOGs wrote their risks as bare paragraphs — `R4 (new, not in Charter): …` at column 0, no bullet, no heading. Format-sensitive matching, zero matches, no error. The AILOGs never even registered as *having* follow-up content. The script wasn't missing features. It was producing **silent false negatives on drift detection itself — the one thing it existed to prevent.**
+
+The lenient parser caught all of them because leniency was a design decision, not an accident. `cli-3.19.1` had already widened status parsing for the same reason: operators annotate in place (`open — **OVERDUE** (…)`) and an exact-match parser would have demoted 4 of Sentinel's 65 entries to `unknown` and written wrong counters on the very first migration. Parse what humans actually write, then let the schema validation advise. Every formatting variant the strict tools dropped on the floor turned out to be load-bearing.
+
+[`fw-4.23.1`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.23.1) closed the report: the migration paragraph in the pattern doc now mandates `--scan-all` on the first post-migration sweep *even if the legacy script said "in sync"* — citing the 8/29 data point as the reason. (Sentinel's other finding, the v0 → v1 upgrade not firing on a no-op `--apply`, had been fixed hours earlier by the LNXDrive lane — the two reports resolved each other's edges without knowing it.)
+
+There was also a quiet confirmation buried in the Sentinel report, and it deserves the spotlight for a sentence. Mid-triage, with 29 entries being reclassified by hand, `status` printed *"frontmatter says total_open: 91 but the real count is 77 — run `straymark followups recount`"* — at exactly the right moment — and one command reconciled everything. The counter-drift failure mode that opened issue #214 is dead, and the adopter who reported it watched it die.
+
+## What we still deliberately didn't do
+
+The restraint section, because every post in this series has one and the discipline only counts if it survives good news.
+
+Sentinel's report offered two more closure idioms (`Validated: … No vulnerabilities found`, `Bundled into CHARTER-19`) — one occurrence each. They are *noted*, not shipped. The pattern doc's new vocabulary section states the rule we're holding ourselves to: propose an idiom upstream when it **recurs**. A vocabulary that absorbs every one-off phrasing stops being a vocabulary.
+
+The schema is still **experimental v1**. Two production migrations with zero schema-level findings is exactly the favorable signal the gate was built to measure — both reports were ergonomics and vocabulary, nothing structural — but the hard-stabilization call is a deliberate decision to take with a clear head, not a reflex to ship in the same week as the feature. And the `charter close` soft-integration (auto-running `drift --apply` at Charter close) stays gated behind a friction signal no adopter has sent.
+
+## If you've read this far
+
+The portable exercise this time is almost embarrassingly small. Pick the file — or the issue label, or the TODO convention — that answers *"what's pending?"* in your project. Now check two things. First: who maintains its summary numbers, a human or a tool? If a human, they're wrong; the only question is by how much (we measured: 18, after four weeks). Second: if your extraction tooling reported "nothing to do" today, would you know whether that's *true* or whether your last three deferred items just didn't match its regex? The difference between those two states is invisible by construction — that's what *silent* means — and the only way out is tooling that's lenient about what it reads and exclusive about what it owns.
+
+And if you maintain a deferred-work convention we haven't seen — a different bucket vocabulary, a different closure idiom, a different answer to who owns the counters — the channel is the same one #214, #222 and #225 went through: [open an issue](https://github.com/StrangeDaysTech/straymark/issues). The v1 schema is experimental precisely because your registry is the one it hasn't met yet.
+
+---
+
+*StrayMark `fw-4.21.0` → `fw-4.23.1`, `cli-3.19.0` → `cli-3.20.0` — ADR [2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md) · Issues [#214](https://github.com/StrangeDaysTech/straymark/issues/214) · [#220](https://github.com/StrangeDaysTech/straymark/issues/220) · [#222](https://github.com/StrangeDaysTech/straymark/issues/222) · [#225](https://github.com/StrangeDaysTech/straymark/issues/225) · PRs [#217](https://github.com/StrangeDaysTech/straymark/pull/217) · [#218](https://github.com/StrangeDaysTech/straymark/pull/218) · [#221](https://github.com/StrangeDaysTech/straymark/pull/221) · [#223](https://github.com/StrangeDaysTech/straymark/pull/223) · [#227](https://github.com/StrangeDaysTech/straymark/pull/227). Pattern: [`FOLLOW-UPS-BACKLOG-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md) (v1, experimental). Predecessors: [What the binary couldn't hide](what-the-binary-couldnt-hide) · [What the feature flag compiled away](what-the-feature-flag-compiled-away).*
+
+*This document was produced with assistance from generative AI tools (Claude Opus 4.8); all responsibility for the content rests with the human author.*

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-06-04-what-the-bash-script-said-was-in-sync.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-06-04-what-the-bash-script-said-was-in-sync.md
@@ -1,0 +1,88 @@
+---
+slug: what-the-bash-script-said-was-in-sync
+title: Lo que el script bash decía que estaba en sync
+authors:
+  - jose
+tags:
+  - straymark
+  - follow-ups
+  - gobernanza
+  - adopters
+  - sentinel
+  - lnxdrive
+  - cli
+date: 2026-06-04T00:00:00.000Z
+description: Los follow-ups se volvieron la segunda entidad de primera clase de StrayMark — y en un día, dos migraciones externas estresaron el diseño. El script bash deprecado del adopter de referencia llevaba reportando "in sync" mientras 29 entradas le eran invisibles.
+---
+*Al día siguiente de que los follow-ups se volvieran una entidad de primera clase — schema, namespace de CLI, directivas de agente que viajan, un skill invocable — dos adopters corrieron la migración de punta a punta y presentaron sus reportes. Uno encontró el loop que no habíamos cerrado. El otro encontró algo mejor: el script bash deprecado al que reemplazaba llevaba ciego en silencio quién sabe cuánto tiempo, reportando "in sync" mientras 8 AILOGs y 29 entradas seguían sin extraer. Ambos reportes se convirtieron en releases el mismo día.*
+
+<!-- truncate -->
+
+> *"…a pesar de que el script legacy reportaba **'in sync' tan recientemente como el día anterior**, incluyendo corridas con `--scan-all`."*
+
+Esa línea viene del Issue [#225](https://github.com/StrangeDaysTech/straymark/issues/225), el reporte de actualización de [Sentinel](https://github.com/StrangeDaysTech/sentinel), y es la frase que da nombre a este post. Para explicar por qué importa — y por qué es el argumento más fuerte a favor del carril de releases que cerró — hay que empezar por qué *es* un follow-up.
+
+## El problema del trabajo pendiente
+
+Todo AILOG en StrayMark puede terminar con una sección `## Follow-ups`: las cosas que este cambio difirió. Los riesgos que afloran a mitad de un Charter reciben el mismo trato — `R4 (new, not in Charter): …`. Es una convención de tiempo de escritura, y en tiempo de escritura funciona perfecto: quien implementa sabe exactamente qué está difiriendo, y lo anota junto al trabajo que lo difirió.
+
+El modo de falla es el tiempo de lectura. *"¿Qué está pendiente en el proyecto?"* es una pregunta de operador, y la convención per-AILOG la responde con un barrido multi-archivo que empeora con cada Charter. El adopter de referencia chocó primero con el muro: para el CHARTER-12 de Sentinel la respuesta tenía 47 follow-ups de profundidad repartidos en docenas de AILOGs, y la respuesta del framework — [`fw-4.10.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.10.0), allá en mayo — fue una *convención*: un archivo de registry central, `.straymark/follow-ups-backlog.md`, cinco buckets organizados por **cuándo se vuelve accionable cada entrada**, y un script bash del lado del adopter (~296 líneas de awk y grep POSIX) para detectar AILOGs cuyos follow-ups aún no habían sido extraídos.
+
+Ese carril v0 funcionó — y luego acumuló exactamente el tipo de deuda que esperarías de una convención mantenida a mano a N=91. El Issue [#214](https://github.com/StrangeDaysTech/straymark/issues/214) documentó las señales desde el asiento del operador. Los contadores del frontmatter, mantenidos manualmente, habían derivado a ficción: `total_open: 47` declarado contra 65 reales, cuatro semanas después de la última reconciliación. Y cada batch de extracción cargaba 20–75% de ruido — entradas que ya estaban *resueltas* cuando el script las agregaba, porque el texto del bullet lo decía (`closed in-Charter`, `fixed in batch 3`) y el script no sabía leer.
+
+## Primera clase, con compuerta
+
+La respuesta fue el [ADR-2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md): el backlog de follow-ups deja de ser una convención y se vuelve el segundo artefacto de primera clase de StrayMark, el mismo carril que tomó Charter — su propio path canónico, su propio schema, su propio namespace de CLI, su propio grupo en la TUI de `explore`.
+
+[`fw-4.21.0` / `cli-3.19.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.19.0) entregó la sustancia:
+
+- **Un schema JSON (v1, experimental)** para el frontmatter del registry, más las dimensiones v1 de entrada que el operador venía improvisando en prosa: `Severity: blocking` (canonicalizando una convención `PROD-BLOCKER` en las notas), `Origin-class` (artefacto de planeación vs realidad de ejecución), `Labels` libres, un vocabulario de `Destination`.
+- **`straymark followups list / status / drift / promote`** — nativo, reemplazando el script bash. `drift --apply` extrae AILOGs no extraídos con granularidad per-AILOG (la que produjo 0 falsos positivos en 76 AILOGs del adopter de referencia), `promote` automatiza la elevación FU → TDE con trazabilidad, `status` es el pulso del registry.
+- **Contadores propiedad del CLI.** Los campos `total_*` se recalculan desde los estados reales de las entradas en cada escritura. El modo de falla del counter-drift silencioso no queda "desaconsejado" — queda mecánicamente muerto.
+- **Extracción anti-ruido.** Los bullets cuyo texto fuente carga un marcador de cierre aterrizan como `suspected-closed` en vez de contaminar el bucket ready como ruido TBD. El operador confirma o reabre en el triage.
+- **Directivas de agente que viajan.** `AGENT-RULES.md §13` se entrega con el framework: mirar el registry al inicio de sesión, `drift --apply` en el mismo commit que el AILOG, triage al cierre de Charter. Los adopters dejaron de copiar un bloque a sus propias configuraciones de agente.
+
+Y un freno deliberado, en el propio ADR: el schema sale como **v1 experimental**. La estabilización dura está gateada a un segundo adopter — la misma disciplina N=2 que [el post anterior](what-the-feature-flag-compiled-away) dedicó su sección central a defender. El workflow de un adopter, por bien documentado que esté, es la forma de un solo stack.
+
+[`fw-4.22.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.22.0) completó la superficie con la parte que tenía que esperar un release de framework: el skill `/straymark-followups`, en las cuatro superficies de agente, envolviendo las directivas del §13. Un wrapper delgado por diseño — su `allowed-tools` omite `Write` deliberadamente, porque toda mutación del registry pasa por el CLI y los contadores siguen siendo propiedad del CLI. El skill conduce la disciplina; no posee lógica.
+
+## Y entonces ambos adopters llegaron a la vez
+
+Lo que pasó después es la parte que vale la pena dejar escrita, porque comprimió en un solo día el ciclo de feedback que la compuerta existe para esperar.
+
+**[LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) adoptó el registry en frío** — primera adopción externa, 74 docs, Issue [#222](https://github.com/StrangeDaysTech/straymark/issues/222). La extracción en sí fue limpia (verificada contra un grep manual: cero AILOGs perdidos). Ambos hallazgos estuvieron en los bordes:
+
+- **El loop que no habíamos cerrado.** El ciclo de vida sanciona explícitamente el triage *manual* — el operador cambia estados a mano. Pero los únicos comandos que recalculaban los contadores propiedad del CLI eran `drift --apply` y `promote`, y ambos son no-ops cuando no hay nada que extraer ni promover. Tras una sesión de triage puro, el registry quedaba con contadores conscientemente obsoletos y sin vía conforme para arreglarlos: editarlos a mano viola el §13, y la promesa del warning de `status` ("la siguiente escritura los recalcula") solo era verdad si una escritura futura llegaba a ocurrir. El workflow sancionado y el invariante no se encontraban.
+- **Un modismo de cierre que no hablábamos.** Las dos entradas extraídas nacieron resueltas — su texto fuente decía `Charter row updated atomically in this PR`. El vocabulario anti-ruido conocía `closed in-Charter`, `fixed in batch N` y hashes de commit; no conocía esta fórmula, así que ambas entradas aterrizaron como ruido TBD `open`. La regresión exacta que el refinamiento existía para matar, a través de un modismo no reconocido.
+
+[`fw-4.23.0` / `cli-3.20.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.20.0) salió el mismo día: un verbo dedicado **`followups recount`** (recalcula contadores, no toca nada más, idempotente), `drift --apply` reconciliando contadores incluso con cero extracciones, la **familia de modismos born-resolved** en el vocabulario de cierre — y, más duradero, la tabla de modismos canónicos documentada en el pattern doc, para que los autores de AILOGs converjan en fórmulas reconocibles al escribir, en vez de descubrir las no reconocidas al extraer.
+
+**Sentinel corrió la migración oficial** — Issue [#225](https://github.com/StrangeDaysTech/straymark/issues/225): borrar el script, `drift --scan-all --apply`, reapuntar el hook de pre-commit. Y el parser nativo extrajo de inmediato 29 entradas de 8 AILOGs que el script bash había reportado como completamente en sync — incluyendo corridas con `--scan-all` — el día anterior.
+
+La causa raíz, verificada contra el script borrado en el historial de git, es del tipo de cosa que hace que "deprecado" se quede corto como palabra. El extractor awk exigía un heading de sección `## Risk` *y* la forma exacta de bullet `- **R<N> (new`. Esos 8 AILOGs escribían sus riesgos como párrafos planos — `R4 (new, not in Charter): …` en columna 0, sin bullet, sin heading. Matching sensible al formato, cero matches, ningún error. Los AILOGs nunca llegaron siquiera a registrar que *tenían* contenido de follow-ups. Al script no le faltaban features. Producía **falsos negativos silenciosos en la propia detección de drift — la única cosa que existía para prevenir.**
+
+El parser leniente los capturó todos porque la leniencia fue una decisión de diseño, no un accidente. `cli-3.19.1` ya había ampliado el parsing de estados por la misma razón: los operadores anotan en línea (`open — **OVERDUE** (…)`) y un parser de match exacto habría degradado 4 de las 65 entradas de Sentinel a `unknown` y escrito contadores incorrectos en la primera migración. Parsear lo que los humanos realmente escriben, y dejar que la validación de schema aconseje. Cada variante de formato que las herramientas estrictas tiraban al piso resultó ser estructural.
+
+[`fw-4.23.1`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.23.1) cerró el reporte: el párrafo de migración del pattern doc ahora manda `--scan-all` en el primer barrido post-migración *aunque el script legacy dijera "in sync"* — citando el dato 8/29 como la razón. (El otro hallazgo de Sentinel, el upgrade v0 → v1 que no disparaba en un `--apply` no-op, había sido arreglado horas antes por el carril de LNXDrive — los dos reportes se resolvieron los bordes mutuamente sin saberlo.)
+
+Hubo también una confirmación silenciosa enterrada en el reporte de Sentinel, y merece el reflector por una frase. A mitad del triage, con 29 entradas siendo reclasificadas a mano, `status` imprimió *"frontmatter says total_open: 91 but the real count is 77 — run `straymark followups recount`"* — en el momento exacto — y un comando reconcilió todo. El modo de falla de counter-drift que abrió el issue #214 está muerto, y el adopter que lo reportó lo vio morir.
+
+## Lo que seguimos sin hacer deliberadamente
+
+La sección de contención, porque todos los posts de esta serie tienen una y la disciplina solo cuenta si sobrevive a las buenas noticias.
+
+El reporte de Sentinel ofreció dos modismos de cierre más (`Validated: … No vulnerabilities found`, `Bundled into CHARTER-19`) — una ocurrencia cada uno. Quedan *anotados*, no entregados. La nueva sección de vocabulario del pattern doc enuncia la regla a la que nos atenemos: proponer un modismo upstream cuando **recurre**. Un vocabulario que absorbe cada fórmula de una sola vez deja de ser un vocabulario.
+
+El schema sigue siendo **v1 experimental**. Dos migraciones productivas con cero hallazgos a nivel de schema es exactamente la señal favorable que la compuerta se construyó para medir — ambos reportes fueron ergonomía y vocabulario, nada estructural — pero la decisión de estabilización dura es una decisión que se toma con la cabeza fría, no un reflejo que se entrega la misma semana que la feature. Y la integración suave con `charter close` (auto-correr `drift --apply` al cierre de Charter) sigue gateada tras una señal de fricción que ningún adopter ha enviado.
+
+## Si llegaste hasta aquí
+
+El ejercicio portátil esta vez es casi vergonzosamente pequeño. Elige el archivo — o la etiqueta de issues, o la convención de TODOs — que responde *"¿qué está pendiente?"* en tu proyecto. Ahora revisa dos cosas. Primera: ¿quién mantiene sus números de resumen, un humano o una herramienta? Si es un humano, están mal; la única pregunta es por cuánto (nosotros lo medimos: 18, después de cuatro semanas). Segunda: si tu tooling de extracción reportó hoy "nada que hacer", ¿sabrías si eso es *verdad* o si tus últimos tres pendientes diferidos simplemente no matchearon su regex? La diferencia entre esos dos estados es invisible por construcción — eso es lo que significa *silencioso* — y la única salida es tooling leniente con lo que lee y exclusivo con lo que posee.
+
+Y si mantienes una convención de trabajo diferido que no hemos visto — otro vocabulario de buckets, otro modismo de cierre, otra respuesta a quién posee los contadores — el canal es el mismo por el que pasaron #214, #222 y #225: [abre un issue](https://github.com/StrangeDaysTech/straymark/issues). El schema v1 es experimental precisamente porque tu registry es el que todavía no conoce.
+
+---
+
+*StrayMark `fw-4.21.0` → `fw-4.23.1`, `cli-3.19.0` → `cli-3.20.0` — ADR [2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md) · Issues [#214](https://github.com/StrangeDaysTech/straymark/issues/214) · [#220](https://github.com/StrangeDaysTech/straymark/issues/220) · [#222](https://github.com/StrangeDaysTech/straymark/issues/222) · [#225](https://github.com/StrangeDaysTech/straymark/issues/225) · PRs [#217](https://github.com/StrangeDaysTech/straymark/pull/217) · [#218](https://github.com/StrangeDaysTech/straymark/pull/218) · [#221](https://github.com/StrangeDaysTech/straymark/pull/221) · [#223](https://github.com/StrangeDaysTech/straymark/pull/223) · [#227](https://github.com/StrangeDaysTech/straymark/pull/227). Patrón: [`FOLLOW-UPS-BACKLOG-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md) (v1, experimental). Predecesores: [Lo que el binario no pudo esconder](what-the-binary-couldnt-hide) · [Lo que el feature flag compiló fuera](what-the-feature-flag-compiled-away).*
+
+*Este documento fue producido con asistencia de herramientas de IA generativa (Claude Opus 4.8); toda la responsabilidad por el contenido recae en el autor humano.*

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-06-04-what-the-bash-script-said-was-in-sync.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-06-04-what-the-bash-script-said-was-in-sync.md
@@ -1,0 +1,81 @@
+---
+slug: what-the-bash-script-said-was-in-sync
+title: bash 脚本口中的"in sync"
+authors:
+  - jose
+tags: [straymark, follow-ups, governance, adopters, sentinel, lnxdrive, cli]
+date: 2026-06-04
+description: Follow-ups 成为 StrayMark 的第二个一等公民实体 —— 一天之内，两次外部迁移对这个设计做了压力测试。参考 adopter 已弃用的 bash 脚本一直在报告"in sync"，而 29 个条目对它完全不可见。
+---
+*就在 follow-ups 成为一等公民实体 —— schema、CLI namespace、随框架发布的代理指令、一个可调用的 skill —— 的次日，两个 adopter 端到端跑完了迁移并提交了报告。一个发现了我们没有闭合的环。另一个发现了更妙的东西：它所替换的那个已弃用的 bash 脚本，不知沉默失明了多久，一边报告"in sync"，一边让 8 个 AILOG 和 29 个条目无人提取。两份报告在同一天变成了 releases。*
+
+<!-- truncate -->
+
+> *"……尽管 legacy 脚本**就在前一天还报告着'in sync'**，包括 `--scan-all` 的运行。"*
+
+这行字来自 Issue [#225](https://github.com/StrangeDaysTech/straymark/issues/225)，[Sentinel](https://github.com/StrangeDaysTech/sentinel) 的更新报告，也是这篇文章标题的出处。要解释它为什么重要 —— 以及为什么它是它所闭合的那条 release 车道最有力的论据 —— 得从 follow-up *是什么*说起。
+
+## 待办工作的问题
+
+StrayMark 里每个 AILOG 都可以用一节 `## Follow-ups` 收尾：这次变更推迟了哪些事。Charter 中途浮现的风险也是同样的写法 —— `R4 (new, not in Charter): …`。这是一个写入时的约定，而在写入时它工作得很完美：实现者清楚自己在推迟什么，并把它写在产生推迟的那份工作旁边。
+
+失败模式在读取时。*"项目里有什么待办？"*是操作员的问题，而 per-AILOG 约定用一次随每个 Charter 不断恶化的多文件扫描来回答它。参考 adopter 最先撞墙：到 Sentinel 的 CHARTER-12 时，答案已经深达 47 个 follow-ups、散落在几十个 AILOG 里。框架的回应 —— [`fw-4.10.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.10.0)，早在五月 —— 是一个*约定*：一个中央注册表文件 `.straymark/follow-ups-backlog.md`，五个以**条目何时可付诸行动**为键的 bucket，以及一个 adopter 侧的 bash 脚本（约 296 行 POSIX awk 和 grep），用于检测 follow-ups 尚未被提取的 AILOG。
+
+那条 v0 车道是工作的 —— 然后它积累了你能想到的、一个在 N=91 规模下手工维护的约定会积累的全部债务。Issue [#214](https://github.com/StrangeDaysTech/straymark/issues/214) 从操作员的座位记录了这些信号。手工维护的 frontmatter 计数器已经漂移成了虚构：声明 `total_open: 47`，实际 65，距离上次对账四个星期。而每一批提取都携带 20–75% 的噪声 —— 脚本追加时就*已经解决*的条目，因为 bullet 文本明明写着（`closed in-Charter`、`fixed in batch 3`），而脚本读不懂。
+
+## 一等公民，带着闸门
+
+回应是 [ADR-2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md)：follow-ups backlog 不再是一个约定，而成为 StrayMark 的第二个一等公民工件，走 Charter 走过的同一条车道 —— 自己的规范路径、自己的 schema、自己的 CLI namespace、自己在 `explore` TUI 中的分组。
+
+[`fw-4.21.0` / `cli-3.19.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.19.0) 交付了实质内容：
+
+- **一个 JSON schema（v1，实验性）**，覆盖注册表 frontmatter，外加操作员此前一直在散文里即兴发挥的 v1 条目维度：`Severity: blocking`（将笔记里的 `PROD-BLOCKER` 约定规范化）、`Origin-class`（规划工件 vs 执行现实）、自由的 `Labels`、一套 `Destination` 词汇。
+- **`straymark followups list / status / drift / promote`** —— 原生实现，替换 bash 脚本。`drift --apply` 以 per-AILOG 粒度提取未提取的 AILOG（这一粒度在参考 adopter 的 76 个 AILOG 上产生了 0 个假阳性），`promote` 以可溯源的方式自动化 FU → TDE 的提升，`status` 是注册表的脉搏。
+- **CLI 拥有的计数器。**每次写入时，`total_*` 字段都从实际条目状态重新计算。静默计数器漂移这一失败模式不是被"劝阻" —— 而是被机制性地杀死。
+- **反噪声提取。**源文本携带关闭标记的 bullet 以 `suspected-closed` 落地，而不是作为 TBD 噪声污染 ready bucket。操作员在分诊时确认或重开。
+- **随框架发布的代理指令。**`AGENT-RULES.md §13` 随框架交付：会话开始时看一眼注册表，与 AILOG 同一个 commit 中运行 `drift --apply`，Charter 关闭时分诊。adopter 们不再往自己的代理配置里复制一段块。
+
+还有一个深思熟虑的刹车，写在 ADR 本身：schema 以**实验性 v1** 发布。硬性稳定化以第二个 adopter 为闸门 —— 与[上一篇文章](what-the-feature-flag-compiled-away)用整个中段为之辩护的 N=2 纪律相同。一个 adopter 的工作流，无论记录得多好，都只是单一 stack 的形状。
+
+[`fw-4.22.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.22.0) 用必须等待框架 release 的那部分补完了表面：`/straymark-followups` skill，覆盖全部四个代理表面，封装 §13 指令。设计上就是薄封装 —— 它的 `allowed-tools` 刻意省略了 `Write`，因为注册表的每次变更都经由 CLI，计数器始终归 CLI 所有。skill 驱动纪律；它不拥有逻辑。
+
+## 然后两个 adopter 同时出现
+
+接下来发生的事值得写下来，因为它把闸门所等待的反馈循环压缩到了一天之内。
+
+**[LNXDrive](https://github.com/StrangeDaysTech/lnxdrive) 冷启动采用了注册表** —— 首次外部采用，74 份文档，Issue [#222](https://github.com/StrangeDaysTech/straymark/issues/222)。提取本身是干净的（与手工 grep 交叉验证：零遗漏 AILOG）。两个发现都在边缘上：
+
+- **我们没有闭合的环。**生命周期明确认可*手动*分诊 —— 操作员手工翻转状态。但唯二会重新计算 CLI 拥有的计数器的命令是 `drift --apply` 和 `promote`，而当没有东西可提取或可提升时，两者都是 no-op。一场纯分诊会话之后，注册表带着明知过期的计数器搁浅，且没有合规的修复方式：手工编辑违反 §13，而 `status` 警告的承诺（"下一次写入会重新计算"）只有在未来恰好发生一次写入时才为真。被认可的工作流与不变量没有交汇。
+- **一个我们不会说的关闭习语。**两个被提取的条目生来就已解决 —— 源文本写着 `Charter row updated atomically in this PR`。反噪声词汇表认识 `closed in-Charter`、`fixed in batch N` 和 commit 哈希；它不认识这个表述，于是两个条目都以 `open` TBD 噪声落地。恰恰是这项精化为之而生要杀死的回归，通过一个未被识别的习语回来了。
+
+[`fw-4.23.0` / `cli-3.20.0`](https://github.com/StrangeDaysTech/straymark/releases/tag/cli-3.20.0) 当天发布：一个专用的 **`followups recount`** 动词（重新计算计数器，不碰其他任何东西，幂等），`drift --apply` 即使零提取也会调和计数器，关闭词汇表中加入 **born-resolved 习语族** —— 以及更持久的一项：规范习语表写入 pattern doc，让 AILOG 作者在写入时就收敛到可识别的表述，而不是在提取时才发现不被识别的那些。
+
+**Sentinel 跑了官方迁移** —— Issue [#225](https://github.com/StrangeDaysTech/straymark/issues/225)：删除脚本，`drift --scan-all --apply`，重指 pre-commit 钩子。原生解析器立刻从 8 个 AILOG 中提取出 29 个条目 —— 而 bash 脚本就在前一天还报告它们完全 in sync，包括 `--scan-all` 的运行。
+
+根因（对照 git 历史里被删除的脚本验证过）属于那种让"已弃用"一词显得不够分量的东西。awk 提取器同时要求 `## Risk` 小节标题*和*精确的 `- **R<N> (new` bullet 形态。那 8 个 AILOG 把风险写成了纯段落 —— `R4 (new, not in Charter): …` 顶格书写，没有 bullet，没有标题。对格式敏感的匹配，零命中，没有报错。这些 AILOG 甚至从未被登记为*含有* follow-up 内容。脚本缺的不是 feature。它在产出**漂移检测本身的静默假阴性 —— 它存在的唯一目的就是防止这件事。**
+
+宽容解析器全部捕获了它们，因为宽容是一个设计决定，不是偶然。`cli-3.19.1` 早已出于同样的原因放宽了状态解析：操作员会就地批注（`open — **OVERDUE** (…)`），而一个精确匹配的解析器会把 Sentinel 65 个条目中的 4 个降级为 `unknown`，并在第一次迁移时就写下错误的计数器。解析人类实际书写的东西，让 schema 验证去提建议。每一种被严格工具丢在地上的格式变体，最终都被证明是承重的。
+
+[`fw-4.23.1`](https://github.com/StrangeDaysTech/straymark/releases/tag/fw-4.23.1) 收尾了这份报告：pattern doc 的迁移段落现在要求首次迁移后扫描带上 `--scan-all`，*即使 legacy 脚本说"in sync"* —— 并引用 8/29 这个数据点作为理由。（Sentinel 的另一个发现 —— v0 → v1 升级在 no-op `--apply` 上不触发 —— 已在数小时前被 LNXDrive 车道修复 —— 两份报告在互不知情的情况下解决了彼此的边缘。）
+
+Sentinel 的报告里还埋着一个安静的确认，值得给它一句话的聚光灯。分诊进行到一半、29 个条目正被手工重新归类时，`status` 打印出 *"frontmatter says total_open: 91 but the real count is 77 — run `straymark followups recount`"* —— 时机分毫不差 —— 一条命令调和了一切。开启 issue #214 的那个计数器漂移失败模式死了，而当初报告它的 adopter 亲眼看着它死去。
+
+## 我们仍然刻意没做的事
+
+克制的小节 —— 这个系列的每篇文章都有一节，而纪律只有在好消息面前活下来才算数。
+
+Sentinel 的报告又提供了两个关闭习语（`Validated: … No vulnerabilities found`、`Bundled into CHARTER-19`）—— 各出现一次。它们被*记录在案*，而非发布。pattern doc 新的词汇小节写明了我们对自己持守的规则：当一个习语**反复出现**时再向上游提议。一个吸收每个一次性表述的词汇表就不再是词汇表了。
+
+schema 仍是**实验性 v1**。两次生产迁移、零 schema 层面的发现，恰恰是闸门为测量而建的有利信号 —— 两份报告都是工效与词汇，没有结构性问题 —— 但硬性稳定化是一个要在头脑冷静时做的深思熟虑的决定，不是与 feature 同一周交付的反射动作。而 `charter close` 软集成（Charter 关闭时自动运行 `drift --apply`）依然闸在一个尚无 adopter 发出的摩擦信号之后。
+
+## 如果你读到了这里
+
+这次的可移植练习小得近乎不好意思。挑出你项目里回答*"有什么待办？"*的那个文件 —— 或 issue 标签，或 TODO 约定。现在检查两件事。第一：它的汇总数字由谁维护，人还是工具？如果是人，它们就是错的；唯一的问题是错多少（我们量过：18，四个星期之后）。第二：如果你的提取工具今天报告"无事可做"，你能分辨那是*真的*，还是你最近推迟的三件事只是没匹配上它的正则？这两种状态之间的差异在构造上就不可见 —— 这正是*静默*的含义 —— 唯一的出路是对读取宽容、对所有权排他的工具。
+
+如果你维护着一个我们还没见过的延迟工作约定 —— 不同的 bucket 词汇、不同的关闭习语、对计数器归谁所有的不同回答 —— 渠道与 #214、#222 和 #225 走过的是同一条：[开一个 issue](https://github.com/StrangeDaysTech/straymark/issues)。v1 schema 之所以是实验性的，恰恰因为你的注册表是它还没见过的那一个。
+
+---
+
+*StrayMark `fw-4.21.0` → `fw-4.23.1`，`cli-3.19.0` → `cli-3.20.0` — ADR [2026-06-03-001](https://github.com/StrangeDaysTech/straymark/blob/main/docs/decisions/ADR-2026-06-03-followups-first-class.md) · Issues [#214](https://github.com/StrangeDaysTech/straymark/issues/214) · [#220](https://github.com/StrangeDaysTech/straymark/issues/220) · [#222](https://github.com/StrangeDaysTech/straymark/issues/222) · [#225](https://github.com/StrangeDaysTech/straymark/issues/225) · PRs [#217](https://github.com/StrangeDaysTech/straymark/pull/217) · [#218](https://github.com/StrangeDaysTech/straymark/pull/218) · [#221](https://github.com/StrangeDaysTech/straymark/pull/221) · [#223](https://github.com/StrangeDaysTech/straymark/pull/223) · [#227](https://github.com/StrangeDaysTech/straymark/pull/227)。Pattern：[`FOLLOW-UPS-BACKLOG-PATTERN.md`](https://github.com/StrangeDaysTech/straymark/blob/main/dist/.straymark/00-governance/FOLLOW-UPS-BACKLOG-PATTERN.md)（v1，实验性）。前篇：[二进制藏不住的东西](what-the-binary-couldnt-hide) · [What the feature flag compiled away](what-the-feature-flag-compiled-away)。*
+
+*本文档在生成式 AI 工具（Claude Opus 4.8）的协助下完成；内容的全部责任由人类作者承担。*


### PR DESCRIPTION
## Summary

Blog post #17, closing the follow-ups arc as the third entry in the trilogy (*What the binary couldn't hide* → *What the feature flag compiled away* → this one):

- **The concept**: per-AILOG `## Follow-ups` convention → read-time failure at scale → v0 registry + 296-line bash script → #214 signals (counter drift 47-vs-65, 20–75% TBD noise).
- **First-class** (ADR-2026-06-03-001, fw-4.21.0/cli-3.19.0): schema v1 experimental, CLI namespace, CLI-owned counters, anti-noise `suspected-closed`, §13 directives, the N=2 gate.
- **The skill** (fw-4.22.0): 4 surfaces, `allowed-tools` without `Write`.
- **Both adopters the same day**: lnxdrive #222 (recount + born-resolved idioms → fw-4.23.0/cli-3.20.0) and Sentinel #225 (the silent false-negatives of the deprecated script — the title finding → fw-4.23.1).
- Restraint section + portable exercise, per series convention.

Full translations: ES + zh-CN (zh-CN catches the blog back up — it was one post behind).

## Verification

- `npm run build` → all 3 locales generated; the post renders at `/blog/`, `/es/blog/` and `/zh-CN/blog/what-the-bash-script-said-was-in-sync` with correct localized titles.
- Merge to main triggers `deploy-website.yml` (paths: `website/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)