### PR TITLE
fix(website): footer "Strange Days Tech" — GitHub org + LinkedIn + sitio web

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -365,7 +365,9 @@ const config: Config = {
         {
           title: 'Strange Days Tech',
           items: [
-            {label: 'Organization', href: 'https://github.com/StrangeDaysTech'},
+            {label: 'GitHub', href: 'https://github.com/StrangeDaysTech'},
+            {label: 'LinkedIn', href: 'https://www.linkedin.com/company/strangedaystech/'},
+            {label: 'Website', href: 'https://strangedays.tech/'},
           ],
         },
         {

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -39,9 +39,13 @@
     "message": "Issues",
     "description": "The label of footer link with label=Issues linking to https://github.com/StrangeDaysTech/straymark/issues"
   },
-  "link.item.label.Organization": {
-    "message": "Organización",
-    "description": "The label of footer link with label=Organization linking to https://github.com/StrangeDaysTech"
+  "link.item.label.LinkedIn": {
+    "message": "LinkedIn",
+    "description": "The label of footer link with label=LinkedIn linking to https://www.linkedin.com/company/strangedaystech/"
+  },
+  "link.item.label.Website": {
+    "message": "Sitio web",
+    "description": "The label of footer link with label=Website linking to https://strangedays.tech/"
   },
   "link.title.Legal": {
     "message": "Legal",

--- a/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -39,9 +39,13 @@
     "message": "Issues",
     "description": "The label of footer link with label=Issues linking to https://github.com/StrangeDaysTech/straymark/issues"
   },
-  "link.item.label.Organization": {
-    "message": "组织",
-    "description": "The label of footer link with label=Organization linking to https://github.com/StrangeDaysTech"
+  "link.item.label.LinkedIn": {
+    "message": "LinkedIn",
+    "description": "The label of footer link with label=LinkedIn linking to https://www.linkedin.com/company/strangedaystech/"
+  },
+  "link.item.label.Website": {
+    "message": "网站",
+    "description": "The label of footer link with label=Website linking to https://strangedays.tech/"
   },
   "link.title.Legal": {
     "message": "法律",


### PR DESCRIPTION
## Qué cambia

En el footer de straymark.dev, la columna **Strange Days Tech** tenía un único enlace
"Organization". Ahora:

- "Organization" → **GitHub** (mismo destino: `github.com/StrangeDaysTech`).
- Nuevo: **LinkedIn** → `https://www.linkedin.com/company/strangedaystech/`
- Nuevo: **Website** → `https://strangedays.tech/`

## Archivos

- `website/docusaurus.config.ts` — items de la columna.
- `website/i18n/es/.../footer.json` — etiqueta `Website` → "Sitio web"; se elimina `Organization`.
- `website/i18n/zh-CN/.../footer.json` — etiqueta `Website` → "网站"; se elimina `Organization`.

> Nota: la columna "Project" ya tiene un "GitHub" que apunta al **repo**; este nuevo "GitHub"
> apunta a la **organización**. Comparten clave i18n (derivada del label), lo cual es benigno
> porque "GitHub" no se traduce.

## Verificación

`npm run build` OK. En el HTML generado se confirman los tres enlaces en `en`/`es`/`zh-CN`,
las etiquetas traducidas ("Sitio web" / "网站") y que no queda rastro de "Organization".

🤖 Generated with [Claude Code](https://claude.com/claude-code)