### PR TITLE
chore(loom): close M3 T3.6 — loom-0.3.0 tagged and released

### DIFF
--- a/experimento/specs/001-loom-server/tasks.md
+++ b/experimento/specs/001-loom-server/tasks.md
@@ -73,7 +73,8 @@
   deep-links + copy-path, client-side; server stays read-only).
 - [x] T3.5 — UI i18n (`en`/`es`/`zh-CN`) driven by the project's configured language;
   resolution moved to `core::config`, served at `/api/meta`. (NFR5)
-- [ ] T3.6 — Acceptance + CHANGELOG → `0.3.0` complete; post-merge tag `loom-0.3.0`.
+- [x] T3.6 — Acceptance + CHANGELOG → `0.3.0` complete; post-merge tag `loom-0.3.0`
+  pushed and released (4-platform assets, `--latest=false`).
 
 ## Graduation (post-M3, evaluated against the Charter's criteria)
 


### PR DESCRIPTION
Procedural follow-up to #243. The post-merge release step is done:

- Tag `loom-0.3.0` pushed.
- `release-loom.yml` succeeded — 4-platform assets published (`--latest=false`, so the CLI update flow on `cli-3.24.0` is unaffected).

Flips the last open M3 checkbox (`T3.6`) in `specs/001-loom-server/tasks.md`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)