### PR TITLE
ci: verify .codex/skills stays in sync with .claude source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - 'dist/.claude/skills/**'
+      - 'dist/.codex/skills/**'
+      - 'cli/src/bin/gen_codex_skills.rs'
+      - '.github/workflows/ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'dist/.claude/skills/**'
+      - 'dist/.codex/skills/**'
+      - 'cli/src/bin/gen_codex_skills.rs'
+      - '.github/workflows/ci.yml'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  codex-skills-sync:
+    name: Codex skills in sync with Claude source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenSSL (Linux)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+
+      - name: Verify .codex/skills is regenerated from .claude/skills
+        working-directory: cli
+        run: |
+          # Fails if dist/.codex/skills/ drifted from what gen_codex_skills would
+          # produce from dist/.claude/skills/. Fix locally with:
+          #   cd cli && cargo run --bin gen_codex_skills
+          cargo run --quiet --bin gen_codex_skills -- --check


### PR DESCRIPTION
## Summary

Adds a CI workflow (`.github/workflows/ci.yml`) that runs `gen_codex_skills --check` to guarantee `dist/.codex/skills/` is always the regenerated output of `dist/.claude/skills/`.

Until now there was **no PR CI** — only the release and website-deploy workflows. The Codex skill tree is generated from the Claude source by `cli/src/bin/gen_codex_skills.rs` and must be regenerated by hand before each framework release. Nothing enforced that step, so a hand-edit to `.claude/skills/` without re-running the generator could ship a stale `.codex/skills/` tree. That is exactly the drift class behind **#232** (Codex inheriting `claude-code-v1.0`).

## Behavior

- **Triggers** only when the relevant files change (on `pull_request` and `push` to `main`):
  - `dist/.claude/skills/**`
  - `dist/.codex/skills/**`
  - `cli/src/bin/gen_codex_skills.rs`
  - the workflow itself
- **Fails** if the committed `.codex/skills/` differs from what the generator would produce. The job log prints the fix: `cd cli && cargo run --bin gen_codex_skills`.
- Follows existing repo conventions (`actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, OpenSSL install for the crate's deps).

## Verification

- Workflow YAML validated locally.
- The exact CI command passes against current `main`: `Codex skills are in sync (12 skills).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)