### PR TITLE
chore(loom): close M2 T2.5 — loom-0.2.0 tagged and released

### DIFF
--- a/experimento/specs/001-loom-server/tasks.md
+++ b/experimento/specs/001-loom-server/tasks.md
@@ -59,8 +59,8 @@
   (FR8, S4)
 - [x] T2.4 — Server-side filters `type/status/risk/tag/from/to` on `/api/graph`; UI
   controls. (FR9, S6)
-- [ ] T2.5 — Acceptance + CHANGELOG → `0.2.0` complete; post-merge tag
-  `loom-0.2.0` pending.
+- [x] T2.5 — Acceptance + CHANGELOG → `0.2.0` complete; post-merge tag
+  `loom-0.2.0` pushed and released (4-platform assets, `--latest=false`).
 
 ## M3 — Rich, Infranodus-like (`loom-0.3.0`)
 


### PR DESCRIPTION
Procedural follow-up to #241. The post-merge release step is done:

- Tag `loom-0.2.0` pushed.
- `release-loom.yml` succeeded — 4-platform assets published (`--latest=false`, so the CLI update flow on `cli-3.24.0` is unaffected).

Flips the last open M2 checkbox (`T2.5`) in `specs/001-loom-server/tasks.md`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)