### PR TITLE
feat(loom): loom-0.1.0 / cli-3.24.0 — Loom M1: walking skeleton (server + UI + CLI launcher)

### DIFF
--- a/.github/workflows/release-loom.yml
+++ b/.github/workflows/release-loom.yml
@@ -1,0 +1,184 @@
+name: Release Loom
+
+# Loom is EXPERIMENTAL: GitHub-release-only (no crates.io publish) while the
+# `loom-0.x` series lasts — see experimento/README.md and plan.md §6.
+
+on:
+  push:
+    tags:
+      - 'loom-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., loom-0.1.0)'
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  resolve-version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve tag and version
+        id: resolve
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+
+          if [[ "$TAG" != loom-* ]]; then
+            echo "ERROR: tag '$TAG' is not a Loom release (must start with loom-)"
+            exit 1
+          fi
+
+          VERSION="${TAG#loom-}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building Loom $VERSION from tag $TAG"
+
+  build-loom:
+    name: Build Loom (${{ matrix.target }})
+    needs: [resolve-version]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-version.outputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: experimento/web/package-lock.json
+
+      - name: Verify Cargo.toml version matches tag
+        shell: bash
+        run: |
+          CARGO_VERSION=$(grep '^version' experimento/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          TAG_VERSION="${{ needs.resolve-version.outputs.version }}"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: experimento/Cargo.toml version ($CARGO_VERSION) does not match tag version ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Build frontend (embedded via rust-embed)
+        shell: bash
+        working-directory: experimento/web
+        run: |
+          npm ci
+          npm run build
+          test -f dist/index.html
+
+      - name: Build release binary
+        run: cargo build --release --manifest-path experimento/Cargo.toml --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          BINARY=target/${{ matrix.target }}/release/straymark-loom
+          ARCHIVE=straymark-loom-v${{ needs.resolve-version.outputs.version }}-${{ matrix.target }}.tar.gz
+          tar czf "$ARCHIVE" -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Package (Windows)
+        if: matrix.archive == 'zip'
+        shell: bash
+        run: |
+          BINARY=target/${{ matrix.target }}/release/straymark-loom.exe
+          ARCHIVE=straymark-loom-v${{ needs.resolve-version.outputs.version }}-${{ matrix.target }}.zip
+          cp "$BINARY" straymark-loom.exe
+          7z a "$ARCHIVE" straymark-loom.exe
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: loom-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  upload-to-release:
+    name: Upload binaries to release
+    needs: [resolve-version, build-loom]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: release-artifacts
+
+      - name: Collect release files
+        run: |
+          mkdir -p release
+          find release-artifacts -type f \( -name "*.zip" -o -name "*.tar.gz" \) -exec cp {} release/ \;
+          ls -la release/
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ needs.resolve-version.outputs.tag }}"
+          VERSION="${{ needs.resolve-version.outputs.version }}"
+
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG exists, uploading binaries..."
+            gh release upload "$TAG" release/* --clobber
+          else
+            echo "Creating release $TAG..."
+            # NOT --latest: Loom is experimental; the CLI release stays the
+            # repo's "latest" so update flows are unaffected.
+            gh release create "$TAG" \
+              --title "StrayMark Loom $VERSION (EXPERIMENTAL)" \
+              --generate-notes \
+              --latest=false \
+              release/*
+          fi
+
+      - name: Delete previous Loom releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          CURRENT_TAG="${{ needs.resolve-version.outputs.tag }}"
+          gh release list --json tagName --jq '.[].tagName' | while read -r tag; do
+            if [[ "$tag" == loom-* && "$tag" != "$CURRENT_TAG" ]]; then
+              echo "Deleting old release $tag..."
+              gh release delete "$tag" --yes --cleanup-tag
+            fi
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,9 @@ yarn-error.log*
 package-lock.json
 yarn.lock
 
-# Website lockfile must be committed — CI uses `npm ci` for reproducible builds.
+# Website and Loom lockfiles must be committed — CI uses `npm ci` for reproducible builds.
 !website/package-lock.json
+!experimento/web/package-lock.json
 
 # =============================================================================
 # Temporary Files
@@ -122,3 +123,10 @@ secrets.json
 api_keys.txt
 api_keys.json
 nul
+
+# =============================================================================
+# Loom (experimento/) — JS confined to web/, built only in CI
+# =============================================================================
+
+experimento/web/node_modules/
+experimento/web/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Loom 0.1.0 / CLI 3.24.0 — Loom M1: the walking skeleton ships
+
+First release of **Loom**, StrayMark's EXPERIMENTAL third component (`CHARTER-01-loom-server` M1): a loopback-only, read-only web dashboard that renders the project's document graph live in the browser.
+
+### Added (Loom)
+
+- **`straymark-loom 0.1.0`** (`loom-0.1.0`, GitHub-release-only): axum + tokio server that discovers and parses StrayMark documents via the shared `straymark-core` crate, builds the typed knowledge graph, and serves `GET /api/graph`, `/api/node/:id`, `/api/node/:id/thread?depth=N`, `/api/stats`, `/healthz`, and `WS /api/stream` over `127.0.0.1` only (Spec 001 §4).
+- **Live rebuilds**: a `notify` watcher (250ms debounce) re-parses on settled `.md` changes and pushes a `rebuild` event over the WebSocket — an open browser reflects an edit in well under 1 second (measured ~255ms).
+- **Web UI** (Sigma.js + graphology, embedded via rust-embed — adopters never run npm): force-directed graph colored by document type and sized by degree; selecting a node lights up its full thread (transitive in/out relationships) and dims the rest; node detail panel with metadata and body excerpt; live type legend and corpus counters.
+- **Security posture** (Spec 001 FR7/NFR4): binds `127.0.0.1` exclusively, rejects non-loopback `Host` headers (anti DNS-rebinding), read-only by construction.
+- **`release-loom.yml`**: 4-platform build matrix with the frontend compiled in CI and embedded; releases marked `--latest=false`.
+
+### Added (CLI)
+
+- **`straymark loom serve [path] [--port] [--no-open]`**: download-on-demand launcher — fetches the latest `loom-*` release binary for the host platform on first use (the download gate *is* the experimental opt-in boundary), caches it under `~/.straymark/bin/`, prints a loud EXPERIMENTAL banner, and launches it pointed at the project. The CLI gains no axum/tokio dependency. Falls back to the cached binary when offline.
+
+### Added (core)
+
+- `straymark-core 0.2.0`: `Graph::thread(id, depth)` — the connected neighborhood of a node (Spec 001 §3.3), powering `/api/node/:id/thread` and the UI's thread highlighting.
+
+---
+
 ## CLI 3.23.1 — `straymark-core` extraction (Loom M0)
 
 First milestone of the experimental **Loom** component (`experimento/`, `CHARTER-01-loom-server`): the document model and traceability graph move into a shared crate so the CLI and the upcoming Loom visualization server parse StrayMark documents with exactly the same code (`ADR-2026-06-02-001`). **No user-facing behavior changes** — the full test suite and the `straymark audit` output are byte-for-byte identical pre/post refactor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,19 @@ straymark/
 │   │   └── utils.rs        # Output helpers, file hashing
 │   ├── tests/              # Integration tests
 │   └── Cargo.toml
+├── experimento/            # Loom (EXPERIMENTAL): straymark-loom server crate
+│   ├── src/                # axum server + notify watcher
+│   ├── web/                # Sigma.js + graphology frontend (Vite/TS, built in CI only)
+│   ├── specs/              # SpecKit sets (001 knowledge graph, 002 architecture plan)
+│   └── CHARTER-01-loom-server.md
 ├── dist/                   # Framework distribution files
 │   ├── .straymark/          # Templates, governance, config
 │   ├── STRAYMARK.md         # Unified governance rules
 │   └── dist-manifest.yml   # What gets installed
 ├── docs/                   # Project documentation (EN + ES + zh-CN)
 ├── .github/workflows/      # CI/CD
-│   ├── release-cli.yml     # Build + release CLI binaries
+│   ├── release-cli.yml     # Build + release CLI binaries (publishes straymark-core first)
+│   ├── release-loom.yml    # Build + release Loom binaries (loom-* tags; npm build step; no crates.io)
 │   └── release-framework.yml
 └── README.md
 ```
@@ -186,6 +192,15 @@ gh release view fw-X.Y.Z --json assets --jq '.assets[].name'
 
 Users can now run `straymark update-framework` to get the new version.
 
+## Release Workflow — Loom (EXPERIMENTAL)
+
+Loom releases are GitHub-release-only (no crates.io while experimental). Tag format: `loom-X.Y.Z`.
+
+1. Bump `version` in `experimento/Cargo.toml` and update `experimento/CHANGELOG.md`.
+2. Commit via PR (same rules as any change).
+3. `git tag loom-X.Y.Z && git push origin loom-X.Y.Z` — `release-loom.yml` verifies the version matches the tag, builds the frontend (`npm ci && npm run build` in `experimento/web/`, embedded via rust-embed), compiles the same 4-platform matrix as the CLI, and uploads `straymark-loom-vX.Y.Z-<target>.{tar.gz,zip}` assets. The release is marked `--latest=false` so CLI update flows are unaffected.
+4. Verify: `gh release view loom-X.Y.Z --json assets --jq '.assets[].name'` (4 binaries). `straymark loom serve` picks the new version automatically (version marker in `~/.straymark/bin/`).
+
 ## Git Workflow
 
 ### Rules
@@ -251,6 +266,7 @@ Users can now run `straymark update-framework` to get the new version.
 | `straymark followups promote FU-NNN` | Elevate an entry to a TDE document with `promoted_from_followup` traceability |
 | `straymark audit [path]` | Generate audit trail reports with timeline and traceability |
 | `straymark explore [path]` | Interactive TUI documentation browser |
+| `straymark loom serve [path] [--port] [--no-open]` | Launch Loom, the EXPERIMENTAL knowledge-graph visualization server (binary downloaded on demand from `loom-*` releases, cached in `~/.straymark/bin/`) |
 | `straymark about` | Show version and license info |
 
 ## Development

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deflate64"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +727,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +815,15 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -952,6 +1031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1050,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1204,6 +1290,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1561,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1483,6 +1625,46 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d88b1a7538054351c8258338df7c931a590513fb3745e8c15eb9ff4199b8d1"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "num"
@@ -2026,6 +2208,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2319,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2190,6 +2415,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2324,7 +2560,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "straymark-cli"
-version = "3.23.1"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "arborist-metrics",
@@ -2357,11 +2593,29 @@ dependencies = [
 
 [[package]]
 name = "straymark-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",
  "serde_yaml",
+]
+
+[[package]]
+name = "straymark-loom"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "colored",
+ "mime_guess",
+ "notify-debouncer-full",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "straymark-core",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -2591,8 +2845,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2613,6 +2880,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2641,6 +2920,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2679,6 +2959,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2839,6 +3120,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,6 +3253,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3128,6 +3435,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "cli"]
+members = ["core", "cli", "experimento"]
 
 # Shared release profile (moved from cli/Cargo.toml when the workspace was
 # introduced in Loom M0 — profiles are only honored at the workspace root).

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ StrayMark uses independent version tags for each component:
 | Component | Tag prefix | Example | Includes |
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.26.0` | Templates (12 types), governance, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.23.1` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.24.0` | The `straymark` binary |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | The `straymark-loom` visualization server, downloaded on demand by `straymark loom serve` |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-cli"
-version = "3.23.1"
+version = "3.24.0"
 edition = "2021"
 description = "CLI for StrayMark — the cognitive discipline your AI-assisted projects need"
 license = "MIT"
@@ -17,7 +17,7 @@ name = "straymark"
 path = "src/main.rs"
 
 [dependencies]
-straymark-core = { version = "0.1.0", path = "../core" }
+straymark-core = { version = "0.2.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }

--- a/cli/src/commands/loom/mod.rs
+++ b/cli/src/commands/loom/mod.rs
@@ -1,0 +1,6 @@
+//! `straymark loom` — launcher for Loom, the EXPERIMENTAL knowledge-graph
+//! visualization server. The server binary is NOT bundled into the CLI: it is
+//! downloaded on demand from the `loom-*` GitHub releases (the download gate
+//! IS the opt-in boundary — see `experimento/README.md`).
+
+pub mod serve;

--- a/cli/src/commands/loom/serve.rs
+++ b/cli/src/commands/loom/serve.rs
@@ -1,0 +1,181 @@
+//! `straymark loom serve` — download-on-demand launcher (Loom plan.md §5).
+//!
+//! 1. Resolve the project root.
+//! 2. Ensure `~/.straymark/bin/straymark-loom` is present and current
+//!    (download + extract the latest `loom-*` release asset otherwise).
+//! 3. Print the EXPERIMENTAL banner and spawn the server pointed at the
+//!    project; optionally open the browser.
+//!
+//! The CLI deliberately has no axum/tokio dependency — it only downloads and
+//! launches (keeps the `opt-level=z` footprint intact).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use colored::Colorize;
+
+use crate::download::{self, strip_tag_prefix};
+use crate::platform;
+use crate::self_update::{extract_from_tar_gz, extract_from_zip};
+use crate::utils;
+
+const BINARY_NAME: &str = if cfg!(windows) {
+    "straymark-loom.exe"
+} else {
+    "straymark-loom"
+};
+
+pub fn run(path: &str, port: u16, no_open: bool) -> Result<()> {
+    banner();
+
+    let project = PathBuf::from(path)
+        .canonicalize()
+        .with_context(|| format!("Cannot resolve project path {path}"))?;
+
+    let binary = ensure_loom_binary()?;
+
+    let url = format!("http://127.0.0.1:{port}");
+    let mut child = Command::new(&binary)
+        .arg(&project)
+        .arg("--port")
+        .arg(port.to_string())
+        .spawn()
+        .with_context(|| format!("Failed to launch {}", binary.display()))?;
+
+    if !no_open {
+        // Give the server a moment to bind before pointing a browser at it.
+        std::thread::sleep(std::time::Duration::from_millis(600));
+        // The server owns the terminal output; browser failure is not fatal.
+        let _ = open_browser(&url);
+    }
+
+    let status = child.wait().context("Loom server exited abnormally")?;
+    if !status.success() {
+        bail!("straymark-loom exited with {status}");
+    }
+    Ok(())
+}
+
+fn banner() {
+    eprintln!();
+    eprintln!(
+        "{}",
+        "  ⚠  LOOM IS EXPERIMENTAL (v0)".yellow().bold()
+    );
+    eprintln!(
+        "{}",
+        "     Unstable: API, CLI surface, and on-disk layout may change or be\n     removed without a deprecation cycle. Loopback-only. Read-only."
+            .yellow()
+    );
+    eprintln!();
+}
+
+/// `~/.straymark/bin/` — the per-user cache for downloaded components.
+fn cache_bin_dir() -> Result<PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .context("Cannot determine the home directory (HOME/USERPROFILE unset)")?;
+    Ok(PathBuf::from(home).join(".straymark").join("bin"))
+}
+
+/// Returns the cached Loom binary, downloading the latest `loom-*` release
+/// when missing or stale. A version marker file next to the binary tracks
+/// what is cached.
+fn ensure_loom_binary() -> Result<PathBuf> {
+    let bin_dir = cache_bin_dir()?;
+    let exe = bin_dir.join(BINARY_NAME);
+    let version_marker = bin_dir.join("straymark-loom.version");
+
+    let release = match download::get_latest_release_by_prefix("loom-") {
+        Ok(r) => r,
+        Err(err) => {
+            // Offline with a cached binary: serve what we have, loudly.
+            if exe.exists() {
+                utils::warn(&format!(
+                    "Cannot check for Loom updates ({err}); using the cached binary"
+                ));
+                return Ok(exe);
+            }
+            return Err(err).context(
+                "Loom is downloaded on demand and no release could be fetched. \
+                 Check your network (or GITHUB_TOKEN for rate limits) and retry",
+            );
+        }
+    };
+    let version = strip_tag_prefix(&release.tag_name).to_string();
+
+    let cached = std::fs::read_to_string(&version_marker)
+        .map(|s| s.trim().to_string())
+        .ok();
+    if exe.exists() && cached.as_deref() == Some(version.as_str()) {
+        return Ok(exe);
+    }
+
+    let target = platform::current_target()?;
+    let ext = platform::archive_extension();
+    let asset_name = format!("straymark-loom-v{version}-{target}.{ext}");
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == asset_name)
+        .with_context(|| {
+            format!(
+                "Release {} has no asset {asset_name} for this platform",
+                release.tag_name
+            )
+        })?;
+
+    utils::info(&format!(
+        "Downloading Loom {version} ({target}) — first use is opt-in by download"
+    ));
+
+    let temp = tempfile::tempdir().context("Failed to create temp dir")?;
+    let archive_path = temp.path().join(&asset_name);
+    download::download_file(&asset.download_url, &archive_path, "straymark-loom")?;
+
+    let extracted = if ext == "zip" {
+        extract_from_zip(&archive_path, temp.path(), BINARY_NAME)?
+    } else {
+        extract_from_tar_gz(&archive_path, temp.path(), BINARY_NAME)?
+    };
+
+    std::fs::create_dir_all(&bin_dir)
+        .with_context(|| format!("Failed to create {}", bin_dir.display()))?;
+    // Replace atomically-ish: copy to a temp name, then rename over.
+    let staging = bin_dir.join(format!("{BINARY_NAME}.new"));
+    std::fs::copy(&extracted, &staging).context("Failed to stage the Loom binary")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o755))?;
+    }
+    std::fs::rename(&staging, &exe).context("Failed to install the Loom binary")?;
+    std::fs::write(&version_marker, &version)?;
+
+    utils::success(&format!("Loom {version} cached at {}", exe.display()));
+    Ok(exe)
+}
+
+fn open_browser(url: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        let mut c = Command::new("open");
+        c.arg(url);
+        c
+    };
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut c = Command::new("cmd");
+        c.args(["/C", "start", "", url]);
+        c
+    };
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let mut cmd = {
+        let mut c = Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+    cmd.spawn().context("Failed to open the browser")?;
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod explore;
 pub mod followups;
 pub mod init;
 pub mod install_skills;
+pub mod loom;
 pub mod metrics;
 pub mod new;
 pub mod remove;

--- a/cli/src/download.rs
+++ b/cli/src/download.rs
@@ -43,10 +43,11 @@ fn build_client() -> Result<reqwest::blocking::Client> {
     builder.build().context("Failed to create HTTP client")
 }
 
-/// Strip known tag prefixes (fw-, cli-, v) and return the version string
+/// Strip known tag prefixes (fw-, cli-, loom-, v) and return the version string
 pub fn strip_tag_prefix(tag: &str) -> &str {
     tag.strip_prefix("fw-")
         .or_else(|| tag.strip_prefix("cli-"))
+        .or_else(|| tag.strip_prefix("loom-"))
         .or_else(|| tag.strip_prefix("v"))
         .unwrap_or(tag)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -280,6 +280,27 @@ enum Commands {
         #[command(subcommand)]
         command: FollowupsCommands,
     },
+    /// Loom — EXPERIMENTAL knowledge-graph visualization server (downloaded on demand)
+    Loom {
+        #[command(subcommand)]
+        command: LoomCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum LoomCommands {
+    /// Launch the Loom server for a project (downloads the binary on first use)
+    Serve {
+        /// Project directory (defaults to the current directory)
+        #[arg(default_value = ".")]
+        path: String,
+        /// Port on 127.0.0.1 to serve on
+        #[arg(long, default_value_t = 7700)]
+        port: u16,
+        /// Do not open the browser automatically
+        #[arg(long)]
+        no_open: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -846,6 +867,11 @@ fn main() {
             FollowupsCommands::Recount { path } => commands::followups::recount::run(&path),
             FollowupsCommands::Promote { fu_id, title, path } => {
                 commands::followups::promote::run(&path, &fu_id, title.as_deref())
+            }
+        },
+        Commands::Loom { command } => match command {
+            LoomCommands::Serve { path, port, no_open } => {
+                commands::loom::serve::run(&path, port, no_open)
             }
         },
     };

--- a/cli/src/self_update.rs
+++ b/cli/src/self_update.rs
@@ -220,7 +220,7 @@ fn perform_github_update() -> Result<()> {
 }
 
 /// Extract a binary from a tar.gz archive
-fn extract_from_tar_gz(archive: &Path, dest: &Path, binary_name: &str) -> Result<PathBuf> {
+pub(crate) fn extract_from_tar_gz(archive: &Path, dest: &Path, binary_name: &str) -> Result<PathBuf> {
     let file = std::fs::File::open(archive).context("Failed to open archive")?;
     let decoder = flate2::read::GzDecoder::new(file);
     let mut tar = tar::Archive::new(decoder);
@@ -245,7 +245,7 @@ fn extract_from_tar_gz(archive: &Path, dest: &Path, binary_name: &str) -> Result
 
 /// Extract a binary from a zip archive
 #[allow(dead_code)]
-fn extract_from_zip(archive: &Path, dest: &Path, binary_name: &str) -> Result<PathBuf> {
+pub(crate) fn extract_from_zip(archive: &Path, dest: &Path, binary_name: &str) -> Result<PathBuf> {
     let file = std::fs::File::open(archive).context("Failed to open archive")?;
     let mut zip = zip::ZipArchive::new(file).context("Failed to read ZIP archive")?;
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Shared document model and knowledge graph for StrayMark — parses governance documents and builds their typed traceability graph"
 license = "MIT"

--- a/core/src/graph.rs
+++ b/core/src/graph.rs
@@ -218,6 +218,90 @@ impl Graph {
     pub fn dangling_edges(&self) -> impl Iterator<Item = &Edge> {
         self.edges.iter().filter(|e| !e.resolved)
     }
+
+    /// The thread of a node (Spec 001 §3.3, story S2): *"everything it links
+    /// to and everything that links to it, transitively"* — its transitive
+    /// **descendants** (following out-edges) plus its transitive **ancestors**
+    /// (following in-edges), optionally bounded by `depth` per direction.
+    ///
+    /// Deliberately NOT the undirected connected component: that would also
+    /// pull in "siblings" (documents merely co-citing a shared neighbor), and
+    /// in tightly-linked corpora it degenerates into highlighting everything.
+    /// The thread is the node's line of reasoning, not its neighborhood.
+    ///
+    /// Returns the node ids and edge indices (into [`Graph::edges`]) to
+    /// highlight. The edge set is every edge whose endpoints both belong to
+    /// the thread, plus the dangling out-edges of thread members.
+    pub fn thread(&self, id: &str, depth: Option<usize>) -> Option<Thread> {
+        let &start = self.node_index.get(id)?;
+
+        let mut in_thread = vec![false; self.nodes.len()];
+        let mut node_ids = Vec::new();
+        in_thread[start] = true;
+        node_ids.push(self.nodes[start].id.clone());
+
+        // Two bounded BFS passes: forward over out-edges, backward over
+        // in-edges. `Forward` follows what the document links to; `Backward`
+        // follows what links to the document.
+        for forward in [true, false] {
+            let mut visited = vec![false; self.nodes.len()];
+            visited[start] = true;
+            let mut frontier = vec![start];
+            let mut level = 0usize;
+            while !frontier.is_empty() && depth.map_or(true, |d| level < d) {
+                let mut next = Vec::new();
+                for idx in frontier {
+                    let edges = if forward { &self.out_edges[idx] } else { &self.in_edges[idx] };
+                    for &e in edges {
+                        let edge = &self.edges[e];
+                        let neighbor = if forward { edge.target.as_str() } else { edge.source.as_str() };
+                        if let Some(&n) = self.node_index.get(neighbor) {
+                            if !visited[n] {
+                                visited[n] = true;
+                                if !in_thread[n] {
+                                    in_thread[n] = true;
+                                    node_ids.push(self.nodes[n].id.clone());
+                                }
+                                next.push(n);
+                            }
+                        }
+                    }
+                }
+                frontier = next;
+                level += 1;
+            }
+        }
+
+        // Highlight every edge internal to the thread (including ones not
+        // walked, e.g. an ancestor linking directly to a descendant), plus
+        // dangling out-edges of thread members.
+        let edge_ids: Vec<usize> = self
+            .edges
+            .iter()
+            .enumerate()
+            .filter(|(_, edge)| {
+                let src_in = self.node_index.get(edge.source.as_str()).is_some_and(|&i| in_thread[i]);
+                if !src_in {
+                    return false;
+                }
+                match self.node_index.get(edge.target.as_str()) {
+                    Some(&t) => in_thread[t],
+                    None => !edge.resolved, // dangling out-edge of a member
+                }
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        Some(Thread { node_ids, edge_ids })
+    }
+}
+
+/// The highlight set for a node's thread (Spec 001 §3.3): node ids plus edge
+/// indices into [`Graph::edges`].
+#[derive(Debug, Clone, Serialize)]
+pub struct Thread {
+    pub node_ids: Vec<String>,
+    pub edge_ids: Vec<usize>,
 }
 
 #[cfg(test)]
@@ -374,6 +458,130 @@ mod tests {
         assert!(e.resolved);
         assert_eq!(e.source, "ADR-2026-03-05-001");
         assert_eq!(e.target, "AILOG-2026-03-03-001");
+    }
+
+    #[test]
+    fn test_thread_full_component_and_depth() {
+        // REQ → ADR → AILOG chain; TDE isolated.
+        let req = make_doc(
+            "REQ-1-a.md",
+            DocType::Req,
+            Frontmatter {
+                id: Some("REQ-1".into()),
+                related: Some(vec!["ADR-1".into()]),
+                ..Default::default()
+            },
+        );
+        let adr = make_doc(
+            "ADR-1-b.md",
+            DocType::Adr,
+            Frontmatter {
+                id: Some("ADR-1".into()),
+                related: Some(vec!["AILOG-1".into()]),
+                ..Default::default()
+            },
+        );
+        let ailog = make_doc(
+            "AILOG-1-c.md",
+            DocType::Ailog,
+            Frontmatter {
+                id: Some("AILOG-1".into()),
+                ..Default::default()
+            },
+        );
+        let tde = make_doc(
+            "TDE-1-d.md",
+            DocType::Tde,
+            Frontmatter {
+                id: Some("TDE-1".into()),
+                ..Default::default()
+            },
+        );
+        let docs = [&req, &adr, &ailog, &tde];
+        let g = Graph::build(&docs);
+
+        // Full component from the middle node reaches both ends, not the orphan.
+        let t = g.thread("ADR-1", None).unwrap();
+        let mut nodes = t.node_ids.clone();
+        nodes.sort();
+        assert_eq!(nodes, vec!["ADR-1", "AILOG-1", "REQ-1"]);
+        assert_eq!(t.edge_ids.len(), 2);
+
+        // Depth 1 from REQ: only the direct neighbor.
+        let t1 = g.thread("REQ-1", Some(1)).unwrap();
+        let mut nodes1 = t1.node_ids.clone();
+        nodes1.sort();
+        assert_eq!(nodes1, vec!["ADR-1", "REQ-1"]);
+
+        // Unknown id → None; isolated node → itself only.
+        assert!(g.thread("NOPE", None).is_none());
+        let t_orphan = g.thread("TDE-1", None).unwrap();
+        assert_eq!(t_orphan.node_ids, vec!["TDE-1"]);
+        assert!(t_orphan.edge_ids.is_empty());
+    }
+
+    #[test]
+    fn test_thread_excludes_siblings() {
+        // A → C ← B: B is a "sibling" of A (co-cites C) — not part of A's
+        // line of reasoning, so it must NOT light up (S2 semantics).
+        let a = make_doc(
+            "REQ-A-a.md",
+            DocType::Req,
+            Frontmatter {
+                id: Some("REQ-A".into()),
+                related: Some(vec!["ADR-C".into()]),
+                ..Default::default()
+            },
+        );
+        let b = make_doc(
+            "REQ-B-b.md",
+            DocType::Req,
+            Frontmatter {
+                id: Some("REQ-B".into()),
+                related: Some(vec!["ADR-C".into()]),
+                ..Default::default()
+            },
+        );
+        let c = make_doc(
+            "ADR-C-c.md",
+            DocType::Adr,
+            Frontmatter {
+                id: Some("ADR-C".into()),
+                ..Default::default()
+            },
+        );
+        let docs = [&a, &b, &c];
+        let g = Graph::build(&docs);
+
+        let t = g.thread("REQ-A", None).unwrap();
+        let mut nodes = t.node_ids.clone();
+        nodes.sort();
+        assert_eq!(nodes, vec!["ADR-C", "REQ-A"]); // B excluded
+        assert_eq!(t.edge_ids, vec![0]); // only A→C, not B→C
+
+        // From C, both citers are ancestors — they DO light up.
+        let tc = g.thread("ADR-C", None).unwrap();
+        let mut nodes_c = tc.node_ids.clone();
+        nodes_c.sort();
+        assert_eq!(nodes_c, vec!["ADR-C", "REQ-A", "REQ-B"]);
+    }
+
+    #[test]
+    fn test_thread_includes_dangling_edges() {
+        let doc = make_doc(
+            "ADR-1-a.md",
+            DocType::Adr,
+            Frontmatter {
+                id: Some("ADR-1".into()),
+                related: Some(vec!["MISSING-1".into()]),
+                ..Default::default()
+            },
+        );
+        let docs = [&doc];
+        let g = Graph::build(&docs);
+        let t = g.thread("ADR-1", None).unwrap();
+        assert_eq!(t.node_ids, vec!["ADR-1"]);
+        assert_eq!(t.edge_ids, vec![0]); // the dangling edge belongs to the thread
     }
 
     #[test]

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -48,7 +48,8 @@ StrayMark uses **independent version tags** for each component:
 | Component | Tag prefix | Example | What it includes |
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.26.0` | Templates (12 types), governance docs, directives, Charter template + schema |
-| CLI | `cli-` | `cli-3.23.1` | The `straymark` binary |
+| CLI | `cli-` | `cli-3.24.0` | The `straymark` binary |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | The `straymark-loom` visualization server, downloaded on demand by `straymark loom serve` |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -1378,6 +1379,39 @@ StrayMark CLI
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark
   Website:           https://strangedays.tech
+```
+
+---
+
+### `straymark loom serve [path] [--port <port>] [--no-open]` *(cli-3.24.0+, EXPERIMENTAL)*
+
+Launch **Loom**, the EXPERIMENTAL knowledge-graph visualization server: a loopback-only, read-only web dashboard that renders the project's StrayMark documents as a live force-directed graph (nodes colored by document type, sized by connectivity; selecting a node lights up its whole thread of relationships; edits to watched `.md` files update the open browser in under a second).
+
+> ⚠️ **Loom is EXPERIMENTAL (v0).** Its API, CLI surface, and very existence may change or be removed without a deprecation cycle. The `straymark-loom` binary is **not** bundled into the CLI — it is downloaded on demand from the `loom-*` GitHub releases on first use and cached under `~/.straymark/bin/`. The download gate *is* the opt-in boundary.
+
+**Arguments and flags:**
+
+| Argument/Flag | Default | Description |
+|---|---|---|
+| `path` | `.` (current directory) | Project directory. Loom watches its `.straymark/` subdirectory if present, otherwise the directory itself |
+| `--port` | `7700` | Port on `127.0.0.1` to serve on |
+| `--no-open` | off | Do not open the browser automatically |
+
+**Security posture:** binds `127.0.0.1` exclusively (refuses to start otherwise), rejects non-loopback `Host` headers (anti DNS-rebinding), and never writes to the watched directory.
+
+**Example:**
+
+```bash
+$ straymark loom serve
+
+  ⚠  LOOM IS EXPERIMENTAL (v0)
+     Unstable: API, CLI surface, and on-disk layout may change or be
+     removed without a deprecation cycle. Loopback-only. Read-only.
+
+ℹ Downloading Loom 0.1.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
+✔ Loom 0.1.0 cached at ~/.straymark/bin/straymark-loom
+loom: watching /project/.straymark (142 docs, 318 links)
+loom: serving http://127.0.0.1:7700
 ```
 
 ---

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -241,7 +241,8 @@ StrayMark usa tags de versión independientes para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Incluye |
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.26.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
-| CLI | `cli-` | `cli-3.23.1` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.24.0` | El binario `straymark` |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | El servidor de visualización `straymark-loom`, descargado bajo demanda por `straymark loom serve` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -48,7 +48,8 @@ StrayMark usa **tags de versión independientes** para cada componente:
 | Componente | Prefijo de tag | Ejemplo | Qué incluye |
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.26.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
-| CLI | `cli-` | `cli-3.23.1` | El binario `straymark` |
+| CLI | `cli-` | `cli-3.24.0` | El binario `straymark` |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | El servidor de visualización `straymark-loom`, descargado bajo demanda por `straymark loom serve` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -1068,6 +1069,39 @@ StrayMark CLI
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark
   Website:           https://strangedays.tech
+```
+
+---
+
+### `straymark loom serve [path] [--port <puerto>] [--no-open]` *(cli-3.24.0+, EXPERIMENTAL)*
+
+Lanza **Loom**, el servidor EXPERIMENTAL de visualización del grafo de conocimiento: un dashboard web solo-loopback y solo-lectura que renderiza los documentos StrayMark del proyecto como un grafo de fuerzas en vivo (nodos coloreados por tipo de documento, dimensionados por conectividad; seleccionar un nodo ilumina todo su hilo de relaciones; las ediciones a archivos `.md` vigilados actualizan el navegador abierto en menos de un segundo).
+
+> ⚠️ **Loom es EXPERIMENTAL (v0).** Su API, superficie de CLI y su propia existencia pueden cambiar o eliminarse sin ciclo de deprecación. El binario `straymark-loom` **no** viene incluido en el CLI — se descarga bajo demanda de los releases `loom-*` de GitHub en el primer uso y se cachea en `~/.straymark/bin/`. La puerta de descarga *es* la frontera de opt-in.
+
+**Argumentos y flags:**
+
+| Argumento/Flag | Default | Descripción |
+|---|---|---|
+| `path` | `.` (directorio actual) | Directorio del proyecto. Loom vigila su subdirectorio `.straymark/` si existe; si no, el directorio mismo |
+| `--port` | `7700` | Puerto en `127.0.0.1` donde servir |
+| `--no-open` | off | No abrir el navegador automáticamente |
+
+**Postura de seguridad:** liga exclusivamente a `127.0.0.1` (rehúsa arrancar de otro modo), rechaza headers `Host` no-loopback (anti DNS-rebinding) y nunca escribe en el directorio vigilado.
+
+**Ejemplo:**
+
+```bash
+$ straymark loom serve
+
+  ⚠  LOOM IS EXPERIMENTAL (v0)
+     Unstable: API, CLI surface, and on-disk layout may change or be
+     removed without a deprecation cycle. Loopback-only. Read-only.
+
+ℹ Downloading Loom 0.1.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
+✔ Loom 0.1.0 cached at ~/.straymark/bin/straymark-loom
+loom: watching /project/.straymark (142 docs, 318 links)
+loom: serving http://127.0.0.1:7700
 ```
 
 ---

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -259,7 +259,8 @@ StrayMark 为每个组件使用独立的版本标签：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.26.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
-| CLI | `cli-` | `cli-3.23.1` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.24.0` | `straymark` 二进制文件 |
+| Loom（实验性） | `loom-` | `loom-0.1.0` | `straymark-loom` 可视化服务器，由 `straymark loom serve` 按需下载 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -48,7 +48,8 @@ StrayMark 为每个组件使用**独立的版本标签**：
 | 组件 | 标签前缀 | 示例 | 包含内容 |
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.26.0` | 模板（12 种类型）、治理文档、指令 |
-| CLI | `cli-` | `cli-3.23.1` | `straymark` 二进制文件 |
+| CLI | `cli-` | `cli-3.24.0` | `straymark` 二进制文件 |
+| Loom（实验性） | `loom-` | `loom-0.1.0` | `straymark-loom` 可视化服务器，由 `straymark loom serve` 按需下载 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -1201,6 +1202,39 @@ StrayMark CLI
   License:           MIT
   Repository:        https://github.com/StrangeDaysTech/straymark
   Website:           https://strangedays.tech
+```
+
+---
+
+### `straymark loom serve [path] [--port <端口>] [--no-open]` *(cli-3.24.0+，实验性)*
+
+启动 **Loom** —— 实验性知识图谱可视化服务器：一个仅回环、只读的 Web 仪表板，将项目的 StrayMark 文档渲染为实时力导向图（节点按文档类型着色、按连接度调整大小；选中节点会点亮其完整的关系线索；对被监视的 `.md` 文件的编辑会在一秒内更新已打开的浏览器）。
+
+> ⚠️ **Loom 是实验性的（v0）。** 其 API、CLI 接口乃至其存在本身都可能在没有弃用周期的情况下更改或移除。`straymark-loom` 二进制文件**不**捆绑在 CLI 中 —— 首次使用时从 `loom-*` GitHub 发布按需下载，并缓存在 `~/.straymark/bin/`。下载门槛*就是*选择加入的边界。
+
+**参数和标志：**
+
+| 参数/标志 | 默认值 | 描述 |
+|---|---|---|
+| `path` | `.`（当前目录） | 项目目录。如果存在 `.straymark/` 子目录则监视它，否则监视目录本身 |
+| `--port` | `7700` | 在 `127.0.0.1` 上服务的端口 |
+| `--no-open` | 关 | 不自动打开浏览器 |
+
+**安全态势：** 仅绑定 `127.0.0.1`（否则拒绝启动），拒绝非回环 `Host` 头（防 DNS 重绑定），且从不写入被监视的目录。
+
+**示例：**
+
+```bash
+$ straymark loom serve
+
+  ⚠  LOOM IS EXPERIMENTAL (v0)
+     Unstable: API, CLI surface, and on-disk layout may change or be
+     removed without a deprecation cycle. Loopback-only. Read-only.
+
+ℹ Downloading Loom 0.1.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
+✔ Loom 0.1.0 cached at ~/.straymark/bin/straymark-loom
+loom: watching /project/.straymark (142 docs, 318 links)
+loom: serving http://127.0.0.1:7700
 ```
 
 ---

--- a/experimento/AILOG-2026-06-12-001-loom-m0-core-extraction.md
+++ b/experimento/AILOG-2026-06-12-001-loom-m0-core-extraction.md
@@ -83,7 +83,8 @@ Completed 2026-06-12 — this AILOG's PR. Regression oracle green (see
 
 ### Batch 2 — M1: walking skeleton (`loom-0.1.0`)
 
-(pending)
+Completed 2026-06-12 — see `AILOG-2026-06-12-002` (the M1 AILOG with its own
+verification table). Ships `loom-0.1.0` + `cli-3.24.0` (+ core 0.2.0).
 
 ### Batch 3 — M2: analytics + panels (`loom-0.2.0`)
 

--- a/experimento/AILOG-2026-06-12-002-loom-m1-walking-skeleton.md
+++ b/experimento/AILOG-2026-06-12-002-loom-m1-walking-skeleton.md
@@ -1,0 +1,172 @@
+---
+id: AILOG-2026-06-12-002
+title: Loom M1 — walking skeleton (loom-0.1.0 server + UI + CLI launcher)
+status: accepted
+created: 2026-06-12
+agent: claude-code-opus-4.8
+confidence: high
+review_required: true
+risk_level: medium
+eu_ai_act_risk: not_applicable
+nist_genai_risks: []
+iso_42001_clause: []
+lines_changed: 1400
+files_modified: [core/src/graph.rs, core/Cargo.toml, experimento/Cargo.toml, experimento/src/main.rs, experimento/src/server.rs, experimento/src/snapshot.rs, experimento/src/watcher.rs, experimento/web/package.json, experimento/web/vite.config.ts, experimento/web/tsconfig.json, experimento/web/index.html, experimento/web/src/main.ts, cli/src/main.rs, cli/src/commands/loom/mod.rs, cli/src/commands/loom/serve.rs, cli/src/download.rs, cli/src/self_update.rs, cli/Cargo.toml, .github/workflows/release-loom.yml, .gitignore, CHANGELOG.md, CLAUDE.md]
+observability_scope: none
+tags: [loom, server, axum, sigma, websocket, walking-skeleton]
+related: [AILOG-2026-06-12-001, ADR-2026-06-02-001]
+---
+
+# AILOG: Loom M1 — walking skeleton (`loom-0.1.0`)
+
+## Summary
+
+Executed milestone **M1** of `CHARTER-01-loom-server` (T1.1–T1.12): the first
+runnable Loom — an axum server that watches a project, builds the typed
+knowledge graph via `straymark-core`, serves the Spec 001 §4 API over loopback
+only, and renders a live Sigma.js force-directed UI with thread highlighting;
+plus the `straymark loom serve` download-on-demand launcher (CLI 3.24.0) and
+the `release-loom.yml` pipeline. All 6 M1 acceptance criteria verified.
+
+## Context
+
+M0 (AILOG-2026-06-12-001, PR #239, `cli-3.23.1`) put the shared parser and
+graph in place. M1 is the "walking skeleton": the thinnest end-to-end slice
+that delivers the core wow — *see* the corpus as a live map (FR1–FR7).
+
+## Actions Performed
+
+1. **core 0.2.0** — `Graph::thread(id, depth)` (Spec §3.3): undirected BFS
+   over incident edges, optional depth bound, dangling out-edges included in
+   the highlight set; 2 new unit tests (20 total in core).
+2. **T1.1** — `experimento/` joined the workspace; `straymark-loom` crate
+   (axum 0.8, tokio, notify-debouncer-full, rust-embed; `publish = false`).
+3. **T1.2/T1.3** — `snapshot.rs`: discover→parse→build via `straymark-core`
+   (unparseable mid-save files skipped, never fatal); precomputed API view
+   with edge index ids; `/api/graph`, `/api/node/:id` (+excerpt, in/out
+   edges), `/api/node/:id/thread?depth`, `/api/stats` (orphans + dangling
+   refs, M1-required data per acceptance 6), `/healthz`.
+4. **T1.4** — security: explicit `127.0.0.1` bind (refuses otherwise; never
+   falls back to a wider interface) + middleware rejecting non-loopback
+   `Host` (allows `localhost`/`127.0.0.0/8`/`[::1]`, with ports); unit-tested
+   against DNS-rebinding shapes (`localhost.evil.com`, etc.).
+5. **T1.5** — watcher: 250ms debounce, `.md`-only relevance filter, rebuild →
+   `Arc` swap → broadcast `{event:"rebuild", graph}` to all WS clients;
+   initial full sync on connect; lagged receivers skip, never crash.
+6. **T1.6/T1.7/T1.8** — `web/`: Vite + TS strict + graphology + Sigma v3.
+   Type-color palette (16 doc types), degree sizing, ForceAtlas2 (300 it
+   first load / 30 on rebuild with positions preserved), thread highlight via
+   node/edge reducers (no relayout), node detail panel, legend, counters, WS
+   auto-reconnect. Bundle 46KB gzip, embedded via rust-embed; `--assets-dir`
+   dev override; SPA fallback.
+7. **T1.9** — CLI 3.24.0: `Loom { Serve { path, --port, --no-open } }`;
+   `commands/loom/serve.rs` reuses `download.rs`/`platform.rs`/
+   `self_update.rs` extractors (made `pub(crate)`); version-marker cache in
+   `~/.straymark/bin/`; offline → cached binary with a warning; EXPERIMENTAL
+   banner; browser auto-open (xdg-open/open/cmd). `strip_tag_prefix` learns
+   `loom-`.
+8. **T1.10** — `release-loom.yml`: version-vs-tag gate on
+   `experimento/Cargo.toml`, `npm ci && npm run build` before cargo (assets
+   embedded), 4-target matrix, workspace `target/` paths, `--latest=false`,
+   prefix-scoped release cleanup. `experimento/web/package-lock.json`
+   committed for `npm ci` (gitignore exception, mirrors `website/`).
+9. **Docs** — versioning tables gain a Loom row and CLI 3.24.0 (README ×3,
+   CLI-REFERENCE ×3); new `loom serve` command section (EN/ES/zh-CN);
+   CLAUDE.md (commands table, structure tree, Loom release workflow); root
+   CHANGELOG and `experimento/CHANGELOG.md` → 0.1.0.
+
+## Modified Files
+
+| File | Lines Changed (+/-) | Change Description |
+|------|--------------------|--------------------|
+| `core/src/graph.rs` | +151/-0 | `thread()` + `Thread` + 2 tests |
+| `experimento/src/{main,server,snapshot,watcher}.rs` | +800/-0 | The Loom server (4 modules, 4 tests) |
+| `experimento/web/**` | +260/-0 (+lockfile) | Vite/TS/Sigma frontend |
+| `experimento/Cargo.toml` | +32/-0 | straymark-loom crate |
+| `cli/src/commands/loom/{mod,serve}.rs` | +200/-0 | Download-on-demand launcher |
+| `cli/src/main.rs` | +30/-0 | `Loom`/`LoomCommands` wiring |
+| `cli/src/{download,self_update}.rs` | +4/-3 | `loom-` prefix; extractors `pub(crate)` |
+| `.github/workflows/release-loom.yml` | +180/-0 | Loom release pipeline |
+| docs (README/CLI-REFERENCE ×6, CLAUDE.md, CHANGELOGs) | ~+150 | Versioning, command docs, release notes |
+
+## Decisions Made
+
+- **core 0.2.0 (not 0.1.1)** for the additive `thread()` API; the CLI's dep
+  bumped to `0.2.0` so the publish-core-before-cli CI step stays coherent.
+- **Edge identity = index** into `graph.edges` (stable per snapshot): gives
+  the UI addressable edges without changing the core `Edge` shape.
+- **Sync ForceAtlas2** (not the worker) at M1 — corpora are small; the worker
+  supervisor is an M3 refinement if needed.
+- **`npm audit`**: 2 high findings in the dev-only esbuild/vite dev-server
+  chain (GHSA esbuild CORS). Not shipped: the production bundle is static JS;
+  builds run only in CI. Accepted for M1; revisit on vite major bumps.
+- **Dangling edges are API-only at M1**: Sigma needs both endpoints, so the
+  UI renders resolved edges; dangling refs surface via `/api/stats` (and the
+  M2 stats panel). The data is never dropped (FR2).
+
+## Impact
+
+- **Functionality**: new, additive. No existing CLI command changes behavior.
+- **Performance**: fixture rebuild ~5ms; live update save→browser ~255ms
+  (debounce-dominated). NFR2 headroom is large at current corpus sizes.
+- **Security**: new localhost listener — mitigated per FR7/NFR4 (loopback
+  bind, `Host` rejection, read-only; refuses to start otherwise). R4 closed
+  for M1.
+- **Privacy**: N/A (serves the user's own local files to their own browser).
+- **Environmental**: N/A.
+
+## Verification
+
+- [x] Code compiles without errors (workspace: core + cli + loom)
+- [x] Tests pass — core 20, loom 4 (snapshot ×2, host-check, unparseable),
+      CLI suite intact (see PR run: full `cargo test` green)
+- [x] **Acceptance 1** — server serves the force-graph UI at `127.0.0.1:7700`
+      (embedded assets; verified by HTTP + visual check in browser)
+- [x] **Acceptance 2** — `/api/graph` ≡ `straymark audit` on the fixture
+      corpus: node id sets and doc types identical; audit chains covered by
+      resolved `RELATED_TO` edges (NFR1)
+- [x] **Acceptance 3** — node selection lights the thread, dims the rest
+      (Sigma reducers; visual check)
+- [x] **Acceptance 4** — live update measured **~255ms** save→browser (<1s)
+      via a WS client driving a real file edit
+- [x] **Acceptance 5** — refuses non-loopback: bind is hardcoded loopback;
+      forged `Host: evil.example.com` → 403 (curl-verified + unit tests)
+- [x] **Acceptance 6** — orphans + dangling references present in
+      `/api/stats` (curl-verified on a corpus containing both)
+- [x] Manual review performed (human review pending at PR — `review_required: true`)
+
+## Follow-ups
+
+Surfaced by smoke-testing M1 against the reference adopter corpus (Sentinel,
+130 discovered docs / 389 edges — **326 dangling**, which is signal, not noise):
+
+- **R1 (new) — reference normalization.** Real `related:` entries reference
+  documents by *filename* (`AILOG-2026-05-07-041-charter-13-….md`, 64 cases)
+  and by *relative path* (`.straymark/audits/…`, `specs/…`; ~90 cases), not
+  only by frontmatter id. The resolver (core::graph; shared with `audit`)
+  could normalize: strip `.md`, match filename stem, resolve paths. Any change
+  must move `audit` and Loom together (NFR1). Candidate: M2.
+- **R2 (new) — Charters as graph nodes.** 47+ dangling refs target
+  `CHARTER-*` ids/paths: Charters are among the most-referenced documents in
+  a real corpus but are not `DocType`s, so they are invisible to the graph.
+  Promoting them to first-class nodes (the CLI already parses them in
+  `charter.rs`) would close the biggest legibility gap. Candidate: M2/M3.
+- **R3 (new) — visual density at 100+ nodes.** Operator verdict on the
+  Sentinel test: improved (short labels, dark hover, threshold 8) but still
+  saturated. Candidates for M2/M3: label fade by zoom level, cluster-aware
+  label budgets, edge bundling/opacity scaling, Louvain coloring (already
+  planned) doubling as visual grouping.
+
+## Additional Notes
+
+- `loom-0.1.0` must be tagged **after** this PR merges so
+  `release-loom.yml` finds matching versions; until the release exists,
+  `straymark loom serve` reports "no release could be fetched" (verified
+  message path).
+- Suggested tag order at merge: `cli-3.24.0` and `loom-0.1.0` can be pushed
+  together (`git push origin cli-3.24.0 loom-0.1.0`); the CLI release will
+  also publish `straymark-core 0.2.0` to crates.io (idempotent step).
+
+---
+
+<!-- Template: StrayMark | https://strangedays.tech -->

--- a/experimento/CHANGELOG.md
+++ b/experimento/CHANGELOG.md
@@ -12,20 +12,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-- Intention documents seeding the component: `README.md` (Loom reframed as a multi-view
-  development dashboard), the SpecKit set `specs/001-loom-server/{spec,plan,tasks}.md`
-  (Knowledge Graph view) and `specs/002-architecture-plan/spec.md` (Architecture Plan view —
-  "you are here" status overlay), the dogfood work-block Charter `CHARTER-01-loom-server.md`,
-  and this changelog. Architecture decisions recorded in
-  `docs/decisions/ADR-2026-06-02-loom-stack.md` (stack) and
-  `docs/decisions/ADR-2026-06-02-002-architecture-plan-format.md` (plan model/format).
-
-### Planned — 0.1.0 (M1, walking skeleton — Knowledge Graph view)
-- `straymark loom serve` launches a loopback-only axum server that watches `.straymark/`
-  (or `docs/`), builds the typed knowledge graph via the shared `straymark-core` crate, and
-  serves a Sigma.js + graphology force-directed web UI with live filesystem updates over
-  WebSocket and node-thread highlighting.
+### Planned — 0.2.0 (M2, analytics + panels)
+- Louvain community coloring, corpus stats panel (orphans, dangling references),
+  server-side filters (`type/status/risk/tag/from/to`) on `/api/graph`.
 
 ### Planned — Architecture Plan view (Spec 002)
 - A1: `straymark-core` "you are here" status projection (component state by file-glob match
@@ -35,4 +24,38 @@ project adheres to [Semantic Versioning](https://semver.org/).
   overlay, layer toggle, component panel, and cross-linking with the Knowledge Graph.
 - A3 (north star): axonometric/BIM exploded-layers view.
 
-[Unreleased]: https://github.com/StrangeDaysTech/straymark/compare/HEAD...HEAD
+## [0.1.0] — 2026-06-12 (M1, walking skeleton — Knowledge Graph view)
+
+### Added
+
+- **Server** (`straymark-loom`, axum + tokio): builds the typed knowledge graph via the
+  shared `straymark-core` crate (FR1/FR2 — same parser as the CLI, NFR1 verified against
+  `straymark audit`) and serves the Spec 001 §4 API: `GET /api/graph`, `/api/node/:id`,
+  `/api/node/:id/thread?depth=N`, `/api/stats` (counts, orphans, dangling references),
+  `/healthz`, and `WS /api/stream`.
+- **Live updates** (FR6/§5): `notify` watcher with 250ms debounce; settled `.md` changes
+  rebuild the snapshot and push a `rebuild` event — measured ~255ms from save to an open
+  browser, well under the 1s acceptance bound.
+- **Security** (FR7/NFR4): binds `127.0.0.1` exclusively (refuses anything else), rejects
+  non-loopback `Host` headers (anti DNS-rebinding), read-only by construction; unparseable
+  (mid-save) documents are skipped, never fatal.
+- **Web UI** (FR4/FR5, Vite + TypeScript + graphology + Sigma.js, embedded via rust-embed):
+  force-directed graph (ForceAtlas2) colored by document type, sized by degree;
+  selecting a node lights its full thread and dims the rest (no relayout); node detail
+  panel (metadata + body excerpt); type legend; corpus counters; WS auto-reconnect;
+  positions preserved across rebuilds. `--assets-dir` overrides the embedded bundle for
+  frontend development.
+- **CLI launcher**: `straymark loom serve` (cli-3.24.0) downloads the platform binary from
+  the latest `loom-*` release on first use, caches it in `~/.straymark/bin/`, prints the
+  EXPERIMENTAL banner, and spawns it (download-on-demand = the opt-in gate).
+- **CI**: `.github/workflows/release-loom.yml` — frontend built in CI and embedded;
+  4-platform matrix; GitHub-release-only (`--latest=false`, no crates.io while experimental).
+
+### Milestone trail
+
+- M0 (the `straymark-core` extraction this release builds on) shipped as `cli-3.23.1`
+  (PR #239) together with the component's intention docs (README, SpecKit sets 001/002,
+  `CHARTER-01-loom-server`, ADR-2026-06-02-001/-002).
+
+[Unreleased]: https://github.com/StrangeDaysTech/straymark/compare/loom-0.1.0...HEAD
+[0.1.0]: https://github.com/StrangeDaysTech/straymark/releases/tag/loom-0.1.0

--- a/experimento/Cargo.toml
+++ b/experimento/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "straymark-loom"
+version = "0.1.0"
+edition = "2021"
+description = "Loom — StrayMark's experimental knowledge-graph visualization server (localhost development dashboard)"
+license = "MIT"
+repository = "https://github.com/StrangeDaysTech/straymark"
+authors = ["Strange Days Tech, S.A.S."]
+# GitHub-release-only while experimental (plan.md §6): no crates.io publish.
+publish = false
+
+[[bin]]
+name = "straymark-loom"
+path = "src/main.rs"
+
+[dependencies]
+straymark-core = { version = "0.2.0", path = "../core" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "fs"] }
+axum = { version = "0.8", features = ["ws"] }
+notify-debouncer-full = "0.5"
+rust-embed = "8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+mime_guess = "2"
+colored = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/experimento/build.rs
+++ b/experimento/build.rs
@@ -1,0 +1,7 @@
+/// rust-embed's `#[folder = "web/dist/"]` requires the directory to exist at
+/// compile time, but it is gitignored (built by Vite, in CI for releases).
+/// Ensure it exists so a fresh clone can `cargo build` without npm.
+fn main() {
+    let dist = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("web/dist");
+    std::fs::create_dir_all(&dist).expect("failed to create web/dist for rust-embed");
+}

--- a/experimento/src/main.rs
+++ b/experimento/src/main.rs
@@ -1,0 +1,107 @@
+//! straymark-loom — Loom, StrayMark's EXPERIMENTAL knowledge-graph
+//! visualization server (Spec 001, `CHARTER-01-loom-server`).
+//!
+//! Loopback-only, read-only: binds 127.0.0.1 exclusively, rejects
+//! non-loopback `Host` headers, and never writes to the watched directory.
+
+mod server;
+mod snapshot;
+mod watcher;
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use colored::Colorize;
+use tokio::sync::broadcast;
+
+use server::AppState;
+use snapshot::Snapshot;
+
+#[derive(Parser)]
+#[command(
+    name = "straymark-loom",
+    version,
+    about = "Loom — StrayMark's EXPERIMENTAL knowledge-graph visualization server"
+)]
+struct Args {
+    /// Project directory (defaults to the current directory). Loom watches
+    /// its `.straymark/` subdirectory if present, otherwise the directory
+    /// itself.
+    #[arg(default_value = ".")]
+    path: String,
+
+    /// Port on 127.0.0.1 to serve on.
+    #[arg(long, default_value_t = 7700)]
+    port: u16,
+
+    /// Serve frontend assets from this directory instead of the embedded
+    /// bundle (frontend development).
+    #[arg(long)]
+    assets_dir: Option<PathBuf>,
+}
+
+/// `.straymark/` when the project has one, else the directory itself
+/// (this source repo dogfoods on `docs/` & co. without a root install).
+fn resolve_watch_dir(path: &str) -> Result<PathBuf> {
+    let base = PathBuf::from(path)
+        .canonicalize()
+        .with_context(|| format!("cannot resolve project path {path}"))?;
+    let straymark = base.join(".straymark");
+    Ok(if straymark.is_dir() { straymark } else { base })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let watch_dir = resolve_watch_dir(&args.path)?;
+
+    let initial = Arc::new(
+        Snapshot::build(&watch_dir)
+            .with_context(|| format!("initial graph build failed for {}", watch_dir.display()))?,
+    );
+    let doc_count = initial.api.stats.total_docs;
+    let edge_count = initial.api.stats.total_edges;
+
+    let snapshot = Arc::new(RwLock::new(initial));
+    let (events, _) = broadcast::channel::<String>(16);
+
+    // Keep the handle alive for the lifetime of the server (drop = unwatch).
+    let _debouncer = watcher::watch(&watch_dir, snapshot.clone(), events.clone())
+        .context("failed to start the filesystem watcher")?;
+
+    let state = AppState {
+        snapshot,
+        events,
+        assets_dir: args.assets_dir,
+    };
+
+    // FR7: loopback bind only. If 127.0.0.1 cannot be bound, refuse to start —
+    // never fall back to a wider interface.
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, args.port));
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("cannot bind {addr} (is another Loom running?)"))?;
+
+    eprintln!(
+        "{}",
+        "⚠ Loom is EXPERIMENTAL (v0) — unstable, loopback-only, read-only".yellow().bold()
+    );
+    eprintln!(
+        "loom: watching {} ({} docs, {} links)",
+        watch_dir.display(),
+        doc_count,
+        edge_count
+    );
+    eprintln!("loom: serving http://{addr}");
+
+    axum::serve(listener, server::router(state))
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+            eprintln!("\nloom: shutting down");
+        })
+        .await?;
+    Ok(())
+}

--- a/experimento/src/server.rs
+++ b/experimento/src/server.rs
@@ -1,0 +1,243 @@
+//! The axum server: read-only HTTP API + WebSocket stream + embedded SPA
+//! (Spec 001 §4), loopback-only with anti-DNS-rebinding `Host` rejection
+//! (FR7/NFR4).
+
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::http::{header, HeaderMap, StatusCode, Uri};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use rust_embed::RustEmbed;
+use serde::Deserialize;
+use tokio::sync::broadcast;
+
+use crate::snapshot::{ApiEdge, Snapshot};
+
+/// Frontend assets built by Vite into `web/dist/` and embedded at compile
+/// time (NFR3 — adopters never run npm). Empty during development; use
+/// `--assets-dir web/dist` (or the Vite dev server) instead.
+#[derive(RustEmbed)]
+#[folder = "web/dist/"]
+struct Assets;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub snapshot: Arc<RwLock<Arc<Snapshot>>>,
+    pub events: broadcast::Sender<String>,
+    pub assets_dir: Option<PathBuf>,
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/graph", get(api_graph))
+        .route("/api/node/{id}", get(api_node))
+        .route("/api/node/{id}/thread", get(api_thread))
+        .route("/api/stats", get(api_stats))
+        .route("/api/stream", get(api_stream))
+        .route("/healthz", get(|| async { "ok" }))
+        .fallback(get(serve_asset))
+        .layer(middleware::from_fn(reject_non_loopback_host))
+        .with_state(state)
+}
+
+/// Anti DNS-rebinding (FR7/NFR4): even though the listener binds 127.0.0.1,
+/// a hostile page can point an attacker-controlled DNS name at 127.0.0.1 and
+/// reach us through the victim's browser. Reject any `Host` that is not a
+/// loopback name.
+async fn reject_non_loopback_host(
+    headers: HeaderMap,
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let host_ok = headers
+        .get(header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .map(is_loopback_host)
+        .unwrap_or(false);
+    if !host_ok {
+        return (
+            StatusCode::FORBIDDEN,
+            "Loom only answers loopback hosts (localhost / 127.0.0.1 / [::1])",
+        )
+            .into_response();
+    }
+    next.run(request).await
+}
+
+/// `host` is the raw `Host` header value (possibly with a port).
+fn is_loopback_host(host: &str) -> bool {
+    // IPv6 literal: [::1] or [::1]:port
+    if let Some(rest) = host.strip_prefix('[') {
+        return matches!(rest.split(']').next(), Some("::1"));
+    }
+    let name = host.split(':').next().unwrap_or("");
+    if name.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // Any 127.0.0.0/8 address is loopback.
+    name.parse::<std::net::Ipv4Addr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+fn current(state: &AppState) -> Arc<Snapshot> {
+    state.snapshot.read().expect("snapshot lock poisoned").clone()
+}
+
+async fn api_graph(State(state): State<AppState>) -> Response {
+    axum::Json(&current(&state).api).into_response()
+}
+
+async fn api_stats(State(state): State<AppState>) -> Response {
+    axum::Json(&current(&state).api.stats).into_response()
+}
+
+async fn api_node(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    let snap = current(&state);
+    let Some(node) = snap.graph.node(&id) else {
+        return (StatusCode::NOT_FOUND, "unknown document id").into_response();
+    };
+    // Edge ids are indices into graph.edges — recover them by pointer-free
+    // comparison against the precomputed API edges (same order).
+    let out_edges: Vec<&ApiEdge> = snap
+        .api
+        .edges
+        .iter()
+        .filter(|e| e.edge.source == node.id)
+        .collect();
+    let in_edges: Vec<&ApiEdge> = snap
+        .api
+        .edges
+        .iter()
+        .filter(|e| e.edge.resolved && e.edge.target == node.id)
+        .collect();
+    axum::Json(serde_json::json!({
+        "node": node,
+        "out_edges": out_edges,
+        "in_edges": in_edges,
+        "excerpt": snap.excerpts.get(&id),
+    }))
+    .into_response()
+}
+
+#[derive(Deserialize)]
+struct ThreadParams {
+    depth: Option<usize>,
+}
+
+async fn api_thread(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Query(params): Query<ThreadParams>,
+) -> Response {
+    let snap = current(&state);
+    match snap.graph.thread(&id, params.depth) {
+        Some(thread) => axum::Json(thread).into_response(),
+        None => (StatusCode::NOT_FOUND, "unknown document id").into_response(),
+    }
+}
+
+/// WS /api/stream — pushes the full current graph on connect, then a
+/// `rebuild` event on every settled filesystem change (M1: full snapshots;
+/// M3 will add deltas).
+async fn api_stream(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    ws.on_upgrade(move |socket| stream_events(socket, state))
+}
+
+async fn stream_events(mut socket: WebSocket, state: AppState) {
+    let mut rx = state.events.subscribe();
+    // Initial sync so a late-joining client doesn't wait for the next change.
+    let initial = current(&state).rebuild_event();
+    if socket.send(Message::Text(initial.into())).await.is_err() {
+        return;
+    }
+    loop {
+        tokio::select! {
+            event = rx.recv() => match event {
+                Ok(msg) => {
+                    if socket.send(Message::Text(msg.into())).await.is_err() {
+                        return; // client gone
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return,
+            },
+            incoming = socket.recv() => match incoming {
+                Some(Ok(_)) => continue,    // ignore client chatter (read-only server)
+                _ => return,                // closed or errored
+            },
+        }
+    }
+}
+
+/// Serve the SPA: embedded `web/dist/` by default, `--assets-dir` override
+/// for frontend development (T1.8).
+async fn serve_asset(State(state): State<AppState>, uri: Uri) -> Response {
+    let path = uri.path().trim_start_matches('/');
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    if let Some(dir) = &state.assets_dir {
+        let file = dir.join(path);
+        // Confine to the assets dir (no traversal).
+        if file.starts_with(dir) {
+            if let Ok(body) = tokio::fs::read(&file).await {
+                return with_mime(path, body);
+            }
+        }
+        // SPA fallback to index.html for client-side routes.
+        if let Ok(body) = tokio::fs::read(dir.join("index.html")).await {
+            return with_mime("index.html", body);
+        }
+        return (StatusCode::NOT_FOUND, "asset not found").into_response();
+    }
+
+    match Assets::get(path).or_else(|| Assets::get("index.html")) {
+        Some(content) => with_mime(path, content.data.into_owned()),
+        None => (
+            StatusCode::NOT_FOUND,
+            "Loom UI assets not embedded in this build — \
+             use --assets-dir web/dist after `npm run build`, \
+             or a release binary",
+        )
+            .into_response(),
+    }
+}
+
+fn with_mime(path: &str, body: Vec<u8>) -> Response {
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    ([(header::CONTENT_TYPE, mime.as_ref().to_string())], body).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_loopback_host() {
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("localhost:7700"));
+        assert!(is_loopback_host("LOCALHOST:7700"));
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("127.0.0.1:7700"));
+        assert!(is_loopback_host("127.0.0.53:80"));
+        assert!(is_loopback_host("[::1]"));
+        assert!(is_loopback_host("[::1]:7700"));
+        // DNS-rebinding shapes must be refused.
+        assert!(!is_loopback_host("evil.example.com"));
+        assert!(!is_loopback_host("evil.example.com:7700"));
+        assert!(!is_loopback_host("192.168.1.10:7700"));
+        assert!(!is_loopback_host("localhost.evil.com"));
+        assert!(!is_loopback_host(""));
+    }
+}

--- a/experimento/src/snapshot.rs
+++ b/experimento/src/snapshot.rs
@@ -1,0 +1,177 @@
+//! The in-memory state Loom serves: the core graph plus the precomputed,
+//! serializable API view (Spec 001 §3–§4). Rebuilt on every settled
+//! filesystem change.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Result;
+use serde::Serialize;
+use straymark_core::document::{discover_documents, parse_document, StrayMarkDocument};
+use straymark_core::graph::{Edge, Graph, Node};
+
+/// How much of a document body `/api/node/:id` returns.
+const EXCERPT_CHARS: usize = 600;
+
+/// An edge as served by the API: the core edge plus its stable index id
+/// (thread highlighting addresses edges by this id).
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiEdge {
+    pub id: usize,
+    #[serde(flatten)]
+    pub edge: Edge,
+}
+
+/// Corpus statistics (Spec 001 §4 `/api/stats`; data required at M1 by
+/// acceptance criterion 6 even though the UI panel ships in M2).
+#[derive(Debug, Clone, Serialize)]
+pub struct Stats {
+    pub total_docs: usize,
+    pub total_edges: usize,
+    pub by_type: BTreeMap<String, usize>,
+    pub by_status: BTreeMap<String, usize>,
+    pub by_risk: BTreeMap<String, usize>,
+    pub orphans: Vec<String>,
+    pub dangling_references: Vec<ApiEdge>,
+}
+
+/// What `/api/graph` returns (and what `rebuild` events push over the WS).
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiGraph {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<ApiEdge>,
+    pub stats: Stats,
+}
+
+/// One rebuilt view of the corpus.
+pub struct Snapshot {
+    /// The core graph (kept for thread queries).
+    pub graph: Graph,
+    /// Precomputed API view.
+    pub api: ApiGraph,
+    /// id → body excerpt, for the node detail endpoint.
+    pub excerpts: BTreeMap<String, String>,
+}
+
+impl Snapshot {
+    /// Discover, parse, and build — the same code path as the CLI (FR1/NFR1).
+    pub fn build(watch_dir: &Path) -> Result<Snapshot> {
+        let paths = discover_documents(watch_dir);
+        // Unparseable files are skipped, never fatal: a half-saved document
+        // must not take the dashboard down mid-edit.
+        let docs: Vec<StrayMarkDocument> = paths
+            .iter()
+            .filter_map(|p| parse_document(p).ok())
+            .collect();
+        let doc_refs: Vec<&StrayMarkDocument> = docs.iter().collect();
+        let graph = Graph::build(&doc_refs);
+
+        let mut excerpts = BTreeMap::new();
+        for (node, doc) in graph.nodes.iter().zip(docs.iter()) {
+            let body = doc.body.trim();
+            let excerpt: String = body.chars().take(EXCERPT_CHARS).collect();
+            excerpts.insert(node.id.clone(), excerpt);
+        }
+
+        let api = build_api_view(&graph);
+        Ok(Snapshot { graph, api, excerpts })
+    }
+
+    /// The serialized WS rebuild event.
+    pub fn rebuild_event(&self) -> String {
+        serde_json::json!({ "event": "rebuild", "graph": &self.api }).to_string()
+    }
+}
+
+fn build_api_view(graph: &Graph) -> ApiGraph {
+    let edges: Vec<ApiEdge> = graph
+        .edges
+        .iter()
+        .enumerate()
+        .map(|(id, edge)| ApiEdge { id, edge: edge.clone() })
+        .collect();
+
+    let mut by_type = BTreeMap::new();
+    let mut by_status = BTreeMap::new();
+    let mut by_risk = BTreeMap::new();
+    for node in &graph.nodes {
+        *by_type.entry(node.doc_type.clone()).or_insert(0) += 1;
+        *by_status.entry(node.status.clone()).or_insert(0) += 1;
+        *by_risk.entry(node.risk_level.clone()).or_insert(0) += 1;
+    }
+
+    let stats = Stats {
+        total_docs: graph.nodes.len(),
+        total_edges: graph.edges.len(),
+        by_type,
+        by_status,
+        by_risk,
+        orphans: graph.orphans().map(|n| n.id.clone()).collect(),
+        dangling_references: edges.iter().filter(|e| !e.edge.resolved).cloned().collect(),
+    };
+
+    ApiGraph { nodes: graph.nodes.clone(), edges, stats }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn test_snapshot_from_fixture_corpus() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            &root.join("01-requirements/REQ-2026-03-01-001-login.md"),
+            "---\nid: REQ-2026-03-01-001\ntitle: Login\nstatus: approved\ncreated: 2026-03-01\nrisk_level: medium\nrelated: [ADR-2026-03-02-001, MISSING-1]\n---\n# Login body\n",
+        );
+        write(
+            &root.join("02-design/decisions/ADR-2026-03-02-001-jwt.md"),
+            "---\nid: ADR-2026-03-02-001\ntitle: JWT\nstatus: accepted\ncreated: 2026-03-02\nrisk_level: high\n---\n# JWT body\n",
+        );
+        write(
+            &root.join("06-evolution/technical-debt/TDE-2026-04-01-001-orphan.md"),
+            "---\nid: TDE-2026-04-01-001\ntitle: Orphan\nstatus: open\ncreated: 2026-04-01\n---\n# Debt\n",
+        );
+
+        let snap = Snapshot::build(root).unwrap();
+        assert_eq!(snap.api.stats.total_docs, 3);
+        assert_eq!(snap.api.stats.total_edges, 2);
+        assert_eq!(snap.api.stats.orphans, vec!["TDE-2026-04-01-001"]);
+        assert_eq!(snap.api.stats.dangling_references.len(), 1);
+        assert_eq!(snap.api.stats.by_type.get("REQ"), Some(&1));
+        assert!(snap.excerpts["ADR-2026-03-02-001"].contains("JWT body"));
+
+        // Edge ids are stable indices into graph.edges.
+        assert_eq!(snap.api.edges[0].id, 0);
+        assert_eq!(snap.api.edges[1].id, 1);
+
+        // Rebuild event is valid JSON with the expected envelope.
+        let event: serde_json::Value =
+            serde_json::from_str(&snap.rebuild_event()).unwrap();
+        assert_eq!(event["event"], "rebuild");
+        assert_eq!(event["graph"]["stats"]["total_docs"], 3);
+    }
+
+    #[test]
+    fn test_unparseable_file_skipped_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            &root.join("01-requirements/REQ-2026-03-01-001-ok.md"),
+            "---\nid: REQ-2026-03-01-001\ntitle: Ok\n---\nbody\n",
+        );
+        // Dated, typed filename but broken frontmatter (mid-save state).
+        write(
+            &root.join("01-requirements/REQ-2026-03-02-001-broken.md"),
+            "---\nid: [unclosed\n",
+        );
+        let snap = Snapshot::build(root).unwrap();
+        assert_eq!(snap.api.stats.total_docs, 1);
+    }
+}

--- a/experimento/src/watcher.rs
+++ b/experimento/src/watcher.rs
@@ -1,0 +1,57 @@
+//! Filesystem watcher (Spec 001 §5): `notify` with a ~250ms debounce to
+//! coalesce editor save storms; on a settled change, rebuild the snapshot
+//! and broadcast a `rebuild` event to every `/api/stream` client.
+
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use anyhow::Result;
+use notify_debouncer_full::notify::RecursiveMode;
+use notify_debouncer_full::{new_debouncer, DebounceEventResult};
+use tokio::sync::broadcast;
+
+use crate::snapshot::Snapshot;
+
+pub const DEBOUNCE: Duration = Duration::from_millis(250);
+
+/// Spawns the watcher. Returns the debouncer handle — drop it and the
+/// watching stops, so the caller must keep it alive.
+pub fn watch(
+    watch_dir: &Path,
+    snapshot: Arc<RwLock<Arc<Snapshot>>>,
+    events: broadcast::Sender<String>,
+) -> Result<impl Sized> {
+    let dir = watch_dir.to_path_buf();
+    let mut debouncer = new_debouncer(
+        DEBOUNCE,
+        None,
+        move |result: DebounceEventResult| {
+            let Ok(batch) = result else { return };
+            // Only .md churn matters; ignore editor lockfiles, swap files, etc.
+            let relevant = batch.iter().any(|e| {
+                e.paths
+                    .iter()
+                    .any(|p| p.extension().and_then(|x| x.to_str()) == Some("md"))
+            });
+            if !relevant {
+                return;
+            }
+            match Snapshot::build(&dir) {
+                Ok(next) => {
+                    let next = Arc::new(next);
+                    let event = next.rebuild_event();
+                    *snapshot.write().expect("snapshot lock poisoned") = next;
+                    // No receivers (no open browser) is fine — ignore the error.
+                    let _ = events.send(event);
+                }
+                Err(err) => {
+                    eprintln!("loom: rebuild failed (will retry on next change): {err:#}");
+                }
+            }
+        },
+    )?;
+
+    debouncer.watch(watch_dir, RecursiveMode::Recursive)?;
+    Ok(debouncer)
+}

--- a/experimento/web/index.html
+++ b/experimento/web/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Loom — StrayMark knowledge graph</title>
+    <style>
+      :root {
+        --bg: #14161c;
+        --panel: #1c1f27;
+        --text: #d6d9e0;
+        --muted: #8b91a0;
+        --accent: #e8833a;
+      }
+      * { box-sizing: border-box; margin: 0; }
+      html, body { height: 100%; }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
+        overflow: hidden;
+      }
+      #graph { position: absolute; inset: 0; }
+      header {
+        position: absolute; top: 0; left: 0; right: 0; z-index: 10;
+        display: flex; align-items: center; gap: 12px;
+        padding: 10px 16px;
+        background: linear-gradient(to bottom, rgba(20,22,28,.95), rgba(20,22,28,0));
+        pointer-events: none;
+      }
+      header h1 { font-size: 16px; font-weight: 650; letter-spacing: .02em; }
+      header h1 span { color: var(--accent); }
+      .badge {
+        font-size: 10px; font-weight: 700; letter-spacing: .08em;
+        color: #14161c; background: var(--accent);
+        padding: 2px 7px; border-radius: 999px; text-transform: uppercase;
+      }
+      #counts { color: var(--muted); font-size: 12px; }
+      #status { margin-left: auto; font-size: 12px; color: var(--muted); }
+      #status.live::before { content: "●"; color: #4caf78; margin-right: 5px; }
+      #status.down::before { content: "●"; color: #c75050; margin-right: 5px; }
+      #selection {
+        position: absolute; right: 14px; top: 54px; z-index: 10;
+        width: 300px; max-height: calc(100% - 80px); overflow: auto;
+        background: var(--panel); border: 1px solid #2a2e3a; border-radius: 10px;
+        padding: 14px 16px; display: none;
+      }
+      #selection.open { display: block; }
+      #selection .doc-type { font-size: 11px; font-weight: 700; letter-spacing: .06em; }
+      #selection h2 { font-size: 14px; margin: 4px 0 8px; }
+      #selection .meta { color: var(--muted); font-size: 12px; margin-bottom: 8px; }
+      #selection p { color: var(--text); font-size: 12px; white-space: pre-wrap; }
+      #legend {
+        position: absolute; left: 14px; bottom: 14px; z-index: 10;
+        background: var(--panel); border: 1px solid #2a2e3a; border-radius: 10px;
+        padding: 10px 14px; font-size: 11px; color: var(--muted);
+        display: flex; flex-wrap: wrap; gap: 6px 14px; max-width: 420px;
+      }
+      #legend i {
+        display: inline-block; width: 9px; height: 9px; border-radius: 50%;
+        margin-right: 5px; vertical-align: -1px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="graph"></div>
+    <header>
+      <h1><span>Loom</span> · knowledge graph</h1>
+      <span class="badge">experimental</span>
+      <span id="counts"></span>
+      <span id="status">connecting…</span>
+    </header>
+    <aside id="selection"></aside>
+    <footer id="legend"></footer>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/experimento/web/package-lock.json
+++ b/experimento/web/package-lock.json
@@ -1,0 +1,1221 @@
+{
+  "name": "straymark-loom-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "straymark-loom-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "graphology": "^0.26.0",
+        "graphology-layout": "^0.6.1",
+        "graphology-layout-forceatlas2": "^0.10.1",
+        "sigma": "^3.0.2"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vite": "^6.3.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graphology": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-layout": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/graphology-layout/-/graphology-layout-0.6.1.tgz",
+      "integrity": "sha512-m9aMvbd0uDPffUCFPng5ibRkb2pmfNvdKjQWeZrf71RS1aOoat5874+DcyNfMeCT4aQguKC7Lj9eCbqZj/h8Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-utils": "^2.3.0",
+        "pandemonium": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-layout-forceatlas2": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/graphology-layout-forceatlas2/-/graphology-layout-forceatlas2-0.10.1.tgz",
+      "integrity": "sha512-ogzBeF1FvWzjkikrIFwxhlZXvD2+wlY54lqhsrWprcdPjopM2J9HoMweUmIgwaTvY4bUYVimpSsOdvDv1gPRFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-utils": "^2.1.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
+    },
+    "node_modules/pandemonium": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/pandemonium/-/pandemonium-2.4.1.tgz",
+      "integrity": "sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==",
+      "license": "MIT",
+      "dependencies": {
+        "mnemonist": "^0.39.2"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sigma": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.3.tgz",
+      "integrity": "sha512-5H0zFlx6/NTQpqBg4Rm569ZOpnBOXMaS25UQThIWMU3XyzI5AhmorK/gnl87BvJBLhQd0tW4C0LIp3enWzMoNw==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "graphology-utils": "^2.5.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/experimento/web/package.json
+++ b/experimento/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "straymark-loom-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "graphology": "^0.26.0",
+    "graphology-layout": "^0.6.1",
+    "graphology-layout-forceatlas2": "^0.10.1",
+    "sigma": "^3.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vite": "^6.3.0"
+  }
+}

--- a/experimento/web/src/main.ts
+++ b/experimento/web/src/main.ts
@@ -1,0 +1,321 @@
+// Loom M1 — walking skeleton (Spec 001 FR4–FR6):
+// force-directed graph colored by doc_type, sized by degree, thread
+// highlighting via Sigma reducers, live rebuilds over WebSocket.
+
+import Graph from 'graphology';
+import { circular } from 'graphology-layout';
+import forceAtlas2 from 'graphology-layout-forceatlas2';
+import Sigma from 'sigma';
+
+// ---- API types (mirror experimento/src/snapshot.rs) -----------------------
+
+interface ApiNode {
+  id: string;
+  has_explicit_id: boolean;
+  doc_type: string;
+  title: string;
+  status: string;
+  risk_level: string;
+  created: string | null;
+  agent: string | null;
+  tags: string[];
+  path: string;
+  degree_in: number;
+  degree_out: number;
+}
+
+interface ApiEdge {
+  id: number;
+  source: string;
+  target: string;
+  edge_type: string;
+  resolved: boolean;
+}
+
+interface ApiStats {
+  total_docs: number;
+  total_edges: number;
+  orphans: string[];
+  dangling_references: ApiEdge[];
+}
+
+interface ApiGraph {
+  nodes: ApiNode[];
+  edges: ApiEdge[];
+  stats: ApiStats;
+}
+
+interface Thread {
+  node_ids: string[];
+  edge_ids: number[];
+}
+
+// ---- Visual encoding -------------------------------------------------------
+
+const TYPE_COLORS: Record<string, string> = {
+  AILOG: '#e8833a', // Loom orange — the most common doc, the project heartbeat
+  AIDEC: '#d4a93c',
+  ADR: '#5d9cec',
+  ETH: '#9b7fd4',
+  REQ: '#4caf78',
+  TES: '#3cbfb4',
+  INC: '#c75050',
+  TDE: '#b06a4f',
+  SEC: '#d4607f',
+  MCARD: '#7f9ad4',
+  SBOM: '#8aa455',
+  DPIA: '#b07fd4',
+  PIPIA: '#c08fb0',
+  CACFILE: '#a0788f',
+  TC260RA: '#90a0b8',
+  AILABEL: '#74b89a',
+};
+const FALLBACK_COLOR = '#8b91a0';
+const DIM_NODE = '#2c303b';
+const DIM_EDGE = '#1b1e25';
+const THREAD_EDGE = '#e8833a'; // Loom accent — the lit thread
+
+const colorFor = (docType: string) => TYPE_COLORS[docType] ?? FALLBACK_COLOR;
+const sizeFor = (n: ApiNode) => 4 + Math.min(10, Math.sqrt(n.degree_in + n.degree_out) * 2.5);
+
+/// Default view shows a compact label (real corpora have paragraph-length
+/// titles); the full title appears on hover/selection and in the panel.
+const SHORT_LABEL_CHARS = 42;
+function shortLabel(title: string): string {
+  if (title.length <= SHORT_LABEL_CHARS) return title;
+  const cut = title.slice(0, SHORT_LABEL_CHARS);
+  const lastSpace = cut.lastIndexOf(' ');
+  return cut.slice(0, lastSpace > 24 ? lastSpace : SHORT_LABEL_CHARS).trimEnd() + '…';
+}
+
+// ---- State -----------------------------------------------------------------
+
+const graph = new Graph({ multi: true, type: 'directed' });
+let thread: { nodes: Set<string>; edges: Set<string> } | null = null;
+let selected: string | null = null;
+let hovered: string | null = null;
+
+const container = document.getElementById('graph')!;
+const countsEl = document.getElementById('counts')!;
+const statusEl = document.getElementById('status')!;
+const selectionEl = document.getElementById('selection')!;
+const legendEl = document.getElementById('legend')!;
+
+/// Hover/highlight label renderer matching the dark theme (Sigma's default
+/// draws a white box, illegible with our light label color).
+function drawDarkNodeHover(
+  context: CanvasRenderingContext2D,
+  data: { x: number; y: number; size: number; color?: string; label?: string | null },
+  settings: { labelSize: number; labelFont: string; labelWeight?: string },
+): void {
+  const size = settings.labelSize;
+  context.font = `${settings.labelWeight ?? 'normal'} ${size}px ${settings.labelFont}`;
+  const label = data.label ?? '';
+  const width = context.measureText(label).width;
+  const x = data.x + data.size + 5;
+  const y = data.y + size / 3;
+
+  context.beginPath();
+  context.roundRect(x - 4, y - size - 2, width + 12, size + 9, 5);
+  context.fillStyle = '#1c1f27';
+  context.fill();
+  context.strokeStyle = '#3a3f4d';
+  context.lineWidth = 1;
+  context.stroke();
+
+  context.fillStyle = '#e8e9ee';
+  context.fillText(label, x + 2, y);
+
+  // Re-draw the node disc on top of its hover halo.
+  context.beginPath();
+  context.arc(data.x, data.y, data.size, 0, Math.PI * 2);
+  context.fillStyle = data.color ?? FALLBACK_COLOR;
+  context.fill();
+}
+
+const renderer = new Sigma(graph, container, {
+  defaultEdgeColor: '#3a3f4d',
+  labelColor: { color: '#d6d9e0' },
+  labelFont: 'system-ui',
+  labelSize: 12,
+  labelRenderedSizeThreshold: 8,
+  defaultDrawNodeHover: drawDarkNodeHover,
+  nodeReducer(node, data) {
+    // Hover/selection promotes the compact label to the full title.
+    const expanded = node === hovered || node === selected;
+    const label = expanded ? (data.fullLabel as string | undefined) ?? data.label : data.label;
+    if (!thread) return { ...data, label };
+    if (thread.nodes.has(node)) {
+      return { ...data, label, zIndex: 1, highlighted: node === selected };
+    }
+    return { ...data, color: DIM_NODE, label: null, zIndex: 0 };
+  },
+  edgeReducer(edge, data) {
+    if (!thread) return data;
+    if (thread.edges.has(edge)) {
+      // Unmissable: accent color + double thickness for the lit thread.
+      return { ...data, color: THREAD_EDGE, size: (data.size ?? 1) * 2, zIndex: 1 };
+    }
+    return { ...data, color: DIM_EDGE, zIndex: 0 };
+  },
+});
+
+// ---- Graph (re)build -------------------------------------------------------
+
+function applyGraph(api: ApiGraph): void {
+  // Preserve positions across rebuilds so the picture doesn't jump on save.
+  const positions = new Map<string, { x: number; y: number }>();
+  graph.forEachNode((id, attrs) =>
+    positions.set(id, { x: attrs.x as number, y: attrs.y as number }),
+  );
+  graph.clear();
+
+  for (const n of api.nodes) {
+    graph.addNode(n.id, {
+      label: shortLabel(n.title),
+      fullLabel: n.title,
+      color: colorFor(n.doc_type),
+      size: sizeFor(n),
+      x: positions.get(n.id)?.x ?? Math.random(),
+      y: positions.get(n.id)?.y ?? Math.random(),
+      docType: n.doc_type,
+      status: n.status,
+      risk: n.risk_level,
+      created: n.created,
+      isNew: !positions.has(n.id),
+    });
+  }
+  // Sigma needs both endpoints; dangling edges are API/stats-only at M1.
+  for (const e of api.edges) {
+    if (e.resolved && graph.hasNode(e.source) && graph.hasNode(e.target)) {
+      graph.addEdgeWithKey(String(e.id), e.source, e.target, {
+        size: e.edge_type === 'RELATED_TO' ? 1 : 1.6,
+        type: 'arrow',
+      });
+    }
+  }
+
+  // strongGravityMode keeps disconnected components (orphans!) from being
+  // repelled out of frame — without it FA2 sends them flying.
+  const fa2Settings = {
+    ...forceAtlas2.inferSettings(graph),
+    strongGravityMode: true,
+    gravity: 0.5,
+  };
+  if (positions.size === 0) {
+    // First load: circular seed then a full ForceAtlas2 pass.
+    circular.assign(graph);
+    forceAtlas2.assign(graph, { iterations: 300, settings: fa2Settings });
+  } else {
+    // Rebuild: settle briefly so new nodes find their place without
+    // reshuffling the existing layout.
+    forceAtlas2.assign(graph, { iterations: 30, settings: fa2Settings });
+  }
+
+  countsEl.textContent =
+    `${api.stats.total_docs} docs · ${api.stats.total_edges} links` +
+    (api.stats.orphans.length ? ` · ${api.stats.orphans.length} orphans` : '') +
+    (api.stats.dangling_references.length
+      ? ` · ${api.stats.dangling_references.length} dangling`
+      : '');
+
+  renderLegend(api);
+
+  // Selection may have disappeared in the rebuild.
+  if (selected && !graph.hasNode(selected)) clearSelection();
+  renderer.refresh();
+}
+
+function renderLegend(api: ApiGraph): void {
+  const seen = new Map<string, number>();
+  for (const n of api.nodes) seen.set(n.doc_type, (seen.get(n.doc_type) ?? 0) + 1);
+  legendEl.innerHTML = [...seen.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(
+      ([t, c]) =>
+        `<span><i style="background:${colorFor(t)}"></i>${t} (${c})</span>`,
+    )
+    .join('');
+}
+
+// ---- Thread highlighting (S2/FR5) ------------------------------------------
+
+async function select(nodeId: string): Promise<void> {
+  selected = nodeId;
+  const [threadRes, nodeRes] = await Promise.all([
+    fetch(`/api/node/${encodeURIComponent(nodeId)}/thread`),
+    fetch(`/api/node/${encodeURIComponent(nodeId)}`),
+  ]);
+  if (!threadRes.ok) return;
+  const t: Thread = await threadRes.json();
+  thread = {
+    nodes: new Set(t.node_ids),
+    edges: new Set(t.edge_ids.map(String)),
+  };
+  if (nodeRes.ok) showDetail(await nodeRes.json());
+  renderer.refresh();
+}
+
+function clearSelection(): void {
+  selected = null;
+  thread = null;
+  selectionEl.classList.remove('open');
+  renderer.refresh();
+}
+
+function showDetail(detail: {
+  node: ApiNode;
+  excerpt: string | null;
+  in_edges: ApiEdge[];
+  out_edges: ApiEdge[];
+}): void {
+  const n = detail.node;
+  const color = colorFor(n.doc_type);
+  selectionEl.innerHTML = `
+    <div class="doc-type" style="color:${color}">${n.doc_type}</div>
+    <h2>${escapeHtml(n.title)}</h2>
+    <div class="meta">
+      ${escapeHtml(n.id)}<br/>
+      status: ${escapeHtml(n.status)} · risk: ${escapeHtml(n.risk_level)}
+      ${n.created ? `· ${escapeHtml(n.created)}` : ''}<br/>
+      links: ${detail.out_edges.length} out · ${detail.in_edges.length} in
+    </div>
+    <p>${escapeHtml(detail.excerpt ?? '')}</p>`;
+  selectionEl.classList.add('open');
+}
+
+const escapeHtml = (s: string) =>
+  s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+
+renderer.on('clickNode', ({ node }) => void select(node));
+renderer.on('clickStage', clearSelection);
+renderer.on('enterNode', ({ node }) => {
+  hovered = node;
+  renderer.refresh();
+});
+renderer.on('leaveNode', () => {
+  hovered = null;
+  renderer.refresh();
+});
+
+// ---- Live updates (S3/FR6) --------------------------------------------------
+
+function connect(): void {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${proto}://${location.host}/api/stream`);
+  ws.onmessage = (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.event === 'rebuild') {
+      statusEl.textContent = 'live';
+      statusEl.className = 'live';
+      applyGraph(msg.graph as ApiGraph);
+    }
+  };
+  ws.onclose = () => {
+    statusEl.textContent = 'reconnecting…';
+    statusEl.className = 'down';
+    setTimeout(connect, 1500);
+  };
+}
+
+connect();

--- a/experimento/web/tsconfig.json
+++ b/experimento/web/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/experimento/web/vite.config.ts
+++ b/experimento/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+
+// Dev-mode proxy: `npm run dev` serves the UI with hot reload while a
+// locally running `straymark-loom` (default port 7700) answers /api.
+export default defineConfig({
+  build: { outDir: 'dist', emptyOutDir: true },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:7700',
+        ws: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Milestone **M1** of `CHARTER-01-loom-server` (T1.1–T1.12): the first runnable Loom — the thinnest end-to-end slice that delivers the core wow: *see* the governance corpus as a live map.

- **`straymark-loom` crate** (axum 0.8 + tokio + notify-debouncer-full, `publish = false`): builds the typed graph via `straymark-core` (FR1/FR2, same parser as the CLI), serves `GET /api/graph`, `/api/node/:id`, `/api/node/:id/thread?depth=N`, `/api/stats`, `/healthz`, `WS /api/stream` — **loopback only** with non-loopback `Host` rejection (FR7/NFR4, unit-tested against DNS-rebinding shapes). Mid-save unparseable docs are skipped, never fatal.
- **`core 0.2.0` — `Graph::thread()`**: directional ancestors∪descendants (S2's *"everything it links to and everything that links to it, transitively"*) — deliberately **not** the connected component, so co-citing "siblings" dim correctly (caught during visual acceptance on the dogfood corpus).
- **Web UI** (Vite + TS strict + graphology + Sigma v3, 46KB gzip, embedded via rust-embed — adopters never run npm): force graph (FA2 with `strongGravityMode` so orphans stay in frame), type colors, degree sizing, **accent-orange thread highlight**, short labels with full title on hover/selection, dark hover panel, auto-reconnecting WS, positions preserved across rebuilds, `--assets-dir` dev override.
- **CLI 3.24.0 — `straymark loom serve`**: download-on-demand launcher (latest `loom-*` release asset per platform, cached in `~/.straymark/bin/`, version marker, offline fallback to cache, EXPERIMENTAL banner, browser auto-open). The CLI gains **no** axum/tokio dependency.
- **`release-loom.yml`**: version-vs-tag gate, `npm ci && npm run build` before cargo, same 4-target matrix, `--latest=false` (CLI release stays the repo's "latest"), prefix-scoped cleanup.

## Acceptance (all 6 criteria — AILOG-2026-06-12-002 §Verification)

1. ✅ Force graph at `127.0.0.1:7700`, nodes colored by type (visual, dogfood corpus)
2. ✅ `/api/graph` ≡ `straymark audit` — node ids + doc types identical (NFR1)
3. ✅ Thread highlight lights the chain, dims the rest (visual)
4. ✅ Live update **~255ms** save→browser, no reload (measured via WS client)
5. ✅ Loopback-only bind + forged `Host: evil.example.com` → 403
6. ✅ Orphans + dangling references served in `/api/stats`

`cargo test` workspace: **641 passed, 0 failed**.

## Real-corpus smoke test (Sentinel, 130 docs / 389 edges)

Cold build <1s, `/api/graph` 10ms/167KB — NFR2 headroom is large. Three follow-ups recorded in the AILOG (`R<N> (new)` format for `followups drift`):
- **R1** — reference normalization (filename/path-style `related:` entries → 326 dangling refs in a real corpus)
- **R2** — Charters as first-class graph nodes (most-referenced docs, currently invisible)
- **R3** — visual density at 100+ nodes (operator verdict: better, still saturated)

## After merge

1. Tag both: `git tag cli-3.24.0 && git tag loom-0.1.0 && git push origin cli-3.24.0 loom-0.1.0`
   - `release-cli.yml` → 4 CLI binaries + publishes `straymark-core 0.2.0` then `straymark-cli 3.24.0` to crates.io
   - `release-loom.yml` → 4 Loom binaries (GitHub-release-only, `--latest=false`)
2. Then `straymark loom serve` works end-to-end for any adopter.
3. Next: M2 (Louvain + panels + filters) — follow-ups R1–R3 are natural candidates to fold in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)