### PR TITLE
feat(loom): loom-0.2.0 — Loom M2: analytics + panels + server-side filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project uses [independent versioning](README.md#versioning) for Framewo
 
 ---
 
+## Loom 0.2.0 — M2 analytics and panels
+
+Completes Loom M2 (`CHARTER-01-loom-server`): the walking skeleton becomes an analytical
+dashboard while remaining loopback-only, read-only, and independently versioned.
+
+### Added (Loom)
+
+- Louvain community detection and cluster coloring over the undirected document graph,
+  with a compact interactive legend labeled by representative document titles.
+- Corpus stats panel with counts by type/status/risk, navigable orphan documents, and
+  dangling references.
+- Expanded node summary panel with clickable incoming/outgoing links, source path, and
+  explicit truncated-excerpt signaling.
+- Server-side `/api/graph` filters for type, status, risk, tag, and inclusive date range,
+  with UI controls and filtered-view live rebuilds.
+
+---
+
 ## Loom 0.1.0 / CLI 3.24.0 — Loom M1: the walking skeleton ships
 
 First release of **Loom**, StrayMark's EXPERIMENTAL third component (`CHARTER-01-loom-server` M1): a loopback-only, read-only web dashboard that renders the project's document graph live in the browser.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "straymark-loom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ StrayMark uses independent version tags for each component:
 | --- | --- | --- | --- |
 | Framework | `fw-` | `fw-4.26.0` | Templates (12 types), governance, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.24.0` | The `straymark` binary |
-| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | The `straymark-loom` visualization server, downloaded on demand by `straymark loom serve` |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.2.0` | The `straymark-loom` visualization server, downloaded on demand by `straymark loom serve` |
 
 Check installed versions with `straymark status` or `straymark about`.
 

--- a/docs/adopters/CLI-REFERENCE.md
+++ b/docs/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark uses **independent version tags** for each component:
 |-----------|-----------|---------|------------------|
 | Framework | `fw-` | `fw-4.26.0` | Templates (12 types), governance docs, directives, Charter template + schema |
 | CLI | `cli-` | `cli-3.24.0` | The `straymark` binary |
-| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | The `straymark-loom` visualization server, downloaded on demand by `straymark loom serve` |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.2.0` | The `straymark-loom` visualization server, downloaded on demand by `straymark loom serve` |
 
 Framework and CLI are released independently. A framework update does not require a CLI update, and vice versa.
 
@@ -1385,7 +1385,7 @@ StrayMark CLI
 
 ### `straymark loom serve [path] [--port <port>] [--no-open]` *(cli-3.24.0+, EXPERIMENTAL)*
 
-Launch **Loom**, the EXPERIMENTAL knowledge-graph visualization server: a loopback-only, read-only web dashboard that renders the project's StrayMark documents as a live force-directed graph (nodes colored by document type, sized by connectivity; selecting a node lights up its whole thread of relationships; edits to watched `.md` files update the open browser in under a second).
+Launch **Loom**, the EXPERIMENTAL knowledge-graph visualization server: a loopback-only, read-only web dashboard that renders the project's StrayMark documents as a live force-directed graph (nodes colored by Louvain community and sized by connectivity; node and corpus-stat panels; server-side metadata/date filters; selecting a node lights up its whole thread of relationships; edits to watched `.md` files update the open browser in under a second).
 
 > ⚠️ **Loom is EXPERIMENTAL (v0).** Its API, CLI surface, and very existence may change or be removed without a deprecation cycle. The `straymark-loom` binary is **not** bundled into the CLI — it is downloaded on demand from the `loom-*` GitHub releases on first use and cached under `~/.straymark/bin/`. The download gate *is* the opt-in boundary.
 
@@ -1408,8 +1408,8 @@ $ straymark loom serve
      Unstable: API, CLI surface, and on-disk layout may change or be
      removed without a deprecation cycle. Loopback-only. Read-only.
 
-ℹ Downloading Loom 0.1.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
-✔ Loom 0.1.0 cached at ~/.straymark/bin/straymark-loom
+ℹ Downloading Loom 0.2.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
+✔ Loom 0.2.0 cached at ~/.straymark/bin/straymark-loom
 loom: watching /project/.straymark (142 docs, 318 links)
 loom: serving http://127.0.0.1:7700
 ```

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -242,7 +242,7 @@ StrayMark usa tags de versión independientes para cada componente:
 |------------|---------------|---------|---------|
 | Framework | `fw-` | `fw-4.26.0` | Plantillas (12 tipos), gobernanza, directivas, plantilla + schema de Charter |
 | CLI | `cli-` | `cli-3.24.0` | El binario `straymark` |
-| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | El servidor de visualización `straymark-loom`, descargado bajo demanda por `straymark loom serve` |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.2.0` | El servidor de visualización `straymark-loom`, descargado bajo demanda por `straymark loom serve` |
 
 Verifica las versiones instaladas con `straymark status` o `straymark about`.
 

--- a/docs/i18n/es/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/es/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark usa **tags de versión independientes** para cada componente:
 |------------|---------------|---------|-------------|
 | Framework | `fw-` | `fw-4.26.0` | Plantillas (12 tipos), docs de gobernanza, directivas |
 | CLI | `cli-` | `cli-3.24.0` | El binario `straymark` |
-| Loom (EXPERIMENTAL) | `loom-` | `loom-0.1.0` | El servidor de visualización `straymark-loom`, descargado bajo demanda por `straymark loom serve` |
+| Loom (EXPERIMENTAL) | `loom-` | `loom-0.2.0` | El servidor de visualización `straymark-loom`, descargado bajo demanda por `straymark loom serve` |
 
 Framework y CLI se publican de forma independiente. Una actualización del framework no requiere actualización del CLI, y viceversa.
 
@@ -1098,8 +1098,8 @@ $ straymark loom serve
      Unstable: API, CLI surface, and on-disk layout may change or be
      removed without a deprecation cycle. Loopback-only. Read-only.
 
-ℹ Downloading Loom 0.1.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
-✔ Loom 0.1.0 cached at ~/.straymark/bin/straymark-loom
+ℹ Downloading Loom 0.2.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
+✔ Loom 0.2.0 cached at ~/.straymark/bin/straymark-loom
 loom: watching /project/.straymark (142 docs, 318 links)
 loom: serving http://127.0.0.1:7700
 ```

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -260,7 +260,7 @@ StrayMark 为每个组件使用独立的版本标签：
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.26.0` | 模板（12 种类型）、治理文档、指令、Charter 模板 + schema |
 | CLI | `cli-` | `cli-3.24.0` | `straymark` 二进制文件 |
-| Loom（实验性） | `loom-` | `loom-0.1.0` | `straymark-loom` 可视化服务器，由 `straymark loom serve` 按需下载 |
+| Loom（实验性） | `loom-` | `loom-0.2.0` | `straymark-loom` 可视化服务器，由 `straymark loom serve` 按需下载 |
 
 使用 `straymark status` 或 `straymark about` 查看已安装的版本。
 

--- a/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
+++ b/docs/i18n/zh-CN/adopters/CLI-REFERENCE.md
@@ -49,7 +49,7 @@ StrayMark 为每个组件使用**独立的版本标签**：
 |------|----------|------|----------|
 | Framework | `fw-` | `fw-4.26.0` | 模板（12 种类型）、治理文档、指令 |
 | CLI | `cli-` | `cli-3.24.0` | `straymark` 二进制文件 |
-| Loom（实验性） | `loom-` | `loom-0.1.0` | `straymark-loom` 可视化服务器，由 `straymark loom serve` 按需下载 |
+| Loom（实验性） | `loom-` | `loom-0.2.0` | `straymark-loom` 可视化服务器，由 `straymark loom serve` 按需下载 |
 
 Framework 和 CLI 独立发布。Framework 更新不需要 CLI 更新，反之亦然。
 
@@ -1231,8 +1231,8 @@ $ straymark loom serve
      Unstable: API, CLI surface, and on-disk layout may change or be
      removed without a deprecation cycle. Loopback-only. Read-only.
 
-ℹ Downloading Loom 0.1.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
-✔ Loom 0.1.0 cached at ~/.straymark/bin/straymark-loom
+ℹ Downloading Loom 0.2.0 (x86_64-unknown-linux-gnu) — first use is opt-in by download
+✔ Loom 0.2.0 cached at ~/.straymark/bin/straymark-loom
 loom: watching /project/.straymark (142 docs, 318 links)
 loom: serving http://127.0.0.1:7700
 ```

--- a/experimento/AILOG-2026-06-12-003-loom-m2-analytics-panels.md
+++ b/experimento/AILOG-2026-06-12-003-loom-m2-analytics-panels.md
@@ -1,0 +1,188 @@
+---
+id: AILOG-2026-06-12-003
+title: Loom M2 — analytics, panels, and server-side graph filters
+status: accepted
+created: 2026-06-12
+agent: codex-gpt-5
+confidence: high
+review_required: true
+risk_level: medium
+eu_ai_act_risk: not_applicable
+nist_genai_risks: []
+iso_42001_clause: []
+lines_changed: 791
+files_modified: [CHANGELOG.md, Cargo.lock, README.md, docs/adopters/CLI-REFERENCE.md, docs/i18n/es/README.md, docs/i18n/es/adopters/CLI-REFERENCE.md, docs/i18n/zh-CN/README.md, docs/i18n/zh-CN/adopters/CLI-REFERENCE.md, experimento/CHANGELOG.md, experimento/Cargo.toml, experimento/specs/001-loom-server/tasks.md, experimento/src/server.rs, experimento/src/snapshot.rs, experimento/web/index.html, experimento/web/package-lock.json, experimento/web/package.json, experimento/web/src/main.ts]
+observability_scope: none
+tags: [loom, analytics, louvain, filters, panels, knowledge-graph]
+related: [AILOG-2026-06-12-002, ADR-2026-06-02-001]
+---
+
+# AILOG: Loom M2 — analytics, panels, and server-side graph filters
+
+## Summary
+
+Executed the implementation portion of milestone **M2** of
+`CHARTER-01-loom-server` (T2.1–T2.4): Loom now colors the graph by Louvain
+community, exposes navigable node and corpus-stat panels, and supports
+server-side graph filters for type, status, risk, tag, and inclusive created
+date bounds. The component and web package were advanced to `0.2.0`; T2.5
+remains open only for the post-merge release tag.
+
+## Context
+
+M1 delivered the live walking skeleton and already exposed basic node detail
+plus corpus statistics through the API. M2 turns those foundations into the
+analytical dashboard defined by Spec 001 FR8–FR10 without changing Loom's
+loopback-only, read-only security posture or the shared `straymark-core`
+parser/graph contract.
+
+## Actions Performed
+
+1. **T2.1 — Louvain communities.** Added
+   `graphology-communities-louvain`; builds an undirected projection from
+   resolved graph edges, computes communities client-side, colors nodes by
+   cluster, and renders a live cluster legend. A seeded RNG keeps cluster
+   identities and colors stable across unchanged rebuilds.
+2. **T2.2 — node summary panel.** Expanded the existing M1 detail panel with
+   metadata, tags, body excerpt, and clickable incoming/outgoing relationship
+   endpoints. Dangling endpoints remain visible but are not clickable.
+3. **T2.3 — corpus stats panel.** Added counts by type/status/risk plus
+   navigable orphan and dangling-reference lists. Selecting an item focuses
+   the document; if an active filter excludes it, Loom clears the filter and
+   reloads the full graph first.
+4. **T2.4 — server-side filters.** `/api/graph` now accepts combinable
+   `type`, `status`, `risk`, `tag`, `from`, and `to` query parameters.
+   Metadata filters are case-insensitive, date bounds are inclusive, and all
+   supplied filters combine with AND.
+5. **Filtered graph semantics.** Responses contain matching nodes, resolved
+   edges only when both endpoints survive, and dangling references whose
+   source survives. Counts and lists are recalculated for the filtered view.
+6. **Live filtered views.** WebSocket rebuilds continue to apply immediately;
+   when filters are active the client refetches `/api/graph` with the active
+   query rather than replacing the view with the unfiltered WS snapshot.
+7. **Release preparation.** Bumped `straymark-loom` and the web package to
+   `0.2.0`, updated `Cargo.lock`, release notes, current-version tables, and
+   marked T2.1–T2.4 complete. T2.5 remains pending until the post-merge
+   `loom-0.2.0` tag is created.
+8. **M2 operator-review polish.** Replaced the exhaustive numeric cluster
+   legend with a compact interactive view of the 8 largest non-singleton
+   communities. Each entry uses its highest-degree document title as the
+   human-facing label; clicking focuses/dims the cluster. The summary reports
+   total communities, isolated nodes, and hidden smaller communities.
+9. **Excerpt clarity.** `/api/node/:id` now returns `excerpt_truncated`; the
+   detail panel labels the body as an excerpt, shows the source path, and
+   explicitly signals when more content exists. Full-document reading remains
+   deferred to M3.
+10. **Operator acceptance on Sentinel.** Reviewed the M2 UI against the
+    reference corpus (130 docs / 389 links). Operator feedback identified the
+    exhaustive numeric legend and ambiguous truncated body as the remaining
+    M2 legibility gaps; both were corrected in this milestone.
+11. **Left-column layout polish.** Expanded orphan/dangling lists scroll
+    inside a bounded statistics panel and can no longer render underneath the
+    community legend. An initial shared transparent rail caused inconsistent
+    hit-testing over Sigma's canvas; it was removed in favor of independent
+    interactive panels with reserved vertical space.
+12. **Panel interaction + live-state fix.** Dynamic actions bind directly to
+    their rendered buttons instead of relying on document-level delegation.
+    More importantly, community focus and open stats sections now survive
+    subsequent WS rebuild renders; previously clicks executed but their state
+    was erased in under 500ms, making them appear non-responsive. Panel
+    stacking is explicit above Sigma and interactive elements declare
+    `pointer-events: auto`.
+
+## Modified Files
+
+| File | Change Description |
+|------|--------------------|
+| `experimento/src/snapshot.rs` | Filter model, induced filtered graph, recalculated stats, and 2 tests |
+| `experimento/src/server.rs` | `/api/graph` query extraction, filtered response, and excerpt truncation signal |
+| `experimento/web/src/main.ts` | Louvain analytics, interactive community focus, panels, filters, live filtered rebuilds |
+| `experimento/web/index.html` | M2 dashboard layout and styles |
+| `experimento/web/package*.json` | Version 0.2.0 and Louvain dependency |
+| `experimento/Cargo.toml`, `Cargo.lock` | Loom version 0.2.0 |
+| `experimento/specs/001-loom-server/tasks.md` | T2.1–T2.4 completion status |
+| changelogs and adopter docs | M2 release notes and current Loom version |
+
+## Decisions Made
+
+- **Louvain remains client-side**, as recommended in the implementation plan,
+  keeping the server thin and avoiding analytics dependencies in Rust.
+- **Filtering returns an induced graph**, not merely a filtered node list, so
+  clients never receive resolved edges whose endpoints are absent.
+- **Dangling references remain first-class signals** when their matching
+  source survives a filter; this preserves FR2/FR8 behavior.
+- **Dates use canonical string comparison** because StrayMark `created`
+  values are normalized ISO `YYYY-MM-DD`; documents without a date do not
+  match a supplied date bound.
+- **T2.5 is not marked complete before merge/tag.** The implementation and
+  acceptance work are complete, but the release tag belongs after merge.
+- **Community labels use representative document titles**, not generated
+  topic names. This makes the legend immediately useful without introducing
+  semantic/topic inference before M3 or post-M3 polish.
+- **The node panel remains a summary surface.** It signals truncation and
+  path clearly; full document reading/open-in-editor remains M3 scope.
+
+## Impact
+
+- **Functionality:** additive analytical UI and API filtering; existing
+  unfiltered `/api/graph`, node detail, thread highlighting, and WS rebuilds
+  remain available.
+- **Performance:** filtered corpora are reduced server-side before transfer;
+  Louvain runs client-side over resolved edges. The production JS bundle is
+  approximately 207 KB / 53 KB gzip.
+- **Security:** unchanged. Loom remains read-only, binds loopback only, and
+  rejects forged non-loopback `Host` headers.
+- **Dependencies:** added `graphology-communities-louvain` and its transitive
+  production dependencies; production dependency audit found no known
+  vulnerabilities.
+
+## Verification
+
+- [x] `npm run build` — TypeScript and Vite production build pass.
+- [x] `cargo test -p straymark-loom` — 6/6 tests pass, including filter
+      semantics and excerpt-truncation coverage.
+- [x] `cargo test -p straymark-core` — 21/21 tests pass.
+- [x] `cargo test` — complete workspace suite passes.
+- [x] `cargo clippy -p straymark-loom --no-deps -- -D warnings` passes.
+- [x] `npm audit --omit=dev` reports 0 vulnerabilities.
+- [x] `git diff --check` passes.
+- [x] Real-server smoke test: embedded/dev asset UI returns HTTP 200;
+      `/api/graph?type=ADR` returns the expected filtered graph and
+      recalculated stats; forged `Host: evil.example.com` returns HTTP 403.
+- [x] Final Sentinel acceptance: compact title-labeled community legend served
+      against 130 docs / 389 links; long-document detail returns and displays
+      `excerpt_truncated: true`.
+- [x] Expanded Sentinel dangling-reference list remains bounded above the
+      community legend in the left column.
+- [x] Left-panel links, details toggles, and community focus buttons remain
+      directly clickable after removing the transparent rail wrapper.
+- [x] Physical Chrome WebGL test at 1920x1080: community focus remains active,
+      stats details remain open, and a visible node link opens the selection
+      panel, all after live rebuilds.
+- [x] Full `cargo clippy -p straymark-loom -- -D warnings` was attempted; it
+      stops on the pre-existing `clippy::unnecessary_map_or` warning at
+      `core/src/graph.rs:251`, outside this milestone's changes.
+
+## Follow-ups
+
+- **T2.5:** merge, run final acceptance in the release revision, then create
+  and push tag `loom-0.2.0`.
+- **M3 analytics:** cycle/SCC reporting, centrality-based sizing, incremental
+  WS deltas, search, pinned subgraphs, and open-in-editor remain deferred.
+- **Post-M3 polish candidate:** infer durable human topic names for
+  communities if operator use shows representative document titles are not
+  sufficient.
+- **Reference normalization and Charter nodes:** M1 follow-ups remain open;
+  high dangling-reference counts in adopter corpora still reduce graph
+  connectivity and therefore community quality.
+
+## Additional Notes
+
+- The development-only Vite/esbuild audit findings documented in M1 remain
+  outside the shipped static production bundle; the M2 production dependency
+  audit is clean.
+- The current UI string table/i18n work remains deferred to M3 per NFR5.
+
+---
+
+<!-- Template: StrayMark | https://strangedays.tech -->

--- a/experimento/CHANGELOG.md
+++ b/experimento/CHANGELOG.md
@@ -12,10 +12,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Planned — 0.2.0 (M2, analytics + panels)
-- Louvain community coloring, corpus stats panel (orphans, dangling references),
-  server-side filters (`type/status/risk/tag/from/to`) on `/api/graph`.
-
 ### Planned — Architecture Plan view (Spec 002)
 - A1: `straymark-core` "you are here" status projection (component state by file-glob match
   over active/closed Charters, drift, TDE, declared-vs-wired) + `straymark architecture
@@ -23,6 +19,29 @@ project adheres to [Semantic Versioning](https://semver.org/).
 - A2: maxGraph rendering of a human-authored `plan.drawio` with a non-destructive status
   overlay, layer toggle, component panel, and cross-linking with the Knowledge Graph.
 - A3 (north star): axonometric/BIM exploded-layers view.
+
+## [0.2.0] — 2026-06-13 (M2, analytics + panels)
+
+### Added
+
+- **Louvain community coloring** over the graph's undirected projection, with cluster
+  colors and a compact interactive legend of the largest communities. Labels use a
+  representative document title; clicking a community focuses its subgraph.
+- **Corpus stats panel** with counts by type/status/risk plus navigable orphan and
+  dangling-reference lists.
+- **Node summary panel** with metadata, body excerpt, and clickable incoming/outgoing
+  relationship endpoints. The panel shows the source path and explicitly identifies
+  truncated excerpts instead of implying that they are complete documents.
+- **Server-side graph filters** for `type`, `status`, `risk`, `tag`, and inclusive
+  `from`/`to` created-date bounds. Filtered responses retain dangling references from
+  matching sources and recalculate their stats.
+- Two filter-behavior tests plus excerpt-truncation coverage, bringing the Loom suite to
+  6 tests.
+
+### Changed
+
+- The web UI now refetches the active filtered view after live rebuild events while
+  preserving the existing thread-highlight and no-reload workflow.
 
 ## [0.1.0] — 2026-06-12 (M1, walking skeleton — Knowledge Graph view)
 
@@ -57,5 +76,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
   (PR #239) together with the component's intention docs (README, SpecKit sets 001/002,
   `CHARTER-01-loom-server`, ADR-2026-06-02-001/-002).
 
-[Unreleased]: https://github.com/StrangeDaysTech/straymark/compare/loom-0.1.0...HEAD
+[Unreleased]: https://github.com/StrangeDaysTech/straymark/compare/loom-0.2.0...HEAD
+[0.2.0]: https://github.com/StrangeDaysTech/straymark/releases/tag/loom-0.2.0
 [0.1.0]: https://github.com/StrangeDaysTech/straymark/releases/tag/loom-0.1.0

--- a/experimento/Cargo.toml
+++ b/experimento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straymark-loom"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Loom — StrayMark's experimental knowledge-graph visualization server (localhost development dashboard)"
 license = "MIT"

--- a/experimento/specs/001-loom-server/tasks.md
+++ b/experimento/specs/001-loom-server/tasks.md
@@ -53,13 +53,14 @@
 
 ## M2 — Analytics + panels (`loom-0.2.0`) — FR8–FR10
 
-- [ ] T2.1 — Louvain communities → `node.community` → cluster coloring.
-- [ ] T2.2 — Node summary panel (metadata + body excerpt + clickable in/out links). (S5)
-- [ ] T2.3 — Corpus stats panel: counts by type/risk, orphan list, dangling-reference list.
+- [x] T2.1 — Louvain communities → `node.community` → cluster coloring.
+- [x] T2.2 — Node summary panel (metadata + body excerpt + clickable in/out links). (S5)
+- [x] T2.3 — Corpus stats panel: counts by type/risk, orphan list, dangling-reference list.
   (FR8, S4)
-- [ ] T2.4 — Server-side filters `type/status/risk/tag/from/to` on `/api/graph`; UI
+- [x] T2.4 — Server-side filters `type/status/risk/tag/from/to` on `/api/graph`; UI
   controls. (FR9, S6)
-- [ ] T2.5 — Acceptance; CHANGELOG → `0.2.0`; tag `loom-0.2.0`.
+- [ ] T2.5 — Acceptance + CHANGELOG → `0.2.0` complete; post-merge tag
+  `loom-0.2.0` pending.
 
 ## M3 — Rich, Infranodus-like (`loom-0.3.0`)
 

--- a/experimento/src/server.rs
+++ b/experimento/src/server.rs
@@ -16,7 +16,7 @@ use rust_embed::RustEmbed;
 use serde::Deserialize;
 use tokio::sync::broadcast;
 
-use crate::snapshot::{ApiEdge, Snapshot};
+use crate::snapshot::{ApiEdge, GraphFilters, Snapshot};
 
 /// Frontend assets built by Vite into `web/dist/` and embedded at compile
 /// time (NFR3 — adopters never run npm). Empty during development; use
@@ -86,21 +86,23 @@ fn is_loopback_host(host: &str) -> bool {
 }
 
 fn current(state: &AppState) -> Arc<Snapshot> {
-    state.snapshot.read().expect("snapshot lock poisoned").clone()
+    state
+        .snapshot
+        .read()
+        .expect("snapshot lock poisoned")
+        .clone()
 }
 
-async fn api_graph(State(state): State<AppState>) -> Response {
-    axum::Json(&current(&state).api).into_response()
+async fn api_graph(State(state): State<AppState>, Query(filters): Query<GraphFilters>) -> Response {
+    let snap = current(&state);
+    axum::Json(snap.api.filtered(&filters)).into_response()
 }
 
 async fn api_stats(State(state): State<AppState>) -> Response {
     axum::Json(&current(&state).api.stats).into_response()
 }
 
-async fn api_node(
-    State(state): State<AppState>,
-    AxumPath(id): AxumPath<String>,
-) -> Response {
+async fn api_node(State(state): State<AppState>, AxumPath(id): AxumPath<String>) -> Response {
     let snap = current(&state);
     let Some(node) = snap.graph.node(&id) else {
         return (StatusCode::NOT_FOUND, "unknown document id").into_response();
@@ -124,6 +126,7 @@ async fn api_node(
         "out_edges": out_edges,
         "in_edges": in_edges,
         "excerpt": snap.excerpts.get(&id),
+        "excerpt_truncated": snap.excerpt_truncated.get(&id).copied().unwrap_or(false),
     }))
     .into_response()
 }
@@ -148,10 +151,7 @@ async fn api_thread(
 /// WS /api/stream — pushes the full current graph on connect, then a
 /// `rebuild` event on every settled filesystem change (M1: full snapshots;
 /// M3 will add deltas).
-async fn api_stream(
-    State(state): State<AppState>,
-    ws: WebSocketUpgrade,
-) -> Response {
+async fn api_stream(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(move |socket| stream_events(socket, state))
 }
 

--- a/experimento/src/snapshot.rs
+++ b/experimento/src/snapshot.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use straymark_core::document::{discover_documents, parse_document, StrayMarkDocument};
 use straymark_core::graph::{Edge, Graph, Node};
 
@@ -43,6 +43,91 @@ pub struct ApiGraph {
     pub stats: Stats,
 }
 
+/// Server-side `/api/graph` filters (Spec 001 FR9/S6). All populated fields
+/// are combined with AND; date bounds are inclusive.
+#[derive(Debug, Default, Deserialize)]
+pub struct GraphFilters {
+    #[serde(rename = "type")]
+    pub doc_type: Option<String>,
+    pub status: Option<String>,
+    pub risk: Option<String>,
+    pub tag: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+}
+
+impl GraphFilters {
+    pub fn is_empty(&self) -> bool {
+        self.doc_type.is_none()
+            && self.status.is_none()
+            && self.risk.is_none()
+            && self.tag.is_none()
+            && self.from.is_none()
+            && self.to.is_none()
+    }
+
+    fn matches(&self, node: &Node) -> bool {
+        matches_value(&self.doc_type, &node.doc_type)
+            && matches_value(&self.status, &node.status)
+            && matches_value(&self.risk, &node.risk_level)
+            && self.tag.as_ref().is_none_or(|tag| {
+                node.tags
+                    .iter()
+                    .any(|candidate| candidate.eq_ignore_ascii_case(tag))
+            })
+            && self
+                .from
+                .as_ref()
+                .is_none_or(|from| node.created.as_ref().is_some_and(|created| created >= from))
+            && self
+                .to
+                .as_ref()
+                .is_none_or(|to| node.created.as_ref().is_some_and(|created| created <= to))
+    }
+}
+
+fn matches_value(filter: &Option<String>, value: &str) -> bool {
+    filter
+        .as_ref()
+        .is_none_or(|wanted| value.eq_ignore_ascii_case(wanted))
+}
+
+impl ApiGraph {
+    /// Return the induced graph for matching nodes. Dangling references from
+    /// matching source nodes remain visible; resolved edges require both
+    /// endpoints to survive the filter.
+    pub fn filtered(&self, filters: &GraphFilters) -> ApiGraph {
+        if filters.is_empty() {
+            return self.clone();
+        }
+
+        let nodes: Vec<Node> = self
+            .nodes
+            .iter()
+            .filter(|node| filters.matches(node))
+            .cloned()
+            .collect();
+        let ids: std::collections::HashSet<&str> =
+            nodes.iter().map(|node| node.id.as_str()).collect();
+        let edges: Vec<ApiEdge> = self
+            .edges
+            .iter()
+            .filter(|edge| {
+                ids.contains(edge.edge.source.as_str())
+                    && (!edge.edge.resolved || ids.contains(edge.edge.target.as_str()))
+            })
+            .cloned()
+            .collect();
+        let stats = build_stats(&nodes, &edges);
+
+        ApiGraph {
+            nodes,
+            edges,
+            stats,
+        }
+    }
+}
+
 /// One rebuilt view of the corpus.
 pub struct Snapshot {
     /// The core graph (kept for thread queries).
@@ -51,6 +136,8 @@ pub struct Snapshot {
     pub api: ApiGraph,
     /// id → body excerpt, for the node detail endpoint.
     pub excerpts: BTreeMap<String, String>,
+    /// id → whether the body continues beyond the returned excerpt.
+    pub excerpt_truncated: BTreeMap<String, bool>,
 }
 
 impl Snapshot {
@@ -67,14 +154,21 @@ impl Snapshot {
         let graph = Graph::build(&doc_refs);
 
         let mut excerpts = BTreeMap::new();
+        let mut excerpt_truncated = BTreeMap::new();
         for (node, doc) in graph.nodes.iter().zip(docs.iter()) {
             let body = doc.body.trim();
             let excerpt: String = body.chars().take(EXCERPT_CHARS).collect();
             excerpts.insert(node.id.clone(), excerpt);
+            excerpt_truncated.insert(node.id.clone(), body.chars().count() > EXCERPT_CHARS);
         }
 
         let api = build_api_view(&graph);
-        Ok(Snapshot { graph, api, excerpts })
+        Ok(Snapshot {
+            graph,
+            api,
+            excerpts,
+            excerpt_truncated,
+        })
     }
 
     /// The serialized WS rebuild event.
@@ -88,29 +182,44 @@ fn build_api_view(graph: &Graph) -> ApiGraph {
         .edges
         .iter()
         .enumerate()
-        .map(|(id, edge)| ApiEdge { id, edge: edge.clone() })
+        .map(|(id, edge)| ApiEdge {
+            id,
+            edge: edge.clone(),
+        })
         .collect();
 
+    let stats = build_stats(&graph.nodes, &edges);
+
+    ApiGraph {
+        nodes: graph.nodes.clone(),
+        edges,
+        stats,
+    }
+}
+
+fn build_stats(nodes: &[Node], edges: &[ApiEdge]) -> Stats {
     let mut by_type = BTreeMap::new();
     let mut by_status = BTreeMap::new();
     let mut by_risk = BTreeMap::new();
-    for node in &graph.nodes {
+    for node in nodes {
         *by_type.entry(node.doc_type.clone()).or_insert(0) += 1;
         *by_status.entry(node.status.clone()).or_insert(0) += 1;
         *by_risk.entry(node.risk_level.clone()).or_insert(0) += 1;
     }
 
-    let stats = Stats {
-        total_docs: graph.nodes.len(),
-        total_edges: graph.edges.len(),
+    Stats {
+        total_docs: nodes.len(),
+        total_edges: edges.len(),
         by_type,
         by_status,
         by_risk,
-        orphans: graph.orphans().map(|n| n.id.clone()).collect(),
+        orphans: nodes
+            .iter()
+            .filter(|node| node.is_orphan())
+            .map(|node| node.id.clone())
+            .collect(),
         dangling_references: edges.iter().filter(|e| !e.edge.resolved).cloned().collect(),
-    };
-
-    ApiGraph { nodes: graph.nodes.clone(), edges, stats }
+    }
 }
 
 #[cfg(test)]
@@ -146,14 +255,14 @@ mod tests {
         assert_eq!(snap.api.stats.dangling_references.len(), 1);
         assert_eq!(snap.api.stats.by_type.get("REQ"), Some(&1));
         assert!(snap.excerpts["ADR-2026-03-02-001"].contains("JWT body"));
+        assert!(!snap.excerpt_truncated["ADR-2026-03-02-001"]);
 
         // Edge ids are stable indices into graph.edges.
         assert_eq!(snap.api.edges[0].id, 0);
         assert_eq!(snap.api.edges[1].id, 1);
 
         // Rebuild event is valid JSON with the expected envelope.
-        let event: serde_json::Value =
-            serde_json::from_str(&snap.rebuild_event()).unwrap();
+        let event: serde_json::Value = serde_json::from_str(&snap.rebuild_event()).unwrap();
         assert_eq!(event["event"], "rebuild");
         assert_eq!(event["graph"]["stats"]["total_docs"], 3);
     }
@@ -173,5 +282,87 @@ mod tests {
         );
         let snap = Snapshot::build(root).unwrap();
         assert_eq!(snap.api.stats.total_docs, 1);
+    }
+
+    #[test]
+    fn test_long_body_marks_excerpt_as_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            &root.join("ADR-2026-03-02-001-long.md"),
+            &format!(
+                "---\nid: ADR-LONG\ntitle: Long body\n---\n{}",
+                "a".repeat(EXCERPT_CHARS + 1)
+            ),
+        );
+
+        let snap = Snapshot::build(root).unwrap();
+        assert_eq!(snap.excerpts["ADR-LONG"].chars().count(), EXCERPT_CHARS);
+        assert!(snap.excerpt_truncated["ADR-LONG"]);
+    }
+
+    #[test]
+    fn test_filtered_graph_combines_metadata_and_date_filters() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            &root.join("REQ-2026-03-01-001-login.md"),
+            "---\nid: REQ-1\ntitle: Login\nstatus: approved\ncreated: 2026-03-01\nrisk_level: high\ntags: [auth]\nrelated: [ADR-1, MISSING]\n---\nbody\n",
+        );
+        write(
+            &root.join("ADR-2026-03-02-001-jwt.md"),
+            "---\nid: ADR-1\ntitle: JWT\nstatus: accepted\ncreated: 2026-03-02\nrisk_level: high\ntags: [auth]\n---\nbody\n",
+        );
+        write(
+            &root.join("ADR-2026-04-02-002-other.md"),
+            "---\nid: ADR-2\ntitle: Other\nstatus: draft\ncreated: 2026-04-02\nrisk_level: low\n---\nbody\n",
+        );
+        let snap = Snapshot::build(root).unwrap();
+
+        let filtered = snap.api.filtered(&GraphFilters {
+            doc_type: Some("adr".into()),
+            risk: Some("HIGH".into()),
+            tag: Some("auth".into()),
+            from: Some("2026-03-01".into()),
+            to: Some("2026-03-31".into()),
+            ..GraphFilters::default()
+        });
+
+        assert_eq!(
+            filtered
+                .nodes
+                .iter()
+                .map(|n| n.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ADR-1"]
+        );
+        assert!(filtered.edges.is_empty());
+        assert_eq!(filtered.stats.by_type.get("ADR"), Some(&1));
+        assert_eq!(filtered.stats.total_docs, 1);
+    }
+
+    #[test]
+    fn test_filtered_graph_keeps_dangling_edges_from_matching_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            &root.join("REQ-2026-03-01-001-login.md"),
+            "---\nid: REQ-1\ntitle: Login\nrelated: [ADR-1, MISSING]\n---\nbody\n",
+        );
+        write(
+            &root.join("ADR-2026-03-02-001-jwt.md"),
+            "---\nid: ADR-1\ntitle: JWT\n---\nbody\n",
+        );
+        let snap = Snapshot::build(root).unwrap();
+
+        let filtered = snap.api.filtered(&GraphFilters {
+            doc_type: Some("REQ".into()),
+            ..GraphFilters::default()
+        });
+
+        assert_eq!(filtered.nodes.len(), 1);
+        assert_eq!(filtered.edges.len(), 1);
+        assert!(!filtered.edges[0].edge.resolved);
+        assert_eq!(filtered.stats.dangling_references.len(), 1);
     }
 }

--- a/experimento/web/index.html
+++ b/experimento/web/index.html
@@ -5,61 +5,62 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Loom — StrayMark knowledge graph</title>
     <style>
-      :root {
-        --bg: #14161c;
-        --panel: #1c1f27;
-        --text: #d6d9e0;
-        --muted: #8b91a0;
-        --accent: #e8833a;
-      }
-      * { box-sizing: border-box; margin: 0; }
-      html, body { height: 100%; }
-      body {
-        background: var(--bg);
-        color: var(--text);
-        font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
-        overflow: hidden;
-      }
-      #graph { position: absolute; inset: 0; }
-      header {
-        position: absolute; top: 0; left: 0; right: 0; z-index: 10;
-        display: flex; align-items: center; gap: 12px;
-        padding: 10px 16px;
-        background: linear-gradient(to bottom, rgba(20,22,28,.95), rgba(20,22,28,0));
-        pointer-events: none;
-      }
-      header h1 { font-size: 16px; font-weight: 650; letter-spacing: .02em; }
-      header h1 span { color: var(--accent); }
-      .badge {
-        font-size: 10px; font-weight: 700; letter-spacing: .08em;
-        color: #14161c; background: var(--accent);
-        padding: 2px 7px; border-radius: 999px; text-transform: uppercase;
-      }
-      #counts { color: var(--muted); font-size: 12px; }
-      #status { margin-left: auto; font-size: 12px; color: var(--muted); }
-      #status.live::before { content: "●"; color: #4caf78; margin-right: 5px; }
-      #status.down::before { content: "●"; color: #c75050; margin-right: 5px; }
-      #selection {
-        position: absolute; right: 14px; top: 54px; z-index: 10;
-        width: 300px; max-height: calc(100% - 80px); overflow: auto;
-        background: var(--panel); border: 1px solid #2a2e3a; border-radius: 10px;
-        padding: 14px 16px; display: none;
-      }
-      #selection.open { display: block; }
-      #selection .doc-type { font-size: 11px; font-weight: 700; letter-spacing: .06em; }
-      #selection h2 { font-size: 14px; margin: 4px 0 8px; }
-      #selection .meta { color: var(--muted); font-size: 12px; margin-bottom: 8px; }
-      #selection p { color: var(--text); font-size: 12px; white-space: pre-wrap; }
-      #legend {
-        position: absolute; left: 14px; bottom: 14px; z-index: 10;
-        background: var(--panel); border: 1px solid #2a2e3a; border-radius: 10px;
-        padding: 10px 14px; font-size: 11px; color: var(--muted);
-        display: flex; flex-wrap: wrap; gap: 6px 14px; max-width: 420px;
-      }
-      #legend i {
-        display: inline-block; width: 9px; height: 9px; border-radius: 50%;
-        margin-right: 5px; vertical-align: -1px;
-      }
+      :root { --bg:#14161c; --panel:#1c1f27; --text:#d6d9e0; --muted:#8b91a0; --accent:#e8833a; --border:#2a2e3a; }
+      * { box-sizing:border-box; margin:0; }
+      html, body { height:100%; }
+      body { background:var(--bg); color:var(--text); font:14px/1.45 system-ui,-apple-system,"Segoe UI",sans-serif; overflow:hidden; }
+      button, input { font:inherit; }
+      button { cursor:pointer; }
+      #graph { position:absolute; inset:0; z-index:0; }
+      #graph canvas { z-index:0 !important; }
+      header { position:absolute; top:0; left:0; right:0; z-index:100; display:flex; align-items:center; gap:12px; padding:10px 16px; background:linear-gradient(to bottom,rgba(20,22,28,.98),rgba(20,22,28,.72)); }
+      header h1 { font-size:16px; font-weight:650; letter-spacing:.02em; white-space:nowrap; }
+      header h1 span { color:var(--accent); }
+      .badge { font-size:10px; font-weight:700; letter-spacing:.08em; color:#14161c; background:var(--accent); padding:2px 7px; border-radius:999px; text-transform:uppercase; }
+      #counts, #status, .muted { color:var(--muted); font-size:12px; }
+      #status { margin-left:auto; white-space:nowrap; }
+      #status.live::before, #status.down::before { content:"●"; margin-right:5px; }
+      #status.live::before { color:#4caf78; } #status.down::before { color:#c75050; }
+      #filters { display:flex; gap:5px; }
+      #filters input { width:82px; color:var(--text); background:var(--panel); border:1px solid var(--border); border-radius:5px; padding:4px 6px; font-size:11px; }
+      #filters input[type="date"] { width:112px; }
+      #filters button { color:var(--text); background:#292d38; border:1px solid #3a3f4d; border-radius:5px; padding:4px 8px; font-size:11px; }
+      aside { position:absolute; z-index:100; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:14px 16px; overflow:auto; }
+      aside h2 { font-size:14px; margin:4px 0 8px; }
+      aside h3 { color:var(--muted); font-size:11px; margin:12px 0 5px; text-transform:uppercase; letter-spacing:.05em; }
+      #stats { left:14px; top:62px; width:260px; max-height:calc(100% - 242px); }
+      #stats, #legend, #selection, #stats button, #legend button, #selection button, summary { pointer-events:auto; }
+      #stats .stat-total { margin-bottom:10px; }
+      #stats .stat-total b { color:var(--accent); }
+      .chips { display:flex; flex-wrap:wrap; gap:4px; }
+      .chips span { color:var(--muted); border:1px solid var(--border); border-radius:999px; padding:2px 6px; font-size:10px; }
+      .chips b { color:var(--text); }
+      details { border-top:1px solid var(--border); margin-top:12px; padding-top:8px; }
+      summary { color:var(--muted); cursor:pointer; font-size:11px; }
+      ul { list-style:none; padding:5px 0 0; font-size:11px; }
+      li { margin:3px 0; overflow-wrap:anywhere; }
+      .node-link { color:#8eb8ed; background:none; border:0; padding:0; text-align:left; font-size:inherit; }
+      .node-link:hover { text-decoration:underline; }
+      .dangling { color:#d98282; }
+      #selection { right:14px; top:62px; width:320px; max-height:calc(100% - 84px); display:none; }
+      #selection.open { display:block; }
+      #selection .close { position:absolute; top:7px; right:10px; color:var(--muted); background:none; border:0; font-size:20px; }
+      #selection .doc-type { font-size:11px; font-weight:700; letter-spacing:.06em; }
+      #selection .meta { color:var(--muted); font-size:12px; margin-bottom:8px; }
+      #selection .path { display:inline-block; margin-top:4px; overflow-wrap:anywhere; }
+      #selection .links { display:flex; flex-wrap:wrap; gap:4px 8px; font-size:11px; }
+      #selection .excerpt { color:var(--text); font-size:12px; white-space:pre-wrap; }
+      #selection .excerpt-note { color:var(--accent); border-top:1px solid var(--border); margin-top:10px; padding-top:8px; font-size:11px; }
+      #legend { position:absolute; left:14px; bottom:14px; z-index:100; width:360px; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:9px 10px; font-size:11px; color:var(--muted); }
+      #legend .legend-summary { margin-bottom:7px; }
+      #legend .legend-summary b { color:var(--text); }
+      #legend .community-list { display:grid; grid-template-columns:1fr 1fr; gap:4px; }
+      #legend .community { display:flex; align-items:center; min-width:0; gap:5px; color:var(--muted); background:#181b22; border:1px solid var(--border); border-radius:5px; padding:4px 6px; text-align:left; }
+      #legend .community:hover, #legend .community.active { color:var(--text); border-color:var(--accent); background:#242731; }
+      #legend .community span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+      #legend .community b { color:var(--text); margin-left:auto; }
+      #legend i { display:inline-block; width:9px; height:9px; border-radius:50%; margin-right:5px; vertical-align:-1px; }
+      @media (max-width:1100px) { #filters input { width:65px; } #filters input[type="date"] { display:none; } }
     </style>
   </head>
   <body>
@@ -68,10 +69,21 @@
       <h1><span>Loom</span> · knowledge graph</h1>
       <span class="badge">experimental</span>
       <span id="counts"></span>
+      <form id="filters">
+        <input name="type" placeholder="type" aria-label="Filter by type" />
+        <input name="status" placeholder="status" aria-label="Filter by status" />
+        <input name="risk" placeholder="risk" aria-label="Filter by risk" />
+        <input name="tag" placeholder="tag" aria-label="Filter by tag" />
+        <input name="from" type="date" aria-label="Created from" />
+        <input name="to" type="date" aria-label="Created to" />
+        <button type="submit">Filter</button>
+        <button type="reset">Clear</button>
+      </form>
       <span id="status">connecting…</span>
     </header>
-    <aside id="selection"></aside>
+    <aside id="stats"></aside>
     <footer id="legend"></footer>
+    <aside id="selection"></aside>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/experimento/web/package-lock.json
+++ b/experimento/web/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "straymark-loom-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "straymark-loom-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "graphology": "^0.26.0",
+        "graphology-communities-louvain": "^2.0.2",
         "graphology-layout": "^0.6.1",
         "graphology-layout-forceatlas2": "^0.10.1",
         "sigma": "^3.0.2"
@@ -911,6 +912,34 @@
       },
       "peerDependencies": {
         "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-communities-louvain": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/graphology-communities-louvain/-/graphology-communities-louvain-2.0.2.tgz",
+      "integrity": "sha512-zt+2hHVPYxjEquyecxWXoUoIuN/UvYzsvI7boDdMNz0rRvpESQ7+e+Ejv6wK7AThycbZXuQ6DkG8NPMCq6XwoA==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-indices": "^0.17.0",
+        "graphology-utils": "^2.4.4",
+        "mnemonist": "^0.39.0",
+        "pandemonium": "^2.4.1"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-indices": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.17.0.tgz",
+      "integrity": "sha512-A7RXuKQvdqSWOpn7ZVQo4S33O0vCfPBnUSf7FwE0zNCasqwZVUaCXePuWo5HBpWw68KJcwObZDHpFk6HKH6MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-utils": "^2.4.2",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
       }
     },
     "node_modules/graphology-layout": {

--- a/experimento/web/package.json
+++ b/experimento/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "straymark-loom-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "graphology": "^0.26.0",
+    "graphology-communities-louvain": "^2.0.2",
     "graphology-layout": "^0.6.1",
     "graphology-layout-forceatlas2": "^0.10.1",
     "sigma": "^3.0.2"

--- a/experimento/web/src/main.ts
+++ b/experimento/web/src/main.ts
@@ -1,13 +1,10 @@
-// Loom M1 — walking skeleton (Spec 001 FR4–FR6):
-// force-directed graph colored by doc_type, sized by degree, thread
-// highlighting via Sigma reducers, live rebuilds over WebSocket.
+// Loom M2 — analytics + panels (Spec 001 FR8–FR10).
 
-import Graph from 'graphology';
+import Graph, { UndirectedGraph } from 'graphology';
+import louvain from 'graphology-communities-louvain';
 import { circular } from 'graphology-layout';
 import forceAtlas2 from 'graphology-layout-forceatlas2';
 import Sigma from 'sigma';
-
-// ---- API types (mirror experimento/src/snapshot.rs) -----------------------
 
 interface ApiNode {
   id: string;
@@ -35,6 +32,9 @@ interface ApiEdge {
 interface ApiStats {
   total_docs: number;
   total_edges: number;
+  by_type: Record<string, number>;
+  by_status: Record<string, number>;
+  by_risk: Record<string, number>;
   orphans: string[];
   dangling_references: ApiEdge[];
 }
@@ -50,37 +50,29 @@ interface Thread {
   edge_ids: number[];
 }
 
-// ---- Visual encoding -------------------------------------------------------
-
+const COMMUNITY_COLORS = [
+  '#e8833a', '#5d9cec', '#4caf78', '#9b7fd4', '#d4a93c', '#3cbfb4',
+  '#d4607f', '#8aa455', '#c75050', '#7f9ad4', '#b06a4f', '#74b89a',
+];
 const TYPE_COLORS: Record<string, string> = {
-  AILOG: '#e8833a', // Loom orange — the most common doc, the project heartbeat
-  AIDEC: '#d4a93c',
-  ADR: '#5d9cec',
-  ETH: '#9b7fd4',
-  REQ: '#4caf78',
-  TES: '#3cbfb4',
-  INC: '#c75050',
-  TDE: '#b06a4f',
-  SEC: '#d4607f',
-  MCARD: '#7f9ad4',
-  SBOM: '#8aa455',
-  DPIA: '#b07fd4',
-  PIPIA: '#c08fb0',
-  CACFILE: '#a0788f',
-  TC260RA: '#90a0b8',
-  AILABEL: '#74b89a',
+  AILOG: '#e8833a', AIDEC: '#d4a93c', ADR: '#5d9cec', ETH: '#9b7fd4',
+  REQ: '#4caf78', TES: '#3cbfb4', INC: '#c75050', TDE: '#b06a4f',
+  SEC: '#d4607f', MCARD: '#7f9ad4', SBOM: '#8aa455', DPIA: '#b07fd4',
+  PIPIA: '#c08fb0', CACFILE: '#a0788f', TC260RA: '#90a0b8', AILABEL: '#74b89a',
 };
 const FALLBACK_COLOR = '#8b91a0';
 const DIM_NODE = '#2c303b';
 const DIM_EDGE = '#1b1e25';
-const THREAD_EDGE = '#e8833a'; // Loom accent — the lit thread
-
-const colorFor = (docType: string) => TYPE_COLORS[docType] ?? FALLBACK_COLOR;
-const sizeFor = (n: ApiNode) => 4 + Math.min(10, Math.sqrt(n.degree_in + n.degree_out) * 2.5);
-
-/// Default view shows a compact label (real corpora have paragraph-length
-/// titles); the full title appears on hover/selection and in the panel.
+const THREAD_EDGE = '#e8833a';
 const SHORT_LABEL_CHARS = 42;
+const MAX_LEGEND_COMMUNITIES = 8;
+
+const colorForCommunity = (community: number) =>
+  COMMUNITY_COLORS[community % COMMUNITY_COLORS.length];
+const sizeFor = (n: ApiNode) => 4 + Math.min(10, Math.sqrt(n.degree_in + n.degree_out) * 2.5);
+const escapeHtml = (s: string) =>
+  s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+
 function shortLabel(title: string): string {
   if (title.length <= SHORT_LABEL_CHARS) return title;
   const cut = title.slice(0, SHORT_LABEL_CHARS);
@@ -88,21 +80,21 @@ function shortLabel(title: string): string {
   return cut.slice(0, lastSpace > 24 ? lastSpace : SHORT_LABEL_CHARS).trimEnd() + '…';
 }
 
-// ---- State -----------------------------------------------------------------
-
 const graph = new Graph({ multi: true, type: 'directed' });
 let thread: { nodes: Set<string>; edges: Set<string> } | null = null;
 let selected: string | null = null;
 let hovered: string | null = null;
+let focusedCommunity: number | null = null;
+const openStatsSections = new Set<string>();
 
 const container = document.getElementById('graph')!;
 const countsEl = document.getElementById('counts')!;
 const statusEl = document.getElementById('status')!;
 const selectionEl = document.getElementById('selection')!;
 const legendEl = document.getElementById('legend')!;
+const statsEl = document.getElementById('stats')!;
+const filterForm = document.getElementById('filters') as HTMLFormElement;
 
-/// Hover/highlight label renderer matching the dark theme (Sigma's default
-/// draws a white box, illegible with our light label color).
 function drawDarkNodeHover(
   context: CanvasRenderingContext2D,
   data: { x: number; y: number; size: number; color?: string; label?: string | null },
@@ -120,13 +112,9 @@ function drawDarkNodeHover(
   context.fillStyle = '#1c1f27';
   context.fill();
   context.strokeStyle = '#3a3f4d';
-  context.lineWidth = 1;
   context.stroke();
-
   context.fillStyle = '#e8e9ee';
   context.fillText(label, x + 2, y);
-
-  // Re-draw the node disc on top of its hover halo.
   context.beginPath();
   context.arc(data.x, data.y, data.size, 0, Math.PI * 2);
   context.fillStyle = data.color ?? FALLBACK_COLOR;
@@ -141,51 +129,83 @@ const renderer = new Sigma(graph, container, {
   labelRenderedSizeThreshold: 8,
   defaultDrawNodeHover: drawDarkNodeHover,
   nodeReducer(node, data) {
-    // Hover/selection promotes the compact label to the full title.
     const expanded = node === hovered || node === selected;
     const label = expanded ? (data.fullLabel as string | undefined) ?? data.label : data.label;
-    if (!thread) return { ...data, label };
-    if (thread.nodes.has(node)) {
-      return { ...data, label, zIndex: 1, highlighted: node === selected };
+    if (thread) {
+      if (thread.nodes.has(node)) {
+        return { ...data, label, zIndex: 1, highlighted: node === selected };
+      }
+      return { ...data, color: DIM_NODE, label: null, zIndex: 0 };
     }
-    return { ...data, color: DIM_NODE, label: null, zIndex: 0 };
+    if (focusedCommunity !== null && data.community !== focusedCommunity) {
+      return { ...data, color: DIM_NODE, label: null, zIndex: 0 };
+    }
+    return { ...data, label, zIndex: focusedCommunity === null ? 0 : 1 };
   },
   edgeReducer(edge, data) {
-    if (!thread) return data;
-    if (thread.edges.has(edge)) {
-      // Unmissable: accent color + double thickness for the lit thread.
-      return { ...data, color: THREAD_EDGE, size: (data.size ?? 1) * 2, zIndex: 1 };
+    if (thread) {
+      if (thread.edges.has(edge)) {
+        return { ...data, color: THREAD_EDGE, size: (data.size ?? 1) * 2, zIndex: 1 };
+      }
+      return { ...data, color: DIM_EDGE, zIndex: 0 };
     }
-    return { ...data, color: DIM_EDGE, zIndex: 0 };
+    if (focusedCommunity !== null) {
+      const [source, target] = graph.extremities(edge);
+      const internal =
+        graph.getNodeAttribute(source, 'community') === focusedCommunity
+        && graph.getNodeAttribute(target, 'community') === focusedCommunity;
+      return internal ? { ...data, zIndex: 1 } : { ...data, color: DIM_EDGE, zIndex: 0 };
+    }
+    return data;
   },
 });
 
-// ---- Graph (re)build -------------------------------------------------------
+function detectCommunities(api: ApiGraph): Record<string, number> {
+  const projection = new UndirectedGraph();
+  for (const node of api.nodes) projection.addNode(node.id);
+  for (const edge of api.edges) {
+    if (edge.resolved && projection.hasNode(edge.source) && projection.hasNode(edge.target)) {
+      projection.mergeEdge(edge.source, edge.target);
+    }
+  }
+  if (projection.size === 0) {
+    return Object.fromEntries(api.nodes.map((node, index) => [node.id, index]));
+  }
+  // Keep cluster ids/colors stable across full rebuilds of unchanged data.
+  let seed = 0x5eed1234;
+  const rng = () => {
+    seed ^= seed << 13;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5;
+    return (seed >>> 0) / 0x100000000;
+  };
+  return louvain(projection, { rng });
+}
 
 function applyGraph(api: ApiGraph): void {
-  // Preserve positions across rebuilds so the picture doesn't jump on save.
   const positions = new Map<string, { x: number; y: number }>();
   graph.forEachNode((id, attrs) =>
     positions.set(id, { x: attrs.x as number, y: attrs.y as number }),
   );
   graph.clear();
 
+  const communities = detectCommunities(api);
   for (const n of api.nodes) {
+    // Louvain's runtime mapping can expose numeric-looking string values
+    // despite its TypeScript declaration. Normalize once so focus/legend
+    // comparisons remain stable.
+    const community = Number(communities[n.id] ?? 0);
     graph.addNode(n.id, {
       label: shortLabel(n.title),
       fullLabel: n.title,
-      color: colorFor(n.doc_type),
+      color: colorForCommunity(community),
       size: sizeFor(n),
       x: positions.get(n.id)?.x ?? Math.random(),
       y: positions.get(n.id)?.y ?? Math.random(),
       docType: n.doc_type,
-      status: n.status,
-      risk: n.risk_level,
-      created: n.created,
-      isNew: !positions.has(n.id),
+      community,
     });
   }
-  // Sigma needs both endpoints; dangling edges are API/stats-only at M1.
   for (const e of api.edges) {
     if (e.resolved && graph.hasNode(e.source) && graph.hasNode(e.target)) {
       graph.addEdgeWithKey(String(e.id), e.source, e.target, {
@@ -195,50 +215,135 @@ function applyGraph(api: ApiGraph): void {
     }
   }
 
-  // strongGravityMode keeps disconnected components (orphans!) from being
-  // repelled out of frame — without it FA2 sends them flying.
   const fa2Settings = {
     ...forceAtlas2.inferSettings(graph),
     strongGravityMode: true,
     gravity: 0.5,
   };
-  if (positions.size === 0) {
-    // First load: circular seed then a full ForceAtlas2 pass.
-    circular.assign(graph);
-    forceAtlas2.assign(graph, { iterations: 300, settings: fa2Settings });
-  } else {
-    // Rebuild: settle briefly so new nodes find their place without
-    // reshuffling the existing layout.
-    forceAtlas2.assign(graph, { iterations: 30, settings: fa2Settings });
+  if (graph.order > 0) {
+    if (positions.size === 0) {
+      circular.assign(graph);
+      forceAtlas2.assign(graph, { iterations: 300, settings: fa2Settings });
+    } else {
+      forceAtlas2.assign(graph, { iterations: 30, settings: fa2Settings });
+    }
   }
 
-  countsEl.textContent =
-    `${api.stats.total_docs} docs · ${api.stats.total_edges} links` +
-    (api.stats.orphans.length ? ` · ${api.stats.orphans.length} orphans` : '') +
-    (api.stats.dangling_references.length
-      ? ` · ${api.stats.dangling_references.length} dangling`
-      : '');
-
-  renderLegend(api);
-
-  // Selection may have disappeared in the rebuild.
+  countsEl.textContent = `${api.stats.total_docs} docs · ${api.stats.total_edges} links`;
+  renderLegend();
+  renderStats(api.stats);
   if (selected && !graph.hasNode(selected)) clearSelection();
   renderer.refresh();
 }
 
-function renderLegend(api: ApiGraph): void {
-  const seen = new Map<string, number>();
-  for (const n of api.nodes) seen.set(n.doc_type, (seen.get(n.doc_type) ?? 0) + 1);
-  legendEl.innerHTML = [...seen.entries()]
+function renderLegend(): void {
+  const communities = new Map<number, Array<{ title: string; degree: number }>>();
+  graph.forEachNode((_id, attrs) => {
+    const community = attrs.community as number;
+    const members = communities.get(community) ?? [];
+    members.push({
+      title: attrs.fullLabel as string,
+      degree: graph.degree(_id),
+    });
+    communities.set(community, members);
+  });
+  const ranked = [...communities.entries()].sort((a, b) => b[1].length - a[1].length);
+  const singletons = ranked.filter(([, members]) => members.length === 1).length;
+  const main = ranked
+    .filter(([, members]) => members.length >= 2)
+    .slice(0, MAX_LEGEND_COMMUNITIES);
+  const hidden = ranked.length - singletons - main.length;
+
+  const buttons = main.map(([community, members]) => {
+    const representative = [...members].sort((a, b) => b.degree - a.degree)[0].title;
+    const active = community === focusedCommunity ? ' active' : '';
+    return `<button type="button" class="community${active}" data-community="${community}"
+      title="Focus ${members.length} documents in this community">
+      <i style="background:${colorForCommunity(community)}"></i>
+      <span>${escapeHtml(shortLabel(representative))}</span><b>${members.length}</b>
+    </button>`;
+  }).join('');
+
+  legendEl.innerHTML = `
+    <div class="legend-summary">
+      <b>${communities.size}</b> communities · <b>${singletons}</b> isolated
+      ${hidden > 0 ? ` · ${hidden} smaller hidden` : ''}
+    </div>
+    <div class="community-list">${buttons}</div>`;
+  legendEl.querySelectorAll<HTMLElement>('[data-community]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      focusCommunity(Number(button.dataset.community));
+    });
+  });
+}
+
+function focusCommunity(community: number): void {
+  const nextCommunity = focusedCommunity === community ? null : community;
+  clearSelection();
+  focusedCommunity = nextCommunity;
+  legendEl.querySelectorAll<HTMLElement>('[data-community]').forEach((button) => {
+    button.classList.toggle(
+      'active',
+      nextCommunity !== null && Number(button.dataset.community) === nextCommunity,
+    );
+  });
+  renderer.refresh();
+}
+
+function countRows(values: Record<string, number>): string {
+  return Object.entries(values)
     .sort((a, b) => b[1] - a[1])
-    .map(
-      ([t, c]) =>
-        `<span><i style="background:${colorFor(t)}"></i>${t} (${c})</span>`,
-    )
+    .map(([label, count]) => `<span>${escapeHtml(label)} <b>${count}</b></span>`)
     .join('');
 }
 
-// ---- Thread highlighting (S2/FR5) ------------------------------------------
+function nodeButton(id: string): string {
+  return `<button type="button" class="node-link" data-node="${escapeHtml(id)}">${escapeHtml(id)}</button>`;
+}
+
+function bindNodeLinks(container: HTMLElement): void {
+  container.querySelectorAll<HTMLElement>('[data-node]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void focusNode(button.dataset.node!);
+    });
+  });
+}
+
+function renderStats(stats: ApiStats): void {
+  const dangling = stats.dangling_references
+    .map((edge) => `<li>${nodeButton(edge.source)} → <span>${escapeHtml(edge.target)}</span></li>`)
+    .join('');
+  statsEl.innerHTML = `
+    <h2>Corpus stats</h2>
+    <div class="stat-total"><b>${stats.total_docs}</b> docs <b>${stats.total_edges}</b> links</div>
+    <h3>Types</h3><div class="chips">${countRows(stats.by_type)}</div>
+    <h3>Status</h3><div class="chips">${countRows(stats.by_status)}</div>
+    <h3>Risk</h3><div class="chips">${countRows(stats.by_risk)}</div>
+    <details data-section="orphans"${openStatsSections.has('orphans') ? ' open' : ''}>
+      <summary>Orphans (${stats.orphans.length})</summary>
+      <ul>${stats.orphans.map((id) => `<li>${nodeButton(id)}</li>`).join('')}</ul>
+    </details>
+    <details data-section="dangling"${openStatsSections.has('dangling') ? ' open' : ''}>
+      <summary>Dangling references (${stats.dangling_references.length})</summary>
+      <ul>${dangling}</ul>
+    </details>`;
+  bindNodeLinks(statsEl);
+  statsEl.querySelectorAll<HTMLElement>('details > summary').forEach((summary) => {
+    summary.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const details = summary.parentElement as HTMLDetailsElement;
+      details.open = !details.open;
+      const section = details.dataset.section!;
+      if (details.open) openStatsSections.add(section);
+      else openStatsSections.delete(section);
+    });
+  });
+}
 
 async function select(nodeId: string): Promise<void> {
   selected = nodeId;
@@ -248,10 +353,7 @@ async function select(nodeId: string): Promise<void> {
   ]);
   if (!threadRes.ok) return;
   const t: Thread = await threadRes.json();
-  thread = {
-    nodes: new Set(t.node_ids),
-    edges: new Set(t.edge_ids.map(String)),
-  };
+  thread = { nodes: new Set(t.node_ids), edges: new Set(t.edge_ids.map(String)) };
   if (nodeRes.ok) showDetail(await nodeRes.json());
   renderer.refresh();
 }
@@ -263,52 +365,99 @@ function clearSelection(): void {
   renderer.refresh();
 }
 
+function edgeLinks(edges: ApiEdge[], direction: 'in' | 'out'): string {
+  if (edges.length === 0) return '<span class="muted">none</span>';
+  return edges.map((edge) => {
+    const endpoint = direction === 'in' ? edge.source : edge.target;
+    return edge.resolved
+      ? nodeButton(endpoint)
+      : `<span class="dangling">${escapeHtml(endpoint)} (dangling)</span>`;
+  }).join('');
+}
+
 function showDetail(detail: {
   node: ApiNode;
   excerpt: string | null;
+  excerpt_truncated: boolean;
   in_edges: ApiEdge[];
   out_edges: ApiEdge[];
 }): void {
   const n = detail.node;
-  const color = colorFor(n.doc_type);
   selectionEl.innerHTML = `
-    <div class="doc-type" style="color:${color}">${n.doc_type}</div>
+    <button type="button" class="close" aria-label="Close">×</button>
+    <div class="doc-type" style="color:${TYPE_COLORS[n.doc_type] ?? FALLBACK_COLOR}">${n.doc_type}</div>
     <h2>${escapeHtml(n.title)}</h2>
-    <div class="meta">
-      ${escapeHtml(n.id)}<br/>
+    <div class="meta">${escapeHtml(n.id)}<br>
       status: ${escapeHtml(n.status)} · risk: ${escapeHtml(n.risk_level)}
-      ${n.created ? `· ${escapeHtml(n.created)}` : ''}<br/>
-      links: ${detail.out_edges.length} out · ${detail.in_edges.length} in
+      ${n.created ? ` · ${escapeHtml(n.created)}` : ''}
+      ${n.tags.length ? `<br>tags: ${n.tags.map(escapeHtml).join(', ')}` : ''}
+      <br><span class="path">${escapeHtml(n.path)}</span>
     </div>
-    <p>${escapeHtml(detail.excerpt ?? '')}</p>`;
+    <h3>Outgoing (${detail.out_edges.length})</h3><div class="links">${edgeLinks(detail.out_edges, 'out')}</div>
+    <h3>Incoming (${detail.in_edges.length})</h3><div class="links">${edgeLinks(detail.in_edges, 'in')}</div>
+    <h3>Excerpt</h3>
+    <p class="excerpt">${escapeHtml(detail.excerpt ?? '')}</p>
+    ${detail.excerpt_truncated
+      ? '<div class="excerpt-note">Excerpt truncated · full document reading arrives in M3</div>'
+      : ''}`;
   selectionEl.classList.add('open');
+  bindNodeLinks(selectionEl);
+  selectionEl.querySelector<HTMLElement>('.close')?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    clearSelection();
+  });
 }
 
-const escapeHtml = (s: string) =>
-  s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+function filterQuery(): string {
+  const params = new URLSearchParams();
+  const data = new FormData(filterForm);
+  for (const [key, value] of data) {
+    const trimmed = String(value).trim();
+    if (trimmed) params.set(key, trimmed);
+  }
+  return params.toString();
+}
+
+async function loadFilteredGraph(): Promise<void> {
+  const query = filterQuery();
+  const response = await fetch(`/api/graph${query ? `?${query}` : ''}`);
+  if (response.ok) {
+    // Filter changes alter the graph projection and therefore community ids.
+    focusedCommunity = null;
+    applyGraph(await response.json());
+  }
+}
+
+async function focusNode(id: string): Promise<void> {
+  if (!graph.hasNode(id)) {
+    filterForm.reset();
+    await loadFilteredGraph();
+  }
+  if (graph.hasNode(id)) await select(id);
+}
 
 renderer.on('clickNode', ({ node }) => void select(node));
 renderer.on('clickStage', clearSelection);
-renderer.on('enterNode', ({ node }) => {
-  hovered = node;
-  renderer.refresh();
-});
-renderer.on('leaveNode', () => {
-  hovered = null;
-  renderer.refresh();
-});
+renderer.on('enterNode', ({ node }) => { hovered = node; renderer.refresh(); });
+renderer.on('leaveNode', () => { hovered = null; renderer.refresh(); });
 
-// ---- Live updates (S3/FR6) --------------------------------------------------
+filterForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  void loadFilteredGraph();
+});
+filterForm.addEventListener('reset', () => setTimeout(() => void loadFilteredGraph(), 0));
 
 function connect(): void {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const ws = new WebSocket(`${proto}://${location.host}/api/stream`);
-  ws.onmessage = (m) => {
-    const msg = JSON.parse(m.data);
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
     if (msg.event === 'rebuild') {
       statusEl.textContent = 'live';
       statusEl.className = 'live';
-      applyGraph(msg.graph as ApiGraph);
+      if (filterQuery()) void loadFilteredGraph();
+      else applyGraph(msg.graph as ApiGraph);
     }
   };
   ws.onclose = () => {


### PR DESCRIPTION
## Loom M2 — analytics, panels, and server-side graph filters

Completes the implementation of **CHARTER-01-loom-server M2** (Spec 001 FR8–FR10).
Turns the M1 walking skeleton into the analytical dashboard while keeping Loom
loopback-only, read-only, and on the shared `straymark-core` parser/graph contract.

### What's in this PR (T2.1–T2.4)

- **T2.1 — Louvain communities**: client-side detection over the undirected graph
  projection with a seeded RNG for stable cluster ids/colors across rebuilds, plus a
  compact interactive legend labeled by representative document titles.
- **T2.2 — Node summary panel**: metadata, tags, source path, body excerpt with explicit
  truncation signaling (`excerpt_truncated`), and clickable incoming/outgoing endpoints.
- **T2.3 — Corpus stats panel**: counts by type/status/risk plus navigable orphan and
  dangling-reference lists.
- **T2.4 — Server-side filters**: `/api/graph` accepts combinable `type`/`status`/`risk`/
  `tag`/`from`/`to` (case-insensitive metadata, inclusive ISO date bounds, AND semantics),
  returning an **induced graph** with recalculated stats. Live WS rebuilds refetch the
  active filtered view instead of replacing it with the unfiltered snapshot.

### Versioning

- `straymark-loom` + web package bumped to **0.2.0**.
- CLI unchanged (already at 3.24.0 from M1).
- **T2.5 (release tag) stays open** — `loom-0.2.0` is created after this merges.

### Verification

- `cargo test` (workspace): 21/21 core, 6/6 loom — pass.
- `cargo clippy -p straymark-loom --no-deps -- -D warnings`: clean.
- `npm audit --omit=dev`: 0 vulnerabilities.
- Smoke test: `/api/graph?type=ADR` returns the filtered graph + recalculated stats;
  forged `Host` header returns HTTP 403. Operator acceptance on the Sentinel corpus
  (130 docs / 389 links).

Detail: `experimento/AILOG-2026-06-12-003-loom-m2-analytics-panels.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)