### PR TITLE
feat(cli): cli-3.22.0 — charter close reconciles follow-ups + offers TDE promotion (#135 Tier 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## CLI 3.22.0 — `charter close` reconciles follow-ups and offers TDE promotion (RFC #135 Tier 3)
+
+Closes the loop between Charter close and the follow-ups registry — the last open tier of the follow-ups automation roadmap ([#135](https://github.com/StrangeDaysTech/straymark/issues/135)), unblocked now that drift detection is reliable (cli-3.21.0, #229/#231).
+
+### Added (CLI)
+
+- **`charter close` follow-ups integration**: after an **interactive** close, the command runs the default `followups drift` scan (committed git range ∪ working tree) over the just-written AILOGs, extracts any `§Follow-ups` / `R<N> (new)` content not yet in the registry into `## Bucket: ready`, and then offers **per-entry TDE promotion** against the four AGENT-RULES.md §3 criteria. Declining a prompt leaves the follow-up extracted (captured, not promoted); accepting runs the `followups promote` flow (creates the TDE with `promoted_from_followup` traceability). No-op when there is no registry or nothing is unextracted; skipped on the `--from-template` paths (no interactive prompt context). The scan reuses the stabilized default drift (not scoped to `originating_ailogs`, which is the ex-ante seed rather than the execution AILOGs where follow-ups live).
+
+### Changed (CLI)
+
+- Refactored `followups drift` into reusable, side-effect-free cores — `detect_drift_candidates()` (scan + per-follow-up hash dedup) and `apply_candidates()` (write + return the created `FU-NNN` ids) — shared by `followups drift` and the new `charter close` integration. `followups drift` output is unchanged.
+
+---
+
 ## Framework 4.25.0 / CLI 3.21.0 — follow-ups drift correctness: see the working tree + catch appended follow-ups
 
 Two silent-data-loss bugs in `straymark followups drift`, both surfaced by the reference adopter (Sentinel) and both prerequisites for wiring drift into the Charter-close flow (RFC [#135](https://github.com/StrangeDaysTech/straymark/issues/135) Tier 3).

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.25.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.21.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.22.0` | The `straymark` binary |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2324,7 +2324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.21.0"
+version = "3.22.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"

--- a/cli/src/commands/charter/close.rs
+++ b/cli/src/commands/charter/close.rs
@@ -21,6 +21,7 @@ use colored::Colorize;
 use std::path::{Path, PathBuf};
 
 use crate::charter::{self, charters_dir, Charter, CharterStatus};
+use crate::followups;
 use crate::prompts;
 use crate::telemetry_schema::TelemetrySchema;
 use crate::utils;
@@ -134,7 +135,90 @@ pub fn run(
             );
         }
     }
+
+    // Tier 3 (RFC #135): in the interactive close, scan recent AILOGs for
+    // unextracted follow-ups, extract them into the registry, and offer to
+    // promote each to a TDE. Only the interactive flow has a confirmed TTY
+    // (require_interactive ran above) and a finalized close; the --from-template
+    // paths are skipped — run `straymark followups drift --apply` there.
+    if !from_template {
+        offer_followup_promotions(path, project_root)?;
+    }
+
     Ok(())
+}
+
+/// Reconcile the follow-ups registry against the work just closed, then offer
+/// per-entry TDE promotion. No-op when the project has no registry or when the
+/// recent AILOGs carry no unextracted follow-up content. (Tier 3, RFC #135.)
+fn offer_followup_promotions(path: &str, project_root: &Path) -> Result<()> {
+    use crate::commands::followups::{drift, promote};
+
+    let registry_path = followups::registry_path(project_root);
+    if !registry_path.exists() {
+        // Project hasn't adopted the follow-ups registry — nothing to reconcile.
+        return Ok(());
+    }
+    let registry = followups::parse_registry(&registry_path)?;
+    // Default scan (git range ∪ working tree): at close time this is exactly the
+    // Charter's just-written AILOGs. Not scoped to `originating_ailogs` — that
+    // field is the ex-ante seed, not the execution AILOGs where follow-ups live.
+    let drifted = drift::detect_drift_candidates(project_root, &registry, false, None);
+    if drifted.is_empty() {
+        return Ok(());
+    }
+
+    let today = Local::now().format("%Y-%m-%d").to_string();
+    let report = drift::apply_candidates(&registry_path, &registry, &drifted, &today)?;
+
+    println!();
+    println!("{}", "── Follow-ups ──".bold());
+    utils::success(&format!(
+        "Extracted {} follow-up{} from {} AILOG(s) into the registry (`## Bucket: ready`).",
+        report.applied.len(),
+        if report.applied.len() == 1 { "" } else { "s" },
+        report.ailogs
+    ));
+    if report.suspected > 0 {
+        println!(
+            "  {} {} carried a closure marker → extracted as suspected-closed; confirm at triage.",
+            "!".magenta().bold(),
+            report.suspected
+        );
+    }
+    println!(
+        "  Review against the TDE-promotion criteria (AGENT-RULES.md §3): prior-Charter heritage, spans multiple modules/Charters, needs a dedicated Charter, or needs human prioritization."
+    );
+
+    for fu in &report.applied {
+        // suspected-closed entries are likely already resolved in-Charter, so
+        // they are rarely transversal debt — flag that context in the prompt.
+        let marker = if fu.suspected_closed {
+            " [suspected-closed]"
+        } else {
+            ""
+        };
+        let label = format!(
+            "Promote {} — {}{} to a TDE?",
+            fu.fu_id,
+            truncate_desc(&fu.description, 60),
+            marker
+        );
+        if prompts::prompt_bool(&label, false)? {
+            promote::run(path, &fu.fu_id, None)?;
+        }
+    }
+    Ok(())
+}
+
+/// Single-line, length-bounded version of a follow-up description for prompts.
+fn truncate_desc(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{}…", truncated.trim_end())
+    }
 }
 
 /// Build the `.straymark/charters/CHARTER-NN.telemetry.yaml` path for a Charter.

--- a/cli/src/commands/followups/drift.rs
+++ b/cli/src/commands/followups/drift.rs
@@ -37,7 +37,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::ailog;
-use crate::followups::{self, ExtractedFu};
+use crate::followups::{self, ExtractedFu, Registry};
 use crate::utils;
 
 pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Result<()> {
@@ -82,52 +82,7 @@ pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Resu
         utils::warn(w);
     }
 
-    // Candidate AILOG files. Default mode unions the committed git range with
-    // the working tree (#229): at pre-commit time the just-written AILOG is
-    // usually untracked, so a range-only scan is blind to exactly the file the
-    // documented `drift --apply` flow targets.
-    let agent_logs = ailog::agent_logs_dir(project_root);
-    let candidates: Vec<PathBuf> = if scan_all {
-        walk_ailogs(&agent_logs)
-    } else {
-        let mut set = ailogs_in_git_range(project_root, &agent_logs, range);
-        for p in ailogs_in_working_tree(project_root, &agent_logs) {
-            if !set.contains(&p) {
-                set.push(p);
-            }
-        }
-        set
-    };
-
-    // Drift = an AILOG carrying follow-up content whose content hash is NOT yet
-    // in the registry (#231). Re-scanning already-extracted AILOGs and deduping
-    // per follow-up by content hash — instead of skipping the whole file once
-    // its id lands in `fully_extracted_ailogs` — is what catches follow-ups
-    // appended to a multi-batch AILOG after its first extraction.
-    let seen_hashes = followups::registry_extracted_hashes(&registry);
-
-    let mut drifted: Vec<(String, PathBuf, Vec<ExtractedFu>)> = Vec::new();
-    for path in candidates {
-        let Some(id) = followups::ailog_id_from_path(&path) else {
-            continue;
-        };
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let new: Vec<ExtractedFu> = followups::extract_followups_from_ailog(&content)
-            .into_iter()
-            .filter(|fu| {
-                !seen_hashes.contains(&followups::fu_content_hash(
-                    &id,
-                    &fu.origin_section,
-                    &fu.description,
-                ))
-            })
-            .collect();
-        if !new.is_empty() {
-            drifted.push((id, path, new));
-        }
-    }
+    let drifted = detect_drift_candidates(project_root, &registry, scan_all, range);
 
     if drifted.is_empty() {
         println!(
@@ -181,24 +136,143 @@ pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Resu
 
     // ── --apply: extract into the registry ──
     let today = Local::now().format("%Y-%m-%d").to_string();
+    let report = apply_candidates(&registry_path, &registry, &drifted, &today)?;
+
+    utils::success(&format!(
+        "Extracted {} entr{} from {} AILOG(s) into `## Bucket: ready`.",
+        report.applied.len(),
+        if report.applied.len() == 1 { "y" } else { "ies" },
+        report.ailogs
+    ));
+    if report.suspected > 0 {
+        println!(
+            "  {} {} extracted as {} (closure marker in source AILOG) — confirm at the next triage.",
+            "!".magenta().bold(),
+            report.suspected,
+            "suspected-closed".magenta()
+        );
+    }
+    if report.was_v0 {
+        utils::info("Registry upgraded to schema v1 (non-destructive — counters are now CLI-owned).");
+    }
+    println!(
+        "  Counters recomputed: {} open / {} suspected-closed / {} promoted (total {}).",
+        report.counters.open,
+        report.counters.suspected_closed,
+        report.counters.promoted,
+        report.counters.total
+    );
+    println!("  Next: reclassify bucket/trigger/destination at triage (`straymark followups list --bucket ready`).");
+    Ok(())
+}
+
+/// Scan candidate AILOGs and return those carrying follow-up content not yet in
+/// the registry, deduped per follow-up by content hash (#231). Pure — no
+/// stdout, no `exit`. The reusable detection core shared by `run` and the
+/// `charter close` integration (Tier 3, RFC #135).
+pub fn detect_drift_candidates(
+    project_root: &Path,
+    registry: &Registry,
+    scan_all: bool,
+    range: Option<&str>,
+) -> Vec<(String, PathBuf, Vec<ExtractedFu>)> {
+    // Candidate AILOG files. Default mode unions the committed git range with
+    // the working tree (#229): at pre-commit time the just-written AILOG is
+    // usually untracked, so a range-only scan is blind to exactly the file the
+    // documented `drift --apply` flow targets.
+    let agent_logs = ailog::agent_logs_dir(project_root);
+    let candidates: Vec<PathBuf> = if scan_all {
+        walk_ailogs(&agent_logs)
+    } else {
+        let mut set = ailogs_in_git_range(project_root, &agent_logs, range);
+        for p in ailogs_in_working_tree(project_root, &agent_logs) {
+            if !set.contains(&p) {
+                set.push(p);
+            }
+        }
+        set
+    };
+
+    let seen_hashes = followups::registry_extracted_hashes(registry);
+
+    let mut drifted: Vec<(String, PathBuf, Vec<ExtractedFu>)> = Vec::new();
+    for path in candidates {
+        let Some(id) = followups::ailog_id_from_path(&path) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let new: Vec<ExtractedFu> = followups::extract_followups_from_ailog(&content)
+            .into_iter()
+            .filter(|fu| {
+                !seen_hashes.contains(&followups::fu_content_hash(
+                    &id,
+                    &fu.origin_section,
+                    &fu.description,
+                ))
+            })
+            .collect();
+        if !new.is_empty() {
+            drifted.push((id, path, new));
+        }
+    }
+    drifted
+}
+
+/// One follow-up extracted into the registry by [`apply_candidates`] — the
+/// handle `charter close` needs to offer per-entry TDE promotion (Tier 3).
+pub struct AppliedFu {
+    pub fu_id: String,
+    pub description: String,
+    pub suspected_closed: bool,
+}
+
+/// Outcome of writing detected candidates into the registry.
+pub struct ApplyReport {
+    pub applied: Vec<AppliedFu>,
+    /// Number of distinct AILOGs that contributed entries.
+    pub ailogs: usize,
+    pub suspected: usize,
+    pub counters: followups::Counters,
+    pub was_v0: bool,
+}
+
+/// Extract `drifted` candidates into the registry's `## Bucket: ready`, append
+/// the AILOG ids to `fully_extracted_ailogs` (deduped), recompute the CLI-owned
+/// counters, and upgrade v0 → v1 in place. Writes the registry and returns the
+/// created entries. The reusable `--apply` core shared by `run` and the
+/// `charter close` integration.
+pub fn apply_candidates(
+    registry_path: &Path,
+    registry: &Registry,
+    drifted: &[(String, PathBuf, Vec<ExtractedFu>)],
+    today: &str,
+) -> Result<ApplyReport> {
     let mut body = registry.body.clone();
-    let mut next_n = followups::next_fu_number(&registry);
-    let mut added = 0usize;
+    let mut next_n = followups::next_fu_number(registry);
+    let mut applied: Vec<AppliedFu> = Vec::new();
     let mut suspected = 0usize;
 
-    for (id, _path, found) in &drifted {
+    for (id, _path, found) in drifted {
         for fu in found {
             // Re-parse spans against the evolving body so each insert lands
             // at the (possibly moved) end of the ready bucket.
-            let current =
-                followups::parse_registry_str(&registry_path, &followups::assemble(&registry.frontmatter_raw, &body))?;
-            let block = followups::render_new_entry(next_n, fu, id, &today);
+            let current = followups::parse_registry_str(
+                registry_path,
+                &followups::assemble(&registry.frontmatter_raw, &body),
+            )?;
+            let block = followups::render_new_entry(next_n, fu, id, today);
             body = followups::insert_into_bucket(&current, "ready", &block);
             if fu.suspected_closed {
                 suspected += 1;
             }
+            applied.push(AppliedFu {
+                fu_id: format!("FU-{:03}", next_n),
+                description: fu.description.clone(),
+                suspected_closed: fu.suspected_closed,
+            });
             next_n += 1;
-            added += 1;
         }
     }
 
@@ -211,7 +285,7 @@ pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Resu
         .map(|s| s.as_str())
         .collect();
     let mut new_ids: Vec<String> = Vec::new();
-    for (id, _, _) in &drifted {
+    for (id, _, _) in drifted {
         if !already.contains(id.as_str()) && !new_ids.contains(id) {
             new_ids.push(id.clone());
         }
@@ -221,38 +295,22 @@ pub fn run(path: &str, apply: bool, scan_all: bool, range: Option<&str>) -> Resu
         "fully_extracted_ailogs",
         &new_ids,
     );
-    fm = followups::fm_set_scalar(&fm, "last_scan", &today);
+    fm = followups::fm_set_scalar(&fm, "last_scan", today);
     let final_registry =
-        followups::parse_registry_str(&registry_path, &followups::assemble(&fm, &body))?;
+        followups::parse_registry_str(registry_path, &followups::assemble(&fm, &body))?;
     let counters = followups::compute_counters(&final_registry);
     fm = followups::fm_apply_counters_and_v1(&fm, &counters);
 
     let was_v0 = registry.is_v0();
-    std::fs::write(&registry_path, followups::assemble(&fm, &body))?;
+    std::fs::write(registry_path, followups::assemble(&fm, &body))?;
 
-    utils::success(&format!(
-        "Extracted {} entr{} from {} AILOG(s) into `## Bucket: ready`.",
-        added,
-        if added == 1 { "y" } else { "ies" },
-        drifted.len()
-    ));
-    if suspected > 0 {
-        println!(
-            "  {} {} extracted as {} (closure marker in source AILOG) — confirm at the next triage.",
-            "!".magenta().bold(),
-            suspected,
-            "suspected-closed".magenta()
-        );
-    }
-    if was_v0 {
-        utils::info("Registry upgraded to schema v1 (non-destructive — counters are now CLI-owned).");
-    }
-    println!(
-        "  Counters recomputed: {} open / {} suspected-closed / {} promoted (total {}).",
-        counters.open, counters.suspected_closed, counters.promoted, counters.total
-    );
-    println!("  Next: reclassify bucket/trigger/destination at triage (`straymark followups list --bucket ready`).");
-    Ok(())
+    Ok(ApplyReport {
+        ailogs: drifted.len(),
+        suspected,
+        counters,
+        was_v0,
+        applied,
+    })
 }
 
 /// All AILOG .md files under the agent-logs directory (recursive).
@@ -405,6 +463,59 @@ fn git_ref_exists(project_root: &Path, r: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn tier3_detect_apply_dedup_roundtrip() {
+        // End-to-end of the reusable core that `charter close` (Tier 3) drives:
+        // detect candidates → apply into the registry → the returned FU ids →
+        // and that a re-scan does not re-drift the now-extracted follow-up.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let agent_logs = root.join(".straymark/07-ai-audit/agent-logs");
+        std::fs::create_dir_all(&agent_logs).unwrap();
+        std::fs::write(
+            agent_logs.join("AILOG-2026-06-11-001-x.md"),
+            "# AILOG\n\n## Follow-ups\n\n- do the thing\n",
+        )
+        .unwrap();
+
+        let registry_path = crate::followups::registry_path(root);
+        std::fs::create_dir_all(registry_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &registry_path,
+            "---\nschema_version: v1\ntotal_open: 0\nbuckets:\n  - ready\nfully_extracted_ailogs: []\n---\n\n## Bucket: ready\n",
+        )
+        .unwrap();
+
+        let registry = crate::followups::parse_registry(&registry_path).unwrap();
+        // scan_all so the test does not depend on a git repo.
+        let drifted = detect_drift_candidates(root, &registry, true, None);
+        assert_eq!(drifted.len(), 1);
+        assert_eq!(drifted[0].0, "AILOG-2026-06-11-001");
+        assert_eq!(drifted[0].2.len(), 1);
+        assert_eq!(drifted[0].2[0].description, "do the thing");
+
+        let report = apply_candidates(&registry_path, &registry, &drifted, "2026-06-11").unwrap();
+        assert_eq!(report.applied.len(), 1);
+        assert_eq!(report.applied[0].fu_id, "FU-001");
+        assert_eq!(report.applied[0].description, "do the thing");
+        assert!(!report.applied[0].suspected_closed);
+
+        let written = std::fs::read_to_string(&registry_path).unwrap();
+        assert!(written.contains("### FU-001 — do the thing"));
+        assert!(written.contains("- **Source-hash**:"));
+        assert!(written.contains("AILOG-2026-06-11-001"));
+
+        // Dedup: a second detect on the updated registry finds nothing new —
+        // the close hook re-running (or a manual drift) must be a no-op.
+        let registry2 = crate::followups::parse_registry(&registry_path).unwrap();
+        let drifted2 = detect_drift_candidates(root, &registry2, true, None);
+        assert!(
+            drifted2.is_empty(),
+            "already-extracted follow-up must not re-drift"
+        );
+    }
 
     #[test]
     fn parse_porcelain_picks_ailogs_across_status_codes() {

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.25.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.21.0` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.22.0` | The `straymark` binary |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -585,7 +585,14 @@ $ straymark charter close CHARTER-01
   ✔ Charter CHARTER-01 closed.
     Telemetry: .straymark/charters/CHARTER-01.telemetry.yaml
     Status updated: in-progress/declared → closed
+
+  ── Follow-ups ──
+  ✔ Extracted 2 follow-ups from 1 AILOG(s) into the registry (`## Bucket: ready`).
+    Review against the TDE-promotion criteria (AGENT-RULES.md §3): ...
+  Promote FU-078 — wire the retry budget into the sync loop to a TDE? [y/N]
 ```
+
+**Follow-ups reconciliation** *(cli-3.22.0+, RFC #135 Tier 3)*. After an **interactive** close, the command runs the default `followups drift` scan (committed git range ∪ working tree) over the recently-written AILOGs, extracts any `§Follow-ups` / `R<N> (new)` content **not yet in the registry** into `## Bucket: ready`, then offers **per-entry TDE promotion** against the four §3 criteria (prior-Charter heritage, multi-module/Charter span, dedicated Charter, human prioritization). Declining a prompt leaves the follow-up extracted (captured in the registry, just not promoted); accepting runs the `followups promote` flow (creates the TDE with `promoted_from_followup` traceability). It is a **no-op** when the project has no follow-ups registry or when nothing is unextracted, and is **skipped on the `--from-template` paths** (no interactive prompt context) — run `straymark followups drift --apply` there.
 
 #### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--no-batch-ledger-check] [--path <dir>]`
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -241,7 +241,7 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.25.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.21.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.22.0` | El binario `straymark` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.25.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.21.0` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.22.0` | El binario `straymark` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -502,7 +502,14 @@ $ straymark charter close CHARTER-01
   ✔ Charter CHARTER-01 closed.
     Telemetry: .straymark/charters/CHARTER-01.telemetry.yaml
     Status updated: in-progress/declared → closed
+
+  ── Follow-ups ──
+  ✔ Extracted 2 follow-ups from 1 AILOG(s) into the registry (`## Bucket: ready`).
+    Review against the TDE-promotion criteria (AGENT-RULES.md §3): ...
+  Promote FU-078 — wire the retry budget into the sync loop to a TDE? [y/N]
 ```
+
+**Reconciliación de follow-ups** *(cli-3.22.0+, RFC #135 Tier 3)*. Tras un cierre **interactivo**, el comando corre el scan por defecto de `followups drift` (rango git commiteado ∪ working tree) sobre los AILOGs recién escritos, extrae el contenido `§Follow-ups` / `R<N> (new)` **que aún no está en el registry** a `## Bucket: ready`, y luego ofrece **promoción a TDE por entrada** contra los cuatro criterios de §3 (herencia de Charter previo, alcance multi-módulo/Charter, Charter dedicado, priorización humana). Declinar un prompt deja el follow-up extraído (capturado en el registry, solo no promovido); aceptar corre el flujo `followups promote` (crea el TDE con trazabilidad `promoted_from_followup`). Es **no-op** cuando el proyecto no tiene registry de follow-ups o cuando no hay nada sin extraer, y se **salta en las rutas `--from-template`** (sin contexto de prompt interactivo) — corre `straymark followups drift --apply` ahí.
 
 #### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--no-batch-ledger-check] [--path <dir>]`
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -259,7 +259,7 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.25.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.21.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.22.0` | `straymark` 二进制文件 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.25.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.21.0` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.22.0` | `straymark` 二进制文件 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -519,7 +519,14 @@ $ straymark charter close CHARTER-01
   ✔ Charter CHARTER-01 closed.
     Telemetry: .straymark/charters/CHARTER-01.telemetry.yaml
     Status updated: in-progress/declared → closed
+
+  ── Follow-ups ──
+  ✔ Extracted 2 follow-ups from 1 AILOG(s) into the registry (`## Bucket: ready`).
+    Review against the TDE-promotion criteria (AGENT-RULES.md §3): ...
+  Promote FU-078 — wire the retry budget into the sync loop to a TDE? [y/N]
 ```
+
+**Follow-up 调和** *(cli-3.22.0+,RFC #135 Tier 3)*。**交互式**关闭后,该命令对最近写入的 AILOG 运行默认的 `followups drift` 扫描(已提交的 git 范围 ∪ 工作树),将**尚未在注册表中**的 `§Follow-ups` / `R<N> (new)` 内容提取到 `## Bucket: ready`,然后针对 §3 的四条标准(先前 Charter 的遗留、跨多个模块/Charter、需要专用 Charter、需要人工排优先级)**逐条提供 TDE 提升**。拒绝某个提示会保留该 follow-up 的提取状态(已捕获进注册表,只是未提升);接受则运行 `followups promote` 流程(创建带 `promoted_from_followup` 溯源的 TDE)。当项目没有 follow-ups 注册表、或没有任何未提取内容时为**空操作**,并在 `--from-template` 路径上**跳过**(无交互提示上下文)—— 在那里请运行 `straymark followups drift --apply`。
 
 #### `straymark charter drift <CHARTER-ID> [--range <REV..REV>] [--no-ailog-suppress] [--no-batch-ledger-check] [--path <dir>]`
 


### PR DESCRIPTION
## Summary

Implements **RFC #135 Tier 3** — the last open tier of the follow-ups automation roadmap. After an interactive `charter close`, the CLI reconciles the follow-ups registry against the just-closed work and offers to promote new entries to TDEs. Unblocked now that drift detection is reliable (cli-3.21.0, #229/#231 in #235).

CLI-only release: **cli-3.22.0** (no framework change).

## Behavior

After an **interactive** `charter close` (the `--from-template` paths are skipped — no prompt context):

1. **Detect** — runs the default `followups drift` scan (committed git range ∪ working tree) over the recently-written AILOGs. No-op if the project has no follow-ups registry or nothing is unextracted.
2. **Extract** — writes any `§Follow-ups` / `R<N> (new)` content not yet in the registry into `## Bucket: ready` (same semantics as `followups drift --apply`, so nothing is lost).
3. **Promote inline** — for each new entry, prompts `Promote FU-NNN — <desc> to a TDE? [y/N]` against the four AGENT-RULES.md §3 criteria. Declining leaves it extracted (captured, not promoted); accepting runs the `followups promote` flow (creates the TDE with `promoted_from_followup` traceability). Entries extracted as `suspected-closed` are flagged in the prompt (likely already resolved → rarely transversal debt).

### Design note — scan scope

The scan reuses the **stabilized default drift** (git range ∪ working tree), **not** `originating_ailogs`. That field is the *ex-ante seed* of the Charter (the AILOGs that motivated it), not the *execution* AILOGs where follow-ups are written — and it is empty for greenfield (`originating_spec`) Charters. At close time the default scan captures exactly the just-written work, with no fragile attribution logic.

## Implementation

Refactored `followups drift` into two reusable, side-effect-free cores, shared by `followups drift` and the close integration (drift's own output is unchanged):
- `detect_drift_candidates(project_root, registry, scan_all, range) -> Vec<…>` — scan + per-follow-up content-hash dedup, no stdout/exit.
- `apply_candidates(registry_path, registry, drifted, today) -> ApplyReport` — writes the registry and **returns the created `FU-NNN` ids** (the handle the close hook needs for the promotion prompts).

The close hook (`offer_followup_promotions`) lives in `charter/close.rs`, guarded to the interactive flow (TTY already confirmed by `require_interactive`).

## Tests

- `tier3_detect_apply_dedup_roundtrip` — end-to-end of the core without git/TTY: detect → apply → assert the returned `FU-001` id + `Source-hash` written → re-detect is empty (dedup).
- Existing `followups drift` integration suite (21 tests) green — the refactor preserved behavior.
- Full suite: 24 suites green. New code clippy-clean.

> Note: the *interactive* close prompt path can't be integration-tested (assert_cmd has no TTY; `require_interactive` rejects), same limitation as the existing interactive-close tests. Coverage lives in the unit test of the extracted cores.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)